### PR TITLE
chore: pre-release 2.7.1 cleanups

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,6 +102,7 @@ jobs:
     name: Deploy to VPS
     needs: build-and-push
     runs-on: ubuntu-latest
+    permissions: {}
     # Only deploy on master branch pushes, not PRs
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,7 @@ jobs:
   test:
     name: Pre-publish Tests
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:

--- a/finance-query-cli/Cargo.toml
+++ b/finance-query-cli/Cargo.toml
@@ -98,9 +98,3 @@ translation-offline = ["finance-query/translation-offline"]
 assert_cmd = "2.2"
 predicates = "3.1"
 tempfile = "3.27"
-
-[profile.release]
-opt-level = 3
-lto = true
-codegen-units = 1
-strip = true

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -99,10 +99,6 @@ pub enum Fetch {
     Sequential,
     /// Fire all providers concurrently; first success wins.
     Parallel,
-    /// Behaves identically to [`Fetch::Parallel`]. Retained for backward compatibility;
-    /// prefer [`Fetch::Parallel`] for new code.
-    #[deprecated(since = "2.6.0", note = "Use `Fetch::Parallel` instead")]
-    All,
 }
 
 /// Capability bits that a provider can declare.
@@ -392,7 +388,6 @@ impl ProviderSet {
         last.unwrap_or_else(|| Self::no_provider(cap))
     }
 
-    #[allow(deprecated)] // must handle Fetch::All internally until it is removed
     pub(crate) async fn fetch<T, F, Fut>(&self, cap: Capability, f: F) -> Result<T>
     where
         F: Fn(&Arc<dyn ProviderAdapter>) -> Fut,
@@ -414,7 +409,7 @@ impl ProviderSet {
                 }
                 Err(Self::finish_err(cap, last))
             }
-            Fetch::Parallel | Fetch::All => {
+            Fetch::Parallel => {
                 let mut futs = futures::stream::FuturesUnordered::new();
                 for p in &candidates {
                     futs.push(f(p));

--- a/tests/doc_providers.rs
+++ b/tests/doc_providers.rs
@@ -33,11 +33,10 @@ fn _verify_provider_enum() {
 // ---------------------------------------------------------------------------
 
 /// Verifies Fetch variants exist with correct type.
-#[allow(dead_code, deprecated)]
+#[allow(dead_code)]
 fn _verify_fetch_variants() {
     let _: Fetch = Fetch::Sequential;
     let _: Fetch = Fetch::Parallel;
-    let _: Fetch = Fetch::All;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description
Pre-release cleanup for v2.7.1 — removes a persistent build warning and a deprecated API variant that has had two full releases to sunset.

## Type of Change
- [x] Refactoring (no functional changes)

## Changes
- Remove duplicate `[profile.release]` from `finance-query-cli/Cargo.toml` — workspace root already defines identical settings, and Cargo ignored the CLI copy while emitting a warning on every build
- Remove `Fetch::All` deprecated variant (deprecated since v2.6.0 as an alias for `Fetch::Parallel`; no remaining callers outside the one match arm and a compile-time variant check)

## Breaking Changes
`Fetch::All` is removed. Callers must use `Fetch::Parallel` instead (identical behavior — it was already an alias).

**Migration Guide:**
```rust
// Before
providers.fetch(Fetch::All)

// After
providers.fetch(Fetch::Parallel)
```

## Testing
- [x] All tests pass (`cargo test`)
- [x] `cargo fmt` passes
- [x] `cargo clippy --workspace --all-targets --all-features` emits zero warnings

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues
Closes