### PR TITLE
patch: fix connection manager import

### DIFF
--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -12,9 +12,8 @@ from fastapi_injectable import injectable
 from redis import Redis
 from starlette.websockets import WebSocket
 
-from connections import ConnectionManager
 from market import MarketSchedule
-from src.connections import RedisConnectionManager
+from src.connections import ConnectionManager, RedisConnectionManager
 from src.constants import proxy, proxy_auth
 from src.context import request_context
 
@@ -141,7 +140,7 @@ async def get_logo(
     return None
 
 
-async def get_auth_data() -> tuple[str, str] | None:
+async def get_auth_data() -> tuple[dict, str] | None:
     """
     Get Yahoo Finance authentication data (cookies and crumb)
 


### PR DESCRIPTION
This pull request makes updates to the `src/dependencies.py` file, focusing on imports and type annotations. The most significant changes include reorganizing imports for clarity and updating the return type of the `get_auth_data` function to better reflect the expected data structure.

### Changes to imports:
* Consolidated imports from `src.connections` by combining `ConnectionManager` and `RedisConnectionManager` into a single line, improving readability. Removed an unused import of `ConnectionManager` from a different path.

### Changes to function type annotations:
* Updated the return type of the `get_auth_data` function from `tuple[str, str] | None` to `tuple[dict, str] | None`, reflecting that the first element of the tuple is now expected to be a dictionary instead of a string.