### PR TITLE
staging 1.9.0.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -68,7 +68,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-      day: "first tuesday"
+      day: "tuesday"
       time: "02:00"
       timezone: "UTC"
     target-branch: "staging"
@@ -90,7 +90,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-      day: "second tuesday"
+      day: "tuesday"
       time: "02:00"
       timezone: "UTC"
     target-branch: "staging"

--- a/Dockerfile.aws
+++ b/Dockerfile.aws
@@ -45,16 +45,5 @@ ENV LOGO_TIMEOUT_SECONDS=1
 ENV LOGO_CIRCUIT_BREAKER_THRESHOLD=5
 ENV LOGO_CIRCUIT_BREAKER_TIMEOUT=300
 
-# Other configuration (runtime configurable)
-ENV REDIS_URL=""
-ENV USE_SECURITY=false
-ENV ADMIN_API_KEY=""
-ENV USE_PROXY=false
-ENV PROXY_URL=""
-ENV PROXY_TOKEN=""
-ENV BYPASS_CACHE=false
-ENV ALGOLIA_APP_ID=""
-ENV ALGOLIA_API_KEY=""
-
 # Set the entry point for the AWS Lambda function
 CMD ["src/main.handler"]


### PR DESCRIPTION
This pull request makes minor configuration updates to the Dependabot schedule and removes unused environment variable declarations from the AWS Dockerfile.

Configuration updates:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L71-R71): Changed the Dependabot update schedule to run on any Tuesday of the month instead of specifically the first or second Tuesday. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L71-R71) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L93-R93)

Cleanup:

* [`Dockerfile.aws`](diffhunk://#diff-e557aff00d82b1bf7f4ff16e96d924002e03e6ab13935f0272077786d3225dbeL48-L58): Removed unused environment variable declarations related to Redis, security, admin API key, proxy, cache bypass, and Algolia configuration.