### PR TITLE
patch: disable translation-offline in CI/CD builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,14 +26,19 @@ jobs:
             context: .
             file: server/Dockerfile
             suffix: v2
+            # translation-offline disabled temporarily
+            build-args: CARGO_FEATURES=translation
           - name: V1 (Python)
             context: v1
             file: v1/Dockerfile
             suffix: v1
+            build-args: ""
           - name: MCP
             context: .
             file: finance-query-mcp/Dockerfile
             suffix: mcp
+            # translation-offline disabled temporarily
+            build-args: CARGO_FEATURES=translation
 
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -63,6 +68,7 @@ jobs:
         with:
           context: ${{ matrix.image.context }}
           file: ${{ matrix.image.file }}
+          build-args: ${{ matrix.image.build-args }}
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ matrix.image.suffix }}:latest

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -30,12 +30,8 @@ services:
     deploy:
       resources:
         limits:
-          # Translation inference is CPU-bound: the offline backend uses up to
-          # 8 intra-op threads, and CTranslate2 holds one small int8 opus-mt
-          # model (~80-210 MB each) per requested language in memory. CPU
-          # headroom matters more than RAM — a full transcript translates in
-          # ~2-4 s at 6 CPUs (vs tens of seconds with fewer).
-          cpus: "6.0"
+          # translation-offline disabled temporarily
+          cpus: "2.0"
           memory: 3G
         reservations:
           cpus: "0.5"


### PR DESCRIPTION
## Description
Temporarily disables the `translation-offline` feature in the images built/pushed by CI, since the current prod VPS only has 2 CPUs and can't spare the headroom CTranslate2 inference needs. Also caps `finance-query-v2`'s CPU limit at 2.0 to match the host (Docker rejects a `deploy.resources.limits.cpus` above the host's CPU count).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes
- `deploy.yml`: build V2/MCP images with `CARGO_FEATURES=translation` instead of the Dockerfile default `translation-offline`
- `docker-compose.prod.yml`: cap `finance-query-v2` CPU limit at 2.0 (was 6.0)

## Testing
- [x] Manual testing performed (validated YAML, confirmed no other service exceeds the 2-CPU limit)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Code formatted (`cargo fmt`)
- [x] Commit messages follow Conventional Commits

## Related Issues
Follow-up to #223. Revert by dropping the two `build-args` lines and restoring `cpus: "6.0"` once the VPS is upsized.