### PR TITLE
fix: add MCP_ALLOWED_HOSTS config for DNS-rebinding protection

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -33,15 +33,24 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '0.5'
+          cpus: "0.5"
           memory: 256M
         reservations:
-          cpus: '0.1'
+          cpus: "0.1"
           memory: 64M
     security_opt:
       - no-new-privileges:true
     healthcheck:
-      test: ["CMD", "curl", "-f", "-s", "-o", "/dev/null", "http://localhost:2019/config/"]
+      test:
+        [
+          "CMD",
+          "curl",
+          "-f",
+          "-s",
+          "-o",
+          "/dev/null",
+          "http://localhost:2019/config/",
+        ]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -84,10 +93,10 @@ services:
           # model (~80-210 MB each) per requested language in memory. CPU
           # headroom matters more than RAM — a full transcript translates in
           # ~2-4 s at 6 CPUs (vs tens of seconds with fewer).
-          cpus: '6.0'
+          cpus: "6.0"
           memory: 3G
         reservations:
-          cpus: '0.5'
+          cpus: "0.5"
           memory: 1G
     security_opt:
       - no-new-privileges:true
@@ -117,6 +126,7 @@ services:
     environment:
       - MCP_TRANSPORT=http
       - MCP_ADDR=0.0.0.0:3000
+      - MCP_ALLOWED_HOSTS=${SERVER_NAME:-localhost}
       - EDGAR_EMAIL=${EDGAR_EMAIL:-}
       - FRED_API_KEY=${FRED_API_KEY:-}
     volumes:
@@ -131,10 +141,10 @@ services:
           # The MCP image is built with translation-offline too: tool calls
           # with a `lang` param load a small per-language opus-mt model
           # in-process (~80-210 MB each).
-          cpus: '2.0'
+          cpus: "2.0"
           memory: 2G
         reservations:
-          cpus: '0.25'
+          cpus: "0.25"
           memory: 256M
     security_opt:
       - no-new-privileges:true
@@ -176,10 +186,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '1.0'
+          cpus: "1.0"
           memory: 512M
         reservations:
-          cpus: '0.25'
+          cpus: "0.25"
           memory: 128M
     security_opt:
       - no-new-privileges:true
@@ -188,7 +198,13 @@ services:
     cap_add:
       - NET_BIND_SERVICE
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/v1/health').read()"]
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://localhost:8000/v1/health').read()",
+        ]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -204,7 +220,7 @@ services:
     image: redis:8.4.0-alpine
     container_name: finance-query-redis
     restart: unless-stopped
-    user: "999:999"  # Redis user
+    user: "999:999" # Redis user
     read_only: true
     tmpfs:
       - /tmp
@@ -225,10 +241,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '0.5'
+          cpus: "0.5"
           memory: 256M
         reservations:
-          cpus: '0.1'
+          cpus: "0.1"
           memory: 64M
     security_opt:
       - no-new-privileges:true
@@ -251,7 +267,7 @@ services:
     image: oliver006/redis_exporter:v1.80.2-alpine
     container_name: finance-query-redis-exporter
     restart: unless-stopped
-    user: "59000:59000"  # Non-root user
+    user: "59000:59000" # Non-root user
     read_only: true
     expose:
       - "9121"
@@ -267,10 +283,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '0.25'
+          cpus: "0.25"
           memory: 64M
         reservations:
-          cpus: '0.05'
+          cpus: "0.05"
           memory: 16M
     security_opt:
       - no-new-privileges:true
@@ -292,7 +308,7 @@ services:
     image: prom/prometheus:v3.5.1
     container_name: finance-query-prometheus
     restart: unless-stopped
-    user: "65534:65534"  # nobody user
+    user: "65534:65534" # nobody user
     read_only: true
     tmpfs:
       - /tmp
@@ -303,12 +319,12 @@ services:
       - ./monitoring/prometheus/alerts:/etc/prometheus/alerts:ro
       - prometheus-data:/prometheus
     command:
-      - '--config.file=/etc/prometheus/prometheus.yml'
-      - '--storage.tsdb.path=/prometheus'
-      - '--storage.tsdb.retention.time=30d'
-      - '--storage.tsdb.retention.size=8GB'
-      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
-      - '--web.console.templates=/usr/share/prometheus/consoles'
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time=30d"
+      - "--storage.tsdb.retention.size=8GB"
+      - "--web.console.libraries=/usr/share/prometheus/console_libraries"
+      - "--web.console.templates=/usr/share/prometheus/consoles"
     depends_on:
       finance-query-v2:
         condition: service_healthy
@@ -317,10 +333,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '0.5'
+          cpus: "0.5"
           memory: 512M
         reservations:
-          cpus: '0.1'
+          cpus: "0.1"
           memory: 128M
     security_opt:
       - no-new-privileges:true
@@ -342,7 +358,7 @@ services:
     image: grafana/grafana:11.6.0
     container_name: finance-query-grafana
     restart: unless-stopped
-    user: "472:472"  # Grafana user
+    user: "472:472" # Grafana user
     # read_only disabled for Grafana - needs write access for plugins/logs
     expose:
       - "3000"
@@ -378,17 +394,21 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '0.5'
+          cpus: "0.5"
           memory: 256M
         reservations:
-          cpus: '0.1'
+          cpus: "0.1"
           memory: 64M
     security_opt:
       - no-new-privileges:true
     cap_drop:
       - ALL
     healthcheck:
-      test: ["CMD-SHELL", "wget --spider -q http://localhost:3000/api/health || exit 1"]
+      test:
+        [
+          "CMD-SHELL",
+          "wget --spider -q http://localhost:3000/api/health || exit 1",
+        ]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/finance-query-mcp/src/main.rs
+++ b/finance-query-mcp/src/main.rs
@@ -17,6 +17,12 @@ struct Cli {
     /// HTTP bind address (only used when transport=http)
     #[arg(long, default_value = "0.0.0.0:3000", env = "MCP_ADDR")]
     addr: String,
+
+    /// Comma-separated `Host` header values to accept on the HTTP transport
+    /// (DNS-rebinding protection). Loopback addresses are always allowed;
+    /// public deployments must add their domain (e.g. "finance-query.com").
+    #[arg(long, env = "MCP_ALLOWED_HOSTS", value_delimiter = ',')]
+    allowed_hosts: Vec<String>,
 }
 
 #[tokio::main]
@@ -53,7 +59,7 @@ async fn main() -> Result<()> {
     let handler = FinanceTools::new();
 
     match cli.transport.as_str() {
-        "http" => start_http(cli.addr, handler).await,
+        "http" => start_http(cli.addr, cli.allowed_hosts, handler).await,
         _ => start_stdio(handler).await,
     }
 }
@@ -68,7 +74,11 @@ async fn start_stdio(handler: FinanceTools) -> Result<()> {
     Ok(())
 }
 
-async fn start_http(addr: String, _handler: FinanceTools) -> Result<()> {
+async fn start_http(
+    addr: String,
+    extra_allowed_hosts: Vec<String>,
+    _handler: FinanceTools,
+) -> Result<()> {
     use axum::{Router, routing::get};
     use rmcp::transport::streamable_http_server::{
         StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
@@ -76,12 +86,27 @@ async fn start_http(addr: String, _handler: FinanceTools) -> Result<()> {
 
     info!("Starting MCP server (HTTP transport) on {addr}");
 
+    // rmcp defaults `allowed_hosts` to loopback only, rejecting any other
+    // `Host` header as a DNS-rebinding protection. Behind a reverse proxy
+    // (Caddy) the original public Host header is forwarded through, so the
+    // public domain must be added explicitly or every request 403s.
+    let mut allowed_hosts = vec![
+        "localhost".to_string(),
+        "127.0.0.1".to_string(),
+        "::1".to_string(),
+    ];
+    allowed_hosts.extend(extra_allowed_hosts);
+    if allowed_hosts.len() > 3 {
+        info!(hosts = ?allowed_hosts, "HTTP transport allowed hosts configured");
+    }
+
     let service = StreamableHttpService::new(
         || Ok(FinanceTools::new()),
         LocalSessionManager::default().into(),
         StreamableHttpServerConfig::default()
             .with_stateful_mode(false)
-            .with_json_response(true),
+            .with_json_response(true)
+            .with_allowed_hosts(allowed_hosts),
     );
 
     let router = Router::new()


### PR DESCRIPTION
## Description
The production MCP server (`finance-query.com/mcp`) was returning 403 Forbidden on every request. `rmcp`'s streamable HTTP transport defaults `allowed_hosts` to loopback-only as DNS-rebinding protection, and since the server sits behind the Caddy reverse proxy, the original public `Host` header is forwarded through and got rejected. This adds a configurable allow-list so the public domain can be added explicitly.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Added `--allowed-hosts` / `MCP_ALLOWED_HOSTS` CLI arg (comma-separated) to `finance-query-mcp`, merged with the always-allowed loopback hosts (`localhost`, `127.0.0.1`, `::1`) and passed to `StreamableHttpServerConfig::with_allowed_hosts`.
- Wired `MCP_ALLOWED_HOSTS=${SERVER_NAME:-localhost}` into the `mcp` service in `docker-compose.prod.yml`.
- Reformatted `docker-compose.prod.yml` quoting/list style (no functional change beyond the above).

## Breaking Changes
None. Default behavior (loopback-only) is unchanged when the new env var/flag is unset; only public deployments need to set it.

## Testing
- [x] Manual testing performed
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests pass (`cargo test`)

Verified locally by starting the MCP server in HTTP transport mode and confirming JSON-RPC requests succeed with the configured `Host` header, and reproduced/resolved the production 403 by setting `MCP_ALLOWED_HOSTS`.

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

(MCP server changes are not tracked in any CHANGELOG per project convention.)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues
Closes #