### PR TITLE
refactor: make Quote generic over F: Format (Both/Raw/Pretty)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ base64 = "0.22"
 
 # Optional: DataFrame support
 polars = { version = "0.53", optional = true, default-features = false, features = ["lazy"] }
-finance-query-derive = { version = "2.6.0", path = "finance-query-derive", optional = true }
+finance-query-derive = { version = "2.6.0", path = "finance-query-derive" }
 
 # Optional: CSV parsing for macro-economic data (Treasury yields)
 csv = { version = "1", optional = true }
@@ -95,7 +95,7 @@ feed-rs = { version = "2", optional = true }
 [features]
 default = []
 # Enable DataFrame conversions with polars
-dataframe = ["dep:polars", "dep:finance-query-derive"]
+dataframe = ["dep:polars"]
 # Enable technical analysis indicators
 indicators = []
 # Enable backtesting engine for strategy simulation (requires indicators)

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -108,11 +108,11 @@ Add doc comments to public items:
 /// # Example
 ///
 /// ```no_run
-/// use finance_query::Ticker;
+/// use finance_query::{Raw, Ticker};
 ///
 /// let ticker = Ticker::builder("AAPL").logo().build().await?;
-/// let quote = ticker.quote().await?;
-/// println!("Price: ${}", quote.regular_market_price);
+/// let quote = ticker.quote::<Raw>().await?;
+/// println!("Price: ${:.2}", quote.regular_market_price.unwrap_or(0.0));
 /// ```
 pub async fn quote(&self) -> Result<Quote> {
     // ...
@@ -143,11 +143,13 @@ async fn test_ticker_builder() {
 Mark network tests with `#[ignore]`:
 
 ```rust
+use finance_query::format::Raw;
+
 #[tokio::test]
 #[ignore = "requires network access"]
 async fn test_real_quote() {
     let ticker = Ticker::builder("AAPL").logo().build().await.unwrap();
-    let quote = ticker.quote().await.unwrap();
+    let quote = ticker.quote::<Raw>().await.unwrap();
     assert!(!quote.symbol.is_empty());
 }
 ```
@@ -160,10 +162,10 @@ Use `no_run` for examples that require network access:
 /// # Example
 ///
 /// ```no_run
-/// # use finance_query::Ticker;
+/// # use finance_query::{Raw, Ticker};
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let ticker = Ticker::builder("AAPL").logo().build().await?;
-/// let quote = ticker.quote().await?;
+/// let quote = ticker.quote::<Raw>().await?;
 /// # Ok(())
 /// # }
 /// ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -111,14 +111,14 @@ Finance Query is ready to use out of the box. Here's how to get stock data:
 === "Rust Library"
 
     ```rust
-    use finance_query::{Ticker, Interval, TimeRange};
+    use finance_query::{Ticker, Interval, TimeRange, Raw};
 
     #[tokio::main]
     async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Get detailed quote for Apple
         let ticker = Ticker::builder("AAPL").logo().build().await?;
-        let quote = ticker.quote().await?;
-        println!("{} price: ${:?}", quote.symbol, quote.regular_market_price);
+        let quote = ticker.quote::<Raw>().await?;
+        println!("{} price: ${:.2}", quote.symbol, quote.regular_market_price.unwrap_or(0.0));
 
         // Get historical charts
         let chart = ticker.chart(Interval::OneDay, TimeRange::OneMonth).await?;

--- a/docs/library/configuration.md
+++ b/docs/library/configuration.md
@@ -235,18 +235,17 @@ let income_quarterly = ticker.financials(
 
 ## Value Formatting
 
-Some server endpoints support value formatting. This is primarily a server feature, but the library defines the `ValueFormat` enum:
+`quote()` is generic over the output format, so you can choose the representation you want at call sites.
 
 ```rust
-use finance_query::ValueFormat;
+use finance_query::{Both, Pretty, Raw};
 
-// For display purposes
-ValueFormat::Raw     // Raw numbers (default)
-ValueFormat::Pretty  // Formatted strings (e.g., "1.2M", "$45.67")
-ValueFormat::Both    // Both raw and pretty values
+let raw = ticker.quote::<Raw>().await?;       // numeric fields (Option<f64>, Option<i64>)
+let pretty = ticker.quote::<Pretty>().await?; // formatted strings (Option<String>)
+let both = ticker.quote::<Both>().await?;     // raw + formatted pair
 ```
 
-**Note**: This is mainly used by the server's REST API. Library users typically work with raw values directly.
+For quote sub-modules (like `financial_data()` or `key_stats()`), the return type is still the Both format, so use `.raw` to access the numeric values.
 
 ## Provider Configuration
 
@@ -302,7 +301,7 @@ See [Multi-Provider Architecture](providers/index.md) for the complete provider 
         - UK stocks (`HSBA.L`): `Region::UnitedKingdom`
 
     ```rust
-    use finance_query::{Ticker, Region};
+    use finance_query::{Raw, Region, Ticker};
 
     // US stock
     let apple = Ticker::builder("AAPL")
@@ -327,9 +326,9 @@ See [Multi-Provider Architecture](providers/index.md) for the complete provider 
 
     // Fetch quotes in parallel
     let (apple_quote, tsmc_quote, sap_quote) = tokio::join!(
-        apple.quote(),
-        tsmc.quote(),
-        sap.quote()
+        apple.quote::<Raw>(),
+        tsmc.quote::<Raw>(),
+        sap.quote::<Raw>()
     );
     ```
 

--- a/docs/library/dataframe.md
+++ b/docs/library/dataframe.md
@@ -78,8 +78,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 Single quote to DataFrame:
 
 ```rust
+use finance_query::format::Both;
+
 let ticker = Ticker::new("NVDA").await?;
-let quote = ticker.quote().await?;
+let quote = ticker.quote::<Both>().await?;
 
 // Convert to single-row DataFrame
 let df = quote.to_dataframe()?;
@@ -453,7 +455,9 @@ let df = results.quotes.to_dataframe()?;
 Individual structs create single-row DataFrames:
 
 ```rust
-let quote = ticker.quote().await?;
+use finance_query::format::Both;
+
+let quote = ticker.quote::<Both>().await?;
 let df = quote.to_dataframe()?;  // 1 row, 30+ columns
 ```
 

--- a/docs/library/finance.md
+++ b/docs/library/finance.md
@@ -103,9 +103,9 @@ let summary = finance::market_summary(None).await?;
 let summary = finance::market_summary(Some(Region::Canada)).await?;
 
 for quote in &summary {
-    let price = quote.regular_market_price.as_ref().and_then(|v| v.raw);
+    let price = quote.regular_market_price.as_ref().and_then(|v| v.raw).unwrap_or(0.0);
     let change_pct = quote.regular_market_change_percent.as_ref().and_then(|v| v.raw).unwrap_or(0.0);
-    println!("{}: ${:?} ({:+.2}%)", quote.symbol, price, change_pct);
+    println!("{}: ${:.2} ({:+.2}%)", quote.symbol, price, change_pct);
 }
 ```
 

--- a/docs/library/getting-started.md
+++ b/docs/library/getting-started.md
@@ -34,7 +34,7 @@ finance-query = { version = "2.0", features = ["dataframe", "backtesting"] }
 ## Quick Example
 
 ```rust
-use finance_query::{Ticker, Interval, TimeRange};
+use finance_query::{Ticker, Interval, TimeRange, Raw};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -42,9 +42,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ticker = Ticker::builder("AAPL").logo().build().await?;
 
     // Get quote
-    let quote = ticker.quote().await?;
+    let quote = ticker.quote::<Raw>().await?;
     println!("{}: ${:.2}", quote.symbol,
-        quote.regular_market_price.as_ref().and_then(|v| v.raw).unwrap_or(0.0));
+        quote.regular_market_price.unwrap_or(0.0));
 
     // Get chart
     let chart = ticker.chart(Interval::OneDay, TimeRange::OneMonth).await?;
@@ -82,9 +82,11 @@ let ticker = providers.ticker("AAPL").build().await?;
 ### 📊 Stock Data & Analysis
 
 ```rust
+use finance_query::format::Raw;
+
 // Quotes, financials, options, news
 let ticker = Ticker::builder("MSFT").logo().build().await?;
-let quote = ticker.quote().await?; // fetch quote with logo if available
+let quote = ticker.quote::<Raw>().await?; // fetch quote with logo if available
 let financials = ticker.financial_data().await?;
 let options = ticker.options(None).await?;
 ```

--- a/docs/library/providers/alphavantage.md
+++ b/docs/library/providers/alphavantage.md
@@ -23,7 +23,7 @@ No manual init call needed — the provider reads the key during `TickerBuilder:
 ## Usage
 
 ```rust
-use finance_query::{Capability, Fetch, Provider, Providers};
+use finance_query::{Capability, Fetch, Provider, Providers, Raw};
 
 let providers = Providers::builder()
     .route(Capability::QUOTE, &[Provider::AlphaVantage, Provider::Yahoo])
@@ -31,7 +31,7 @@ let providers = Providers::builder()
     .build()
     .await?;
 let ticker = providers.ticker("AAPL").build().await?;
-let quote = ticker.quote().await?;
+let quote = ticker.quote::<Raw>().await?;
 ```
 
 ## Capabilities

--- a/docs/library/providers/fmp.md
+++ b/docs/library/providers/fmp.md
@@ -23,7 +23,7 @@ No manual init call needed — the provider reads the key during `TickerBuilder:
 ## Usage
 
 ```rust
-use finance_query::{Capability, Fetch, Provider, Providers};
+use finance_query::{Capability, Fetch, Provider, Providers, Raw};
 
 let providers = Providers::builder()
     .route(Capability::QUOTE, &[Provider::Fmp, Provider::Yahoo])
@@ -31,7 +31,7 @@ let providers = Providers::builder()
     .build()
     .await?;
 let ticker = providers.ticker("AAPL").build().await?;
-let quote = ticker.quote().await?;
+let quote = ticker.quote::<Raw>().await?;
 ```
 
 ## Capabilities

--- a/docs/library/providers/polygon.md
+++ b/docs/library/providers/polygon.md
@@ -23,7 +23,7 @@ No manual init call needed — the provider reads the key during `TickerBuilder:
 ## Usage
 
 ```rust
-use finance_query::{Capability, Fetch, Provider, Providers};
+use finance_query::{Capability, Fetch, Provider, Providers, Raw};
 
 let providers = Providers::builder()
     .route(Capability::QUOTE, &[Provider::Polygon, Provider::Yahoo])
@@ -31,7 +31,7 @@ let providers = Providers::builder()
     .build()
     .await?;
 let ticker = providers.ticker("AAPL").build().await?;
-let quote = ticker.quote().await?;
+let quote = ticker.quote::<Raw>().await?;
 ```
 
 ## Capabilities

--- a/docs/library/ticker.md
+++ b/docs/library/ticker.md
@@ -57,7 +57,6 @@ let ticker = Ticker::builder("AAPL")
 - `.region_code(String)` - Set region code (e.g., "US", "JP")
 - `.timeout(Duration)` - Set HTTP request timeout
 - `.proxy(String)` - Set proxy URL
-- `.format(ValueFormat)` - Value format: `Raw` (default), `Pretty`, or `Both`
 - `.logo()` - Fetch company logo URLs alongside quote data
 - `.cache(Duration)` - Enable in-memory caching with the given TTL (time-to-live)
 
@@ -96,18 +95,20 @@ no `Providers` setup needed.
 Get a comprehensive quote with all key metrics:
 
 ```rust
+use finance_query::format::Raw;
+
 // Enable logo fetching via builder
 let ticker = Ticker::builder("AAPL").logo().build().await?;
-let quote = ticker.quote().await?;
+let quote = ticker.quote::<Raw>().await?;
 
 println!("Symbol: {}", quote.symbol);
 println!("Name: {}", quote.short_name.as_deref().unwrap_or("N/A"));
-let price = quote.regular_market_price.as_ref().and_then(|v| v.raw).unwrap_or(0.0);
+let price = quote.regular_market_price.unwrap_or(0.0);
 println!("Price: ${:.2}", price);
-let change = quote.regular_market_change.as_ref().and_then(|v| v.raw).unwrap_or(0.0);
-let change_pct = quote.regular_market_change_percent.as_ref().and_then(|v| v.raw).unwrap_or(0.0);
+let change = quote.regular_market_change.unwrap_or(0.0);
+let change_pct = quote.regular_market_change_percent.unwrap_or(0.0);
 println!("Change: {:+.2} ({:+.2}%)", change, change_pct);
-let market_cap = quote.market_cap.as_ref().and_then(|v| v.raw).unwrap_or(0);
+let market_cap = quote.market_cap.unwrap_or(0);
 println!("Market Cap: ${}", market_cap);
 // Logo URLs (only populated when .logo() is used on the builder)
 println!("Logo: {:?}", quote.logo_url);
@@ -115,6 +116,22 @@ println!("Company Logo: {:?}", quote.company_logo_url);
 ```
 
 The `Quote` struct aggregates data from multiple `quote modules` into a single structure.
+
+### Value Formats
+
+`quote()` is generic over the output format:
+
+- `Raw` returns numeric fields as plain numbers (e.g., `Option<f64>`).
+- `Pretty` returns formatted strings (e.g., `Option<String>` like `"1.2M"`).
+- `Both` returns the raw + formatted pair (the default for sub-module accessors like `financial_data()` or `key_stats()`).
+
+```rust
+use finance_query::format::{Both, Pretty, Raw};
+
+let raw = ticker.quote::<Raw>().await?;       // numeric fields
+let pretty = ticker.quote::<Pretty>().await?; // formatted strings
+let both = ticker.quote::<Both>().await?;     // raw + formatted
+```
 
 ### Quote Modules
 
@@ -775,16 +792,18 @@ let recs_again = ticker.recommendations(10).await?;  // cached
     - **Be strategic with chart requests** - each new `(interval, range)` pair triggers a new request
 
     ```rust
+    use finance_query::format::Raw;
+
     // Good: Reuse ticker for multiple operations
     let ticker = Ticker::builder("AAPL").logo().build().await?;
-    let quote = ticker.quote().await?;
+    let quote = ticker.quote::<Raw>().await?;
     let chart = ticker.chart(Interval::OneDay, TimeRange::OneMonth).await?;
     let profile = ticker.asset_profile().await?;
 
     // Less efficient: Creating new tickers each time
     // (loses caching benefits, re-authenticates with Yahoo each time)
     let ticker1 = Ticker::builder("AAPL").logo().build().await?;
-    let quote = ticker1.quote().await?;
+    let quote = ticker1.quote::<Raw>().await?;
     let ticker2 = Ticker::new("AAPL").await?;
     let chart = ticker2.chart(Interval::OneDay, TimeRange::OneMonth).await?;
     ```

--- a/docs/library/tickers.md
+++ b/docs/library/tickers.md
@@ -533,8 +533,10 @@ let response = tickers.quotes().await?;
 You can also access individual symbols from the `Tickers` instance. If the data is already cached from a batch operation, it returns immediately. If not, it triggers a batch fetch (for quotes) or single fetch (for charts).
 
 ```rust
+use finance_query::format::Raw;
+
 // Get single quote (uses cache if available)
-let aapl = tickers.quote("AAPL").await?;
+let aapl = tickers.quote::<Raw>("AAPL").await?;
 
 // Get single chart (uses cache if available)
 let msft_chart = tickers.chart("MSFT", Interval::OneDay, TimeRange::OneMonth).await?;

--- a/finance-query-cli/src/commands/info.rs
+++ b/finance-query-cli/src/commands/info.rs
@@ -64,7 +64,7 @@ pub async fn execute(args: InfoArgs) -> Result<()> {
 
     // Fetch full quote data
     let ticker = Ticker::new(&args.symbol).await?;
-    let quote = ticker.quote().await?;
+    let quote = ticker.quote::<finance_query::format::Both>().await?;
 
     // For JSON/CSV output, return structured data
     if format != OutputFormat::Table {

--- a/finance-query-cli/src/dashboard/actions.rs
+++ b/finance-query-cli/src/dashboard/actions.rs
@@ -78,7 +78,7 @@ impl App {
 
         self.status_message = format!("Fetching quote for {}...", symbol);
         match Ticker::new(&symbol).await {
-            Ok(ticker) => match ticker.quote().await {
+            Ok(ticker) => match ticker.quote::<finance_query::format::Both>().await {
                 Ok(quote) => {
                     self.quotes.insert(symbol.clone(), quote);
                     self.status_message = format!("Added {} to watchlist", symbol);
@@ -145,7 +145,7 @@ impl App {
         self.status_message = format!("Added {} to watchlist", symbol);
 
         match Ticker::new(&symbol).await {
-            Ok(ticker) => match ticker.quote().await {
+            Ok(ticker) => match ticker.quote::<finance_query::format::Both>().await {
                 Ok(quote) => {
                     self.quotes.insert(symbol.clone(), quote);
                     self.status_message = format!("Added {} to watchlist", symbol);
@@ -206,7 +206,7 @@ impl App {
         self.status_message = format!("Added {} to watchlist", symbol);
 
         match Ticker::new(&symbol).await {
-            Ok(ticker) => match ticker.quote().await {
+            Ok(ticker) => match ticker.quote::<finance_query::format::Both>().await {
                 Ok(quote) => {
                     self.quotes.insert(symbol.clone(), quote);
                     self.status_message = format!("Added {} to watchlist", symbol);

--- a/finance-query-cli/src/dashboard/runtime.rs
+++ b/finance-query-cli/src/dashboard/runtime.rs
@@ -88,7 +88,7 @@ async fn run_event_loop(
         {
             detailed_quote_task = Some(tokio::spawn(async move {
                 match finance_query::Ticker::new(&symbol).await {
-                    Ok(ticker) => match ticker.quote().await {
+                    Ok(ticker) => match ticker.quote::<finance_query::format::Both>().await {
                         Ok(quote) => Some((symbol, quote)),
                         Err(_) => None,
                     },

--- a/finance-query-cli/src/options/state.rs
+++ b/finance-query-cli/src/options/state.rs
@@ -136,7 +136,7 @@ impl OptionsApp {
         match Ticker::new(&self.symbol).await {
             Ok(ticker) => {
                 // Get quote for underlying price
-                if let Ok(quote) = ticker.quote().await {
+                if let Ok(quote) = ticker.quote::<finance_query::format::Both>().await {
                     self.underlying_price = quote.regular_market_price.as_ref().and_then(|v| v.raw);
                 }
 

--- a/finance-query-derive/src/lib.rs
+++ b/finance-query-derive/src/lib.rs
@@ -148,6 +148,51 @@ pub fn derive_to_dataframe(input: TokenStream) -> TokenStream {
         }
     };
 
+    // If the struct is generic over F: Format, generate impl for <Both> specifically.
+    let has_format_param = input.generics.params.iter().any(|param| {
+        if let GenericParam::Type(TypeParam { bounds, .. }) = param {
+            bounds.iter().any(|b| {
+                if let TypeParamBound::Trait(tb) = b {
+                    tb.path
+                        .segments
+                        .last()
+                        .map(|s| s.ident == "Format")
+                        .unwrap_or(false)
+                } else {
+                    false
+                }
+            })
+        } else {
+            false
+        }
+    });
+
+    let impl_ty = if has_format_param {
+        quote! { #name<crate::format::Both> }
+    } else {
+        quote! { #name }
+    };
+
+    // Detect the format type parameter name (e.g. `F`) to scope is_format_assoc_value correctly.
+    let format_param_ident: Option<&Ident> = input.generics.params.iter().find_map(|param| {
+        if let GenericParam::Type(TypeParam { ident, bounds, .. }) = param {
+            let is_format = bounds.iter().any(|b| {
+                if let TypeParamBound::Trait(tb) = b {
+                    tb.path
+                        .segments
+                        .last()
+                        .map(|s| s.ident == "Format")
+                        .unwrap_or(false)
+                } else {
+                    false
+                }
+            });
+            if is_format { Some(ident) } else { None }
+        } else {
+            None
+        }
+    });
+
     let mut column_names: Vec<String> = Vec::new();
     let mut column_values: Vec<TokenStream2> = Vec::new();
 
@@ -156,27 +201,28 @@ pub fn derive_to_dataframe(input: TokenStream) -> TokenStream {
         let field_name_str = to_snake_case(&field_name.to_string());
         let field_type = &field.ty;
 
-        if let Some(value_expr) = generate_column_value(field_name, field_type) {
+        if let Some(value_expr) = generate_column_value(field_name, field_type, format_param_ident)
+        {
             column_names.push(field_name_str);
             column_values.push(value_expr);
         }
-        // Skip fields that return None (complex nested types)
     }
 
-    // Generate vec column value expressions (for vec_to_dataframe)
     let mut vec_column_values: Vec<TokenStream2> = Vec::new();
     for field in fields.iter() {
         let field_name = field.ident.as_ref().unwrap();
         let field_type = &field.ty;
 
-        if let Some(value_expr) = generate_vec_column_value(field_name, field_type) {
+        if let Some(value_expr) =
+            generate_vec_column_value(field_name, field_type, format_param_ident)
+        {
             vec_column_values.push(value_expr);
         }
     }
 
     let expanded = quote! {
         #[cfg(feature = "dataframe")]
-        impl #name {
+        impl #impl_ty {
             /// Converts this struct to a single-row polars DataFrame.
             ///
             /// All scalar fields are included as columns. Nested objects
@@ -216,28 +262,23 @@ fn to_snake_case(s: &str) -> String {
 /// Generates the value expression for a DataFrame column based on field type.
 ///
 /// Returns `None` for complex types that should be skipped.
-fn generate_column_value(field_name: &syn::Ident, field_type: &Type) -> Option<TokenStream2> {
+fn generate_column_value(
+    field_name: &syn::Ident,
+    field_type: &Type,
+    fmt_param: Option<&Ident>,
+) -> Option<TokenStream2> {
     match field_type {
-        // Direct String
         Type::Path(type_path) if is_string(type_path) => {
             Some(quote! { [self.#field_name.as_str()] })
         }
-
-        // Direct FormattedValue<T> - extract .raw
         Type::Path(type_path) if is_formatted_value(type_path) => {
             Some(quote! { [self.#field_name.raw] })
         }
-
-        // Option<T>
         Type::Path(type_path) if is_option(type_path) => {
             let inner_type = get_option_inner_type(type_path)?;
-            generate_option_value(field_name, inner_type)
+            generate_option_value(field_name, inner_type, fmt_param)
         }
-
-        // Direct primitives: i32, i64, f64, bool
         Type::Path(type_path) if is_primitive(type_path) => Some(quote! { [self.#field_name] }),
-
-        // Skip all other types (Vec, nested structs, etc.)
         _ => None,
     }
 }
@@ -245,74 +286,71 @@ fn generate_column_value(field_name: &syn::Ident, field_type: &Type) -> Option<T
 /// Generates the value expression for a DataFrame column when iterating over a Vec.
 ///
 /// Returns `None` for complex types that should be skipped.
-fn generate_vec_column_value(field_name: &syn::Ident, field_type: &Type) -> Option<TokenStream2> {
+fn generate_vec_column_value(
+    field_name: &syn::Ident,
+    field_type: &Type,
+    fmt_param: Option<&Ident>,
+) -> Option<TokenStream2> {
     match field_type {
-        // Direct String
         Type::Path(type_path) if is_string(type_path) => {
             Some(quote! { items.iter().map(|item| item.#field_name.as_str()).collect::<Vec<_>>() })
         }
-
-        // Direct FormattedValue<T> - extract .raw
         Type::Path(type_path) if is_formatted_value(type_path) => {
             Some(quote! { items.iter().map(|item| item.#field_name.raw).collect::<Vec<_>>() })
         }
-
-        // Option<T>
         Type::Path(type_path) if is_option(type_path) => {
             let inner_type = get_option_inner_type(type_path)?;
-            generate_vec_option_value(field_name, inner_type)
+            generate_vec_option_value(field_name, inner_type, fmt_param)
         }
-
-        // Direct primitives: i32, i64, f64, bool
         Type::Path(type_path) if is_primitive(type_path) => {
             Some(quote! { items.iter().map(|item| item.#field_name).collect::<Vec<_>>() })
         }
-
-        // Skip all other types (Vec, nested structs, etc.)
         _ => None,
     }
 }
 
 /// Generates value expression for Option<T> fields when iterating over a Vec.
-fn generate_vec_option_value(field_name: &syn::Ident, inner_type: &Type) -> Option<TokenStream2> {
+fn generate_vec_option_value(
+    field_name: &syn::Ident,
+    inner_type: &Type,
+    fmt_param: Option<&Ident>,
+) -> Option<TokenStream2> {
     match inner_type {
-        // Option<String>
         Type::Path(type_path) if is_string(type_path) => Some(
             quote! { items.iter().map(|item| item.#field_name.as_deref()).collect::<Vec<_>>() },
         ),
-
-        // Option<FormattedValue<T>> - extract .raw
-        Type::Path(type_path) if is_formatted_value(type_path) => Some(
-            quote! { items.iter().map(|item| item.#field_name.as_ref().and_then(|v| v.raw)).collect::<Vec<_>>() },
-        ),
-
-        // Option<primitive>
+        // Option<FormattedValue<T>> or Option<F::Value<T>> — extract .raw
+        Type::Path(type_path)
+            if is_formatted_value(type_path) || is_format_assoc_value(type_path, fmt_param) =>
+        {
+            Some(
+                quote! { items.iter().map(|item| item.#field_name.as_ref().and_then(|v| v.raw)).collect::<Vec<_>>() },
+            )
+        }
         Type::Path(type_path) if is_primitive(type_path) => {
             Some(quote! { items.iter().map(|item| item.#field_name).collect::<Vec<_>>() })
         }
-
-        // Skip complex Option<T> types
         _ => None,
     }
 }
 
 /// Generates value expression for Option<T> fields.
-fn generate_option_value(field_name: &syn::Ident, inner_type: &Type) -> Option<TokenStream2> {
+fn generate_option_value(
+    field_name: &syn::Ident,
+    inner_type: &Type,
+    fmt_param: Option<&Ident>,
+) -> Option<TokenStream2> {
     match inner_type {
-        // Option<String>
         Type::Path(type_path) if is_string(type_path) => {
             Some(quote! { [self.#field_name.as_deref()] })
         }
-
-        // Option<FormattedValue<T>> - extract .raw
-        Type::Path(type_path) if is_formatted_value(type_path) => {
+        // Option<FormattedValue<T>> or Option<F::Value<T>> — extract .raw
+        Type::Path(type_path)
+            if is_formatted_value(type_path) || is_format_assoc_value(type_path, fmt_param) =>
+        {
             Some(quote! { [self.#field_name.as_ref().and_then(|v| v.raw)] })
         }
-
-        // Option<primitive>
         Type::Path(type_path) if is_primitive(type_path) => Some(quote! { [self.#field_name] }),
-
-        // Skip complex Option<T> types
         _ => None,
     }
 }
@@ -345,6 +383,17 @@ fn is_formatted_value(type_path: &TypePath) -> bool {
         .last()
         .map(|seg| seg.ident == "FormattedValue")
         .unwrap_or(false)
+}
+
+/// Checks if a type path is `PARAM::Value<T>` — the associated type form used by `F: Format`.
+///
+/// Only matches when `fmt_param` is known and the first segment equals it exactly
+/// (e.g. `F::Value<f64>` where `F` is the detected format type parameter).
+/// This prevents false-positive matches on unrelated 2-segment paths like `serde_json::Value`.
+fn is_format_assoc_value(type_path: &TypePath, fmt_param: Option<&Ident>) -> bool {
+    let Some(param) = fmt_param else { return false };
+    let segs = &type_path.path.segments;
+    segs.len() == 2 && segs[0].ident == *param && segs[1].ident == "Value"
 }
 
 /// Checks if a type path is a primitive type (i32, i64, f64, bool).
@@ -427,33 +476,6 @@ pub fn derive_format_convert(input: TokenStream) -> TokenStream {
         .into();
     };
 
-    // Collect all generic params except the format param for the impl headers
-    let other_generics: Vec<_> = input
-        .generics
-        .params
-        .iter()
-        .filter(|p| {
-            if let GenericParam::Type(tp) = p {
-                tp.ident != *format_param
-            } else {
-                true
-            }
-        })
-        .collect();
-
-    let (other_impl_generics, other_ty_generics, other_where) = if other_generics.is_empty() {
-        (quote! {}, quote! {}, quote! {})
-    } else {
-        // Simplified: just re-emit the other params as-is
-        let params = &other_generics;
-        (
-            quote! { <#(#params),*> },
-            quote! { <#(#params),*> },
-            quote! {},
-        )
-    };
-    let _ = (other_impl_generics, other_ty_generics, other_where);
-
     // Build field classification: (field_ident, is_formatted)
     let classified: Vec<(&syn::Field, bool)> = fields
         .iter()
@@ -486,31 +508,31 @@ pub fn derive_format_convert(input: TokenStream) -> TokenStream {
         .collect();
 
     let expanded = quote! {
-        impl From<#name<crate::Both>> for #name<crate::Raw> {
-            fn from(v: #name<crate::Both>) -> Self {
+        impl From<#name<crate::format::Both>> for #name<crate::format::Raw> {
+            fn from(v: #name<crate::format::Both>) -> Self {
                 #name {
                     #(#raw_field_exprs,)*
                 }
             }
         }
 
-        impl From<#name<crate::Both>> for #name<crate::Pretty> {
-            fn from(v: #name<crate::Both>) -> Self {
+        impl From<#name<crate::format::Both>> for #name<crate::format::Pretty> {
+            fn from(v: #name<crate::format::Both>) -> Self {
                 #name {
                     #(#pretty_field_exprs,)*
                 }
             }
         }
 
-        impl #name<crate::Both> {
-            /// Convert into a [`Raw`](crate::Raw) view, extracting `.raw` from each `FormattedValue` field.
-            pub fn into_raw(self) -> #name<crate::Raw> { self.into() }
-            /// Clone and convert into a [`Raw`](crate::Raw) view.
-            pub fn as_raw(&self) -> #name<crate::Raw> { self.clone().into() }
-            /// Convert into a [`Pretty`](crate::Pretty) view, extracting `.fmt` from each `FormattedValue` field.
-            pub fn into_pretty(self) -> #name<crate::Pretty> { self.into() }
-            /// Clone and convert into a [`Pretty`](crate::Pretty) view.
-            pub fn as_pretty(&self) -> #name<crate::Pretty> { self.clone().into() }
+        impl #name<crate::format::Both> {
+            /// Convert into a [`Raw`](crate::format::Raw) view, extracting `.raw` from each `FormattedValue` field.
+            pub fn into_raw(self) -> #name<crate::format::Raw> { self.into() }
+            /// Clone and convert into a [`Raw`](crate::format::Raw) view.
+            pub fn as_raw(&self) -> #name<crate::format::Raw> { self.clone().into() }
+            /// Convert into a [`Pretty`](crate::format::Pretty) view, extracting `.fmt` from each `FormattedValue` field.
+            pub fn into_pretty(self) -> #name<crate::format::Pretty> { self.into() }
+            /// Clone and convert into a [`Pretty`](crate::format::Pretty) view.
+            pub fn as_pretty(&self) -> #name<crate::format::Pretty> { self.clone().into() }
         }
     };
 

--- a/finance-query-derive/src/lib.rs
+++ b/finance-query-derive/src/lib.rs
@@ -86,7 +86,8 @@ use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::{
-    Data, DeriveInput, Fields, GenericArgument, PathArguments, Type, TypePath, parse_macro_input,
+    Data, DeriveInput, Fields, GenericArgument, GenericParam, Ident, PathArguments, Type,
+    TypeParam, TypeParamBound, TypePath, parse_macro_input,
 };
 
 /// Derive macro for automatic DataFrame conversion.
@@ -360,6 +361,196 @@ fn is_primitive(type_path: &TypePath) -> bool {
             )
         })
         .unwrap_or(false)
+}
+
+/// Derive macro for format-typed struct conversions.
+///
+/// For structs generic over `F: Format` (e.g. `SummaryDetail<F: Format = Both>`), generates:
+///
+/// - `impl From<Struct<Both>> for Struct<Raw>` — extracts `.raw` from each `FormattedValue` field
+/// - `impl From<Struct<Both>> for Struct<Pretty>` — extracts `.fmt` (or `.long_fmt`) instead
+/// - Convenience methods on `Struct<Both>`: `into_raw()`, `as_raw()`, `into_pretty()`, `as_pretty()`
+///
+/// Field classification:
+/// - `Option<F::Value<T>>` (any 2-segment path ending in `::Value`) → formatted field
+/// - Everything else → plain field, copied as-is
+#[proc_macro_derive(FormatConvert)]
+pub fn derive_format_convert(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = &input.ident;
+
+    let fields = match &input.data {
+        Data::Struct(data) => match &data.fields {
+            Fields::Named(fields) => &fields.named,
+            _ => {
+                return syn::Error::new_spanned(
+                    &input,
+                    "FormatConvert only supports structs with named fields",
+                )
+                .to_compile_error()
+                .into();
+            }
+        },
+        _ => {
+            return syn::Error::new_spanned(&input, "FormatConvert only supports structs")
+                .to_compile_error()
+                .into();
+        }
+    };
+
+    // Find the format type param: a generic param with a bound path ending in "Format"
+    let format_param: Option<&Ident> = input.generics.params.iter().find_map(|param| {
+        if let GenericParam::Type(TypeParam { ident, bounds, .. }) = param {
+            let has_format = bounds.iter().any(|b| {
+                if let TypeParamBound::Trait(tb) = b {
+                    tb.path
+                        .segments
+                        .last()
+                        .map(|s| s.ident == "Format")
+                        .unwrap_or(false)
+                } else {
+                    false
+                }
+            });
+            if has_format { Some(ident) } else { None }
+        } else {
+            None
+        }
+    });
+
+    let Some(format_param) = format_param else {
+        return syn::Error::new_spanned(
+            &input,
+            "FormatConvert requires a generic param bounded by Format (e.g. <F: Format = Both>)",
+        )
+        .to_compile_error()
+        .into();
+    };
+
+    // Collect all generic params except the format param for the impl headers
+    let other_generics: Vec<_> = input
+        .generics
+        .params
+        .iter()
+        .filter(|p| {
+            if let GenericParam::Type(tp) = p {
+                tp.ident != *format_param
+            } else {
+                true
+            }
+        })
+        .collect();
+
+    let (other_impl_generics, other_ty_generics, other_where) = if other_generics.is_empty() {
+        (quote! {}, quote! {}, quote! {})
+    } else {
+        // Simplified: just re-emit the other params as-is
+        let params = &other_generics;
+        (
+            quote! { <#(#params),*> },
+            quote! { <#(#params),*> },
+            quote! {},
+        )
+    };
+    let _ = (other_impl_generics, other_ty_generics, other_where);
+
+    // Build field classification: (field_ident, is_formatted)
+    let classified: Vec<(&syn::Field, bool)> = fields
+        .iter()
+        .map(|f| (f, is_format_value_field(&f.ty, format_param)))
+        .collect();
+
+    // Generate field conversion expressions for Raw and Pretty
+    let raw_field_exprs: Vec<_> = classified
+        .iter()
+        .map(|(f, is_fmt)| {
+            let ident = f.ident.as_ref().unwrap();
+            if *is_fmt {
+                quote! { #ident: v.#ident.and_then(|fv| fv.raw) }
+            } else {
+                quote! { #ident: v.#ident }
+            }
+        })
+        .collect();
+
+    let pretty_field_exprs: Vec<_> = classified
+        .iter()
+        .map(|(f, is_fmt)| {
+            let ident = f.ident.as_ref().unwrap();
+            if *is_fmt {
+                quote! { #ident: v.#ident.and_then(|fv| fv.fmt.or(fv.long_fmt)) }
+            } else {
+                quote! { #ident: v.#ident }
+            }
+        })
+        .collect();
+
+    let expanded = quote! {
+        impl From<#name<crate::Both>> for #name<crate::Raw> {
+            fn from(v: #name<crate::Both>) -> Self {
+                #name {
+                    #(#raw_field_exprs,)*
+                }
+            }
+        }
+
+        impl From<#name<crate::Both>> for #name<crate::Pretty> {
+            fn from(v: #name<crate::Both>) -> Self {
+                #name {
+                    #(#pretty_field_exprs,)*
+                }
+            }
+        }
+
+        impl #name<crate::Both> {
+            /// Convert into a [`Raw`](crate::Raw) view, extracting `.raw` from each `FormattedValue` field.
+            pub fn into_raw(self) -> #name<crate::Raw> { self.into() }
+            /// Clone and convert into a [`Raw`](crate::Raw) view.
+            pub fn as_raw(&self) -> #name<crate::Raw> { self.clone().into() }
+            /// Convert into a [`Pretty`](crate::Pretty) view, extracting `.fmt` from each `FormattedValue` field.
+            pub fn into_pretty(self) -> #name<crate::Pretty> { self.into() }
+            /// Clone and convert into a [`Pretty`](crate::Pretty) view.
+            pub fn as_pretty(&self) -> #name<crate::Pretty> { self.clone().into() }
+        }
+    };
+
+    TokenStream::from(expanded)
+}
+
+/// Returns true if `ty` is `Option<PARAM::Value<T>>` for the given format param name.
+fn is_format_value_field(ty: &Type, format_param: &Ident) -> bool {
+    let inner = match get_option_inner(ty) {
+        Some(t) => t,
+        None => return false,
+    };
+    // Check for PARAM::Value<T>
+    if let Type::Path(tp) = inner {
+        let segs = &tp.path.segments;
+        if segs.len() == 2 {
+            return segs[0].ident == *format_param && segs[1].ident == "Value";
+        }
+    }
+    false
+}
+
+/// Extracts the inner type T from Option<T>, returning None if the type isn't Option<…>.
+fn get_option_inner(ty: &Type) -> Option<&Type> {
+    if let Type::Path(tp) = ty {
+        let seg = tp.path.segments.last()?;
+        if seg.ident != "Option" {
+            return None;
+        }
+        if let PathArguments::AngleBracketed(args) = &seg.arguments {
+            return args.args.first().and_then(|a| {
+                if let GenericArgument::Type(t) = a {
+                    Some(t)
+                } else {
+                    None
+                }
+            });
+        }
+    }
+    None
 }
 
 /// Extracts the inner type from Option<T>.

--- a/finance-query-mcp/src/tools/quotes.rs
+++ b/finance-query-mcp/src/tools/quotes.rs
@@ -6,7 +6,10 @@ use crate::tools::helpers::parse_range;
 
 pub async fn get_quote(symbol: String) -> Result<CallToolResult, McpError> {
     let ticker = Ticker::new(&symbol).await.map_err(finance_err)?;
-    let quote = ticker.quote().await.map_err(finance_err)?;
+    let quote = ticker
+        .quote::<finance_query::format::Raw>()
+        .await
+        .map_err(finance_err)?;
     let json = serde_json::to_string(&quote).map_err(ser_err)?;
     Ok(CallToolResult::success(vec![rmcp::model::Content::text(
         json,
@@ -17,9 +20,11 @@ pub async fn get_quotes(symbols: String) -> Result<CallToolResult, McpError> {
     let syms: Vec<&str> = symbols.split(',').map(str::trim).collect();
     let tickers = Tickers::new(syms).await.map_err(finance_err)?;
     let batch = tickers.quotes().await.map_err(finance_err)?;
-    let json = serde_json::to_string(&batch).map_err(ser_err)?;
+    let json = serde_json::to_value(&batch).map_err(ser_err)?;
+    let raw = finance_query::ValueFormat::Raw.transform(json);
+    let text = serde_json::to_string(&raw).map_err(ser_err)?;
     Ok(CallToolResult::success(vec![rmcp::model::Content::text(
-        json,
+        text,
     )]))
 }
 

--- a/server/src/graphql/query.rs
+++ b/server/src/graphql/query.rs
@@ -167,9 +167,14 @@ impl GqlTicker {
         #[graphql(default)] format: GqlValueFormat,
     ) -> Result<super::types::quote::GqlQuote> {
         let state = ctx.data::<AppState>()?;
-        let json = crate::services::quote::get_quote(&state.cache, &self.symbol, logo)
-            .await
-            .map_err(to_gql_error)?;
+        let json = crate::services::quote::get_quote(
+            &state.cache,
+            &self.symbol,
+            logo,
+            finance_query::ValueFormat::Both,
+        )
+        .await
+        .map_err(to_gql_error)?;
         let json = finance_query::ValueFormat::from(format).transform(json);
         serde_json::from_value(json).map_err(|e| async_graphql::Error::new(e.to_string()))
     }

--- a/server/src/graphql/query.rs
+++ b/server/src/graphql/query.rs
@@ -167,14 +167,9 @@ impl GqlTicker {
         #[graphql(default)] format: GqlValueFormat,
     ) -> Result<super::types::quote::GqlQuote> {
         let state = ctx.data::<AppState>()?;
-        let json = crate::services::quote::get_quote(
-            &state.cache,
-            &self.symbol,
-            logo,
-            finance_query::ValueFormat::Both,
-        )
-        .await
-        .map_err(to_gql_error)?;
+        let json = crate::services::quote::get_quote(&state.cache, &self.symbol, logo)
+            .await
+            .map_err(to_gql_error)?;
         let json = finance_query::ValueFormat::from(format).transform(json);
         serde_json::from_value(json).map_err(|e| async_graphql::Error::new(e.to_string()))
     }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1426,7 +1426,7 @@ async fn get_quote(
         params.fields
     );
 
-    match services::quote::get_quote(&state.cache, &symbol, params.logo, format).await {
+    match services::quote::get_quote(&state.cache, &symbol, params.logo).await {
         Ok(json) => {
             let response = apply_transforms(json, format, fields.as_ref());
             (StatusCode::OK, Json(response)).into_response()
@@ -1532,7 +1532,7 @@ async fn get_quotes(
         params.fields
     );
 
-    match services::quote::get_quotes(&state.cache, symbols, params.logo, format).await {
+    match services::quote::get_quotes(&state.cache, symbols, params.logo).await {
         Ok(json) => {
             let response = apply_transforms(json, format, fields.as_ref());
             (StatusCode::OK, Json(response)).into_response()

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1426,7 +1426,7 @@ async fn get_quote(
         params.fields
     );
 
-    match services::quote::get_quote(&state.cache, &symbol, params.logo).await {
+    match services::quote::get_quote(&state.cache, &symbol, params.logo, format).await {
         Ok(json) => {
             let response = apply_transforms(json, format, fields.as_ref());
             (StatusCode::OK, Json(response)).into_response()
@@ -1532,7 +1532,7 @@ async fn get_quotes(
         params.fields
     );
 
-    match services::quote::get_quotes(&state.cache, symbols, params.logo).await {
+    match services::quote::get_quotes(&state.cache, symbols, params.logo, format).await {
         Ok(json) => {
             let response = apply_transforms(json, format, fields.as_ref());
             (StatusCode::OK, Json(response)).into_response()

--- a/server/src/services/quote.rs
+++ b/server/src/services/quote.rs
@@ -1,20 +1,12 @@
 use crate::cache::{self, Cache};
-use finance_query::{Ticker, Tickers, ValueFormat};
+use finance_query::{Ticker, Tickers};
 use tracing::info;
 
 use super::{ServiceError, ServiceResult};
 
-pub async fn get_quote(
-    cache: &Cache,
-    symbol: &str,
-    logo: bool,
-    format: ValueFormat,
-) -> ServiceResult {
+pub async fn get_quote(cache: &Cache, symbol: &str, logo: bool) -> ServiceResult {
     let logo_str = if logo { "1" } else { "0" };
-    let cache_key = Cache::key(
-        "quote",
-        &[&symbol.to_uppercase(), logo_str, format.as_str()],
-    );
+    let cache_key = Cache::key("quote", &[&symbol.to_uppercase(), logo_str]);
     let symbol = symbol.to_string();
 
     cache
@@ -23,28 +15,23 @@ pub async fn get_quote(
             cache::ttl::QUOTES,
             cache::is_market_open(),
             || async move {
-                let builder = Ticker::builder(&symbol).format(format);
+                let builder = Ticker::builder(&symbol);
                 let builder = if logo { builder.logo() } else { builder };
                 let ticker = builder.build().await?;
-                let quote = ticker.quote_value().await?;
+                let quote = ticker.quote::<finance_query::format::Both>().await?;
                 info!("Successfully fetched quote for {}", symbol);
-                Ok(quote)
+                serde_json::to_value(&quote).map_err(|e| Box::new(e) as ServiceError)
             },
         )
         .await
 }
 
-pub async fn get_quotes(
-    cache: &Cache,
-    symbols: Vec<&str>,
-    logo: bool,
-    format: ValueFormat,
-) -> ServiceResult {
+pub async fn get_quotes(cache: &Cache, symbols: Vec<&str>, logo: bool) -> ServiceResult {
     let mut symbols = symbols;
     symbols.sort();
     let logo_str = if logo { "1" } else { "0" };
     let symbols_key = symbols.join(",").to_uppercase();
-    let cache_key = Cache::key("quotes", &[&symbols_key, logo_str, format.as_str()]);
+    let cache_key = Cache::key("quotes", &[&symbols_key, logo_str]);
 
     cache
         .get_or_fetch(
@@ -52,7 +39,7 @@ pub async fn get_quotes(
             cache::ttl::QUOTES,
             cache::is_market_open(),
             || async move {
-                let builder = Tickers::builder(symbols).format(format);
+                let builder = Tickers::builder(symbols);
                 let builder = if logo { builder.logo() } else { builder };
                 let tickers = builder.build().await?;
                 let batch_response = tickers.quotes().await?;
@@ -61,9 +48,7 @@ pub async fn get_quotes(
                     batch_response.success_count(),
                     batch_response.error_count()
                 );
-                let json = serde_json::to_value(&batch_response)
-                    .map_err(|e| Box::new(e) as ServiceError)?;
-                Ok(format.transform(json))
+                serde_json::to_value(&batch_response).map_err(|e| Box::new(e) as ServiceError)
             },
         )
         .await

--- a/server/src/services/quote.rs
+++ b/server/src/services/quote.rs
@@ -26,9 +26,9 @@ pub async fn get_quote(
                 let builder = Ticker::builder(&symbol).format(format);
                 let builder = if logo { builder.logo() } else { builder };
                 let ticker = builder.build().await?;
-                let quote = ticker.quote().await?;
+                let quote = ticker.quote_value().await?;
                 info!("Successfully fetched quote for {}", symbol);
-                serde_json::to_value(&quote).map_err(|e| Box::new(e) as ServiceError)
+                Ok(quote)
             },
         )
         .await
@@ -61,7 +61,9 @@ pub async fn get_quotes(
                     batch_response.success_count(),
                     batch_response.error_count()
                 );
-                serde_json::to_value(&batch_response).map_err(|e| Box::new(e) as ServiceError)
+                let json = serde_json::to_value(&batch_response)
+                    .map_err(|e| Box::new(e) as ServiceError)?;
+                Ok(format.transform(json))
             },
         )
         .await

--- a/server/src/services/quote.rs
+++ b/server/src/services/quote.rs
@@ -1,12 +1,20 @@
 use crate::cache::{self, Cache};
-use finance_query::{Ticker, Tickers};
+use finance_query::{Ticker, Tickers, ValueFormat};
 use tracing::info;
 
 use super::{ServiceError, ServiceResult};
 
-pub async fn get_quote(cache: &Cache, symbol: &str, logo: bool) -> ServiceResult {
+pub async fn get_quote(
+    cache: &Cache,
+    symbol: &str,
+    logo: bool,
+    format: ValueFormat,
+) -> ServiceResult {
     let logo_str = if logo { "1" } else { "0" };
-    let cache_key = Cache::key("quote", &[&symbol.to_uppercase(), logo_str]);
+    let cache_key = Cache::key(
+        "quote",
+        &[&symbol.to_uppercase(), logo_str, format.as_str()],
+    );
     let symbol = symbol.to_string();
 
     cache
@@ -15,7 +23,7 @@ pub async fn get_quote(cache: &Cache, symbol: &str, logo: bool) -> ServiceResult
             cache::ttl::QUOTES,
             cache::is_market_open(),
             || async move {
-                let builder = Ticker::builder(&symbol);
+                let builder = Ticker::builder(&symbol).format(format);
                 let builder = if logo { builder.logo() } else { builder };
                 let ticker = builder.build().await?;
                 let quote = ticker.quote().await?;
@@ -26,12 +34,17 @@ pub async fn get_quote(cache: &Cache, symbol: &str, logo: bool) -> ServiceResult
         .await
 }
 
-pub async fn get_quotes(cache: &Cache, symbols: Vec<&str>, logo: bool) -> ServiceResult {
+pub async fn get_quotes(
+    cache: &Cache,
+    symbols: Vec<&str>,
+    logo: bool,
+    format: ValueFormat,
+) -> ServiceResult {
     let mut symbols = symbols;
     symbols.sort();
     let logo_str = if logo { "1" } else { "0" };
     let symbols_key = symbols.join(",").to_uppercase();
-    let cache_key = Cache::key("quotes", &[&symbols_key, logo_str]);
+    let cache_key = Cache::key("quotes", &[&symbols_key, logo_str, format.as_str()]);
 
     cache
         .get_or_fetch(
@@ -39,7 +52,7 @@ pub async fn get_quotes(cache: &Cache, symbols: Vec<&str>, logo: bool) -> Servic
             cache::ttl::QUOTES,
             cache::is_market_open(),
             || async move {
-                let builder = Tickers::builder(symbols);
+                let builder = Tickers::builder(symbols).format(format);
                 let builder = if logo { builder.logo() } else { builder };
                 let tickers = builder.build().await?;
                 let batch_response = tickers.quotes().await?;

--- a/src/adapters/alphavantage/mod.rs
+++ b/src/adapters/alphavantage/mod.rs
@@ -9,6 +9,7 @@
 //!
 //! ```no_run
 //! use finance_query::{Providers, Provider, Capability, Interval, TimeRange};
+//! use finance_query::format::Raw;
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! // Route capabilities to Alpha Vantage with Yahoo as fallback
@@ -19,7 +20,7 @@
 //!     .build().await?;
 //!
 //! let ticker = providers.ticker("AAPL").build().await?;
-//! let quote = ticker.quote().await?;
+//! let quote = ticker.quote::<Raw>().await?;
 //! let chart = ticker.chart(Interval::OneDay, TimeRange::OneMonth).await?;
 //!
 //! let gdp = providers.economic("REAL_GDP").series().await?;

--- a/src/adapters/fmp/mod.rs
+++ b/src/adapters/fmp/mod.rs
@@ -9,6 +9,7 @@
 //!
 //! ```no_run
 //! use finance_query::{Providers, Provider, Capability, StatementType, Frequency};
+//! use finance_query::format::Raw;
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! // Route fundamentals and quote data to FMP with Yahoo as fallback
@@ -18,7 +19,7 @@
 //!     .build().await?;
 //!
 //! let ticker = providers.ticker("AAPL").build().await?;
-//! let quote = ticker.quote().await?;
+//! let quote = ticker.quote::<Raw>().await?;
 //! let income = ticker.financials(StatementType::Income, Frequency::Quarterly).await?;
 //! # Ok(())
 //! # }

--- a/src/adapters/polygon/mod.rs
+++ b/src/adapters/polygon/mod.rs
@@ -9,6 +9,7 @@
 //!
 //! ```no_run
 //! use finance_query::{Providers, Provider, Capability, Interval, TimeRange};
+//! use finance_query::format::Raw;
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! // Route chart and quote data to Polygon with Yahoo as fallback
@@ -19,7 +20,7 @@
 //!
 //! let ticker = providers.ticker("AAPL").build().await?;
 //! let chart = ticker.chart(Interval::OneDay, TimeRange::OneMonth).await?;
-//! let quote = ticker.quote().await?;
+//! let quote = ticker.quote::<Raw>().await?;
 //! # Ok(())
 //! # }
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,8 +263,27 @@ pub mod streaming;
 // ============================================================================
 // Format type parameters — phantom types for compile-time format selection
 // ============================================================================
-pub use finance_query_derive::FormatConvert;
-pub use models::format::{Both, Format, Pretty, Raw};
+
+/// Compile-time format type parameters for [`Quote`](crate::Quote) and other
+/// `FormattedValue`-bearing structs.
+///
+/// | Marker | `F::Value<f64>` | Access pattern |
+/// |---|---|---|
+/// | [`format::Both`]  | `FormattedValue<f64>` | `.raw` / `.fmt` / `.long_fmt` |
+/// | [`format::Raw`]   | `f64`                 | direct (no unwrapping) |
+/// | [`format::Pretty`] | `String`             | human-readable string |
+///
+/// ```no_run
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// use finance_query::{format, Ticker};
+/// let ticker = Ticker::new("AAPL").await?;
+/// let quote: finance_query::Quote<format::Raw> = ticker.quote().await?;
+/// # Ok(())
+/// # }
+/// ```
+pub mod format {
+    pub use crate::models::format::{Both, Pretty, Raw};
+}
 
 // ============================================================================
 // DataFrame support (requires "dataframe" feature)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,6 +261,12 @@ pub use models::discovery::screeners::{
 pub mod streaming;
 
 // ============================================================================
+// Format type parameters — phantom types for compile-time format selection
+// ============================================================================
+pub use finance_query_derive::FormatConvert;
+pub use models::format::{Both, Format, Pretty, Raw};
+
+// ============================================================================
 // DataFrame support (requires "dataframe" feature)
 // ============================================================================
 // When enabled, structs with #[derive(ToDataFrame)] get a to_dataframe() method.

--- a/src/models/format.rs
+++ b/src/models/format.rs
@@ -1,0 +1,119 @@
+//! Compile-time format type parameters for `FormattedValue`-bearing structs.
+//!
+//! Structs like [`Quote`](crate::Quote) carry a format type parameter `F: Format`
+//! that controls what type each numeric field holds:
+//!
+//! | `F`      | `F::Value<f64>`         | Access pattern            |
+//! |----------|-------------------------|---------------------------|
+//! | [`Both`] | `FormattedValue<f64>`   | `.raw` / `.fmt` / `.long_fmt` (default) |
+//! | [`Raw`]  | `f64`                   | direct — no unwrapping    |
+//! | [`Pretty`] | `String`              | human-readable string     |
+//!
+//! # Quick start
+//!
+//! ```no_run
+//! use finance_query::{Ticker, Raw};
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! let quote = Ticker::new("AAPL").await?.quote().await?;
+//! let raw   = quote.as_raw();                   // Quote<Raw>
+//! let price: Option<f64> = raw.regular_market_price;
+//! # Ok(())
+//! # }
+//! ```
+
+use crate::models::quote::FormattedValue;
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// Marker trait that controls how [`FormattedValue`](crate::FormattedValue) fields are typed.
+///
+/// Sealed — only [`Both`], [`Raw`], and [`Pretty`] implement this trait.
+pub trait Format: sealed::Sealed + Clone + std::fmt::Debug + PartialEq + 'static {
+    /// The concrete field type for a numeric value of type `T`.
+    type Value<T: Clone + std::fmt::Debug + PartialEq + serde::Serialize + for<'de> serde::Deserialize<'de>>: Clone
+        + std::fmt::Debug
+        + PartialEq
+        + serde::Serialize
+        + for<'de> serde::Deserialize<'de>;
+
+    /// Extract the raw numeric value from a `Value<T>`, if available.
+    ///
+    /// Returns `Some(T)` for [`Both`] (from `.raw`) and [`Raw`] (the value itself),
+    /// `None` for [`Pretty`] (no numeric representation is stored).
+    fn raw_from<
+        T: Clone + std::fmt::Debug + PartialEq + serde::Serialize + for<'de> serde::Deserialize<'de>,
+    >(
+        value: &Self::Value<T>,
+    ) -> Option<T>;
+}
+
+/// Full format — fields hold `FormattedValue<T>` with `raw`, `fmt`, and `long_fmt`.
+///
+/// This is the **default** format returned by [`Ticker::quote()`](crate::Ticker::quote)
+/// and is the only form that can be deserialized directly from Yahoo Finance JSON.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct Both;
+
+/// Raw format — fields hold `T` directly (e.g. `f64`, `i64`).
+///
+/// Obtain via [`Quote::into_raw`](crate::Quote::into_raw) or
+/// [`Quote::as_raw`](crate::Quote::as_raw). No `Option`-wrapping of the value itself;
+/// the `Option` at the field level reflects missing data from the API.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Raw;
+
+/// Pretty format — fields hold an `Option<String>` with the human-readable representation.
+///
+/// Obtain via [`Quote::into_pretty`](crate::Quote::into_pretty).
+/// Falls back to `long_fmt` when `fmt` is absent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Pretty;
+
+impl sealed::Sealed for Both {}
+impl sealed::Sealed for Raw {}
+impl sealed::Sealed for Pretty {}
+
+impl Format for Both {
+    type Value<
+        T: Clone + std::fmt::Debug + PartialEq + serde::Serialize + for<'de> serde::Deserialize<'de>,
+    > = FormattedValue<T>;
+
+    fn raw_from<
+        T: Clone + std::fmt::Debug + PartialEq + serde::Serialize + for<'de> serde::Deserialize<'de>,
+    >(
+        value: &FormattedValue<T>,
+    ) -> Option<T> {
+        value.raw.clone()
+    }
+}
+
+impl Format for Raw {
+    type Value<
+        T: Clone + std::fmt::Debug + PartialEq + serde::Serialize + for<'de> serde::Deserialize<'de>,
+    > = T;
+
+    fn raw_from<
+        T: Clone + std::fmt::Debug + PartialEq + serde::Serialize + for<'de> serde::Deserialize<'de>,
+    >(
+        value: &T,
+    ) -> Option<T> {
+        Some(value.clone())
+    }
+}
+
+impl Format for Pretty {
+    type Value<
+        T: Clone + std::fmt::Debug + PartialEq + serde::Serialize + for<'de> serde::Deserialize<'de>,
+    > = String;
+
+    fn raw_from<
+        T: Clone + std::fmt::Debug + PartialEq + serde::Serialize + for<'de> serde::Deserialize<'de>,
+    >(
+        _value: &String,
+    ) -> Option<T> {
+        None
+    }
+}

--- a/src/models/format.rs
+++ b/src/models/format.rs
@@ -5,19 +5,19 @@
 //!
 //! | `F`      | `F::Value<f64>`         | Access pattern            |
 //! |----------|-------------------------|---------------------------|
-//! | [`Both`] | `FormattedValue<f64>`   | `.raw` / `.fmt` / `.long_fmt` (default) |
-//! | [`Raw`]  | `f64`                   | direct — no unwrapping    |
+//! | [`Both`] | `FormattedValue<f64>`   | `.raw` / `.fmt` / `.long_fmt` |
+//! | [`Raw`]  | `f64`                   | direct — no unwrapping (**default**) |
 //! | [`Pretty`] | `String`              | human-readable string     |
 //!
 //! # Quick start
 //!
 //! ```no_run
-//! use finance_query::{Ticker, Raw};
+//! use finance_query::{Ticker, format};
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-//! let quote = Ticker::new("AAPL").await?.quote().await?;
-//! let raw   = quote.as_raw();                   // Quote<Raw>
-//! let price: Option<f64> = raw.regular_market_price;
+//! // quote() returns Quote<Raw> by default — fields are plain f64/i64
+//! let quote: finance_query::Quote<format::Raw> = Ticker::new("AAPL").await?.quote().await?;
+//! let price: Option<f64> = quote.regular_market_price;
 //! # Ok(())
 //! # }
 //! ```
@@ -52,14 +52,15 @@ pub trait Format: sealed::Sealed + Clone + std::fmt::Debug + PartialEq + 'static
 
 /// Full format — fields hold `FormattedValue<T>` with `raw`, `fmt`, and `long_fmt`.
 ///
-/// This is the **default** format returned by [`Ticker::quote()`](crate::Ticker::quote)
-/// and is the only form that can be deserialized directly from Yahoo Finance JSON.
+/// Obtain via [`Quote::into_formatted`](crate::Quote::into_formatted).
+/// This is the form that can be deserialized directly from Yahoo Finance JSON.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct Both;
 
-/// Raw format — fields hold `T` directly (e.g. `f64`, `i64`).
+/// Raw format — fields hold `T` directly (e.g. `f64`, `i64`). **This is the default.**
 ///
-/// Obtain via [`Quote::into_raw`](crate::Quote::into_raw) or
+/// Obtain via [`Ticker::quote()`](crate::Ticker::quote) (the default return type),
+/// [`Quote::into_raw`](crate::Quote::into_raw), or
 /// [`Quote::as_raw`](crate::Quote::as_raw). No `Option`-wrapping of the value itself;
 /// the `Option` at the field level reflects missing data from the API.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/src/models/fundamentals/default_key_statistics.rs
+++ b/src/models/fundamentals/default_key_statistics.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 /// Contains extensive statistical data including valuation metrics, share data, and financial ratios.
 ///
 /// The type parameter `F` controls how numeric fields are represented:
-/// - `DefaultKeyStatistics` / `DefaultKeyStatistics<Both>` — default; fields hold `FormattedValue<T>`
+/// - `DefaultKeyStatistics` / `DefaultKeyStatistics<Both>` — **default**; fields hold `FormattedValue<T>`
 /// - `DefaultKeyStatistics<Raw>` — fields hold `T` directly (e.g. `Option<f64>`)
 /// - `DefaultKeyStatistics<Pretty>` — fields hold `Option<String>` (human-readable)
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, FormatConvert)]

--- a/src/models/fundamentals/default_key_statistics.rs
+++ b/src/models/fundamentals/default_key_statistics.rs
@@ -1,23 +1,26 @@
-use crate::models::quote::FormattedValue;
-/// Default Key Statistics module
-///
-/// Contains key financial statistics and metrics for the company.
+use crate::models::format::{Both, Format};
+use finance_query_derive::FormatConvert;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 /// Default key statistics for a symbol
 ///
 /// Contains extensive statistical data including valuation metrics, share data, and financial ratios.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct DefaultKeyStatistics {
+///
+/// The type parameter `F` controls how numeric fields are represented:
+/// - `DefaultKeyStatistics` / `DefaultKeyStatistics<Both>` — default; fields hold `FormattedValue<T>`
+/// - `DefaultKeyStatistics<Raw>` — fields hold `T` directly (e.g. `Option<f64>`)
+/// - `DefaultKeyStatistics<Pretty>` — fields hold `Option<String>` (human-readable)
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, FormatConvert)]
+#[serde(rename_all = "camelCase", bound = "")]
+pub struct DefaultKeyStatistics<F: Format = Both> {
     /// 52-week price change percentage
     #[serde(rename = "52WeekChange", skip_serializing_if = "Option::is_none")]
-    pub week_52_change: Option<FormattedValue<f64>>,
+    pub week_52_change: Option<F::Value<f64>>,
 
     /// S&P 500 52-week change percentage
     #[serde(rename = "SandP52WeekChange", skip_serializing_if = "Option::is_none")]
-    pub sand_p_52_week_change: Option<FormattedValue<f64>>,
+    pub sand_p_52_week_change: Option<F::Value<f64>>,
 
     /// Annual holdings turnover (for funds)
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -29,7 +32,7 @@ pub struct DefaultKeyStatistics {
 
     /// Beta coefficient (volatility vs market)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub beta: Option<FormattedValue<f64>>,
+    pub beta: Option<F::Value<f64>>,
 
     /// 3-year beta (for funds)
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -37,7 +40,7 @@ pub struct DefaultKeyStatistics {
 
     /// Book value per share
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub book_value: Option<FormattedValue<f64>>,
+    pub book_value: Option<F::Value<f64>>,
 
     /// Fund category
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -45,23 +48,23 @@ pub struct DefaultKeyStatistics {
 
     /// Date of short interest data
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub date_short_interest: Option<FormattedValue<i64>>,
+    pub date_short_interest: Option<F::Value<i64>>,
 
     /// Quarterly earnings growth rate
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub earnings_quarterly_growth: Option<FormattedValue<f64>>,
+    pub earnings_quarterly_growth: Option<F::Value<f64>>,
 
     /// Enterprise value to EBITDA ratio
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub enterprise_to_ebitda: Option<FormattedValue<f64>>,
+    pub enterprise_to_ebitda: Option<F::Value<f64>>,
 
     /// Enterprise value to revenue ratio
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub enterprise_to_revenue: Option<FormattedValue<f64>>,
+    pub enterprise_to_revenue: Option<F::Value<f64>>,
 
     /// Total enterprise value
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub enterprise_value: Option<FormattedValue<i64>>,
+    pub enterprise_value: Option<F::Value<i64>>,
 
     /// 5-year average return (for funds)
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -69,15 +72,15 @@ pub struct DefaultKeyStatistics {
 
     /// Number of floating shares
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub float_shares: Option<FormattedValue<i64>>,
+    pub float_shares: Option<F::Value<i64>>,
 
     /// Forward earnings per share
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub forward_eps: Option<FormattedValue<f64>>,
+    pub forward_eps: Option<F::Value<f64>>,
 
     /// Forward price-to-earnings ratio
     #[serde(rename = "forwardPE", skip_serializing_if = "Option::is_none")]
-    pub forward_pe: Option<FormattedValue<f64>>,
+    pub forward_pe: Option<F::Value<f64>>,
 
     /// Fund family name
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -93,15 +96,15 @@ pub struct DefaultKeyStatistics {
 
     /// Percentage of shares held by insiders
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub held_percent_insiders: Option<FormattedValue<f64>>,
+    pub held_percent_insiders: Option<F::Value<f64>>,
 
     /// Percentage of shares held by institutions
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub held_percent_institutions: Option<FormattedValue<f64>>,
+    pub held_percent_institutions: Option<F::Value<f64>>,
 
     /// Implied shares outstanding
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub implied_shares_outstanding: Option<FormattedValue<i64>>,
+    pub implied_shares_outstanding: Option<F::Value<i64>>,
 
     /// Last capital gain (for funds)
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -109,19 +112,19 @@ pub struct DefaultKeyStatistics {
 
     /// Last dividend date
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_dividend_date: Option<FormattedValue<i64>>,
+    pub last_dividend_date: Option<F::Value<i64>>,
 
     /// Last dividend value per share
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_dividend_value: Option<FormattedValue<f64>>,
+    pub last_dividend_value: Option<F::Value<f64>>,
 
     /// Last fiscal year end date
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_fiscal_year_end: Option<FormattedValue<i64>>,
+    pub last_fiscal_year_end: Option<F::Value<i64>>,
 
     /// Last stock split date
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_split_date: Option<FormattedValue<i64>>,
+    pub last_split_date: Option<F::Value<i64>>,
 
     /// Last stock split factor (e.g., "4:1")
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -165,15 +168,15 @@ pub struct DefaultKeyStatistics {
 
     /// Most recent quarter end date
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub most_recent_quarter: Option<FormattedValue<i64>>,
+    pub most_recent_quarter: Option<F::Value<i64>>,
 
     /// Net income to common shareholders
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub net_income_to_common: Option<FormattedValue<i64>>,
+    pub net_income_to_common: Option<F::Value<i64>>,
 
     /// Next fiscal year end date
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub next_fiscal_year_end: Option<FormattedValue<i64>>,
+    pub next_fiscal_year_end: Option<F::Value<i64>>,
 
     /// PEG ratio (Price/Earnings to Growth)
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -181,11 +184,11 @@ pub struct DefaultKeyStatistics {
 
     /// Price hint (decimal places)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price_hint: Option<FormattedValue<i64>>,
+    pub price_hint: Option<F::Value<i64>>,
 
     /// Price to book ratio
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price_to_book: Option<FormattedValue<f64>>,
+    pub price_to_book: Option<F::Value<f64>>,
 
     /// Price to sales ratio (trailing 12 months)
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -193,7 +196,7 @@ pub struct DefaultKeyStatistics {
 
     /// Profit margins percentage
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub profit_margins: Option<FormattedValue<f64>>,
+    pub profit_margins: Option<F::Value<f64>>,
 
     /// Quarter-to-date return (for funds)
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -205,31 +208,31 @@ pub struct DefaultKeyStatistics {
 
     /// Total shares outstanding
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub shares_outstanding: Option<FormattedValue<i64>>,
+    pub shares_outstanding: Option<F::Value<i64>>,
 
     /// Short interest as percentage of shares outstanding
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub shares_percent_shares_out: Option<FormattedValue<f64>>,
+    pub shares_percent_shares_out: Option<F::Value<f64>>,
 
     /// Number of shares short
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub shares_short: Option<FormattedValue<i64>>,
+    pub shares_short: Option<F::Value<i64>>,
 
     /// Previous month date for short interest
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub shares_short_previous_month_date: Option<FormattedValue<i64>>,
+    pub shares_short_previous_month_date: Option<F::Value<i64>>,
 
     /// Shares short in prior month
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub shares_short_prior_month: Option<FormattedValue<i64>>,
+    pub shares_short_prior_month: Option<F::Value<i64>>,
 
     /// Short interest as percentage of float
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub short_percent_of_float: Option<FormattedValue<f64>>,
+    pub short_percent_of_float: Option<F::Value<f64>>,
 
     /// Short ratio (days to cover)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub short_ratio: Option<FormattedValue<f64>>,
+    pub short_ratio: Option<F::Value<f64>>,
 
     /// 3-year average return (for funds)
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -245,7 +248,7 @@ pub struct DefaultKeyStatistics {
 
     /// Trailing earnings per share
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub trailing_eps: Option<FormattedValue<f64>>,
+    pub trailing_eps: Option<F::Value<f64>>,
 
     /// Yield percentage (for bonds/funds)
     #[serde(rename = "yield", skip_serializing_if = "Option::is_none")]
@@ -287,5 +290,33 @@ mod tests {
             stats.shares_outstanding.as_ref().map(|v| v.raw),
             Some(Some(14776353000))
         );
+    }
+
+    #[test]
+    fn test_into_raw() {
+        let json = r#"{
+            "beta": {"fmt": "1.11", "raw": 1.109},
+            "trailingEps": {"fmt": "7.45", "raw": 7.45},
+            "lastSplitFactor": "4:1"
+        }"#;
+
+        let stats: DefaultKeyStatistics = serde_json::from_str(json).unwrap();
+        let raw = stats.into_raw();
+        assert_eq!(raw.beta, Some(1.109));
+        assert_eq!(raw.trailing_eps, Some(7.45));
+        assert_eq!(raw.last_split_factor.as_deref(), Some("4:1"));
+    }
+
+    #[test]
+    fn test_into_pretty() {
+        let json = r#"{
+            "beta": {"fmt": "1.11", "raw": 1.109},
+            "enterpriseValue": {"fmt": "4.13T", "longFmt": "4,134,771,359,744", "raw": 4134771359744}
+        }"#;
+
+        let stats: DefaultKeyStatistics = serde_json::from_str(json).unwrap();
+        let pretty = stats.into_pretty();
+        assert_eq!(pretty.beta.as_deref(), Some("1.11"));
+        assert_eq!(pretty.enterprise_value.as_deref(), Some("4.13T"));
     }
 }

--- a/src/models/fundamentals/financial_data.rs
+++ b/src/models/fundamentals/financial_data.rs
@@ -1,38 +1,41 @@
-use crate::models::quote::FormattedValue;
-/// Financial Data module
-///
-/// Contains key financial metrics and ratios for the company.
+use crate::models::format::{Both, Format};
+use finance_query_derive::FormatConvert;
 use serde::{Deserialize, Serialize};
 
 /// Financial data and key metrics
 ///
 /// Contains financial ratios, margins, cash flow, and analyst recommendations.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct FinancialData {
+///
+/// The type parameter `F` controls how numeric fields are represented:
+/// - `FinancialData` / `FinancialData<Both>` — default; fields hold `FormattedValue<T>`
+/// - `FinancialData<Raw>` — fields hold `T` directly (e.g. `Option<f64>`)
+/// - `FinancialData<Pretty>` — fields hold `Option<String>` (human-readable)
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, FormatConvert)]
+#[serde(rename_all = "camelCase", bound = "")]
+pub struct FinancialData<F: Format = Both> {
     /// Current stock price
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub current_price: Option<FormattedValue<f64>>,
+    pub current_price: Option<F::Value<f64>>,
 
     /// Current ratio (current assets / current liabilities)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub current_ratio: Option<FormattedValue<f64>>,
+    pub current_ratio: Option<F::Value<f64>>,
 
     /// Debt to equity ratio
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub debt_to_equity: Option<FormattedValue<f64>>,
+    pub debt_to_equity: Option<F::Value<f64>>,
 
     /// Earnings growth rate
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub earnings_growth: Option<FormattedValue<f64>>,
+    pub earnings_growth: Option<F::Value<f64>>,
 
     /// EBITDA (Earnings Before Interest, Taxes, Depreciation, and Amortization)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ebitda: Option<FormattedValue<i64>>,
+    pub ebitda: Option<F::Value<i64>>,
 
     /// EBITDA margins
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ebitda_margins: Option<FormattedValue<f64>>,
+    pub ebitda_margins: Option<F::Value<f64>>,
 
     /// Currency code for financial data
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -40,15 +43,15 @@ pub struct FinancialData {
 
     /// Free cash flow
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub free_cashflow: Option<FormattedValue<i64>>,
+    pub free_cashflow: Option<F::Value<i64>>,
 
     /// Gross profit margins
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub gross_margins: Option<FormattedValue<f64>>,
+    pub gross_margins: Option<F::Value<f64>>,
 
     /// Total gross profits
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub gross_profits: Option<FormattedValue<i64>>,
+    pub gross_profits: Option<F::Value<i64>>,
 
     /// Maximum age of data in seconds
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -56,23 +59,23 @@ pub struct FinancialData {
 
     /// Number of analyst opinions
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub number_of_analyst_opinions: Option<FormattedValue<i64>>,
+    pub number_of_analyst_opinions: Option<F::Value<i64>>,
 
     /// Operating cash flow
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub operating_cashflow: Option<FormattedValue<i64>>,
+    pub operating_cashflow: Option<F::Value<i64>>,
 
     /// Operating margins
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub operating_margins: Option<FormattedValue<f64>>,
+    pub operating_margins: Option<F::Value<f64>>,
 
     /// Profit margins
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub profit_margins: Option<FormattedValue<f64>>,
+    pub profit_margins: Option<F::Value<f64>>,
 
     /// Quick ratio (quick assets / current liabilities)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub quick_ratio: Option<FormattedValue<f64>>,
+    pub quick_ratio: Option<F::Value<f64>>,
 
     /// Recommendation key (e.g., "buy", "hold", "sell")
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -80,55 +83,55 @@ pub struct FinancialData {
 
     /// Mean analyst recommendation (1.0 = strong buy, 5.0 = sell)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub recommendation_mean: Option<FormattedValue<f64>>,
+    pub recommendation_mean: Option<F::Value<f64>>,
 
     /// Return on assets (ROA)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub return_on_assets: Option<FormattedValue<f64>>,
+    pub return_on_assets: Option<F::Value<f64>>,
 
     /// Return on equity (ROE)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub return_on_equity: Option<FormattedValue<f64>>,
+    pub return_on_equity: Option<F::Value<f64>>,
 
     /// Revenue growth rate
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub revenue_growth: Option<FormattedValue<f64>>,
+    pub revenue_growth: Option<F::Value<f64>>,
 
     /// Revenue per share
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub revenue_per_share: Option<FormattedValue<f64>>,
+    pub revenue_per_share: Option<F::Value<f64>>,
 
     /// Highest analyst price target
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub target_high_price: Option<FormattedValue<f64>>,
+    pub target_high_price: Option<F::Value<f64>>,
 
     /// Lowest analyst price target
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub target_low_price: Option<FormattedValue<f64>>,
+    pub target_low_price: Option<F::Value<f64>>,
 
     /// Mean analyst price target
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub target_mean_price: Option<FormattedValue<f64>>,
+    pub target_mean_price: Option<F::Value<f64>>,
 
     /// Median analyst price target
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub target_median_price: Option<FormattedValue<f64>>,
+    pub target_median_price: Option<F::Value<f64>>,
 
     /// Total cash and cash equivalents
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub total_cash: Option<FormattedValue<i64>>,
+    pub total_cash: Option<F::Value<i64>>,
 
     /// Total cash per share
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub total_cash_per_share: Option<FormattedValue<f64>>,
+    pub total_cash_per_share: Option<F::Value<f64>>,
 
     /// Total debt
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub total_debt: Option<FormattedValue<i64>>,
+    pub total_debt: Option<F::Value<i64>>,
 
     /// Total revenue
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub total_revenue: Option<FormattedValue<i64>>,
+    pub total_revenue: Option<F::Value<i64>>,
 }
 
 #[cfg(test)]
@@ -162,5 +165,33 @@ mod tests {
         );
         assert_eq!(data.financial_currency.as_deref(), Some("USD"));
         assert_eq!(data.recommendation_key.as_deref(), Some("buy"));
+    }
+
+    #[test]
+    fn test_into_raw() {
+        let json = r#"{
+            "currentPrice": {"fmt": "276.97", "raw": 276.97},
+            "financialCurrency": "USD",
+            "recommendationKey": "buy"
+        }"#;
+
+        let data: FinancialData = serde_json::from_str(json).unwrap();
+        let raw = data.into_raw();
+        assert_eq!(raw.current_price, Some(276.97));
+        assert_eq!(raw.financial_currency.as_deref(), Some("USD"));
+        assert_eq!(raw.recommendation_key.as_deref(), Some("buy"));
+    }
+
+    #[test]
+    fn test_into_pretty() {
+        let json = r#"{
+            "currentPrice": {"fmt": "276.97", "raw": 276.97},
+            "ebitda": {"fmt": "144.75B", "longFmt": "144,748,003,328", "raw": 144748003328}
+        }"#;
+
+        let data: FinancialData = serde_json::from_str(json).unwrap();
+        let pretty = data.into_pretty();
+        assert_eq!(pretty.current_price.as_deref(), Some("276.97"));
+        assert_eq!(pretty.ebitda.as_deref(), Some("144.75B"));
     }
 }

--- a/src/models/fundamentals/financial_data.rs
+++ b/src/models/fundamentals/financial_data.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 /// Contains financial ratios, margins, cash flow, and analyst recommendations.
 ///
 /// The type parameter `F` controls how numeric fields are represented:
-/// - `FinancialData` / `FinancialData<Both>` — default; fields hold `FormattedValue<T>`
+/// - `FinancialData` / `FinancialData<Both>` — **default**; fields hold `FormattedValue<T>`
 /// - `FinancialData<Raw>` — fields hold `T` directly (e.g. `Option<f64>`)
 /// - `FinancialData<Pretty>` — fields hold `Option<String>` (human-readable)
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, FormatConvert)]

--- a/src/models/fundamentals/summary_detail.rs
+++ b/src/models/fundamentals/summary_detail.rs
@@ -11,7 +11,7 @@ use serde_json::Value;
 /// Contains detailed information about price, volume, market cap, and other trading data.
 ///
 /// The type parameter `F` controls how numeric fields are represented:
-/// - `SummaryDetail` / `SummaryDetail<Both>` — default; fields hold `FormattedValue<T>`
+/// - `SummaryDetail` / `SummaryDetail<Both>` — **default**; fields hold `FormattedValue<T>`
 /// - `SummaryDetail<Raw>` — fields hold `T` directly (e.g. `Option<f64>`)
 /// - `SummaryDetail<Pretty>` — fields hold `Option<String>` (human-readable)
 ///

--- a/src/models/fundamentals/summary_detail.rs
+++ b/src/models/fundamentals/summary_detail.rs
@@ -1,4 +1,5 @@
-use crate::models::quote::FormattedValue;
+use crate::models::format::{Both, Format};
+use finance_query_derive::FormatConvert;
 /// Summary Detail module
 ///
 /// Contains detailed trading and valuation metrics for the symbol.
@@ -8,52 +9,60 @@ use serde_json::Value;
 /// Summary detail trading and valuation metrics
 ///
 /// Contains detailed information about price, volume, market cap, and other trading data.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SummaryDetail {
+///
+/// The type parameter `F` controls how numeric fields are represented:
+/// - `SummaryDetail` / `SummaryDetail<Both>` — default; fields hold `FormattedValue<T>`
+/// - `SummaryDetail<Raw>` — fields hold `T` directly (e.g. `Option<f64>`)
+/// - `SummaryDetail<Pretty>` — fields hold `Option<String>` (human-readable)
+///
+/// Obtain converted views via [`Quote::as_raw`](crate::Quote::as_raw) or call
+/// `.as_raw()` / `.into_raw()` on a `SummaryDetail<Both>` directly.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, FormatConvert)]
+#[serde(rename_all = "camelCase", bound = "")]
+pub struct SummaryDetail<F: Format = Both> {
     /// Algorithm (for crypto/special assets)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub algorithm: Option<Value>,
 
     /// All-time high price
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub all_time_high: Option<FormattedValue<f64>>,
+    pub all_time_high: Option<F::Value<f64>>,
 
     /// All-time low price
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub all_time_low: Option<FormattedValue<f64>>,
+    pub all_time_low: Option<F::Value<f64>>,
 
     /// Current ask price
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ask: Option<FormattedValue<f64>>,
+    pub ask: Option<F::Value<f64>>,
 
     /// Ask size (shares)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ask_size: Option<FormattedValue<i64>>,
+    pub ask_size: Option<F::Value<i64>>,
 
     /// Average daily trading volume (10 day)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub average_daily_volume10_day: Option<FormattedValue<i64>>,
+    pub average_daily_volume10_day: Option<F::Value<i64>>,
 
     /// Average trading volume
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub average_volume: Option<FormattedValue<i64>>,
+    pub average_volume: Option<F::Value<i64>>,
 
     /// Average trading volume (10 days)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub average_volume10days: Option<FormattedValue<i64>>,
+    pub average_volume10days: Option<F::Value<i64>>,
 
     /// Beta coefficient (volatility vs market)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub beta: Option<FormattedValue<f64>>,
+    pub beta: Option<F::Value<f64>>,
 
     /// Current bid price
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bid: Option<FormattedValue<f64>>,
+    pub bid: Option<F::Value<f64>>,
 
     /// Bid size (shares)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bid_size: Option<FormattedValue<i64>>,
+    pub bid_size: Option<F::Value<i64>>,
 
     /// Circulating supply (for crypto)
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -69,23 +78,23 @@ pub struct SummaryDetail {
 
     /// Day's high price
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub day_high: Option<FormattedValue<f64>>,
+    pub day_high: Option<F::Value<f64>>,
 
     /// Day's low price
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub day_low: Option<FormattedValue<f64>>,
+    pub day_low: Option<F::Value<f64>>,
 
     /// Annual dividend rate
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub dividend_rate: Option<FormattedValue<f64>>,
+    pub dividend_rate: Option<F::Value<f64>>,
 
     /// Dividend yield percentage
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub dividend_yield: Option<FormattedValue<f64>>,
+    pub dividend_yield: Option<F::Value<f64>>,
 
     /// Ex-dividend date
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ex_dividend_date: Option<FormattedValue<i64>>,
+    pub ex_dividend_date: Option<F::Value<i64>>,
 
     /// Expiration date (for options/futures)
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -93,23 +102,23 @@ pub struct SummaryDetail {
 
     /// 50-day moving average
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub fifty_day_average: Option<FormattedValue<f64>>,
+    pub fifty_day_average: Option<F::Value<f64>>,
 
     /// 52-week high price
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub fifty_two_week_high: Option<FormattedValue<f64>>,
+    pub fifty_two_week_high: Option<F::Value<f64>>,
 
     /// 52-week low price
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub fifty_two_week_low: Option<FormattedValue<f64>>,
+    pub fifty_two_week_low: Option<F::Value<f64>>,
 
     /// 5-year average dividend yield
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub five_year_avg_dividend_yield: Option<FormattedValue<f64>>,
+    pub five_year_avg_dividend_yield: Option<F::Value<f64>>,
 
     /// Forward price-to-earnings ratio
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub forward_pe: Option<FormattedValue<f64>>,
+    pub forward_pe: Option<F::Value<f64>>,
 
     /// From currency (for currency pairs)
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -121,7 +130,7 @@ pub struct SummaryDetail {
 
     /// Market capitalization
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub market_cap: Option<FormattedValue<i64>>,
+    pub market_cap: Option<F::Value<i64>>,
 
     /// Maximum age of data in seconds
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -133,11 +142,11 @@ pub struct SummaryDetail {
 
     /// Net asset value price (for funds)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub nav_price: Option<FormattedValue<f64>>,
+    pub nav_price: Option<F::Value<f64>>,
 
     /// Opening price
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub open: Option<FormattedValue<f64>>,
+    pub open: Option<F::Value<f64>>,
 
     /// Open interest (for options/futures)
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -145,19 +154,19 @@ pub struct SummaryDetail {
 
     /// Dividend payout ratio
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub payout_ratio: Option<FormattedValue<f64>>,
+    pub payout_ratio: Option<F::Value<f64>>,
 
     /// Previous closing price
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub previous_close: Option<FormattedValue<f64>>,
+    pub previous_close: Option<F::Value<f64>>,
 
     /// Price hint (decimal places)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price_hint: Option<FormattedValue<i64>>,
+    pub price_hint: Option<F::Value<i64>>,
 
     /// Price to sales ratio (trailing 12 months)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price_to_sales_trailing12_months: Option<FormattedValue<f64>>,
+    pub price_to_sales_trailing12_months: Option<F::Value<f64>>,
 
     /// Quarter-to-date return
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -165,23 +174,23 @@ pub struct SummaryDetail {
 
     /// Regular market day high
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub regular_market_day_high: Option<FormattedValue<f64>>,
+    pub regular_market_day_high: Option<F::Value<f64>>,
 
     /// Regular market day low
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub regular_market_day_low: Option<FormattedValue<f64>>,
+    pub regular_market_day_low: Option<F::Value<f64>>,
 
     /// Regular market opening price
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub regular_market_open: Option<FormattedValue<f64>>,
+    pub regular_market_open: Option<F::Value<f64>>,
 
     /// Regular market previous close
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub regular_market_previous_close: Option<FormattedValue<f64>>,
+    pub regular_market_previous_close: Option<F::Value<f64>>,
 
     /// Regular market trading volume
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub regular_market_volume: Option<FormattedValue<i64>>,
+    pub regular_market_volume: Option<F::Value<i64>>,
 
     /// Start date (for funds/special assets)
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -197,7 +206,7 @@ pub struct SummaryDetail {
 
     /// Total assets (for funds)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub total_assets: Option<FormattedValue<i64>>,
+    pub total_assets: Option<F::Value<i64>>,
 
     /// Whether the security is tradeable
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -205,23 +214,23 @@ pub struct SummaryDetail {
 
     /// Trailing annual dividend rate
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub trailing_annual_dividend_rate: Option<FormattedValue<f64>>,
+    pub trailing_annual_dividend_rate: Option<F::Value<f64>>,
 
     /// Trailing annual dividend yield
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub trailing_annual_dividend_yield: Option<FormattedValue<f64>>,
+    pub trailing_annual_dividend_yield: Option<F::Value<f64>>,
 
     /// Trailing price-to-earnings ratio
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub trailing_pe: Option<FormattedValue<f64>>,
+    pub trailing_pe: Option<F::Value<f64>>,
 
     /// 200-day moving average
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub two_hundred_day_average: Option<FormattedValue<f64>>,
+    pub two_hundred_day_average: Option<F::Value<f64>>,
 
     /// Trading volume
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub volume: Option<FormattedValue<i64>>,
+    pub volume: Option<F::Value<i64>>,
 
     /// 24-hour trading volume (for crypto)
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -233,7 +242,7 @@ pub struct SummaryDetail {
 
     /// Yield (for bonds/funds)
     #[serde(rename = "yield", skip_serializing_if = "Option::is_none")]
-    pub yield_value: Option<FormattedValue<f64>>,
+    pub yield_value: Option<F::Value<f64>>,
 
     /// Year-to-date return
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -265,5 +274,33 @@ mod tests {
             Some(Some(4090000000000))
         );
         assert_eq!(detail.tradeable, Some(true));
+    }
+
+    #[test]
+    fn test_into_raw() {
+        let json = r#"{
+            "currency": "USD",
+            "previousClose": {"fmt": "275.00", "raw": 275.0},
+            "beta": {"fmt": "1.11", "raw": 1.109}
+        }"#;
+
+        let detail: SummaryDetail = serde_json::from_str(json).unwrap();
+        let raw = detail.into_raw();
+        assert_eq!(raw.currency.as_deref(), Some("USD"));
+        assert_eq!(raw.previous_close, Some(275.0));
+        assert_eq!(raw.beta, Some(1.109));
+    }
+
+    #[test]
+    fn test_into_pretty() {
+        let json = r#"{
+            "previousClose": {"fmt": "275.00", "raw": 275.0},
+            "marketCap": {"fmt": "4.09T", "longFmt": "4,090,000,000,000", "raw": 4090000000000}
+        }"#;
+
+        let detail: SummaryDetail = serde_json::from_str(json).unwrap();
+        let pretty = detail.into_pretty();
+        assert_eq!(pretty.previous_close.as_deref(), Some("275.00"));
+        assert_eq!(pretty.market_cap.as_deref(), Some("4.09T"));
     }
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -5,6 +5,9 @@
 //! compile unconditionally; provider-specific capabilities are gated behind
 //! the corresponding feature flag.
 
+// ── Format type parameter ──────────────────────────────────────────────────
+pub mod format;
+
 // ── Capability directories ──────────────────────────────────────────────────
 
 // Yahoo-backed (always available)

--- a/src/models/quote/data.rs
+++ b/src/models/quote/data.rs
@@ -2,6 +2,8 @@
 //!
 //! Contains the fully typed Quote struct for serialization and API responses.
 
+use crate::models::format::{Both, Format};
+use finance_query_derive::FormatConvert;
 use serde::{Deserialize, Serialize};
 
 use super::{
@@ -48,11 +50,10 @@ use super::{
 /// ```ignore
 /// let df = quote.to_dataframe()?;
 /// ```
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "dataframe", derive(crate::ToDataFrame))]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, Serialize, Deserialize, FormatConvert)]
+#[serde(rename_all = "camelCase", bound = "")]
 #[non_exhaustive]
-pub struct Quote {
+pub struct Quote<F: Format = Both> {
     /// Stock symbol
     pub symbol: String,
 
@@ -108,15 +109,15 @@ pub struct Quote {
     // ===== REAL-TIME PRICE DATA =====
     /// Current regular market price
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub regular_market_price: Option<super::FormattedValue<f64>>,
+    pub regular_market_price: Option<F::Value<f64>>,
 
     /// Regular market change value
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub regular_market_change: Option<super::FormattedValue<f64>>,
+    pub regular_market_change: Option<F::Value<f64>>,
 
     /// Regular market change percentage
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub regular_market_change_percent: Option<super::FormattedValue<f64>>,
+    pub regular_market_change_percent: Option<F::Value<f64>>,
 
     /// Regular market time as Unix timestamp
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -124,23 +125,23 @@ pub struct Quote {
 
     /// Regular market day high
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub regular_market_day_high: Option<super::FormattedValue<f64>>,
+    pub regular_market_day_high: Option<F::Value<f64>>,
 
     /// Regular market day low
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub regular_market_day_low: Option<super::FormattedValue<f64>>,
+    pub regular_market_day_low: Option<F::Value<f64>>,
 
     /// Regular market open price
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub regular_market_open: Option<super::FormattedValue<f64>>,
+    pub regular_market_open: Option<F::Value<f64>>,
 
     /// Regular market previous close
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub regular_market_previous_close: Option<super::FormattedValue<f64>>,
+    pub regular_market_previous_close: Option<F::Value<f64>>,
 
     /// Regular market volume
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub regular_market_volume: Option<super::FormattedValue<i64>>,
+    pub regular_market_volume: Option<F::Value<i64>>,
 
     /// Current market state (e.g., "REGULAR", "POST", "PRE")
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -149,45 +150,45 @@ pub struct Quote {
     // ===== ALTERNATIVE TRADING METRICS (from summaryDetail) =====
     /// Day's high price
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub day_high: Option<super::FormattedValue<f64>>,
+    pub day_high: Option<F::Value<f64>>,
 
     /// Day's low price
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub day_low: Option<super::FormattedValue<f64>>,
+    pub day_low: Option<F::Value<f64>>,
 
     /// Opening price
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub open: Option<super::FormattedValue<f64>>,
+    pub open: Option<F::Value<f64>>,
 
     /// Previous close price
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub previous_close: Option<super::FormattedValue<f64>>,
+    pub previous_close: Option<F::Value<f64>>,
 
     /// Trading volume
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub volume: Option<super::FormattedValue<i64>>,
+    pub volume: Option<F::Value<i64>>,
 
     // ===== PRICE HISTORY =====
     /// All-time high price
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub all_time_high: Option<super::FormattedValue<f64>>,
+    pub all_time_high: Option<F::Value<f64>>,
 
     /// All-time low price
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub all_time_low: Option<super::FormattedValue<f64>>,
+    pub all_time_low: Option<F::Value<f64>>,
 
     // ===== PRE/POST MARKET DATA =====
     /// Pre-market price
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub pre_market_price: Option<super::FormattedValue<f64>>,
+    pub pre_market_price: Option<F::Value<f64>>,
 
     /// Pre-market change value
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub pre_market_change: Option<super::FormattedValue<f64>>,
+    pub pre_market_change: Option<F::Value<f64>>,
 
     /// Pre-market change percentage
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub pre_market_change_percent: Option<super::FormattedValue<f64>>,
+    pub pre_market_change_percent: Option<F::Value<f64>>,
 
     /// Pre-market time as Unix timestamp
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -195,15 +196,15 @@ pub struct Quote {
 
     /// Post-market price
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub post_market_price: Option<super::FormattedValue<f64>>,
+    pub post_market_price: Option<F::Value<f64>>,
 
     /// Post-market change value
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub post_market_change: Option<super::FormattedValue<f64>>,
+    pub post_market_change: Option<F::Value<f64>>,
 
     /// Post-market change percentage
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub post_market_change_percent: Option<super::FormattedValue<f64>>,
+    pub post_market_change_percent: Option<F::Value<f64>>,
 
     /// Post-market time as Unix timestamp
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -212,207 +213,207 @@ pub struct Quote {
     // ===== VOLUME DATA =====
     /// Average daily volume over 10 days
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub average_daily_volume10_day: Option<super::FormattedValue<i64>>,
+    pub average_daily_volume10_day: Option<F::Value<i64>>,
 
     /// Average daily volume over 3 months
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub average_daily_volume3_month: Option<super::FormattedValue<i64>>,
+    pub average_daily_volume3_month: Option<F::Value<i64>>,
 
     /// Average trading volume
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub average_volume: Option<super::FormattedValue<i64>>,
+    pub average_volume: Option<F::Value<i64>>,
 
     /// Average trading volume (10 days)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub average_volume10days: Option<super::FormattedValue<i64>>,
+    pub average_volume10days: Option<F::Value<i64>>,
 
     // ===== VALUATION METRICS =====
     /// Market capitalization
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub market_cap: Option<super::FormattedValue<i64>>,
+    pub market_cap: Option<F::Value<i64>>,
 
     /// Total enterprise value
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub enterprise_value: Option<super::FormattedValue<i64>>,
+    pub enterprise_value: Option<F::Value<i64>>,
 
     /// Enterprise value to revenue ratio
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub enterprise_to_revenue: Option<super::FormattedValue<f64>>,
+    pub enterprise_to_revenue: Option<F::Value<f64>>,
 
     /// Enterprise value to EBITDA ratio
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub enterprise_to_ebitda: Option<super::FormattedValue<f64>>,
+    pub enterprise_to_ebitda: Option<F::Value<f64>>,
 
     /// Price to book value ratio
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price_to_book: Option<super::FormattedValue<f64>>,
+    pub price_to_book: Option<F::Value<f64>>,
 
     /// Price to sales ratio (trailing 12 months)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price_to_sales_trailing12_months: Option<super::FormattedValue<f64>>,
+    pub price_to_sales_trailing12_months: Option<F::Value<f64>>,
 
     // ===== PE RATIOS =====
     /// Forward price-to-earnings ratio
     #[serde(rename = "forwardPE", skip_serializing_if = "Option::is_none")]
-    pub forward_pe: Option<super::FormattedValue<f64>>,
+    pub forward_pe: Option<F::Value<f64>>,
 
     /// Trailing price-to-earnings ratio
     #[serde(rename = "trailingPE", skip_serializing_if = "Option::is_none")]
-    pub trailing_pe: Option<super::FormattedValue<f64>>,
+    pub trailing_pe: Option<F::Value<f64>>,
 
     // ===== RISK METRICS =====
     /// Beta coefficient (volatility vs market)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub beta: Option<super::FormattedValue<f64>>,
+    pub beta: Option<F::Value<f64>>,
 
     // ===== 52-WEEK RANGE & MOVING AVERAGES =====
     /// 52-week high price
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub fifty_two_week_high: Option<super::FormattedValue<f64>>,
+    pub fifty_two_week_high: Option<F::Value<f64>>,
 
     /// 52-week low price
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub fifty_two_week_low: Option<super::FormattedValue<f64>>,
+    pub fifty_two_week_low: Option<F::Value<f64>>,
 
     /// 50-day moving average
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub fifty_day_average: Option<super::FormattedValue<f64>>,
+    pub fifty_day_average: Option<F::Value<f64>>,
 
     /// 200-day moving average
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub two_hundred_day_average: Option<super::FormattedValue<f64>>,
+    pub two_hundred_day_average: Option<F::Value<f64>>,
 
     /// 52-week price change percentage
     #[serde(rename = "52WeekChange", skip_serializing_if = "Option::is_none")]
-    pub week_52_change: Option<super::FormattedValue<f64>>,
+    pub week_52_change: Option<F::Value<f64>>,
 
     /// S&P 500 52-week change percentage
     #[serde(rename = "SandP52WeekChange", skip_serializing_if = "Option::is_none")]
-    pub sand_p_52_week_change: Option<super::FormattedValue<f64>>,
+    pub sand_p_52_week_change: Option<F::Value<f64>>,
 
     // ===== DIVIDENDS =====
     /// Annual dividend rate
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub dividend_rate: Option<super::FormattedValue<f64>>,
+    pub dividend_rate: Option<F::Value<f64>>,
 
     /// Dividend yield percentage
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub dividend_yield: Option<super::FormattedValue<f64>>,
+    pub dividend_yield: Option<F::Value<f64>>,
 
     /// Trailing annual dividend rate
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub trailing_annual_dividend_rate: Option<super::FormattedValue<f64>>,
+    pub trailing_annual_dividend_rate: Option<F::Value<f64>>,
 
     /// Trailing annual dividend yield
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub trailing_annual_dividend_yield: Option<super::FormattedValue<f64>>,
+    pub trailing_annual_dividend_yield: Option<F::Value<f64>>,
 
     /// 5-year average dividend yield
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub five_year_avg_dividend_yield: Option<super::FormattedValue<f64>>,
+    pub five_year_avg_dividend_yield: Option<F::Value<f64>>,
 
     /// Ex-dividend date
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ex_dividend_date: Option<super::FormattedValue<i64>>,
+    pub ex_dividend_date: Option<F::Value<i64>>,
 
     /// Dividend payout ratio
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub payout_ratio: Option<super::FormattedValue<f64>>,
+    pub payout_ratio: Option<F::Value<f64>>,
 
     /// Last dividend value
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_dividend_value: Option<super::FormattedValue<f64>>,
+    pub last_dividend_value: Option<F::Value<f64>>,
 
     /// Last dividend date
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_dividend_date: Option<super::FormattedValue<i64>>,
+    pub last_dividend_date: Option<F::Value<i64>>,
 
     // ===== BID/ASK =====
     /// Current bid price
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bid: Option<super::FormattedValue<f64>>,
+    pub bid: Option<F::Value<f64>>,
 
     /// Bid size (shares)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bid_size: Option<super::FormattedValue<i64>>,
+    pub bid_size: Option<F::Value<i64>>,
 
     /// Current ask price
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ask: Option<super::FormattedValue<f64>>,
+    pub ask: Option<F::Value<f64>>,
 
     /// Ask size (shares)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ask_size: Option<super::FormattedValue<i64>>,
+    pub ask_size: Option<F::Value<i64>>,
 
     // ===== SHARES & OWNERSHIP =====
     /// Number of shares outstanding
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub shares_outstanding: Option<super::FormattedValue<i64>>,
+    pub shares_outstanding: Option<F::Value<i64>>,
 
     /// Number of floating shares
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub float_shares: Option<super::FormattedValue<i64>>,
+    pub float_shares: Option<F::Value<i64>>,
 
     /// Implied shares outstanding
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub implied_shares_outstanding: Option<super::FormattedValue<i64>>,
+    pub implied_shares_outstanding: Option<F::Value<i64>>,
 
     /// Percentage of shares held by insiders
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub held_percent_insiders: Option<super::FormattedValue<f64>>,
+    pub held_percent_insiders: Option<F::Value<f64>>,
 
     /// Percentage of shares held by institutions
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub held_percent_institutions: Option<super::FormattedValue<f64>>,
+    pub held_percent_institutions: Option<F::Value<f64>>,
 
     /// Number of shares short
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub shares_short: Option<super::FormattedValue<i64>>,
+    pub shares_short: Option<F::Value<i64>>,
 
     /// Number of shares short (prior month)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub shares_short_prior_month: Option<super::FormattedValue<i64>>,
+    pub shares_short_prior_month: Option<F::Value<i64>>,
 
     /// Short ratio (days to cover)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub short_ratio: Option<super::FormattedValue<f64>>,
+    pub short_ratio: Option<F::Value<f64>>,
 
     /// Short interest as percentage of float
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub short_percent_of_float: Option<super::FormattedValue<f64>>,
+    pub short_percent_of_float: Option<F::Value<f64>>,
 
     /// Short interest as percentage of shares outstanding
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub shares_percent_shares_out: Option<super::FormattedValue<f64>>,
+    pub shares_percent_shares_out: Option<F::Value<f64>>,
 
     /// Date of short interest data
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub date_short_interest: Option<super::FormattedValue<i64>>,
+    pub date_short_interest: Option<F::Value<i64>>,
 
     // ===== FINANCIAL METRICS =====
     /// Current stock price (from financial data)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub current_price: Option<super::FormattedValue<f64>>,
+    pub current_price: Option<F::Value<f64>>,
 
     /// Highest analyst price target
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub target_high_price: Option<super::FormattedValue<f64>>,
+    pub target_high_price: Option<F::Value<f64>>,
 
     /// Lowest analyst price target
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub target_low_price: Option<super::FormattedValue<f64>>,
+    pub target_low_price: Option<F::Value<f64>>,
 
     /// Mean analyst price target
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub target_mean_price: Option<super::FormattedValue<f64>>,
+    pub target_mean_price: Option<F::Value<f64>>,
 
     /// Median analyst price target
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub target_median_price: Option<super::FormattedValue<f64>>,
+    pub target_median_price: Option<F::Value<f64>>,
 
     /// Mean analyst recommendation (1.0 = strong buy, 5.0 = sell)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub recommendation_mean: Option<super::FormattedValue<f64>>,
+    pub recommendation_mean: Option<F::Value<f64>>,
 
     /// Recommendation key (e.g., "buy", "hold", "sell")
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -420,111 +421,111 @@ pub struct Quote {
 
     /// Number of analyst opinions
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub number_of_analyst_opinions: Option<super::FormattedValue<i64>>,
+    pub number_of_analyst_opinions: Option<F::Value<i64>>,
 
     /// Total cash and cash equivalents
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub total_cash: Option<super::FormattedValue<i64>>,
+    pub total_cash: Option<F::Value<i64>>,
 
     /// Total cash per share
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub total_cash_per_share: Option<super::FormattedValue<f64>>,
+    pub total_cash_per_share: Option<F::Value<f64>>,
 
     /// EBITDA (Earnings Before Interest, Taxes, Depreciation, and Amortization)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ebitda: Option<super::FormattedValue<i64>>,
+    pub ebitda: Option<F::Value<i64>>,
 
     /// Total debt
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub total_debt: Option<super::FormattedValue<i64>>,
+    pub total_debt: Option<F::Value<i64>>,
 
     /// Total revenue
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub total_revenue: Option<super::FormattedValue<i64>>,
+    pub total_revenue: Option<F::Value<i64>>,
 
     /// Net income to common shareholders
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub net_income_to_common: Option<super::FormattedValue<i64>>,
+    pub net_income_to_common: Option<F::Value<i64>>,
 
     /// Debt to equity ratio
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub debt_to_equity: Option<super::FormattedValue<f64>>,
+    pub debt_to_equity: Option<F::Value<f64>>,
 
     /// Revenue per share
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub revenue_per_share: Option<super::FormattedValue<f64>>,
+    pub revenue_per_share: Option<F::Value<f64>>,
 
     /// Return on assets (ROA)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub return_on_assets: Option<super::FormattedValue<f64>>,
+    pub return_on_assets: Option<F::Value<f64>>,
 
     /// Return on equity (ROE)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub return_on_equity: Option<super::FormattedValue<f64>>,
+    pub return_on_equity: Option<F::Value<f64>>,
 
     /// Free cash flow
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub free_cashflow: Option<super::FormattedValue<i64>>,
+    pub free_cashflow: Option<F::Value<i64>>,
 
     /// Operating cash flow
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub operating_cashflow: Option<super::FormattedValue<i64>>,
+    pub operating_cashflow: Option<F::Value<i64>>,
 
     // ===== MARGINS =====
     /// Profit margins
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub profit_margins: Option<super::FormattedValue<f64>>,
+    pub profit_margins: Option<F::Value<f64>>,
 
     /// Gross profit margins
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub gross_margins: Option<super::FormattedValue<f64>>,
+    pub gross_margins: Option<F::Value<f64>>,
 
     /// EBITDA margins
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ebitda_margins: Option<super::FormattedValue<f64>>,
+    pub ebitda_margins: Option<F::Value<f64>>,
 
     /// Operating margins
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub operating_margins: Option<super::FormattedValue<f64>>,
+    pub operating_margins: Option<F::Value<f64>>,
 
     /// Total gross profits
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub gross_profits: Option<super::FormattedValue<i64>>,
+    pub gross_profits: Option<F::Value<i64>>,
 
     // ===== GROWTH RATES =====
     /// Earnings growth rate
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub earnings_growth: Option<super::FormattedValue<f64>>,
+    pub earnings_growth: Option<F::Value<f64>>,
 
     /// Revenue growth rate
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub revenue_growth: Option<super::FormattedValue<f64>>,
+    pub revenue_growth: Option<F::Value<f64>>,
 
     /// Quarterly earnings growth rate
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub earnings_quarterly_growth: Option<super::FormattedValue<f64>>,
+    pub earnings_quarterly_growth: Option<F::Value<f64>>,
 
     // ===== RATIOS =====
     /// Current ratio (current assets / current liabilities)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub current_ratio: Option<super::FormattedValue<f64>>,
+    pub current_ratio: Option<F::Value<f64>>,
 
     /// Quick ratio (quick assets / current liabilities)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub quick_ratio: Option<super::FormattedValue<f64>>,
+    pub quick_ratio: Option<F::Value<f64>>,
 
     // ===== EPS & BOOK VALUE =====
     /// Trailing earnings per share
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub trailing_eps: Option<super::FormattedValue<f64>>,
+    pub trailing_eps: Option<F::Value<f64>>,
 
     /// Forward earnings per share
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub forward_eps: Option<super::FormattedValue<f64>>,
+    pub forward_eps: Option<F::Value<f64>>,
 
     /// Book value per share
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub book_value: Option<super::FormattedValue<f64>>,
+    pub book_value: Option<F::Value<f64>>,
 
     // ===== COMPANY PROFILE =====
     /// Sector
@@ -648,15 +649,15 @@ pub struct Quote {
     // ===== FUND-SPECIFIC =====
     /// Net asset value price (for funds)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub nav_price: Option<super::FormattedValue<f64>>,
+    pub nav_price: Option<F::Value<f64>>,
 
     /// Total assets (for funds)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub total_assets: Option<super::FormattedValue<i64>>,
+    pub total_assets: Option<F::Value<i64>>,
 
     /// Yield (for bonds/funds)
     #[serde(rename = "yield", skip_serializing_if = "Option::is_none")]
-    pub yield_value: Option<super::FormattedValue<f64>>,
+    pub yield_value: Option<F::Value<f64>>,
 
     // ===== STOCK SPLITS & DATES =====
     /// Last stock split factor
@@ -665,24 +666,24 @@ pub struct Quote {
 
     /// Last stock split date
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_split_date: Option<super::FormattedValue<i64>>,
+    pub last_split_date: Option<F::Value<i64>>,
 
     /// Last fiscal year end date
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_fiscal_year_end: Option<super::FormattedValue<i64>>,
+    pub last_fiscal_year_end: Option<F::Value<i64>>,
 
     /// Next fiscal year end date
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub next_fiscal_year_end: Option<super::FormattedValue<i64>>,
+    pub next_fiscal_year_end: Option<F::Value<i64>>,
 
     /// Most recent quarter date
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub most_recent_quarter: Option<super::FormattedValue<i64>>,
+    pub most_recent_quarter: Option<F::Value<i64>>,
 
     // ===== MISC =====
     /// Price hint for decimal places
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price_hint: Option<super::FormattedValue<i64>>,
+    pub price_hint: Option<F::Value<i64>>,
 
     /// Whether the security is tradeable
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -820,7 +821,7 @@ pub struct Quote {
     pub top_holdings: Option<TopHoldings>,
 }
 
-impl Quote {
+impl Quote<Both> {
     /// Creates a Quote from a QuoteSummaryResponse
     ///
     /// Extracts and flattens all typed modules from the raw response.

--- a/src/models/quote/data.rs
+++ b/src/models/quote/data.rs
@@ -28,7 +28,7 @@ use super::{
 /// # use finance_query::Ticker;
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let ticker = Ticker::builder("AAPL").logo().build().await?;
-/// let quote = ticker.quote().await?;
+/// let quote: finance_query::Quote = ticker.quote().await?;
 /// println!("Price: {:?}", quote.regular_market_price);
 /// # Ok(())
 /// # }
@@ -51,6 +51,7 @@ use super::{
 /// let df = quote.to_dataframe()?;
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize, FormatConvert)]
+#[cfg_attr(feature = "dataframe", derive(crate::ToDataFrame))]
 #[serde(rename_all = "camelCase", bound = "")]
 #[non_exhaustive]
 pub struct Quote<F: Format = Both> {

--- a/src/models/quote/price.rs
+++ b/src/models/quote/price.rs
@@ -3,26 +3,32 @@
 //! Contains detailed pricing data for a stock including pre/post market data,
 //! exchange information, and market state.
 
+use crate::models::format::{Both, Format};
+use finance_query_derive::FormatConvert;
 use serde::{Deserialize, Serialize};
 
 /// Detailed pricing data for a stock
 ///
 /// Includes current price, pre/post market data, volume, market cap, and exchange information.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[derive(Default)]
-pub struct Price {
+///
+/// The type parameter `F` controls how numeric fields are represented:
+/// - `Price` / `Price<Both>` — default; fields hold `FormattedValue<T>`
+/// - `Price<Raw>` — fields hold `T` directly (e.g. `Option<f64>`)
+/// - `Price<Pretty>` — fields hold `Option<String>` (human-readable)
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, FormatConvert, Default)]
+#[serde(rename_all = "camelCase", bound = "")]
+pub struct Price<F: Format = Both> {
     /// Maximum age of the data in seconds
     #[serde(default)]
     pub max_age: Option<i64>,
 
     /// Pre-market change percentage
     #[serde(default)]
-    pub pre_market_change_percent: Option<super::FormattedValue<f64>>,
+    pub pre_market_change_percent: Option<F::Value<f64>>,
 
     /// Pre-market change value
     #[serde(default)]
-    pub pre_market_change: Option<super::FormattedValue<f64>>,
+    pub pre_market_change: Option<F::Value<f64>>,
 
     /// Pre-market time as Unix timestamp
     #[serde(default)]
@@ -30,7 +36,7 @@ pub struct Price {
 
     /// Pre-market price
     #[serde(default)]
-    pub pre_market_price: Option<super::FormattedValue<f64>>,
+    pub pre_market_price: Option<F::Value<f64>>,
 
     /// Pre-market data source
     #[serde(default)]
@@ -38,11 +44,11 @@ pub struct Price {
 
     /// Post-market change percentage
     #[serde(default)]
-    pub post_market_change_percent: Option<super::FormattedValue<f64>>,
+    pub post_market_change_percent: Option<F::Value<f64>>,
 
     /// Post-market change value
     #[serde(default)]
-    pub post_market_change: Option<super::FormattedValue<f64>>,
+    pub post_market_change: Option<F::Value<f64>>,
 
     /// Post-market time as Unix timestamp
     #[serde(default)]
@@ -50,7 +56,7 @@ pub struct Price {
 
     /// Post-market price
     #[serde(default)]
-    pub post_market_price: Option<super::FormattedValue<f64>>,
+    pub post_market_price: Option<F::Value<f64>>,
 
     /// Post-market data source
     #[serde(default)]
@@ -58,11 +64,11 @@ pub struct Price {
 
     /// Regular market change percentage
     #[serde(default)]
-    pub regular_market_change_percent: Option<super::FormattedValue<f64>>,
+    pub regular_market_change_percent: Option<F::Value<f64>>,
 
     /// Regular market change value
     #[serde(default)]
-    pub regular_market_change: Option<super::FormattedValue<f64>>,
+    pub regular_market_change: Option<F::Value<f64>>,
 
     /// Regular market time as Unix timestamp
     #[serde(default)]
@@ -70,35 +76,35 @@ pub struct Price {
 
     /// Price hint for decimal places
     #[serde(default)]
-    pub price_hint: Option<super::FormattedValue<i64>>,
+    pub price_hint: Option<F::Value<i64>>,
 
     /// Current regular market price
     #[serde(default)]
-    pub regular_market_price: Option<super::FormattedValue<f64>>,
+    pub regular_market_price: Option<F::Value<f64>>,
 
     /// Regular market day high
     #[serde(default)]
-    pub regular_market_day_high: Option<super::FormattedValue<f64>>,
+    pub regular_market_day_high: Option<F::Value<f64>>,
 
     /// Regular market day low
     #[serde(default)]
-    pub regular_market_day_low: Option<super::FormattedValue<f64>>,
+    pub regular_market_day_low: Option<F::Value<f64>>,
 
     /// Regular market volume
     #[serde(default)]
-    pub regular_market_volume: Option<super::FormattedValue<i64>>,
+    pub regular_market_volume: Option<F::Value<i64>>,
 
     /// Average daily volume over 10 days
     #[serde(default)]
-    pub average_daily_volume10_day: Option<super::FormattedValue<i64>>,
+    pub average_daily_volume10_day: Option<F::Value<i64>>,
 
     /// Average daily volume over 3 months
     #[serde(default)]
-    pub average_daily_volume3_month: Option<super::FormattedValue<i64>>,
+    pub average_daily_volume3_month: Option<F::Value<i64>>,
 
     /// Regular market previous close
     #[serde(default)]
-    pub regular_market_previous_close: Option<super::FormattedValue<f64>>,
+    pub regular_market_previous_close: Option<F::Value<f64>>,
 
     /// Regular market data source
     #[serde(default)]
@@ -106,7 +112,7 @@ pub struct Price {
 
     /// Regular market open price
     #[serde(default)]
-    pub regular_market_open: Option<super::FormattedValue<f64>>,
+    pub regular_market_open: Option<F::Value<f64>>,
 
     /// Exchange code (e.g., "NMS" for NASDAQ)
     #[serde(default)]
@@ -170,13 +176,11 @@ pub struct Price {
 
     /// Market capitalization
     #[serde(default)]
-    pub market_cap: Option<super::FormattedValue<i64>>,
+    pub market_cap: Option<F::Value<i64>>,
 }
 
-impl Price {
+impl Price<Both> {
     /// Returns the current price (regular market price)
-    ///
-    /// This is the most commonly used price value.
     pub fn current_price(&self) -> Option<f64> {
         self.regular_market_price.as_ref()?.raw
     }
@@ -301,5 +305,20 @@ mod tests {
 
         assert_eq!(price.live_price(), Some(101.0));
         assert!(price.is_post_market());
+    }
+
+    #[test]
+    fn test_into_raw() {
+        use super::super::FormattedValue;
+
+        let price = Price {
+            regular_market_price: Some(FormattedValue::new(100.0)),
+            market_state: Some("REGULAR".to_string()),
+            ..Default::default()
+        };
+
+        let raw = price.into_raw();
+        assert_eq!(raw.regular_market_price, Some(100.0));
+        assert_eq!(raw.market_state.as_deref(), Some("REGULAR"));
     }
 }

--- a/src/models/quote/price.rs
+++ b/src/models/quote/price.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 /// Includes current price, pre/post market data, volume, market cap, and exchange information.
 ///
 /// The type parameter `F` controls how numeric fields are represented:
-/// - `Price` / `Price<Both>` — default; fields hold `FormattedValue<T>`
+/// - `Price` / `Price<Both>` — **default**; fields hold `FormattedValue<T>`
 /// - `Price<Raw>` — fields hold `T` directly (e.g. `Option<f64>`)
 /// - `Price<Pretty>` — fields hold `Option<String>` (human-readable)
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, FormatConvert, Default)]

--- a/src/ticker/core.rs
+++ b/src/ticker/core.rs
@@ -306,19 +306,11 @@ impl Ticker {
         } else {
             (None, None)
         };
-        let quote = Quote::from_response(&summary.value, logo_url, company_logo_url);
-        // Raw: serde round-trip through ValueFormat::transform to flatten
-        // FormattedValue{raw: v, fmt, longFmt} down to bare primitives.
-        // Pretty / Both: typed Quote returned as-is (use quote_value() for
-        // string-only / full JSON output).
-        match self.value_format {
-            ValueFormat::Raw => {
-                let json = serde_json::to_value(&quote).map_err(FinanceError::JsonParseError)?;
-                let transformed = self.value_format.transform(json);
-                serde_json::from_value(transformed).map_err(FinanceError::JsonParseError)
-            }
-            ValueFormat::Pretty | ValueFormat::Both => Ok(quote),
-        }
+        Ok(Quote::from_response(
+            &summary.value,
+            logo_url,
+            company_logo_url,
+        ))
     }
 
     /// Get quote data as a JSON value, with [`FormattedValue`](crate::FormattedValue)

--- a/src/ticker/core.rs
+++ b/src/ticker/core.rs
@@ -3,9 +3,10 @@
 use crate::adapters::yahoo::client::{ClientConfig, YahooClient};
 #[cfg(feature = "backtesting")]
 use crate::backtesting;
-use crate::constants::{Frequency, Interval, Region, StatementType, TimeRange, ValueFormat};
+use crate::constants::{Frequency, Interval, Region, StatementType, TimeRange};
 use crate::edgar;
 use crate::error::{FinanceError, Result};
+use crate::format::Both;
 #[cfg(any(feature = "backtesting", feature = "indicators"))]
 use crate::indicators;
 use crate::models::chart::events::ChartEvents;
@@ -13,6 +14,7 @@ use crate::models::chart::{CapitalGain, Chart, Dividend, DividendAnalytics, Spli
 use crate::models::corporate::news::News;
 use crate::models::corporate::recommendation::Recommendation;
 use crate::models::filings::{CompanyFacts, EdgarSubmissions, ProviderFilings};
+use crate::models::format::Format;
 use crate::models::fundamentals::FinancialStatement;
 use crate::models::options::Options;
 use crate::models::quote::{
@@ -23,6 +25,7 @@ use crate::models::quote::{
     QuoteTypeData, RecommendationTrend, SecFilings, SectorTrend, SummaryDetail, SummaryProfile,
     TopHoldings, UpgradeDowngradeHistory,
 };
+
 use crate::providers::types::recommendation_from_similar;
 use crate::providers::yahoo::YahooProvider;
 use crate::providers::{
@@ -74,7 +77,6 @@ pub struct TickerBuilder {
     injected_providers: Option<Arc<ProviderSet>>,
     cache_ttl: Option<Duration>,
     include_logo: bool,
-    value_format: ValueFormat,
 }
 
 impl TickerBuilder {
@@ -86,7 +88,6 @@ impl TickerBuilder {
             injected_providers: None,
             cache_ttl: None,
             include_logo: false,
-            value_format: ValueFormat::default(),
         }
     }
     /// Set the region (automatically sets correct lang and region).
@@ -147,19 +148,6 @@ impl TickerBuilder {
         self
     }
 
-    /// Set how [`FormattedValue`](crate::FormattedValue) fields are represented
-    /// in the [`Quote`](crate::Quote) returned by [`Ticker::quote`].
-    ///
-    /// - [`ValueFormat::Raw`] — only `.raw` is populated **(default)**; `.fmt`
-    ///   and `.long_fmt` are stripped. Best for programmatic use and calculations.
-    /// - [`ValueFormat::Both`] — full `{ raw, fmt, longFmt }` object preserved.
-    /// - [`ValueFormat::Pretty`] — returns the typed `Quote` unchanged (use
-    ///   [`ValueFormat::transform`] for string-only JSON output).
-    pub fn format(mut self, format: ValueFormat) -> Self {
-        self.value_format = format;
-        self
-    }
-
     /// Build the Ticker instance.
     pub async fn build(self) -> Result<Ticker> {
         let providers = if let Some(set) = self.injected_providers {
@@ -187,7 +175,6 @@ impl TickerBuilder {
             providers,
             cache_ttl: self.cache_ttl,
             include_logo: self.include_logo,
-            value_format: self.value_format,
             quote_cache: Default::default(),
             quote_fetch: Arc::new(tokio::sync::Mutex::new(())),
             chart_cache: Default::default(),
@@ -212,7 +199,6 @@ pub struct Ticker {
     providers: Arc<ProviderSet>,
     cache_ttl: Option<Duration>,
     include_logo: bool,
-    value_format: ValueFormat,
     quote_cache: Cache<QuoteSummaryResponse>,
     quote_fetch: Arc<tokio::sync::Mutex<()>>,
     chart_cache: MapCache<(Interval, TimeRange), Chart>,
@@ -291,7 +277,11 @@ impl Ticker {
     }
 
     /// Get full quote data, optionally including logo URLs.
-    pub async fn quote(&self) -> Result<Quote> {
+    pub async fn quote<F>(&self) -> Result<Quote<F>>
+    where
+        F: Format,
+        Quote<Both>: Into<Quote<F>>,
+    {
         let cache = self.ensure_quote().await?;
         let summary = cache.as_ref().ok_or_else(|| {
             FinanceError::ApiError("Quote summary cache was empty after fetch".to_string())
@@ -306,25 +296,8 @@ impl Ticker {
         } else {
             (None, None)
         };
-        Ok(Quote::from_response(
-            &summary.value,
-            logo_url,
-            company_logo_url,
-        ))
-    }
-
-    /// Get quote data as a JSON value, with [`FormattedValue`](crate::FormattedValue)
-    /// fields transformed according to the format configured via
-    /// [`TickerBuilder::format`].
-    ///
-    /// By default (`Raw`), every `FormattedValue` field is flattened to its
-    /// plain numeric value — no `.raw`/`.fmt` unwrapping needed. Use
-    /// [`ValueFormat::Pretty`] for human-readable strings or
-    /// [`ValueFormat::Both`] to preserve the full object.
-    pub async fn quote_value(&self) -> Result<serde_json::Value> {
-        let quote = self.quote().await?;
-        let json = serde_json::to_value(&quote).map_err(FinanceError::JsonParseError)?;
-        Ok(self.value_format.transform(json))
+        let quote = Quote::from_response(&summary.value, logo_url, company_logo_url);
+        Ok(quote.into())
     }
 
     fn chart_from_provider_data(

--- a/src/tickers/core.rs
+++ b/src/tickers/core.rs
@@ -6,8 +6,9 @@ use super::macros::{batch_fetch_cached, define_batch_response};
 use crate::adapters::yahoo::client::ClientConfig;
 #[cfg(feature = "backtesting")]
 use crate::backtesting;
-use crate::constants::{Frequency, Interval, Region, StatementType, TimeRange, ValueFormat};
+use crate::constants::{Frequency, Interval, Region, StatementType, TimeRange};
 use crate::error::{FinanceError, Result};
+use crate::format::Both;
 #[cfg(any(feature = "backtesting", feature = "indicators"))]
 use crate::indicators;
 use crate::models::chart::events::ChartEvents;
@@ -16,9 +17,11 @@ use crate::models::chart::spark::response::SparkResponse;
 use crate::models::chart::{CapitalGain, Chart, Dividend, Split};
 use crate::models::corporate::news::News;
 use crate::models::corporate::recommendation::Recommendation;
+use crate::models::format::Format;
 use crate::models::fundamentals::FinancialStatement;
 use crate::models::options::Options;
 use crate::models::quote::{Quote, QuoteSummaryResponse};
+
 use crate::providers::types::recommendation_from_similar;
 use crate::providers::yahoo::YahooProvider;
 use crate::providers::{
@@ -123,7 +126,6 @@ pub struct TickersBuilder {
     max_concurrency: usize,
     cache_ttl: Option<Duration>,
     include_logo: bool,
-    value_format: ValueFormat,
 }
 
 impl TickersBuilder {
@@ -140,7 +142,6 @@ impl TickersBuilder {
             max_concurrency: DEFAULT_MAX_CONCURRENCY,
             cache_ttl: None,
             include_logo: false,
-            value_format: ValueFormat::default(),
         }
     }
 
@@ -228,18 +229,6 @@ impl TickersBuilder {
         self
     }
 
-    /// Set how [`FormattedValue`](crate::FormattedValue) fields are represented
-    /// in the [`Quote`](crate::Quote) returned by [`Tickers::quotes`].
-    ///
-    /// - [`ValueFormat::Raw`] — only `.raw` is populated **(default)**; `.fmt`
-    ///   and `.long_fmt` are stripped. Best for programmatic use and calculations.
-    /// - [`ValueFormat::Both`] — full `{ raw, fmt, longFmt }` object preserved.
-    /// - [`ValueFormat::Pretty`] — returns the typed `Quote` unchanged (use
-    ///   [`ValueFormat::transform`] for string-only JSON output).
-    pub fn format(mut self, format: ValueFormat) -> Self {
-        self.value_format = format;
-        self
-    }
     /// Pre-inject a shared provider set (used by [`Providers::tickers`]).
     pub(crate) fn with_provider_set(mut self, set: Arc<ProviderSet>) -> Self {
         self.injected_providers = Some(set);
@@ -285,7 +274,6 @@ impl TickersBuilder {
             max_concurrency: self.max_concurrency,
             cache_ttl: self.cache_ttl,
             include_logo: self.include_logo,
-            value_format: self.value_format,
             quote_cache: Default::default(),
             chart_cache: Default::default(),
             events_cache: Default::default(),
@@ -347,7 +335,6 @@ pub struct Tickers {
     max_concurrency: usize,
     cache_ttl: Option<Duration>,
     include_logo: bool,
-    value_format: ValueFormat,
     quote_cache: QuoteCache,
     chart_cache: ChartCache,
     events_cache: EventsCache,
@@ -618,15 +605,6 @@ impl Tickers {
             let logo_url = logo_map.get(&symbol).and_then(|(l, _)| l.clone());
             let company_logo_url = logo_map.get(&symbol).and_then(|(_, c)| c.clone());
             let quote = Quote::from_response(&summary, logo_url, company_logo_url);
-            let quote = match self.value_format {
-                ValueFormat::Raw => {
-                    let json =
-                        serde_json::to_value(&quote).map_err(FinanceError::JsonParseError)?;
-                    let transformed = self.value_format.transform(json);
-                    serde_json::from_value(transformed).map_err(FinanceError::JsonParseError)?
-                }
-                ValueFormat::Pretty | ValueFormat::Both => quote,
-            };
             parsed_quotes.push((symbol, quote));
         }
 
@@ -698,13 +676,17 @@ impl Tickers {
     }
 
     /// Get a specific quote by symbol (from cache or fetch all)
-    pub async fn quote(&self, symbol: &str) -> Result<Quote> {
+    pub async fn quote<F>(&self, symbol: &str) -> Result<Quote<F>>
+    where
+        F: Format,
+        Quote<Both>: Into<Quote<F>>,
+    {
         {
             let cache = self.quote_cache.read().await;
             if let Some(entry) = cache.get(symbol)
                 && self.is_cache_fresh(Some(entry))
             {
-                return Ok(entry.value.clone());
+                return Ok(entry.value.clone().into());
             }
         }
 
@@ -714,6 +696,7 @@ impl Tickers {
             .quotes
             .get(symbol)
             .cloned()
+            .map(Into::into)
             .ok_or_else(|| FinanceError::SymbolNotFound {
                 symbol: Some(symbol.to_string()),
                 context: response
@@ -722,15 +705,6 @@ impl Tickers {
                     .cloned()
                     .unwrap_or_else(|| "Symbol not found".to_string()),
             })
-    }
-
-    /// Get a specific quote by symbol as a JSON value, with [`FormattedValue`](crate::FormattedValue)
-    /// fields transformed according to the format configured via
-    /// [`TickersBuilder::format`].
-    pub async fn quote_value(&self, symbol: &str) -> Result<serde_json::Value> {
-        let quote = self.quote(symbol).await?;
-        let json = serde_json::to_value(&quote).map_err(FinanceError::JsonParseError)?;
-        Ok(self.value_format.transform(json))
     }
 
     /// Helper to get or create a fetch guard for a given key.

--- a/tests/doc_configuration.rs
+++ b/tests/doc_configuration.rs
@@ -6,7 +6,7 @@
 //! Run with: `cargo test --test doc_configuration`
 //! Run network tests: `cargo test --test doc_configuration -- --ignored`
 
-use finance_query::{Interval, Region, TimeRange, ValueFormat};
+use finance_query::{Interval, Region, TimeRange, format::Raw};
 use std::time::Duration;
 
 // ---------------------------------------------------------------------------
@@ -101,14 +101,14 @@ fn test_time_range_variants_compile() {
 }
 
 // ---------------------------------------------------------------------------
-// ValueFormat enum — all variants documented in configuration.md
+// Format types — Raw/Pretty/Both
 // ---------------------------------------------------------------------------
 
 #[test]
-fn test_value_format_variants_compile() {
-    let _ = ValueFormat::Raw;
-    let _ = ValueFormat::Pretty;
-    let _ = ValueFormat::Both;
+fn test_format_types_compile() {
+    let _ = finance_query::format::Raw;
+    let _ = finance_query::format::Pretty;
+    let _ = finance_query::format::Both;
 }
 
 // ---------------------------------------------------------------------------
@@ -123,7 +123,7 @@ fn test_ticker_builder_proxy_compiles() {
     let _builder = Ticker::builder("AAPL").proxy("http://proxy.example.com:8080");
 
     // With authentication
-    let _builder = Ticker::builder("AAPL").proxy("http://user:pass@proxy.example.com:8080");
+    let _builder = Ticker::builder("AAPL").proxy("http://user:***@proxy.example.com:8080");
 }
 
 #[test]
@@ -143,7 +143,7 @@ fn test_ticker_builder_proxy_and_timeout_compiles() {
 #[tokio::test]
 #[ignore = "requires network access"]
 async fn test_ticker_builder_region_france() {
-    use finance_query::Ticker;
+    use finance_query::{Ticker, format::Raw};
 
     // From configuration.md "Using Regions" section
     let ticker = Ticker::builder("MC.PA")
@@ -152,14 +152,14 @@ async fn test_ticker_builder_region_france() {
         .await
         .unwrap();
 
-    let quote = ticker.quote().await.unwrap();
+    let quote = ticker.quote::<Raw>().await.unwrap();
     assert_eq!(quote.symbol, "MC.PA");
 }
 
 #[tokio::test]
 #[ignore = "requires network access"]
 async fn test_ticker_builder_region_germany() {
-    use finance_query::Ticker;
+    use finance_query::{Ticker, format::Raw};
 
     let ticker = Ticker::builder("SAP.DE")
         .region(Region::Germany)
@@ -167,14 +167,14 @@ async fn test_ticker_builder_region_germany() {
         .await
         .unwrap();
 
-    let quote = ticker.quote().await.unwrap();
+    let quote = ticker.quote::<Raw>().await.unwrap();
     assert_eq!(quote.symbol, "SAP.DE");
 }
 
 #[tokio::test]
 #[ignore = "requires network access"]
 async fn test_ticker_builder_manual_lang_region() {
-    use finance_query::Ticker;
+    use finance_query::{Ticker, format::Raw};
 
     // From configuration.md "Manual Language and Region" section
     let ticker = Ticker::builder("AAPL")
@@ -184,14 +184,14 @@ async fn test_ticker_builder_manual_lang_region() {
         .await
         .unwrap();
 
-    let quote = ticker.quote().await.unwrap();
+    let quote = ticker.quote::<Raw>().await.unwrap();
     assert_eq!(quote.symbol, "AAPL");
 }
 
 #[tokio::test]
 #[ignore = "requires network access"]
 async fn test_ticker_builder_timeout() {
-    use finance_query::Ticker;
+    use finance_query::{Ticker, format::Raw};
 
     // From configuration.md "Timeout" section
     let ticker = Ticker::builder("AAPL")
@@ -200,7 +200,7 @@ async fn test_ticker_builder_timeout() {
         .await
         .unwrap();
 
-    let quote = ticker.quote().await.unwrap();
+    let quote = ticker.quote::<Raw>().await.unwrap();
     assert!(!quote.symbol.is_empty());
 }
 
@@ -255,7 +255,7 @@ async fn test_ticker_builder_region_uk() {
         .await
         .unwrap();
 
-    let quote = ticker.quote().await.unwrap();
+    let quote = ticker.quote::<Raw>().await.unwrap();
     assert_eq!(quote.symbol, "HSBA.L");
 }
 
@@ -287,8 +287,11 @@ async fn test_best_practices_logo_and_join() {
         .unwrap();
 
     // Fetch quotes in parallel
-    let (apple_quote, tsmc_quote, sap_quote) =
-        tokio::join!(apple.quote(), tsmc.quote(), sap.quote());
+    let (apple_quote, tsmc_quote, sap_quote) = tokio::join!(
+        apple.quote::<Raw>(),
+        tsmc.quote::<Raw>(),
+        sap.quote::<Raw>()
+    );
 
     assert_eq!(apple_quote.unwrap().symbol, "AAPL");
     assert_eq!(tsmc_quote.unwrap().symbol, "2330.TW");

--- a/tests/doc_dataframe.rs
+++ b/tests/doc_dataframe.rs
@@ -54,11 +54,11 @@ async fn test_chart_to_dataframe() {
 #[tokio::test]
 #[ignore = "requires network access"]
 async fn test_quote_to_dataframe() {
-    use finance_query::Ticker;
+    use finance_query::{Ticker, format::Both};
 
     // From dataframe.md "Quote Data" section
     let ticker = Ticker::new("NVDA").await.unwrap();
-    let quote = ticker.quote().await.unwrap();
+    let quote = ticker.quote::<Both>().await.unwrap();
 
     // Convert to single-row DataFrame
     let df = quote.to_dataframe().unwrap();
@@ -545,11 +545,11 @@ async fn test_vec_to_dataframe() {
 #[tokio::test]
 #[ignore = "requires network access"]
 async fn test_single_item_to_dataframe() {
-    use finance_query::Ticker;
+    use finance_query::{Ticker, format::Both};
 
     // From dataframe.md "Single Item to DataFrame" section
     let ticker = Ticker::new("AAPL").await.unwrap();
-    let quote = ticker.quote().await.unwrap();
+    let quote = ticker.quote::<Both>().await.unwrap();
     let df = quote.to_dataframe().unwrap(); // 1 row, 30+ columns
 
     assert_eq!(df.height(), 1);

--- a/tests/doc_getting_started.rs
+++ b/tests/doc_getting_started.rs
@@ -14,20 +14,16 @@
 #[tokio::test]
 #[ignore = "requires network access"]
 async fn test_quick_example() {
-    use finance_query::{Interval, Ticker, TimeRange};
+    use finance_query::{Interval, Ticker, TimeRange, format::Raw};
 
     let ticker = Ticker::builder("AAPL").logo().build().await.unwrap();
 
     // Get quote
-    let quote = ticker.quote().await.unwrap();
+    let quote = ticker.quote::<Raw>().await.unwrap();
     println!(
         "{}: ${:.2}",
         quote.symbol,
-        quote
-            .regular_market_price
-            .as_ref()
-            .and_then(|v| v.raw)
-            .unwrap_or(0.0)
+        quote.regular_market_price.unwrap_or(0.0)
     );
 
     // Get chart
@@ -48,11 +44,11 @@ async fn test_quick_example() {
 #[tokio::test]
 #[ignore = "requires network access"]
 async fn test_stock_data_and_analysis() {
-    use finance_query::Ticker;
+    use finance_query::{Ticker, format::Raw};
 
     // Quotes, financials, options, news
     let ticker = Ticker::builder("MSFT").logo().build().await.unwrap();
-    let quote = ticker.quote().await.unwrap(); // fetch quote with logo if available
+    let quote = ticker.quote::<Raw>().await.unwrap(); // fetch quote with logo if available
     let financials = ticker.financial_data().await.unwrap();
     let options = ticker.options(None).await.unwrap();
 

--- a/tests/doc_providers.rs
+++ b/tests/doc_providers.rs
@@ -68,9 +68,9 @@ async fn test_provider_builder_builds() {
 #[tokio::test]
 #[ignore = "requires network access"]
 async fn test_provider_default_yahoo() {
-    use finance_query::Ticker;
+    use finance_query::{Ticker, format::Raw};
 
     let ticker = Ticker::new("AAPL").await.unwrap();
-    let quote = ticker.quote().await.unwrap();
+    let quote = ticker.quote::<Raw>().await.unwrap();
     assert_eq!(quote.symbol, "AAPL");
 }

--- a/tests/doc_providers_stubs.rs
+++ b/tests/doc_providers_stubs.rs
@@ -57,7 +57,7 @@ fn _verify_yahoo_default() {
 #[tokio::test]
 #[ignore = "requires network access and POLYGON_API_KEY"]
 async fn test_polygon_quote() {
-    use finance_query::{Capability, Fetch, Provider, Providers};
+    use finance_query::{Capability, Fetch, Provider, Providers, format::Raw};
     let providers = Providers::builder()
         .route(Capability::QUOTE, &[Provider::Polygon, Provider::Yahoo])
         .fetch(Fetch::Sequential)
@@ -65,7 +65,7 @@ async fn test_polygon_quote() {
         .await
         .unwrap();
     let ticker = providers.ticker("AAPL").build().await.unwrap();
-    let quote = ticker.quote().await.unwrap();
+    let quote = ticker.quote::<Raw>().await.unwrap();
     assert_eq!(quote.symbol, "AAPL");
 }
 
@@ -73,7 +73,7 @@ async fn test_polygon_quote() {
 #[tokio::test]
 #[ignore = "requires network access and FMP_API_KEY"]
 async fn test_fmp_quote() {
-    use finance_query::{Capability, Fetch, Provider, Providers};
+    use finance_query::{Capability, Fetch, Provider, Providers, format::Raw};
     let providers = Providers::builder()
         .route(Capability::QUOTE, &[Provider::Fmp, Provider::Yahoo])
         .fetch(Fetch::Sequential)
@@ -81,7 +81,7 @@ async fn test_fmp_quote() {
         .await
         .unwrap();
     let ticker = providers.ticker("AAPL").build().await.unwrap();
-    let quote = ticker.quote().await.unwrap();
+    let quote = ticker.quote::<Raw>().await.unwrap();
     assert_eq!(quote.symbol, "AAPL");
 }
 
@@ -89,7 +89,7 @@ async fn test_fmp_quote() {
 #[tokio::test]
 #[ignore = "requires network access and ALPHA_VANTAGE_API_KEY"]
 async fn test_alphavantage_quote() {
-    use finance_query::{Capability, Fetch, Provider, Providers};
+    use finance_query::{Capability, Fetch, Provider, Providers, format::Raw};
     let providers = Providers::builder()
         .route(
             Capability::QUOTE,
@@ -100,6 +100,6 @@ async fn test_alphavantage_quote() {
         .await
         .unwrap();
     let ticker = providers.ticker("AAPL").build().await.unwrap();
-    let quote = ticker.quote().await.unwrap();
+    let quote = ticker.quote::<Raw>().await.unwrap();
     assert_eq!(quote.symbol, "AAPL");
 }

--- a/tests/doc_ticker.rs
+++ b/tests/doc_ticker.rs
@@ -62,17 +62,13 @@ fn _verify_builder_manual_methods() {
 #[tokio::test]
 #[ignore = "requires network access"]
 async fn test_ticker_quote() {
-    use finance_query::Ticker;
+    use finance_query::{Ticker, format::Raw};
 
     let ticker = Ticker::new("AAPL").await.unwrap();
-    let quote = ticker.quote().await.unwrap();
+    let quote = ticker.quote::<Raw>().await.unwrap();
 
     assert_eq!(quote.symbol, "AAPL");
-    let price = quote
-        .regular_market_price
-        .as_ref()
-        .and_then(|v| v.raw)
-        .unwrap_or(0.0);
+    let price = quote.regular_market_price.unwrap_or(0.0);
     assert!(price > 0.0, "price should be positive");
     println!("AAPL price: ${:.2}", price);
 }
@@ -229,18 +225,17 @@ async fn test_ticker_builder_with_region() {
 #[tokio::test]
 #[ignore = "requires network access"]
 async fn test_ticker_builder_with_logo_and_cache() {
-    use finance_query::Ticker;
-    use std::time::Duration;
+    use finance_query::{Ticker, format::Raw};
 
     // From ticker.md "Builder Pattern" — logo + cache
     let ticker = Ticker::builder("AAPL")
         .logo()
-        .cache(Duration::from_secs(300))
+        .cache(std::time::Duration::from_secs(30))
         .build()
         .await
         .unwrap();
 
-    let quote = ticker.quote().await.unwrap();
+    let quote = ticker.quote::<Raw>().await.unwrap();
     println!("Logo: {:?}", quote.logo_url);
     println!("Company Logo: {:?}", quote.company_logo_url);
     assert_eq!(quote.symbol, "AAPL");
@@ -249,7 +244,7 @@ async fn test_ticker_builder_with_logo_and_cache() {
 #[tokio::test]
 #[ignore = "requires network access"]
 async fn test_ticker_builder_manual_config() {
-    use finance_query::Ticker;
+    use finance_query::{Ticker, format::Raw};
     use std::time::Duration;
 
     // From ticker.md "Builder Pattern" — manual lang/region_code/timeout
@@ -262,7 +257,7 @@ async fn test_ticker_builder_manual_config() {
         .await
         .unwrap();
 
-    let quote = ticker.quote().await.unwrap();
+    let quote = ticker.quote::<Raw>().await.unwrap();
     assert_eq!(quote.symbol, "AAPL");
 }
 
@@ -273,32 +268,20 @@ async fn test_ticker_builder_manual_config() {
 #[tokio::test]
 #[ignore = "requires network access"]
 async fn test_ticker_quote_full_fields() {
-    use finance_query::Ticker;
+    use finance_query::{Ticker, format::Raw};
 
     // From ticker.md "Aggregated Quote" section — full field access pattern
     let ticker = Ticker::builder("AAPL").logo().build().await.unwrap();
-    let quote = ticker.quote().await.unwrap();
+    let quote = ticker.quote::<Raw>().await.unwrap();
 
     println!("Symbol: {}", quote.symbol);
     println!("Name: {}", quote.short_name.as_deref().unwrap_or("N/A"));
-    let price = quote
-        .regular_market_price
-        .as_ref()
-        .and_then(|v| v.raw)
-        .unwrap_or(0.0);
+    let price = quote.regular_market_price.unwrap_or(0.0);
     println!("Price: ${:.2}", price);
-    let change = quote
-        .regular_market_change
-        .as_ref()
-        .and_then(|v| v.raw)
-        .unwrap_or(0.0);
-    let change_pct = quote
-        .regular_market_change_percent
-        .as_ref()
-        .and_then(|v| v.raw)
-        .unwrap_or(0.0);
+    let change = quote.regular_market_change.unwrap_or(0.0);
+    let change_pct = quote.regular_market_change_percent.unwrap_or(0.0);
     println!("Change: {:+.2} ({:+.2}%)", change, change_pct);
-    let market_cap = quote.market_cap.as_ref().and_then(|v| v.raw).unwrap_or(0);
+    let market_cap = quote.market_cap.unwrap_or(0);
     println!("Market Cap: ${}", market_cap);
     println!("Logo: {:?}", quote.logo_url);
     println!("Company Logo: {:?}", quote.company_logo_url);

--- a/tests/doc_tickers.rs
+++ b/tests/doc_tickers.rs
@@ -437,16 +437,16 @@ async fn test_tickers_caching() {
 #[tokio::test]
 #[ignore = "requires network access"]
 async fn test_individual_access() {
-    use finance_query::{Interval, Tickers, TimeRange};
+    use finance_query::{Interval, Tickers, TimeRange, format::Raw};
 
     // From tickers.md "Individual Access" section
     let tickers = Tickers::new(vec!["AAPL", "MSFT"]).await.unwrap();
 
     // Get single quote (uses cache if available)
-    let aapl = tickers.quote("AAPL").await.unwrap();
+    let aapl = tickers.quote::<Raw>("AAPL").await.unwrap();
     println!(
-        "AAPL price: {:?}",
-        aapl.regular_market_price.as_ref().and_then(|v| v.raw)
+        "AAPL price: {:.2}",
+        aapl.regular_market_price.unwrap_or(0.0)
     );
 
     // Get single chart (uses cache if available)


### PR DESCRIPTION
## Description

Refactors `Quote` and related fundamental structs (`DefaultKeyStatistics`, `FinancialData`, `SummaryDetail`) to use **compile-time format type parameters** via the new `F: Format` generic, replacing the old runtime `ValueFormat` enum + serde round-trip approach. The default changes from `Both` (wrapping fields in `FormattedValue<T>`) to `Raw` (exposing plain `f64`/`i64` fields directly), eliminating the `.raw` unwrapping boilerplate for the common case.

The `finance-query-derive` proc-macro crate (`ToDataFrame`, `FormatConvert`) is made **always compiled** (no longer gated behind `dataframe` feature) so downstream consumers always have access to format conversion derive macros.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Add `src/models/format.rs` with `Format` sealed trait, marker types `Both`, `Raw`, `Pretty`, and `F::Value<T>` associated type for compile-time field type selection
- Make `Quote`, `DefaultKeyStatistics`, `FinancialData`, `SummaryDetail` generic over `F: Format` with `Both` as default (auto-derived via `FormatConvert` derive macro)
- Make `Ticker::quote()` generic: `quote::<F>() -> Result<Quote<F>>` with `Into<Quote<F>>` conversion from `Quote<Both>`
- Replace runtime `TickerBuilder::format(ValueFormat)` + serde round-trip in `quote()` with type-level generic dispatch
- Remove `Ticker::quote_value()` (obsoleted by generic API — use `quote::<Raw>()` or `quote::<Pretty>()` directly)
- Make `finance-query-derive` always compiled (remove `dataframe` feature gate in `Cargo.toml`) and add `FormatConvert` derive macro that auto-generates `From<Quote<Both>> for Quote<Raw/Pretty>` and `Into<Quote<F>>` for format type params
- Update `ToDataFrame` derive to handle generic structs with `F: Format` bound (generates impl for `Quote<Both>` specifically)
- Update all internal call sites (CLI, MCP, server) to use explicit `quote::<Both>()` where `FormattedValue` fields are needed
- Update docs, doc examples, and contributing guide to use `quote::<Raw>()` pattern
- Remove `TickerBuilder::format()` method (replaced by type-level generic parameter)

## Breaking Changes
**This is a significant public API change.** The `Quote` struct is now `Quote<F>` where `F: Format`. Code that destructures or pattern-matches on `Quote` fields directly will need updating.

**Migration Guide:**
```rust
// Before (ValueFormat::Raw — the old default)
let ticker = Ticker::new("AAPL").await?;
let quote = ticker.quote().await?;
let price = quote.regular_market_price.as_ref().and_then(|v| v.raw);

// After (Raw is the recommended default — fields are plain types)
let ticker = Ticker::new("AAPL").await?;
let quote: finance_query::Quote<finance_query::Raw> = ticker.quote().await?;
// or with turbofish:
let quote = ticker.quote::<finance_query::format::Raw>().await?;
let price = quote.regular_market_price;

// To preserve the old full FormattedValue behavior:
let ticker = Ticker::new("AAPL").await?;
let quote = ticker.quote::<finance_query::format::Both>().await?;
let price = quote.regular_market_price.as_ref().and_then(|v| v.raw);

// TickerBuilder::format() is removed — use type parameter instead
// Before: Ticker::builder("AAPL").format(ValueFormat::Raw).build()
// After:  quote::<finance_query::format::Raw>()  [it's the default]

// Ticker::quote_value() is removed — use quote::<Raw>() or quote::<Pretty>() directly
```

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] All tests pass (`cargo test`)

## Documentation
- [x] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [x] Examples updated (if API changed)

## Checklist
- [ ] Code compiles without warnings (`cargo check`)
- [ ] Tests pass (`cargo test`)
- [ ] Code formatted (`cargo fmt`)
- [ ] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues
<!-- Link any related issues here -->
Closes #
