### PR TITLE
chore: revamp issue templates and add tech-debt/perf/docs types

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,37 +1,23 @@
 ---
 name: Bug report
-about: Create a report to help us improve
-title: "[BUG]"
+about: Report something that isn't working
+title: "[BUG] "
 labels: bug
 assignees: Verdenroz
-
 ---
 
-# Bug Report
-
-## Description
-A clear and concise description of the bug.
+## What happened
+<!-- What went wrong and what you expected instead. Include error messages or stack traces. -->
 
 ## Environment
-- **Component**: [library / server / CLI (`fq`) / MCP server]
-- **Version**: [e.g. `finance-query 2.6.0`, `fq 0.3.0`]
-- **OS and Rust version**: [e.g. Ubuntu 24.04, rustc 1.87.0]
+- **Component**: library / server / CLI (`fq`) / MCP
+- **Version**: <!-- e.g. finance-query 2.7.0, fq 0.3.0 -->
+- **OS / Rust**: <!-- e.g. Ubuntu 24.04, rustc 1.87.0 -->
 
-## Steps to Reproduce
-1. [First step]
-2. [Second step]
-3. [Third step]
-
-## Expected Behavior
-What you expected to happen.
-
-## Actual Behavior
-What happened instead. Include any error messages or stack traces.
-
-## Minimal Reproduction
+## Reproduction
 ```rust
-// Minimal code example that reproduces the issue
+// Minimal example, or numbered steps to reproduce.
 ```
 
-## Additional Context
-Any other relevant context (network conditions, provider API keys present/absent, etc.).
+## Additional context
+<!-- Network conditions, provider API keys present/absent, etc. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/Verdenroz/finance-query/security/advisories/new
+    about: Report security issues privately — please do not open a public issue.
+  - name: Question or discussion
+    url: https://github.com/Verdenroz/finance-query/discussions
+    about: Ask questions, share ideas, or get help using Finance Query.

--- a/.github/ISSUE_TEMPLATE/docs.md
+++ b/.github/ISSUE_TEMPLATE/docs.md
@@ -1,0 +1,14 @@
+---
+name: Documentation
+about: Something missing, wrong, or unclear in the docs
+title: "[DOCS] "
+labels: documentation
+assignees: Verdenroz
+---
+
+## Where
+<!-- Page or file: docs/..., README, rustdoc, OpenAPI/AsyncAPI/MCP reference, etc. -->
+
+## What's wrong or missing
+
+## Suggested fix

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,59 +1,20 @@
 ---
 name: Feature request
-about: Suggest an idea for this project
-title: "[FEATURE REQUEST]"
+about: Suggest a new capability, endpoint, or data source
+title: "[FEATURE] "
 labels: enhancement
 assignees: Verdenroz
-
 ---
 
-# Feature Request
-
 ## Summary
-A clear and concise description of the feature you'd like to see added to FinanceQuery.
+<!-- The feature in one or two sentences. -->
 
-## Problem Statement
-Describe the problem or limitation you're experiencing that this feature would solve.
-- What are you trying to accomplish?
-- What current workflow or process is inefficient?
-- Is this related to a missing data source, endpoint, or functionality?
+## Problem
+<!-- What you're trying to accomplish and why it's hard or impossible today. -->
 
-## Proposed Solution
-Describe the solution you'd like to see implemented.
-- How should this feature work?
-- What would the API endpoint look like?
-- What parameters or options should be available?
+## Proposed solution
+<!-- How it should work: API shape, endpoint, parameters. If it needs a new
+     provider or dependency, name it. -->
 
-
-Expected response format (if applicable):
-```json
-{
-  "example": "response structure"
-}
-```
-
-## Use Cases
-Describe specific scenarios where this feature would be valuable:
-1. [Use case 1]
-2. [Use case 2]
-3. [Use case 3]
-
-## Alternatives Considered
-Describe any alternative solutions or workarounds you've considered.
-- Have you tried using existing endpoints in a different way?
-- Are there external tools or APIs you're currently using as a workaround?
-
-## Additional Context
-- Would this feature require new dependencies or external APIs?
-- Are there any performance or rate limiting considerations?
-- Would this be a breaking change to existing functionality?
-
-## Priority
-How important is this feature to your workflow?
-- [ ] Critical - Blocking my use of the project
-- [ ] High - Would significantly improve my workflow
-- [ ] Medium - Would be nice to have
-- [ ] Low - Minor improvement
-
-## Screenshots/Mockups
-If applicable, add screenshots, diagrams, or mockups to help explain your feature request.
+## Alternatives considered
+<!-- Workarounds you've tried or other approaches you weighed. -->

--- a/.github/ISSUE_TEMPLATE/performance.md
+++ b/.github/ISSUE_TEMPLATE/performance.md
@@ -1,0 +1,19 @@
+---
+name: Performance
+about: A slowdown, regression, or optimization opportunity
+title: "[PERF] "
+labels: performance
+assignees: Verdenroz
+---
+
+## Summary
+<!-- What is slow or regressed, and where. -->
+
+## Measurement
+<!-- Benchmark, profile, or timing that shows it. Which bench / endpoint / input? -->
+
+## Expected vs actual
+<!-- Baseline you expected vs what you observed. -->
+
+## Ideas
+<!-- Optional: suspected cause or optimization approach. -->

--- a/.github/ISSUE_TEMPLATE/refactor.md
+++ b/.github/ISSUE_TEMPLATE/refactor.md
@@ -1,0 +1,19 @@
+---
+name: Refactor / tech debt
+about: Internal cleanup or architectural change with no new user-facing feature
+title: "[TECH DEBT] "
+labels: refactor
+assignees: Verdenroz
+---
+
+## Summary
+<!-- What should change internally, in one or two sentences. -->
+
+## Current state
+<!-- What exists today and why it's a problem. Link code, e.g. `src/foo.rs:42`. -->
+
+## Proposed change
+<!-- The refactor. Note if it touches the public API (SemVer impact). -->
+
+## Acceptance
+<!-- How we'll know it's done (behavior unchanged, tests pass, debt removed). -->


### PR DESCRIPTION
## Summary

The issue tracker only had two templates (bug report, feature request), both verbose prose checklists, and blank issues were allowed — so refactors, performance work, and docs fixes had no home and landed as mislabeled `enhancement`s.

This revamps `.github/ISSUE_TEMPLATE/`:

- **Trims** `bug_report.md` and `feature_request.md` to short, comment-driven prompts.
- **Shortens** the feature title prefix `[FEATURE REQUEST]` → `[FEATURE]`.
- **Adds three types** that previously had nowhere to go:
  - `refactor.md` → `[TECH DEBT]` (label `refactor`)
  - `performance.md` → `[PERF]` (label `performance`)
  - `docs.md` → `[DOCS]` (label `documentation`)
- **Adds `config.yml`**: disables blank issues and redirects security reports to private advisories and questions to Discussions.

New labels `refactor` and `performance` were created to back the new templates.
