### PR TITLE
fix: handle Redis unavailability gracefully and prevent disk-fill outage

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -194,9 +194,13 @@ services:
       - /tmp
     volumes:
       - redis-data:/data
+    # Redis is used purely as a cache (data is reconstructable from upstream APIs),
+    # so persistence is disabled. This prevents the AOF/RDB from growing unbounded
+    # or blocking writes (stop-writes-on-bgsave-error) when disk is low.
     command: >
       sh -c "redis-server
-      --appendonly yes
+      --appendonly no
+      --save ''
       --requirepass ${REDIS_PASSWORD}
       --maxmemory 256mb
       --maxmemory-policy allkeys-lru"
@@ -286,6 +290,7 @@ services:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'
       - '--storage.tsdb.retention.time=30d'
+      - '--storage.tsdb.retention.size=8GB'
       - '--web.console.libraries=/usr/share/prometheus/console_libraries'
       - '--web.console.templates=/usr/share/prometheus/consoles'
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,8 +90,10 @@ services:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./nginx/certs:/etc/nginx/certs:ro
     depends_on:
-      - finance-query-v1
-      - finance-query-v2
+      finance-query-v1:
+        condition: service_healthy
+      finance-query-v2:
+        condition: service_healthy
     networks:
       - finance-query-network
 

--- a/v1/Dockerfile
+++ b/v1/Dockerfile
@@ -4,6 +4,7 @@ FROM python:3.14.0-slim
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
     ca-certificates \
+    curl \
     libkrb5-dev \
     libicu-dev \
     zlib1g-dev \

--- a/v1/src/utils/cache.py
+++ b/v1/src/utils/cache.py
@@ -87,6 +87,9 @@ class RedisCacheHandler(BaseCacheHandler):
         try:
             request = request_context.get()
             redis = request.app.state.redis
+            if redis is None:
+                # Redis unavailable (failed to connect at startup) -> treat as cache miss
+                return None
             if not redis.exists(key):
                 return None
             kt = redis.type(key)
@@ -99,13 +102,17 @@ class RedisCacheHandler(BaseCacheHandler):
                 item_type = get_args(return_type)[0] if hasattr(return_type, "__args__") else Any
                 return [self.deserialize_data(item, item_type) for item in items]
             return None
-        except (RedisError, orjson.JSONDecodeError):
+        except (RedisError, orjson.JSONDecodeError, AttributeError):
             return None
 
     async def set(self, key: str, result: Any, expire_time: int) -> None:
         try:
             request = request_context.get()
-            pipe = request.app.state.redis.pipeline()
+            redis = request.app.state.redis
+            if redis is None:
+                # Redis unavailable -> skip caching, behave as a no-op
+                return
+            pipe = redis.pipeline()
             if isinstance(result, dict):
                 pipe.set(key, self.serialize_data(result))
             elif isinstance(result, BaseModel):
@@ -124,7 +131,7 @@ class RedisCacheHandler(BaseCacheHandler):
                     pipe.rpush(key, self.serialize_data(item))
             pipe.expire(key, expire_time)
             pipe.execute()
-        except RedisError:
+        except (RedisError, AttributeError):
             pass
 
 


### PR DESCRIPTION
## Description
Fixes a production outage where every cached `/v1/*` endpoint returned `500` while `/v1/health` stayed green. Root cause was the host disk filling to 100%, driven by Redis's append-only file (AOF) growing unbounded — which then disabled Redis writes (`stop-writes-on-bgsave-error`), so v1's startup Redis connection failed and `app.state.redis` was left `None`. An uncaught `AttributeError` in the cache layer turned that into a hard `500` on every cached endpoint. This PR addresses the root cause and adds defense-in-depth so a cache outage can never take down the API again.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- **`docker-compose.prod.yml` — Redis is now a pure cache.** `--appendonly no --save ''` disables persistence. The data is reconstructable from upstream APIs, so durability bought nothing while creating two failure modes: unbounded AOF growth (filled the disk) and `stop-writes-on-bgsave-error` (blocked writes on snapshot failure). Capped already by `maxmemory 256mb` + `allkeys-lru`.
- **`docker-compose.prod.yml` — Prometheus disk guardrail.** Added `--storage.tsdb.retention.size=8GB` as a hard backstop. Retention stays at `30d` (Prometheus was only ~1.2 GB and not the cause); the size cap only bites in a pathological TSDB-growth scenario so a bad day can't refill the disk.
- **`v1/src/utils/cache.py` — graceful degradation when Redis is down.** Guard against `app.state.redis is None` in `get`/`set` and catch `AttributeError`. A Redis outage now serves uncached `200` responses instead of `500` (Redis was always documented as optional with an in-memory fallback — this completes that contract).
- **`v1/Dockerfile` — add `curl`.** The image had no `curl`, so the dev compose's `curl`-based healthcheck always failed and reported v1 `unhealthy`.
- **`docker-compose.yml` (dev) — nginx waits for healthy backends.** nginx `depends_on` now uses `condition: service_healthy` for v1/v2. nginx resolves upstreams at startup, so booting before the backends were ready caused a `host not found in upstream` crash loop.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] All tests pass (`cargo test`)

Manual verification on the production host:
- Confirmed root cause via logs: `MISCONF ... unable to persist to disk` / `No space left on device`, and `AttributeError: 'NoneType' object has no attribute 'exists'`.
- Disk breakdown: Redis AOF had grown to ~30 GB of a 38 GB disk; Prometheus was only ~1.2 GB.
- Clearing the corrupt AOF + restarting Redis dropped `redis-data` from ~30 GB to ~31 MB; Redis healthy, v1 reconnected, `/v1/quotes` returned `200`.
- Changes are config-only for the compose files (apply via recreate); `cache.py` ships with the next v1 image build.

## Documentation
- [x] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

> Note: these changes are confined to the legacy `v1/` Python service and Docker/compose infra; the `finance-query` library CHANGELOG is not affected.

## Checklist
- [x] Code compiles without warnings (`cargo check`) — N/A; changes are Python (`v1/`) + Docker/compose
- [x] Tests pass (`cargo test`) — N/A; no Rust changes
- [x] Code formatted (`cargo fmt`) — N/A
- [x] Clippy checks pass (`cargo clippy`) — N/A
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues
<!-- Link any related issues here -->
