### PR TITLE
feat: offline VADER news & transcript sentiment scoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1903,6 +1903,7 @@ dependencies = [
  "tokio-tungstenite 0.28.0",
  "tracing",
  "url",
+ "vader_sentiment",
  "zip",
 ]
 
@@ -3029,6 +3030,12 @@ name = "macro_rules_attribute-proc_macro"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "markup5ever"
@@ -6455,6 +6462,18 @@ dependencies = [
  "js-sys",
  "serde_core",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "vader_sentiment"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f79fb65bbfaf53d62afa05b1d162ff245cda71257d094e5d2de022fa5cff112"
+dependencies = [
+ "lazy_static",
+ "maplit",
+ "regex",
+ "unicase",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,9 @@ rayon = { version = "1", optional = true }
 # Optional: RSS/Atom feed parsing
 feed-rs = { version = "2", optional = true }
 
+# Optional: offline VADER lexicon-based news/text sentiment scoring
+vader_sentiment = { version = "0.1", optional = true }
+
 # Optional: fully local machine translation (CTranslate2 + opus-mt bilingual)
 ct2rs = { version = "0.9.19", optional = true, default-features = false, features = ["dnnl", "tokenizers", "sentencepiece"] }
 # Extract Argos `.argosmodel` packages (zip: CT2 model dir + SentencePiece)
@@ -113,6 +116,7 @@ full = [
     "fmp",
     "risk",
     "translation",
+    "sentiment",
 ]
 # Enable DataFrame conversions with polars
 dataframe = ["dep:polars"]
@@ -126,6 +130,8 @@ fred = ["dep:csv"]
 crypto = []
 # Enable RSS/Atom news feed aggregation
 rss = ["dep:feed-rs"]
+# Enable offline VADER lexicon-based news/transcript sentiment scoring
+sentiment = ["dep:vader_sentiment"]
 # Enable Alpha Vantage financial data API
 alphavantage = []
 # Enable Polygon.io financial data API
@@ -146,7 +152,7 @@ translation-offline = ["translation", "dep:ct2rs", "dep:zip"]
 # compute or serde. HTTP-only providers (alphavantage/polygon/fmp) hit the same
 # public models already covered; dataframe/translation-offline are too heavy for
 # valgrind (excluded by design — see .claude/rules/benches.md).
-bench-gate = ["risk", "backtesting", "rss", "translation", "fred", "crypto"]
+bench-gate = ["risk", "backtesting", "rss", "translation", "fred", "crypto", "sentiment"]
 
 [package.metadata.docs.rs]
 # Everything except `translation-offline`: docs.rs cannot afford the
@@ -164,6 +170,7 @@ features = [
     "fmp",
     "risk",
     "translation",
+    "sentiment",
 ]
 rustdoc-args = ["--cfg", "docsrs"]
 
@@ -233,6 +240,14 @@ name = "feeds"
 harness = false
 required-features = ["rss"]
 
+# Offline VADER sentiment scoring latency over real captured news + transcript
+# payloads. Criterion-only (wall-clock); the regression gate guards the same
+# scoring path via its `sentiment` iai group.
+[[bench]]
+name = "sentiment"
+harness = false
+required-features = ["sentiment"]
+
 # One-shot latency harness (not criterion): downloads opus-mt models on first
 # run and reports cold-batch translation times + cross-language spread.
 [[bench]]
@@ -251,7 +266,7 @@ required-features = ["translation-offline"]
 [[bench]]
 name = "regression"
 harness = false
-required-features = ["risk", "backtesting", "rss", "translation"]
+required-features = ["risk", "backtesting", "rss", "translation", "sentiment"]
 
 [profile.release]
 opt-level = 3

--- a/benches/regression.rs
+++ b/benches/regression.rs
@@ -52,7 +52,7 @@ use finance_query::streaming::{MarketHoursType, OptionType, PriceUpdate, QuoteTy
 use finance_query::translation::{Lang, translate_texts};
 use finance_query::{
     Candle, Chart, CompanyFacts, Currency, EdgarSubmissions, FinancialStatement, News, Options,
-    Quote, ScreenerResults, SearchResults,
+    Quote, ScreenerResults, SearchResults, Transcript, analyze_sentiment,
 };
 use iai_callgrind::{
     Callgrind, EventKind, LibraryBenchmarkConfig, library_benchmark, library_benchmark_group, main,
@@ -696,6 +696,39 @@ library_benchmark_group!(
     benchmarks = translate_dictionary
 );
 
+// ── Offline VADER sentiment scoring (feature: sentiment, pure Rust) ───────────
+//
+// Gates the lexicon-scoring path behind `Ticker::news()` /
+// `Transcript::overall_sentiment()` over real captured payloads.
+
+static NEWS_SYMBOL_JSON: &str = include_str!("fixtures/news_symbol.json");
+static SENTIMENT_TRANSCRIPT_JSON: &str = include_str!("fixtures/transcripts.json");
+
+fn news_titles() -> Vec<String> {
+    let news: Vec<News> = serde_json::from_str(NEWS_SYMBOL_JSON).unwrap();
+    news.into_iter().map(|n| n.title).collect()
+}
+
+#[library_benchmark]
+#[bench::headlines(setup = news_titles)]
+fn score_news(titles: Vec<String>) -> usize {
+    titles
+        .iter()
+        .filter(|t| black_box(analyze_sentiment(t)).score != 0.0)
+        .count()
+}
+
+#[library_benchmark]
+fn score_transcript() -> f64 {
+    let t: Transcript = serde_json::from_str(SENTIMENT_TRANSCRIPT_JSON).unwrap();
+    black_box(black_box(&t).overall_sentiment()).score
+}
+
+library_benchmark_group!(
+    name = sentiment;
+    benchmarks = score_news, score_transcript
+);
+
 // ── Gate: fail any benchmark whose instruction count regresses > 5% ──────────
 
 main!(
@@ -711,5 +744,5 @@ main!(
             "glibc.cpu.hwcaps=-AVX512F,-AVX512VL,-AVX512BW,-AVX512DQ,-AVX512CD,-AVX512IFMA,-AVX512_VBMI,-AVX512_VBMI2,-AVX512_VNNI,-AVX512_BITALG,-AVX512_VPOPCNTDQ",
         );
     library_benchmark_groups = indicators, backtesting, risk, streaming, providers, model_serde,
-        endpoint_serde, economic_serde, crypto_serde, feeds, translation
+        endpoint_serde, economic_serde, crypto_serde, feeds, translation, sentiment
 );

--- a/benches/sentiment.rs
+++ b/benches/sentiment.rs
@@ -1,0 +1,81 @@
+//! Offline VADER sentiment-scoring latency (feature: `sentiment`).
+//!
+//! Scores real captured news + transcript payloads exactly as `Ticker::news()`
+//! and `Transcript::overall_sentiment()` do
+//!
+//! ```text
+//! cargo bench --bench sentiment --features finance-query/sentiment
+//! ```
+
+use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
+use finance_query::{News, Transcript, analyze_sentiment};
+
+static NEWS_GENERAL: &str = include_str!("fixtures/news.json");
+static NEWS_SYMBOL: &str = include_str!("fixtures/news_symbol.json");
+static TRANSCRIPT: &str = include_str!("fixtures/transcripts.json");
+
+fn news_titles(json: &str) -> Vec<String> {
+    let news: Vec<News> = serde_json::from_str(json).expect("valid news fixture");
+    news.into_iter().map(|n| n.title).collect()
+}
+
+fn transcript_paragraphs(json: &str) -> (Transcript, usize) {
+    let t: Transcript = serde_json::from_str(json).expect("valid transcript fixture");
+    let chars = t
+        .transcript_content
+        .transcript
+        .as_ref()
+        .map(|d| d.text.len())
+        .unwrap_or(0);
+    (t, chars)
+}
+
+fn bench_news(c: &mut Criterion) {
+    let general = news_titles(NEWS_GENERAL);
+    let symbol = news_titles(NEWS_SYMBOL);
+
+    let mut g = c.benchmark_group("endpoint_news");
+    for (name, titles) in [("general", &general), ("symbol", &symbol)] {
+        let total_bytes: usize = titles.iter().map(|t| t.len()).sum();
+        g.throughput(Throughput::Bytes(total_bytes as u64));
+        g.bench_function(format!("{name}_{}_titles", titles.len()), |b| {
+            b.iter(|| {
+                for title in titles {
+                    black_box(analyze_sentiment(black_box(title)));
+                }
+            })
+        });
+    }
+    g.finish();
+}
+
+/// Aggregate the whole earnings call — `Transcript::overall_sentiment()`, the
+/// largest single payload sentiment ever runs over.
+fn bench_transcript(c: &mut Criterion) {
+    let (transcript, chars) = transcript_paragraphs(TRANSCRIPT);
+
+    let mut g = c.benchmark_group("endpoint_transcript");
+    g.throughput(Throughput::Bytes(chars as u64));
+    g.bench_function(format!("overall_sentiment_{chars}_chars"), |b| {
+        b.iter(|| {
+            black_box(black_box(&transcript).overall_sentiment());
+        })
+    });
+    g.finish();
+}
+
+/// Per-headline cost in isolation (the unit the feature claims is sub-millisecond).
+fn bench_single(c: &mut Criterion) {
+    let headline = "Apple stock surges to record high on blockbuster earnings beat";
+    c.bench_function("single_headline", |b| {
+        b.iter(|| black_box(analyze_sentiment(black_box(headline))))
+    });
+}
+
+criterion_group!(
+    sentiment_benches,
+    bench_single,
+    bench_news,
+    bench_transcript
+);
+criterion_main!(sentiment_benches);

--- a/finance-query-mcp/Cargo.toml
+++ b/finance-query-mcp/Cargo.toml
@@ -19,6 +19,7 @@ finance-query = { path = "..", features = [
     "rss",
     "risk",
     "translation",
+    "sentiment",
 ] }
 
 # MCP SDK (official Rust MCP SDK from modelcontextprotocol/rust-sdk)

--- a/finance-query-mcp/Dockerfile
+++ b/finance-query-mcp/Dockerfile
@@ -39,7 +39,7 @@ RUN mkdir -p src server/src finance-query-derive/src finance-query-cli/src finan
     echo "" > finance-query-derive/src/lib.rs && \
     echo "fn main() {}" > finance-query-cli/src/main.rs && \
     echo "fn main() {}" > finance-query-mcp/src/main.rs && \
-    for b in indicators backtesting ticker tickers finance stream translation risk providers regression serde dataframe feeds; do \
+    for b in indicators backtesting ticker tickers finance stream translation risk providers regression serde dataframe feeds sentiment; do \
         echo "fn main() {}" > benches/$b.rs; \
     done && \
     cargo build --release -p finance-query-mcp --features translation-offline && \

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Finance library (our own)
-finance-query = { path = "..", features = ["indicators", "fred", "crypto", "rss", "risk"] }
+finance-query = { path = "..", features = ["indicators", "fred", "crypto", "rss", "risk", "sentiment"] }
 
 # GraphQL
 async-graphql = { version = "7", features = ["graphiql"] }

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -40,7 +40,7 @@ RUN mkdir -p src server/src finance-query-derive/src finance-query-cli/src finan
     echo "" > finance-query-derive/src/lib.rs && \
     echo "fn main() {}" > finance-query-cli/src/main.rs && \
     echo "fn main() {}" > finance-query-mcp/src/main.rs && \
-    for b in indicators backtesting ticker tickers finance stream translation risk providers regression serde dataframe feeds; do \
+    for b in indicators backtesting ticker tickers finance stream translation risk providers regression serde dataframe feeds sentiment; do \
         echo "fn main() {}" > benches/$b.rs; \
     done && \
     cargo build --release -p finance-query-server --features translation-offline && \

--- a/src/adapters/alphavantage/corporate/mod.rs
+++ b/src/adapters/alphavantage/corporate/mod.rs
@@ -203,6 +203,8 @@ pub async fn fetch_news_response(
             img: String::new(),
             time: a.time_published,
             provider_id: Some(crate::Provider::AlphaVantage),
+            #[cfg(feature = "sentiment")]
+            sentiment: None,
         })
         .collect())
 }

--- a/src/adapters/fmp/corporate/news.rs
+++ b/src/adapters/fmp/corporate/news.rs
@@ -98,6 +98,8 @@ fn stock_news_to_canonical(
             img: String::new(),
             time: a.published_date.unwrap_or_default(),
             provider_id: Some(crate::providers::Provider::Fmp),
+            #[cfg(feature = "sentiment")]
+            sentiment: None,
         })
         .collect()
 }

--- a/src/adapters/polygon/corporate/news.rs
+++ b/src/adapters/polygon/corporate/news.rs
@@ -88,6 +88,8 @@ pub async fn fetch_news_response(symbol: &str) -> Result<Vec<News>> {
             img: String::new(),
             time: a.published_utc.unwrap_or_default(),
             provider_id: Some(Provider::Polygon),
+            #[cfg(feature = "sentiment")]
+            sentiment: None,
         })
         .collect())
 }

--- a/src/adapters/yahoo/corporate/news.rs
+++ b/src/adapters/yahoo/corporate/news.rs
@@ -20,6 +20,8 @@ pub(crate) async fn fetch_news(symbol: &str) -> Result<Vec<News>> {
             img: String::new(),
             time: n.time,
             provider_id: Some(Provider::Yahoo),
+            #[cfg(feature = "sentiment")]
+            sentiment: None,
         })
         .collect())
 }

--- a/src/finance.rs
+++ b/src/finance.rs
@@ -51,7 +51,17 @@ pub use crate::adapters::yahoo::discovery::search::SearchOptions;
 /// ```
 pub async fn search(query: &str, options: &SearchOptions) -> Result<SearchResults> {
     let client = YahooClient::new(ClientConfig::default()).await?;
-    client.search(query, options).await
+    let results = client.search(query, options).await;
+    #[cfg(feature = "sentiment")]
+    let results = results.map(|mut r| {
+        for article in r.news.0.iter_mut() {
+            if let Some(title) = article.title.as_deref() {
+                article.sentiment = Some(crate::models::sentiment::analyze(title));
+            }
+        }
+        r
+    });
+    results
 }
 
 /// Look up symbols by type (equity, ETF, mutual fund, index, future, currency, cryptocurrency)
@@ -178,7 +188,15 @@ pub async fn custom_screener<F: crate::models::discovery::screeners::ScreenerFie
 /// # }
 /// ```
 pub async fn news() -> Result<Vec<crate::models::corporate::news::News>> {
-    crate::scrapers::stockanalysis::scrape_general_news().await
+    let news = crate::scrapers::stockanalysis::scrape_general_news().await;
+    #[cfg(feature = "sentiment")]
+    let news = news.map(|mut articles| {
+        for article in articles.iter_mut() {
+            article.sentiment = Some(crate::models::sentiment::analyze(&article.title));
+        }
+        articles
+    });
+    news
 }
 
 /// Get earnings transcript for a symbol
@@ -215,8 +233,16 @@ pub async fn earnings_transcript(
     year: Option<i32>,
 ) -> Result<Transcript> {
     let client = YahooClient::new(ClientConfig::default()).await?;
-    crate::adapters::yahoo::corporate::transcripts::fetch_for_symbol(&client, symbol, quarter, year)
-        .await
+    let transcript = crate::adapters::yahoo::corporate::transcripts::fetch_for_symbol(
+        &client, symbol, quarter, year,
+    )
+    .await;
+    #[cfg(feature = "sentiment")]
+    let transcript = transcript.map(|mut t| {
+        t.score_sentiment();
+        t
+    });
+    transcript
 }
 
 /// Get all earnings transcripts for a symbol
@@ -250,8 +276,18 @@ pub async fn earnings_transcripts(
     limit: Option<usize>,
 ) -> Result<Vec<TranscriptWithMeta>> {
     let client = YahooClient::new(ClientConfig::default()).await?;
-    crate::adapters::yahoo::corporate::transcripts::fetch_all_for_symbol(&client, symbol, limit)
-        .await
+    let transcripts = crate::adapters::yahoo::corporate::transcripts::fetch_all_for_symbol(
+        &client, symbol, limit,
+    )
+    .await;
+    #[cfg(feature = "sentiment")]
+    let transcripts = transcripts.map(|mut list| {
+        for t in list.iter_mut() {
+            t.transcript.score_sentiment();
+        }
+        list
+    });
+    transcripts
 }
 
 /// Get market hours/status

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,6 +204,9 @@ pub use models::{
     quote::Quote,
     sentiment::{FearAndGreed, FearGreedLabel, SymbolSentiment},
 };
+// Offline VADER sentiment scoring (feature-gated)
+#[cfg(feature = "sentiment")]
+pub use models::sentiment::{Sentiment, SentimentLabel, analyze as analyze_sentiment};
 // Multi-provider capability response types (feature-gated)
 #[cfg(any(feature = "fmp", feature = "alphavantage"))]
 pub use models::commodities::CommodityQuote;

--- a/src/models/corporate/news/scraped.rs
+++ b/src/models/corporate/news/scraped.rs
@@ -24,6 +24,12 @@ pub struct News {
 
     /// Which provider supplied this article (None = Yahoo Finance default)
     pub provider_id: Option<crate::providers::Provider>,
+
+    /// Sentiment score for this article's title (VADER lexicon-based).
+    /// Only present when the `sentiment` feature is enabled.
+    #[cfg(feature = "sentiment")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub sentiment: Option<crate::models::sentiment::Sentiment>,
 }
 
 impl News {
@@ -42,6 +48,8 @@ impl News {
             img,
             time,
             provider_id: None,
+            #[cfg(feature = "sentiment")]
+            sentiment: None,
         }
     }
 }

--- a/src/models/corporate/transcript/mod.rs
+++ b/src/models/corporate/transcript/mod.rs
@@ -43,6 +43,35 @@ impl Transcript {
             .map(|s| s.speaker_data.name.as_str())
     }
 
+    /// Populate per-paragraph sentiment scores in place (VADER lexicon-based).
+    ///
+    /// Only available when the `sentiment` feature is enabled. Called
+    /// automatically when a transcript is fetched.
+    #[cfg(feature = "sentiment")]
+    pub(crate) fn score_sentiment(&mut self) {
+        if let Some(t) = self.transcript_content.transcript.as_mut() {
+            for p in t.paragraphs.iter_mut() {
+                p.sentiment = Some(crate::models::sentiment::analyze(&p.text));
+            }
+        }
+    }
+
+    /// Aggregate sentiment across the whole call, weighted by paragraph length.
+    ///
+    /// Returns a neutral, zero-confidence score for an empty transcript. Only
+    /// available when the `sentiment` feature is enabled.
+    #[cfg(feature = "sentiment")]
+    pub fn overall_sentiment(&self) -> crate::models::sentiment::Sentiment {
+        let texts: Vec<&str> = self
+            .transcript_content
+            .transcript
+            .as_ref()
+            .map(|t| t.paragraphs.iter().map(|p| p.text.as_str()).collect())
+            .unwrap_or_default();
+        crate::models::sentiment::aggregate_weighted(&texts)
+            .unwrap_or_else(crate::models::sentiment::Sentiment::neutral)
+    }
+
     /// Get all paragraphs with speaker names resolved.
     pub fn paragraphs_with_speakers(&self) -> Vec<(&Paragraph, Option<&str>)> {
         self.transcript_content
@@ -131,6 +160,11 @@ pub struct Paragraph {
     /// Sentences in this paragraph.
     #[serde(default)]
     pub sentences: Vec<Sentence>,
+    /// Sentiment score for this paragraph (VADER lexicon-based).
+    /// Only present when the `sentiment` feature is enabled.
+    #[cfg(feature = "sentiment")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub sentiment: Option<crate::models::sentiment::Sentiment>,
 }
 
 /// A sentence within a paragraph.

--- a/src/models/discovery/search/news.rs
+++ b/src/models/discovery/search/news.rs
@@ -82,4 +82,9 @@ pub struct SearchNews {
     /// Related stock symbols (excluded from DataFrame)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub related_tickers: Option<Vec<String>>,
+    /// Sentiment score for this article's title (VADER lexicon-based).
+    /// Only present when the `sentiment` feature is enabled.
+    #[cfg(feature = "sentiment")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub sentiment: Option<crate::models::sentiment::Sentiment>,
 }

--- a/src/models/sentiment/mod.rs
+++ b/src/models/sentiment/mod.rs
@@ -5,7 +5,16 @@
 
 pub(crate) mod response;
 
+#[cfg(feature = "sentiment")]
+mod score;
+
 pub use response::{FearAndGreed, FearGreedLabel};
+
+#[cfg(feature = "sentiment")]
+pub use score::{Sentiment, SentimentLabel, analyze};
+
+#[cfg(feature = "sentiment")]
+pub(crate) use score::{aggregate, aggregate_weighted};
 
 use serde::{Deserialize, Serialize};
 

--- a/src/models/sentiment/score.rs
+++ b/src/models/sentiment/score.rs
@@ -1,0 +1,180 @@
+//! Offline lexicon-based sentiment scoring (VADER)
+
+use serde::{Deserialize, Serialize};
+use std::sync::OnceLock;
+use vader_sentiment::SentimentIntensityAnalyzer;
+
+/// Standard VADER decision threshold on the compound score.
+const THRESHOLD: f64 = 0.05;
+
+/// Directional sentiment classification for a piece of text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum SentimentLabel {
+    /// Net positive tone (`compound >= 0.05`).
+    Bullish,
+    /// Tone within the neutral band (`-0.05 < compound < 0.05`).
+    Neutral,
+    /// Net negative tone (`compound <= -0.05`).
+    Bearish,
+}
+
+impl SentimentLabel {
+    /// Human-readable label.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Bullish => "Bullish",
+            Self::Neutral => "Neutral",
+            Self::Bearish => "Bearish",
+        }
+    }
+}
+
+/// Sentiment score for a news article or transcript segment.
+///
+/// Only present when the `sentiment` feature is enabled.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "dataframe", derive(crate::ToDataFrame))]
+#[non_exhaustive]
+pub struct Sentiment {
+    /// Directional classification.
+    pub label: SentimentLabel,
+    /// Compound score: -1.0 (most bearish) to +1.0 (most bullish).
+    pub score: f64,
+    /// Confidence: 0.0 to 1.0 (magnitude of the compound score).
+    pub confidence: f64,
+}
+
+impl Sentiment {
+    /// Build a [`Sentiment`] from a VADER compound score in `[-1.0, 1.0]`.
+    pub fn from_compound(score: f64) -> Self {
+        let label = if score >= THRESHOLD {
+            SentimentLabel::Bullish
+        } else if score <= -THRESHOLD {
+            SentimentLabel::Bearish
+        } else {
+            SentimentLabel::Neutral
+        };
+        Self {
+            label,
+            score,
+            confidence: score.abs().clamp(0.0, 1.0),
+        }
+    }
+
+    /// A neutral, zero-confidence score (used as the empty aggregate).
+    pub fn neutral() -> Self {
+        Self {
+            label: SentimentLabel::Neutral,
+            score: 0.0,
+            confidence: 0.0,
+        }
+    }
+}
+
+/// Single shared analyzer — `new()` rebinds the lexicon refs, so reuse it.
+fn analyzer() -> &'static SentimentIntensityAnalyzer<'static> {
+    static ANALYZER: OnceLock<SentimentIntensityAnalyzer<'static>> = OnceLock::new();
+    ANALYZER.get_or_init(SentimentIntensityAnalyzer::new)
+}
+
+/// Score a single piece of text.
+///
+/// Lexicon lookup is O(tokens) — typically well under a millisecond per
+/// headline. Empty/whitespace text scores [`Sentiment::neutral`].
+pub fn analyze(text: &str) -> Sentiment {
+    if text.trim().is_empty() {
+        return Sentiment::neutral();
+    }
+    let scores = analyzer().polarity_scores(text);
+    let compound = scores.get("compound").copied().unwrap_or(0.0);
+    Sentiment::from_compound(compound)
+}
+
+/// Aggregate compound scores into a single [`Sentiment`] (simple mean).
+///
+/// Returns `None` when there is nothing to aggregate.
+pub(crate) fn aggregate(scores: &[f64]) -> Option<Sentiment> {
+    if scores.is_empty() {
+        return None;
+    }
+    let mean = scores.iter().sum::<f64>() / scores.len() as f64;
+    Some(Sentiment::from_compound(mean))
+}
+
+/// Aggregate texts weighted by length (longer segments count more).
+///
+/// Used for transcript-level scoring where paragraphs differ widely in length.
+pub(crate) fn aggregate_weighted(texts: &[&str]) -> Option<Sentiment> {
+    let mut weighted_sum = 0.0;
+    let mut total_weight = 0.0;
+    for text in texts {
+        let weight = text.trim().len() as f64;
+        if weight == 0.0 {
+            continue;
+        }
+        weighted_sum += analyze(text).score * weight;
+        total_weight += weight;
+    }
+    if total_weight == 0.0 {
+        return None;
+    }
+    Some(Sentiment::from_compound(weighted_sum / total_weight))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bullish_headline() {
+        let s = analyze("Apple stock surges to record high on blockbuster earnings");
+        assert_eq!(s.label, SentimentLabel::Bullish);
+        assert!(s.score > 0.0);
+    }
+
+    #[test]
+    fn bearish_headline() {
+        let s = analyze("Recession fears mount as inflation disappoints investors");
+        assert_eq!(s.label, SentimentLabel::Bearish);
+        assert!(s.score < 0.0);
+    }
+
+    #[test]
+    fn neutral_empty() {
+        let s = analyze("   ");
+        assert_eq!(s.label, SentimentLabel::Neutral);
+        assert_eq!(s.score, 0.0);
+        assert_eq!(s.confidence, 0.0);
+    }
+
+    #[test]
+    fn from_compound_thresholds() {
+        assert_eq!(
+            Sentiment::from_compound(0.05).label,
+            SentimentLabel::Bullish
+        );
+        assert_eq!(
+            Sentiment::from_compound(-0.05).label,
+            SentimentLabel::Bearish
+        );
+        assert_eq!(Sentiment::from_compound(0.0).label, SentimentLabel::Neutral);
+        assert_eq!(
+            Sentiment::from_compound(0.04).label,
+            SentimentLabel::Neutral
+        );
+    }
+
+    #[test]
+    fn aggregate_mean() {
+        let agg = aggregate(&[0.8, 0.6, -0.2]).unwrap();
+        assert!((agg.score - 0.4).abs() < 1e-9);
+        assert_eq!(agg.label, SentimentLabel::Bullish);
+        assert!(aggregate(&[]).is_none());
+    }
+
+    #[test]
+    fn confidence_is_magnitude() {
+        assert!((Sentiment::from_compound(-0.8).confidence - 0.8).abs() < 1e-9);
+    }
+}

--- a/src/ticker/core.rs
+++ b/src/ticker/core.rs
@@ -494,6 +494,15 @@ impl Ticker {
             })
             .await?;
         let news = data;
+        // Score titles before translation — VADER is English-lexicon based.
+        #[cfg(feature = "sentiment")]
+        let news = {
+            let mut news = news;
+            for article in news.iter_mut() {
+                article.sentiment = Some(crate::models::sentiment::analyze(&article.title));
+            }
+            news
+        };
         #[cfg(feature = "translation")]
         let news = {
             let mut news = news;
@@ -505,6 +514,23 @@ impl Ticker {
             *c = Some(CacheEntry::new(news.clone()));
         }
         Ok(news)
+    }
+
+    /// Average sentiment across recent news headlines for this symbol.
+    ///
+    /// Positive = net bullish coverage, negative = net bearish. Returns a
+    /// neutral, zero-confidence score when there are no headlines.
+    ///
+    /// Only available when the `sentiment` feature is enabled.
+    #[cfg(feature = "sentiment")]
+    pub async fn news_sentiment(&self) -> Result<crate::models::sentiment::Sentiment> {
+        let news = self.news().await?;
+        let scores: Vec<f64> = news
+            .iter()
+            .filter_map(|n| n.sentiment.as_ref().map(|s| s.score))
+            .collect();
+        Ok(crate::models::sentiment::aggregate(&scores)
+            .unwrap_or_else(crate::models::sentiment::Sentiment::neutral))
     }
 
     /// Get the options chain.


### PR DESCRIPTION
## Description
Adds a `sentiment` feature that scores news headlines and earnings-transcript paragraphs as **Bullish / Bearish / Neutral** using the offline VADER lexicon — no API key, no model download, no network. When enabled, `News`, `SearchNews`, and transcript `Paragraph` automatically gain a `sentiment` field (populated before the data is returned), plus aggregate helpers `Ticker::news_sentiment()` and `Transcript::overall_sentiment()`. The field is `#[cfg(feature = "sentiment")]` and skipped-when-`None`, so JSON shape is identical for callers that don't enable it.

Note: the issue proposed `vader-sentiment`; this uses `vader_sentiment` (the canonical ckw017 MIT port). The real bar here was **latency**, not the exact crate — sentiment had to add well under 2–3 s to a fetch. It does, by ~500x (full 52 KB transcript scores in ~4 ms), so the heavier parts of the suggested solution were unnecessary. FinBERT was rejected for the same zero-setup reason the `translation` feature avoids heavy models.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement

## Changes
- `src/models/sentiment/score.rs`: `Sentiment` / `SentimentLabel` types, standard VADER thresholds (±0.05), a process-wide `OnceLock` analyzer (lexicon parsed once, reused), and `analyze` / `aggregate` / `aggregate_weighted` helpers. Exported as `Sentiment`, `SentimentLabel`, `analyze_sentiment`.
- Automatic scoring, applied **before** translation (VADER is English-lexicon based): `News.sentiment` in `Ticker::news()` + `finance::news()`, `SearchNews.sentiment` in `finance::search()`, `Paragraph.sentiment` in `finance::earnings_transcript[s]()`.
- Aggregates: `Ticker::news_sentiment()` (mean over headlines) and `Transcript::overall_sentiment()` (length-weighted over paragraphs).
- Feature wiring: `sentiment = ["dep:vader_sentiment"]`, added to `full`, `bench-gate`, and docs.rs features. Enabled in `server/Cargo.toml` and `finance-query-mcp/Cargo.toml` so the field auto-surfaces in `/v2/news*`, `/v2/transcripts*`, and the MCP `get_news` tool (JSON → zero extra wiring). Docker images inherit it via each crate's manifest. The CLI is intentionally left off (its fixed table/TUI would drop the score without dedicated column/filter work).
- Guardrails: `benches/sentiment.rs` (criterion wall-clock) + a `sentiment` group in the iai regression gate (`score_news`, `score_transcript`) so the scoring path is gated on instruction count, not just compiled. Registered in both Dockerfile bench-stub loops.

## Benchmark results
Criterion, real captured payloads, same machine — budget is **< 2–3 s** added to a fetch:

| Workload | Latency |
|----------|--------:|
| Single headline | **9.4 µs** |
| 10 news titles (full `Ticker::news()` pass) | **~115 µs** |
| Full earnings transcript, 51,837 chars (`overall_sentiment()`) | **4.34 ms** |

The largest payload sentiment ever runs over scores in ~4 ms — ~500x under budget. The lexicon is `lazy_static`, so the analyzer `new()` is ~140 ns after first init. The regression gate (`--features bench-gate`) guards this path going forward (+5% Ir / +10% EstimatedCycles soft limits).

## Breaking Changes
None — `sentiment` is feature-gated; with it disabled the struct layouts and JSON output are byte-identical (`skip_serializing_if = "Option::is_none"`).

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All tests pass (`cargo test`)

6 unit tests in `score.rs` (thresholds, aggregation, empty/neutral, confidence); `cargo test --features full --lib` → 718 passed. Manual: live server verified on `/v2/news`, `/v2/news/{symbol}`, `/v2/transcripts/{symbol}` and the MCP `get_news` tool over stdio — scores track lexical tone (e.g. *"oil glut: …demand destruction"* → −0.89; *"shares Climb …Boost Outlook"* → +0.60; *"Tesla Stock Is Down …Won't Help"* → −0.31; all 120 transcript paragraphs scored).

## Documentation
- [x] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy --features full --all-targets`; server + MCP clean)
- [x] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues
Closes #135
