### PR TITLE
fix: add missing checkout step to Detect Changes job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
         with:


### PR DESCRIPTION
## Summary
- The new `Detect Changes` job (added in #219) runs `dorny/paths-filter` without ever checking out the repo, so its internal `git rev-parse --abbrev-ref HEAD` call fails with `fatal: not a git repository` on every push to master (confirmed on the #219 merge commit's own CI run).
- Adds `actions/checkout` before the `paths-filter` step, matching every other job in `ci.yml`.

## Test plan
- [ ] CI passes on this PR (Detect Changes job green)
- [ ] Confirm downstream jobs correctly gate on the `rust`/`server_docker`/`mcp_docker`/`fuzz` outputs as intended