### PR TITLE
fix: exports FinancialStatement for cache

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -26,3 +26,4 @@ from .analysis import (
     RevenueEstimateResponse,
     EarningsHistoryResponse,
 )
+from .financials import FinancialStatement


### PR DESCRIPTION
This pull request introduces a small change to the `src/models/__init__.py` file by adding an import for the `FinancialStatement` model,  allowing other modules to access `FinancialStatement` directly from the `models` package. This fixes a critical bug where financial statement endpoints crash after a cache hit.

* Thanks again @realwahyuputra for pointing this out.