### PR TITLE
patch: fixes market import

### DIFF
--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -12,10 +12,10 @@ from fastapi_injectable import injectable
 from redis import Redis
 from starlette.websockets import WebSocket
 
-from src.market import MarketSchedule
 from src.connections import ConnectionManager, RedisConnectionManager
 from src.constants import proxy, proxy_auth
 from src.context import request_context
+from src.market import MarketSchedule
 
 
 async def get_request_context() -> Request | WebSocket:

--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -12,7 +12,7 @@ from fastapi_injectable import injectable
 from redis import Redis
 from starlette.websockets import WebSocket
 
-from market import MarketSchedule
+from src.market import MarketSchedule
 from src.connections import ConnectionManager, RedisConnectionManager
 from src.constants import proxy, proxy_auth
 from src.context import request_context


### PR DESCRIPTION
I swear this is the last '-'

This pull request updates the import statement in `src/dependencies.py` to ensure proper module referencing. The change replaces the import of `MarketSchedule` from `market` with an import from `src.market`.

* Updated import path for `MarketSchedule` to `src.market` to align with the project's module structure. (`src/dependencies.py`, [src/dependencies.pyL15-R18](diffhunk://#diff-ef173fd45ba5b889bc97b5fbb29bfe8cf38497c066568375f9d82d92ccb17df9L15-R18))