### PR TITLE
feat: chart() / history() on all domain handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`chart()` / `history()` on domain handles** — `ForexPair`, `CryptoCoin`,
+  `Index`, `FuturesContract`, and `Commodity` now expose historical OHLCV data,
+  bringing them toward parity with `Ticker`. Both route through
+  `Capability::CHART` (Yahoo by default) and cache per `(symbol, interval, range)`
+  when `.cache(ttl)` is set. `history(range)` is sugar for
+  `chart(range.default_interval(), range)`.
+  - `CryptoCoin::chart`/`history` take a `vs_currency` and build the chart symbol
+    as `"{ID}-{VS}"` (e.g. `"BTC-USD"`), which resolves on the default Yahoo route
+    for ticker-style ids; CoinGecko-id coins should route `Capability::CHART` to a
+    crypto-aware provider.
+- **`TimeRange::default_interval()`** — the per-range default candle interval used
+  by `history()` (finer granularity for short ranges, coarser for long ones).
+
 ## [2.7.1] - 2026-06-20
 
 Maintenance and internal-architecture release. Domain handles gain opt-in

--- a/docs/library/providers/index.md
+++ b/docs/library/providers/index.md
@@ -161,13 +161,15 @@ let sec   = providers.filings("AAPL");                        // → Filings
 
 | Handle | Method | Returns |
 |--------|--------|---------|
-| `ForexPair` | `.quote()` | `ForexQuote` |
-| `CryptoCoin` | `.quote(vs_currency)` | `CryptoQuote` |
+| `ForexPair` | `.quote()` · `.chart(interval, range)` · `.history(range)` | `ForexQuote` · `Chart` |
+| `CryptoCoin` | `.quote(vs_currency)` · `.chart(vs_currency, interval, range)` · `.history(vs_currency, range)` | `CryptoQuote` · `Chart` |
 | `EconomicIndicator` | `.series()` | `EconomicSeries` |
-| `Index` | `.quote()` | `IndexQuote` |
-| `FuturesContract` | `.quote()` | `FuturesQuote` |
-| `Commodity` | `.quote()` | `CommodityQuote` |
+| `Index` | `.quote()` · `.chart(interval, range)` · `.history(range)` | `IndexQuote` · `Chart` |
+| `FuturesContract` | `.quote()` · `.chart(interval, range)` · `.history(range)` | `FuturesQuote` · `Chart` |
+| `Commodity` | `.quote()` · `.chart(interval, range)` · `.history(range)` | `CommodityQuote` · `Chart` |
 | `Filings` | `.get()` | `ProviderFilings` |
+
+All chart-capable handles route through `Capability::CHART` (Yahoo by default) and cache per `(symbol, interval, range)` when `.cache(ttl)` is set. `history(range)` is sugar for `chart(range.default_interval(), range)`. The handle's identifier is passed to the chart route as-is, so it must be a chart-route symbol (e.g. `^GSPC`, `NQ=F`, `GC=F`); `CryptoCoin` builds `"{ID}-{VS}"` (e.g. `"BTC-USD"`), which resolves on Yahoo only for ticker-style ids.
 
 ## Tickers and Providers
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -871,6 +871,23 @@ impl TimeRange {
             TimeRange::Max => "max",
         }
     }
+
+    /// A sensible default candle interval for this range, used by the
+    /// `history(range)` convenience on domain handles: finer granularity for
+    /// short ranges, coarser for long ones.
+    pub fn default_interval(&self) -> Interval {
+        match self {
+            TimeRange::OneDay => Interval::FiveMinutes,
+            TimeRange::FiveDays => Interval::FifteenMinutes,
+            TimeRange::OneMonth
+            | TimeRange::ThreeMonths
+            | TimeRange::SixMonths
+            | TimeRange::OneYear
+            | TimeRange::YearToDate => Interval::OneDay,
+            TimeRange::TwoYears | TimeRange::FiveYears => Interval::OneWeek,
+            TimeRange::TenYears | TimeRange::Max => Interval::OneMonth,
+        }
+    }
 }
 
 impl std::fmt::Display for TimeRange {
@@ -2135,5 +2152,19 @@ mod tests {
         assert_eq!(TimeRange::OneMonth.as_str(), "1mo");
         assert_eq!(TimeRange::OneYear.as_str(), "1y");
         assert_eq!(TimeRange::Max.as_str(), "max");
+    }
+
+    #[test]
+    fn test_default_interval_buckets() {
+        // Intraday ranges → sub-day candles; long ranges → coarse candles.
+        assert_eq!(TimeRange::OneDay.default_interval(), Interval::FiveMinutes);
+        assert_eq!(
+            TimeRange::FiveDays.default_interval(),
+            Interval::FifteenMinutes
+        );
+        assert_eq!(TimeRange::OneMonth.default_interval(), Interval::OneDay);
+        assert_eq!(TimeRange::OneYear.default_interval(), Interval::OneDay);
+        assert_eq!(TimeRange::TwoYears.default_interval(), Interval::OneWeek);
+        assert_eq!(TimeRange::Max.default_interval(), Interval::OneMonth);
     }
 }

--- a/src/domains/commodities.rs
+++ b/src/domains/commodities.rs
@@ -2,14 +2,16 @@
 //!
 //! Created via [`Providers::commodity`](crate::Providers::commodity).
 
+use crate::constants::{Interval, TimeRange};
 use crate::error::Result;
+use crate::models::chart::Chart;
 
 domain_handle! {
     /// A commodity backed by configured data providers.
     ///
     /// Created via [`Providers::commodity`](crate::Providers::commodity).
     pub struct Commodity { symbol, symbol }
-    cache: crate::models::commodities::CommodityQuote
+    cache: crate::models::commodities::CommodityQuote, chart
 }
 
 impl Commodity {
@@ -22,5 +24,21 @@ impl Commodity {
             fetch_commodities_quote,
             crate::models::commodities::CommodityQuote
         )
+    }
+
+    /// Fetch historical OHLCV candles for this commodity.
+    ///
+    /// The symbol is passed to the `CHART` route as-is. Note this expects the
+    /// route's chart-symbol form (e.g. the Yahoo futures symbol `GC=F` for
+    /// gold), which differs from the commodity *names* (`WHEAT`) some providers
+    /// use for [`quote`](Self::quote).
+    pub async fn chart(&self, interval: Interval, range: TimeRange) -> Result<Chart> {
+        fetch_chart_via!(self, self.symbol.to_string(), interval, range)
+    }
+
+    /// Fetch historical candles over `range` at a sensible default interval
+    /// ([`TimeRange::default_interval`]).
+    pub async fn history(&self, range: TimeRange) -> Result<Chart> {
+        self.chart(range.default_interval(), range).await
     }
 }

--- a/src/domains/crypto.rs
+++ b/src/domains/crypto.rs
@@ -2,14 +2,16 @@
 //!
 //! Created via [`Providers::crypto`](crate::Providers::crypto).
 
+use crate::constants::{Interval, TimeRange};
 use crate::error::Result;
+use crate::models::chart::Chart;
 
 domain_handle! {
     /// A cryptocurrency coin backed by configured data providers.
     ///
     /// Created via [`Providers::crypto`](crate::Providers::crypto).
     pub struct CryptoCoin { id, id }
-    cache: crate::models::crypto::CryptoQuote
+    cache: crate::models::crypto::CryptoQuote, chart
 }
 
 impl CryptoCoin {
@@ -23,5 +25,34 @@ impl CryptoCoin {
             vs_currency,
             crate::models::crypto::CryptoQuote
         )
+    }
+
+    /// Fetch historical OHLCV candles for this coin priced in `vs_currency`.
+    ///
+    /// Unlike [`quote`](Self::quote) (which uses the coin *id*, e.g.
+    /// `"bitcoin"`), the `CHART` route is symbol-based, so the chart symbol is
+    /// built as `"{ID}-{VS}"` uppercased (e.g. `"BTC-USD"`). This resolves on
+    /// the default Yahoo route only when the handle's id is the coin's *ticker*
+    /// (`providers.crypto("BTC")`); coins identified by a CoinGecko id should
+    /// route `Capability::CHART` to a crypto-aware provider.
+    pub async fn chart(
+        &self,
+        vs_currency: &str,
+        interval: Interval,
+        range: TimeRange,
+    ) -> Result<Chart> {
+        let symbol = format!(
+            "{}-{}",
+            self.id().to_uppercase(),
+            vs_currency.to_uppercase()
+        );
+        fetch_chart_via!(self, symbol, interval, range)
+    }
+
+    /// Fetch historical candles over `range` at a sensible default interval
+    /// ([`TimeRange::default_interval`]).
+    pub async fn history(&self, vs_currency: &str, range: TimeRange) -> Result<Chart> {
+        self.chart(vs_currency, range.default_interval(), range)
+            .await
     }
 }

--- a/src/domains/forex.rs
+++ b/src/domains/forex.rs
@@ -2,8 +2,10 @@
 //!
 //! Created via [`Providers::forex`](crate::Providers::forex).
 
+use crate::constants::{Interval, TimeRange};
 use crate::domains::DomainCache;
 use crate::error::Result;
+use crate::models::chart::Chart;
 use crate::providers::{Capability, ProviderSet};
 use std::sync::Arc;
 use std::time::Duration;
@@ -16,6 +18,7 @@ pub struct ForexPair {
     to: Arc<str>,
     providers: Arc<ProviderSet>,
     cache: DomainCache<crate::models::forex::ForexQuote>,
+    chart_cache: DomainCache<Chart>,
 }
 
 impl ForexPair {
@@ -29,6 +32,7 @@ impl ForexPair {
             to,
             providers,
             cache: DomainCache::new(None),
+            chart_cache: DomainCache::new(None),
         }
     }
 
@@ -36,6 +40,7 @@ impl ForexPair {
     /// Off by default (each call fetches fresh).
     pub fn cache(mut self, ttl: Duration) -> Self {
         self.cache = DomainCache::new(Some(ttl));
+        self.chart_cache = DomainCache::new(Some(ttl));
         self
     }
 
@@ -66,5 +71,32 @@ impl ForexPair {
                     .await
             })
             .await
+    }
+
+    /// Fetch historical OHLCV candles for this currency pair.
+    ///
+    /// The pair is mapped to the `CHART` route's symbol form `"{FROM}{TO}=X"`
+    /// (e.g. `"USDEUR=X"`, the Yahoo FX convention).
+    pub async fn chart(&self, interval: Interval, range: TimeRange) -> Result<Chart> {
+        let symbol = format!("{}{}=X", self.from, self.to);
+        let providers = Arc::clone(&self.providers);
+        let key = format!("{symbol}:{interval}:{range}");
+        self.chart_cache
+            .get_or_try(key, move || async move {
+                providers
+                    .fetch(Capability::CHART, move |p| {
+                        let s = symbol.clone();
+                        let p = p.clone();
+                        async move { p.fetch_chart(&s, interval, range).await }
+                    })
+                    .await
+            })
+            .await
+    }
+
+    /// Fetch historical candles over `range` at a sensible default interval
+    /// ([`TimeRange::default_interval`]).
+    pub async fn history(&self, range: TimeRange) -> Result<Chart> {
+        self.chart(range.default_interval(), range).await
     }
 }

--- a/src/domains/futures.rs
+++ b/src/domains/futures.rs
@@ -2,14 +2,16 @@
 //!
 //! Created via [`Providers::futures`](crate::Providers::futures).
 
+use crate::constants::{Interval, TimeRange};
 use crate::error::Result;
+use crate::models::chart::Chart;
 
 domain_handle! {
     /// A futures contract backed by configured data providers.
     ///
     /// Created via [`Providers::futures`](crate::Providers::futures).
     pub struct FuturesContract { symbol, symbol }
-    cache: crate::models::futures::FuturesQuote
+    cache: crate::models::futures::FuturesQuote, chart
 }
 
 impl FuturesContract {
@@ -22,5 +24,19 @@ impl FuturesContract {
             fetch_futures_quote,
             crate::models::futures::FuturesQuote
         )
+    }
+
+    /// Fetch historical OHLCV candles for this futures contract.
+    ///
+    /// The symbol is passed to the `CHART` route as-is (e.g. Yahoo futures
+    /// symbols like `NQ=F`).
+    pub async fn chart(&self, interval: Interval, range: TimeRange) -> Result<Chart> {
+        fetch_chart_via!(self, self.symbol.to_string(), interval, range)
+    }
+
+    /// Fetch historical candles over `range` at a sensible default interval
+    /// ([`TimeRange::default_interval`]).
+    pub async fn history(&self, range: TimeRange) -> Result<Chart> {
+        self.chart(range.default_interval(), range).await
     }
 }

--- a/src/domains/indices.rs
+++ b/src/domains/indices.rs
@@ -2,14 +2,16 @@
 //!
 //! Created via [`Providers::index`](crate::Providers::index).
 
+use crate::constants::{Interval, TimeRange};
 use crate::error::Result;
+use crate::models::chart::Chart;
 
 domain_handle! {
     /// A stock market index backed by configured data providers.
     ///
     /// Created via [`Providers::index`](crate::Providers::index).
     pub struct Index { symbol, symbol }
-    cache: crate::models::indices::IndexQuote
+    cache: crate::models::indices::IndexQuote, chart
 }
 
 impl Index {
@@ -22,5 +24,19 @@ impl Index {
             fetch_indices_quote,
             crate::models::indices::IndexQuote
         )
+    }
+
+    /// Fetch historical OHLCV candles for this index.
+    ///
+    /// The symbol is passed to the `CHART` route as-is, so it should be in the
+    /// form the route expects (e.g. Yahoo index symbols like `^GSPC`).
+    pub async fn chart(&self, interval: Interval, range: TimeRange) -> Result<Chart> {
+        fetch_chart_via!(self, self.symbol.to_string(), interval, range)
+    }
+
+    /// Fetch historical candles over `range` at a sensible default interval
+    /// ([`TimeRange::default_interval`]).
+    pub async fn history(&self, range: TimeRange) -> Result<Chart> {
+        self.chart(range.default_interval(), range).await
     }
 }

--- a/src/domains/mod.rs
+++ b/src/domains/mod.rs
@@ -76,6 +76,45 @@ impl<V: Clone> DomainCache<V> {
 /// a string accessor, and an optional response cache (`.cache(ttl)`).
 /// Callers add fetch methods manually.
 macro_rules! domain_handle {
+    // Chartable variant — adds a `Chart` response cache read by `chart()`.
+    ($(#[$meta:meta])* pub struct $name:ident { $field:ident, $accessor:ident } cache: $val:ty, chart) => {
+        $(#[$meta])*
+        pub struct $name {
+            $field: std::sync::Arc<str>,
+            providers: std::sync::Arc<crate::providers::ProviderSet>,
+            cache: crate::domains::DomainCache<$val>,
+            chart_cache: crate::domains::DomainCache<crate::models::chart::Chart>,
+        }
+
+        impl $name {
+            pub(crate) fn with_providers(
+                $field: std::sync::Arc<str>,
+                providers: std::sync::Arc<crate::providers::ProviderSet>,
+            ) -> Self {
+                Self {
+                    $field,
+                    providers,
+                    cache: crate::domains::DomainCache::new(None),
+                    chart_cache: crate::domains::DomainCache::new(None),
+                }
+            }
+
+            /// Cache responses for `ttl`, deduplicating concurrent identical
+            /// requests. Off by default (each call fetches fresh).
+            pub fn cache(mut self, ttl: std::time::Duration) -> Self {
+                self.cache = crate::domains::DomainCache::new(Some(ttl));
+                self.chart_cache = crate::domains::DomainCache::new(Some(ttl));
+                self
+            }
+
+            /// The handle's identifier string.
+            pub fn $accessor(&self) -> &str {
+                &self.$field
+            }
+        }
+    };
+
+    // Non-chartable variant.
     ($(#[$meta:meta])* pub struct $name:ident { $field:ident, $accessor:ident } cache: $val:ty) => {
         $(#[$meta])*
         pub struct $name {
@@ -149,6 +188,31 @@ macro_rules! fetch_via_with {
                         let __a = __arg.clone();
                         let p = p.clone();
                         async move { p.$fetch(&__s, &__a).await }
+                    })
+                    .await
+            })
+            .await
+    }};
+}
+
+/// Fetch chart candles via the `CHART` capability, keyed by `(interval, range)`.
+/// `$sym` is the chart-ready symbol expression for this asset class.
+#[allow(unused_macros)]
+macro_rules! fetch_chart_via {
+    ($self:expr, $sym:expr, $interval:expr, $range:expr) => {{
+        let __sym: String = $sym;
+        let __interval = $interval;
+        let __range = $range;
+        let __providers = std::sync::Arc::clone(&$self.providers);
+        let __key = format!("{}:{}:{}", __sym, __interval, __range);
+        $self
+            .chart_cache
+            .get_or_try(__key, move || async move {
+                __providers
+                    .fetch(crate::providers::Capability::CHART, move |p| {
+                        let __s = __sym.clone();
+                        let p = p.clone();
+                        async move { p.fetch_chart(&__s, __interval, __range).await }
                     })
                     .await
             })

--- a/tests/domain_charts.rs
+++ b/tests/domain_charts.rs
@@ -1,0 +1,67 @@
+//! Network integration tests for `chart()` / `history()` on domain handles (#197).
+//!
+//! All chart-capable handles route through `Capability::CHART` (Yahoo by
+//! default), so these exercise the symbol mapping per asset class against the
+//! live Yahoo chart endpoint.
+//!
+//!   cargo test --test domain_charts --features fmp,polygon,crypto -- --ignored
+
+#![cfg(feature = "fmp")]
+
+use finance_query::{Interval, Providers, TimeRange};
+
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn forex_chart_maps_to_yahoo_fx_symbol() {
+    let providers = Providers::builder().build().await.unwrap();
+    let pair = providers.forex("USD", "EUR");
+    let chart = pair
+        .chart(Interval::OneDay, TimeRange::OneMonth)
+        .await
+        .unwrap();
+    assert!(!chart.candles.is_empty(), "expected USDEUR=X candles");
+}
+
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn index_chart_passes_symbol_through() {
+    let providers = Providers::builder().build().await.unwrap();
+    let idx = providers.index("^GSPC");
+    let chart = idx.history(TimeRange::OneMonth).await.unwrap();
+    assert!(!chart.candles.is_empty(), "expected ^GSPC candles");
+}
+
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn commodity_chart_uses_futures_symbol() {
+    let providers = Providers::builder().build().await.unwrap();
+    let gold = providers.commodity("GC=F");
+    let chart = gold
+        .chart(Interval::OneDay, TimeRange::OneMonth)
+        .await
+        .unwrap();
+    assert!(!chart.candles.is_empty(), "expected GC=F candles");
+}
+
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn crypto_chart_builds_ticker_pair_symbol() {
+    let providers = Providers::builder().build().await.unwrap();
+    // Ticker-style id resolves on the default Yahoo route ("BTC-USD").
+    let btc = providers.crypto("BTC");
+    let chart = btc
+        .chart("USD", Interval::OneDay, TimeRange::OneMonth)
+        .await
+        .unwrap();
+    assert!(!chart.candles.is_empty(), "expected BTC-USD candles");
+}
+
+#[cfg(feature = "polygon")]
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn futures_chart_passes_symbol_through() {
+    let providers = Providers::builder().build().await.unwrap();
+    let cl = providers.futures("CL=F");
+    let chart = cl.history(TimeRange::OneMonth).await.unwrap();
+    assert!(!chart.candles.is_empty(), "expected CL=F candles");
+}


### PR DESCRIPTION
## Description
Brings the non-equity domain handles toward parity with `Ticker` by adding historical OHLCV access. `ForexPair`, `CryptoCoin`, `Index`, `FuturesContract`, and `Commodity` now expose `chart(interval, range)` and a `history(range)` convenience. First chunk of the 2.8.0 "Unified domains" milestone; unblocks #198 (indicators/risk on handles).

No new provider infrastructure — everything routes through the existing `Capability::CHART` dispatch and `ProviderAdapter::fetch_chart` (Yahoo by default, which serves all these asset classes). The substance is per-asset-class **symbol mapping**.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Added `chart()` / `history()` to `ForexPair`, `CryptoCoin`, `Index`, `FuturesContract`, `Commodity`.
- Symbol mapping per asset class: forex → `{FROM}{TO}=X` (`USDEUR=X`), crypto → `{ID}-{VS}` (`BTC-USD`), index/futures/commodity → pass-through (`^GSPC`, `NQ=F`, `GC=F`).
- Extended the `domain_handle!` macro with a chartable variant (adds a `DomainCache<Chart>` field) + a `fetch_chart_via!` dispatch macro; chart responses cache per `(symbol, interval, range)` when `.cache(ttl)` is set.
- Added `TimeRange::default_interval()` (drives `history(range)`).
- Updated the Domain Handle Methods table in `docs/library/providers/index.md`.

### Crypto caveat (documented)
`CryptoCoin::chart`/`history` take a `vs_currency` and build `{ID}-{VS}`. This resolves on the default Yahoo route only for ticker-style ids (`providers.crypto("BTC")`); CoinGecko-id coins (`"bitcoin"`) should route `Capability::CHART` to a crypto-aware provider. This is the dual-identity wart of crypto (quote uses CoinGecko id, chart route is symbol-based).

## Breaking Changes
None — purely additive.

## Testing
- [x] Unit tests added/updated (`TimeRange::default_interval` bucket test)
- [x] Integration tests added/updated (`tests/domain_charts.rs` — network, `#[ignore]`)
- [x] Manual testing performed (ran the 5 network tests against live Yahoo — forex/index/commodity/futures/crypto all return candles)
- [x] All tests pass (`cargo test -p finance-query --features fmp,polygon,alphavantage,crypto`)

## Documentation
- [x] Code documentation updated (doc comments on every new method)
- [ ] README updated (if needed)
- [x] CHANGELOG.md updated (under `[Unreleased]` → Added)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check --workspace`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy --features full`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues
Closes #197