### PR TITLE
refactor: prune indicatif, governor, scraper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,6 +328,7 @@ jobs:
         with:
           context: .
           file: server/Dockerfile
+          build-args: CARGO_FEATURES=translation
           push: false
           load: true
           tags: financequery:v2-ci
@@ -381,6 +382,7 @@ jobs:
         with:
           context: .
           file: finance-query-mcp/Dockerfile
+          build-args: CARGO_FEATURES=translation
           push: false
           load: true
           tags: financequery:mcp-ci

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -126,7 +126,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -963,7 +963,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1272,29 +1272,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cssparser"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
-dependencies = [
- "cssparser-macros",
- "dtoa-short",
- "itoa",
- "phf 0.13.1",
- "smallvec",
-]
-
-[[package]]
-name = "cssparser-macros"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
-dependencies = [
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1472,20 +1449,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1610,7 +1573,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1650,21 +1613,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
-name = "dtoa"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6add3b8cff394282be81f3fc1a0605db594ed69890078ca6e2cab1c408bcf04"
-
-[[package]]
-name = "dtoa-short"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
-dependencies = [
- "dtoa",
-]
-
-[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1675,12 +1623,6 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
-
-[[package]]
-name = "ego-tree"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2972feb8dffe7bc8c5463b1dacda1b0dfbed3710e50f977d965429692d74cd8"
 
 [[package]]
 name = "either"
@@ -1743,7 +1685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1873,7 +1815,6 @@ dependencies = [
  "rayon",
  "regex",
  "reqwest",
- "scraper",
  "serde",
  "serde_json",
  "serde_repr",
@@ -1904,7 +1845,6 @@ dependencies = [
  "dirs",
  "finance-query",
  "futures",
- "indicatif",
  "notify-rust",
  "predicates",
  "ratatui",
@@ -1963,7 +1903,6 @@ dependencies = [
  "dotenvy",
  "finance-query",
  "futures-util",
- "governor",
  "lazy_static",
  "mockito",
  "prometheus",
@@ -2054,16 +1993,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
-name = "futf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
-dependencies = [
- "mac",
- "new_debug_unreachable",
-]
-
-[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2148,12 +2077,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
-
-[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2178,15 +2101,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "getopts"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -2237,29 +2151,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
-name = "governor"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9efcab3c1958580ff1f25a2a41be1668f7603d849bb63af523b208a3cc1223b8"
-dependencies = [
- "cfg-if",
- "dashmap",
- "futures-sink",
- "futures-timer",
- "futures-util",
- "getrandom 0.3.4",
- "hashbrown 0.16.1",
- "nonzero_ext",
- "parking_lot",
- "portable-atomic",
- "quanta",
- "rand 0.9.4",
- "smallvec",
- "spinning_top",
- "web-time",
-]
-
-[[package]]
 name = "h2"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2306,12 +2197,6 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -2383,16 +2268,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "html5ever"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6452c4751a24e1b99c3260d505eaeee76a050573e61f30ac2c924ddc7236f01e"
-dependencies = [
- "log",
- "markup5ever",
 ]
 
 [[package]]
@@ -2746,7 +2621,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2974,12 +2849,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
-name = "mac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
-
-[[package]]
 name = "mac-notification-sys"
 version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3024,17 +2893,6 @@ name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
-
-[[package]]
-name = "markup5ever"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c3294c4d74d0742910f8c7b466f44dda9eb2d5742c1e430138df290a1e8451c"
-dependencies = [
- "log",
- "tendril",
- "web_atoms",
-]
 
 [[package]]
 name = "matchers"
@@ -3190,12 +3048,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3232,12 +3084,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nonzero_ext"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
-
-[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3263,7 +3109,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3595,7 +3441,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros 0.11.3",
+ "phf_macros",
  "phf_shared 0.11.3",
 ]
 
@@ -3609,34 +3455,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "phf"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
-dependencies = [
- "phf_macros 0.13.1",
- "phf_shared 0.13.1",
- "serde",
-]
-
-[[package]]
 name = "phf_codegen"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
- "phf_generator 0.11.3",
+ "phf_generator",
  "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
-dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -3650,36 +3475,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "phf_generator"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
-dependencies = [
- "fastrand",
- "phf_shared 0.13.1",
-]
-
-[[package]]
 name = "phf_macros"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
- "phf_generator 0.11.3",
+ "phf_generator",
  "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
-dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -3699,15 +3501,6 @@ name = "phf_shared"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -4230,12 +4023,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
 name = "predicates"
 version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4397,21 +4184,6 @@ checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
 dependencies = [
  "idna",
  "psl-types",
-]
-
-[[package]]
-name = "quanta"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
-dependencies = [
- "crossbeam-utils",
- "libc",
- "once_cell",
- "raw-cpuid",
- "wasi",
- "web-sys",
- "winapi",
 ]
 
 [[package]]
@@ -4972,7 +4744,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5029,7 +4801,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5113,21 +4885,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "scraper"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93cecd86d6259499c844440546d02f55f3e17bd286e529e48d1f9f67e92315cb"
-dependencies = [
- "cssparser",
- "ego-tree",
- "getopts",
- "html5ever",
- "precomputed-hash",
- "selectors",
- "tendril",
-]
-
-[[package]]
 name = "scratch"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5154,25 +4911,6 @@ checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
-]
-
-[[package]]
-name = "selectors"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feef350c36147532e1b79ea5c1f3791373e61cbd9a6a2615413b3807bb164fb7"
-dependencies = [
- "bitflags 2.13.0",
- "cssparser",
- "derive_more",
- "log",
- "new_debug_unreachable",
- "phf 0.13.1",
- "phf_codegen 0.13.1",
- "precomputed-hash",
- "rustc-hash",
- "servo_arc",
- "smallvec",
 ]
 
 [[package]]
@@ -5321,15 +5059,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "servo_arc"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
-dependencies = [
- "stable_deref_trait",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5464,7 +5193,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5472,15 +5201,6 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
-name = "spinning_top"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "spm_precompiled"
@@ -5571,31 +5291,6 @@ name = "strength_reduce"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
-
-[[package]]
-name = "string_cache"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
-dependencies = [
- "new_debug_unreachable",
- "parking_lot",
- "phf_shared 0.13.1",
- "precomputed-hash",
- "serde",
-]
-
-[[package]]
-name = "string_cache_codegen"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
-dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
- "proc-macro2",
- "quote",
-]
 
 [[package]]
 name = "strsim"
@@ -5760,18 +5455,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tendril"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
-dependencies = [
- "futf",
- "mac",
- "utf-8",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5793,7 +5477,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook 0.3.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5805,7 +5489,7 @@ dependencies = [
  "fnv",
  "nom",
  "phf 0.11.3",
- "phf_codegen 0.11.3",
+ "phf_codegen",
 ]
 
 [[package]]
@@ -6669,18 +6353,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "web_atoms"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd0c322f146d0f8aad130ce6c187953889359584497dac6561204c8e17bb43d"
-dependencies = [
- "phf 0.13.1",
- "phf_codegen 0.13.1",
- "string_cache",
- "string_cache_codegen",
-]
-
-[[package]]
 name = "webpki-root-certs"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6801,7 +6473,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -126,7 +126,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -963,7 +963,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1310,9 +1310,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.194"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747d8437319e3a2f43d93b341c137927ca70c0f5dabeea7a005a73665e247c7e"
+checksum = "00424da159cc5adcb4eeea7e7b5cb1d96df41f5fa695ec596922181bdc36232a"
 dependencies = [
  "cc",
  "cxx-build",
@@ -1325,9 +1325,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.194"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0f4697d190a142477b16aef7da8a99bfdc41e7e8b1687583c0d23a79c7afc1e"
+checksum = "43e05269dbed4dab7072ae0f04ef31799ad189d52ce2ac12710c2997b754f86a"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1340,9 +1340,9 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-cmd"
-version = "1.0.194"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0956799fa8678d4c50eed028f2de1c0552ae183c76e976cf7ca8c4e36a7c328"
+checksum = "e2f017b07e0da7f425642339faff0edc9f0de6459a18180183d086d1f3381e89"
 dependencies = [
  "clap",
  "codespan-reporting",
@@ -1354,15 +1354,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.194"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23384a836ab4f0ad98ace7e3955ad2de39de42378ab487dc28d3990392cb283a"
+checksum = "293d267f43a5778bf3b89fff2a658f081166e7f152d9640e2ee3d917d065a5fc"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.194"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6acc6b5822b9526adfb4fc377b67128fdd60aac757cc4a741a6278603f763cf"
+checksum = "72dd233dc128223fe85d2afa5c617c79743c0f47fb495b69234b5da680d4986a"
 dependencies = [
  "indexmap",
  "proc-macro2",
@@ -1685,7 +1685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2621,7 +2621,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4187,15 +4187,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-xml"
-version = "0.37.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4248,7 +4239,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4744,7 +4735,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4801,7 +4792,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5193,7 +5184,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5435,11 +5426,10 @@ dependencies = [
 
 [[package]]
 name = "tauri-winrt-notification"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
 dependencies = [
- "quick-xml",
  "thiserror 2.0.18",
  "windows",
  "windows-version",
@@ -5455,7 +5445,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5477,7 +5467,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook 0.3.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6473,7 +6463,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6661,15 +6651,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -6701,28 +6682,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link 0.2.1",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -6756,12 +6720,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6772,12 +6730,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6792,22 +6744,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6822,12 +6762,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6838,12 +6772,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6858,12 +6786,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6874,12 +6796,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -259,8 +259,8 @@ required-features = ["risk", "backtesting", "translation", "sentiment"]
 
 [profile.release]
 opt-level = 3
-lto = "thin"
-codegen-units = 16
+lto = true
+codegen-units = 1
 strip = true
 
 [profile.dev]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,9 +69,6 @@ const_format = "0.2"
 # Logging and tracing
 tracing = "0.1"
 
-# HTML parsing for web scraping
-scraper = "0.25.0"
-
 # WebSocket streaming support
 tokio-tungstenite = { version = "0.28.0", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
 tokio-stream = { version = "0.1", features = ["sync"] }

--- a/finance-query-cli/Cargo.toml
+++ b/finance-query-cli/Cargo.toml
@@ -67,9 +67,6 @@ thiserror = "2.0"
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = "0.10"
 
-# Progress indicators
-indicatif = "0.18.4"
-
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -59,9 +59,6 @@ dotenvy = "0.15"
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = "0.10"
 
-# Rate limiting
-governor = "0.10.4"
-
 # UUID for request IDs
 uuid = { version = "1", features = ["v4", "serde"] }
 

--- a/server/README.md
+++ b/server/README.md
@@ -119,7 +119,7 @@ Requires `EDGAR_EMAIL` environment variable.
 ## Features
 
 - **Redis caching** (enabled by default with market-hours-aware TTLs) - Disable with `--no-default-features`
-- **Rate limiting** - Governor-based rate limiting (60 requests/minute by default, configurable via `RATE_LIMIT_PER_MINUTE`)
+- **Rate limiting** - Global token-bucket rate limiting (60 requests/minute by default, configurable via `RATE_LIMIT_PER_MINUTE`)
 - **Graceful shutdown** - Handles SIGTERM/SIGINT for clean WebSocket closure
 - **CORS** - Configured for cross-origin requests
 - **Compression** - gzip/brotli response compression

--- a/server/src/rate_limit.rs
+++ b/server/src/rate_limit.rs
@@ -1,22 +1,27 @@
-//! Rate limiting middleware using governor.
+//! Global (non-keyed) rate limiting middleware.
 //!
-//! Provides per-IP rate limiting to prevent abuse and protect upstream Yahoo Finance API.
+//! Applies one shared token bucket across all requests to protect the
+//! upstream Yahoo Finance API. Per-IP tracking would require additional
+//! state management and isn't implemented.
+//!
+//! Hand-rolled rather than a general-purpose crate: the only capability
+//! this needs is a single continuously-refilling counter, which a `Mutex`
+//! around a token count + timestamp covers in a few dozen lines, at none of
+//! the transitive dependency weight (keyed limiters, jitter, jemalloc-style
+//! CPU timing) a multi-tenant rate-limiting library carries for capabilities
+//! this middleware never exercises.
 
 use axum::{
     Json,
     body::Body,
+    extract::State,
     http::{Request, StatusCode},
     middleware::Next,
     response::IntoResponse,
 };
-use governor::{
-    Quota, RateLimiter,
-    clock::{Clock, DefaultClock},
-    state::{InMemoryState, NotKeyed},
-};
 use serde::Serialize;
-use std::num::NonZeroU32;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 use tracing::warn;
 
 /// Rate limit configuration
@@ -49,24 +54,66 @@ impl RateLimitConfig {
     }
 }
 
+/// Continuously-refilling token bucket: capacity and refill rate are both
+/// derived from `requests_per_minute`, so a bucket allows an initial burst
+/// up to that count and then admits one request every `60s / count`.
+struct TokenBucket {
+    capacity: f64,
+    refill_per_sec: f64,
+    tokens: f64,
+    last_refill: Instant,
+}
+
+impl TokenBucket {
+    fn new(requests_per_minute: u32) -> Self {
+        let capacity = requests_per_minute.max(1) as f64;
+        Self {
+            capacity,
+            refill_per_sec: capacity / 60.0,
+            tokens: capacity,
+            last_refill: Instant::now(),
+        }
+    }
+
+    /// Attempt to consume one token. `Ok` on success; `Err(retry_after)` on
+    /// failure, with the wait time until the next token would be available.
+    fn check(&mut self) -> Result<(), Duration> {
+        let now = Instant::now();
+        let elapsed = now.duration_since(self.last_refill).as_secs_f64();
+        self.tokens = (self.tokens + elapsed * self.refill_per_sec).min(self.capacity);
+        self.last_refill = now;
+
+        if self.tokens >= 1.0 {
+            self.tokens -= 1.0;
+            Ok(())
+        } else {
+            let deficit = 1.0 - self.tokens;
+            Err(Duration::from_secs_f64(deficit / self.refill_per_sec))
+        }
+    }
+}
+
 /// Shared rate limiter state
 #[derive(Clone)]
 pub struct RateLimiterState {
-    limiter: Arc<RateLimiter<NotKeyed, InMemoryState, DefaultClock>>,
+    bucket: Arc<Mutex<TokenBucket>>,
 }
 
 impl RateLimiterState {
     /// Create a new rate limiter with the given configuration
     pub fn new(config: RateLimitConfig) -> Self {
-        let quota = Quota::per_minute(
-            NonZeroU32::new(config.requests_per_minute).unwrap_or(NonZeroU32::new(60).unwrap()),
-        );
-
         crate::metrics::RATE_LIMIT_QUOTA_PER_MINUTE.set(config.requests_per_minute as f64);
 
         Self {
-            limiter: Arc::new(RateLimiter::direct(quota)),
+            bucket: Arc::new(Mutex::new(TokenBucket::new(config.requests_per_minute))),
         }
+    }
+
+    fn check(&self) -> Result<(), Duration> {
+        self.bucket
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .check()
     }
 }
 
@@ -84,25 +131,20 @@ struct RateLimitError {
 /// Applies global rate limiting to all requests.
 /// Note: Per-IP tracking would require additional state management.
 pub async fn rate_limit_middleware(
-    State(limiter): axum::extract::State<RateLimiterState>,
+    State(limiter): State<RateLimiterState>,
     request: Request<Body>,
     next: Next,
 ) -> impl IntoResponse {
-    // Check rate limit
-    match limiter.limiter.check() {
-        Ok(_) => {
+    match limiter.check() {
+        Ok(()) => {
             crate::metrics::RATE_LIMIT_ALLOWED.inc();
             next.run(request).await.into_response()
         }
-        Err(not_until) => {
-            // Rate limit exceeded
-            let retry_after = not_until
-                .wait_time_from(DefaultClock::default().now())
-                .as_secs();
+        Err(retry_after) => {
+            let retry_after = retry_after.as_secs().max(1);
 
             warn!("Rate limit exceeded (retry after {} seconds)", retry_after);
 
-            // Track rate limit rejection
             crate::metrics::RATE_LIMIT_REJECTIONS.inc();
 
             let error_response = RateLimitError {
@@ -127,9 +169,6 @@ pub async fn rate_limit_middleware(
     }
 }
 
-// Import State extractor for middleware
-use axum::extract::State;
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -148,6 +187,37 @@ mod tests {
         let state = RateLimiterState::new(config);
 
         // Verify we can check rate limits
-        assert!(state.limiter.check().is_ok());
+        assert!(state.check().is_ok());
+    }
+
+    #[test]
+    fn allows_burst_up_to_capacity() {
+        let mut bucket = TokenBucket::new(5);
+        for _ in 0..5 {
+            assert!(bucket.check().is_ok());
+        }
+        assert!(bucket.check().is_err());
+    }
+
+    #[test]
+    fn denies_beyond_capacity_with_retry_after() {
+        let mut bucket = TokenBucket::new(1);
+        assert!(bucket.check().is_ok());
+        let err = bucket.check().unwrap_err();
+        // At 1 request/minute, the next token is ~60s away.
+        assert!(err.as_secs_f64() > 50.0 && err.as_secs_f64() <= 60.0);
+    }
+
+    #[test]
+    fn refills_over_time() {
+        let mut bucket = TokenBucket::new(60); // 1 token/sec
+        for _ in 0..60 {
+            assert!(bucket.check().is_ok());
+        }
+        assert!(bucket.check().is_err());
+
+        // Simulate elapsed time by rewinding last_refill instead of sleeping.
+        bucket.last_refill = Instant::now() - Duration::from_secs(1);
+        assert!(bucket.check().is_ok());
     }
 }

--- a/server/src/rate_limit.rs
+++ b/server/src/rate_limit.rs
@@ -27,7 +27,7 @@ use tracing::warn;
 /// Rate limit configuration
 #[derive(Debug, Clone)]
 pub struct RateLimitConfig {
-    /// Requests per minute per IP
+    /// Requests per minute, shared globally across all clients (not per-IP).
     pub requests_per_minute: u32,
 }
 

--- a/src/scrapers/html.rs
+++ b/src/scrapers/html.rs
@@ -1,0 +1,463 @@
+//! Minimal, dependency-free HTML element matcher.
+//!
+//! finance-query's scraping needs are narrow: find elements by tag name
+//! (optionally scoped inside another element), read one attribute off a
+//! start tag, and read an element's concatenated text content. That's a
+//! small enough surface that owning it outright removes an entire class of
+//! transitive dependency risk from a general-purpose HTML5 engine -- the
+//! same reasoning behind `feeds::parser`'s hand-rolled RSS/Atom extractor,
+//! whose byte-scanning approach (and entity decoding) this mirrors.
+//!
+//! This is NOT a spec-compliant parser: no implicit tag-closing rules, no
+//! DOM tree, no CSS combinators beyond what callers build by chaining
+//! `find_first`/`find_all` (e.g. `h3 a` is `find_first(scope, "h3")` then
+//! `find_first(h3.inner, "a")`). Unclosed tags are tolerated -- the
+//! element's content is treated as running to the end of its search scope
+//! -- rather than erroring, since real-world third-party HTML is far less
+//! predictable than the RSS/Atom feeds `feeds::parser` handles.
+
+const VOID_TAGS: &[&[u8]] = &[
+    b"area", b"base", b"br", b"col", b"embed", b"hr", b"img", b"input", b"link", b"meta", b"param",
+    b"source", b"track", b"wbr",
+];
+
+fn is_void(tag: &[u8]) -> bool {
+    VOID_TAGS.iter().any(|v| v.eq_ignore_ascii_case(tag))
+}
+
+/// One matched HTML element.
+pub(crate) struct Element<'a> {
+    open_tag: &'a [u8],
+    pub(crate) inner: &'a str,
+}
+
+impl Element<'_> {
+    /// The value of `name` on this element's opening tag, if present.
+    pub(crate) fn attr(&self, name: &str) -> Option<String> {
+        find_attr(self.open_tag, name.as_bytes())
+    }
+
+    /// Concatenated text content, tags stripped, entities decoded.
+    pub(crate) fn text(&self) -> String {
+        strip_tags(self.inner.as_bytes())
+    }
+}
+
+/// Find the first `<tag ...>` in `scope` and return it with its content
+/// span. Tag matching is case-insensitive, like real HTML.
+pub(crate) fn find_first<'a>(scope: &'a str, tag: &str) -> Option<Element<'a>> {
+    let bytes = scope.as_bytes();
+    let start = find_tag_open(bytes, tag.as_bytes())?;
+    parse_element(bytes, start, tag.as_bytes()).map(|(el, _)| el)
+}
+
+/// Find every `<tag ...>` in `scope`, at any nesting depth -- including
+/// tags nested inside other matches of the same name (matching
+/// `document.select(&Selector::parse("tag"))`'s "all descendants"
+/// semantics).
+pub(crate) fn find_all<'a>(scope: &'a str, tag: &str) -> Vec<Element<'a>> {
+    let bytes = scope.as_bytes();
+    let tag = tag.as_bytes();
+    let mut out = Vec::new();
+    let mut i = 0;
+    while let Some(rel) = find_tag_open(&bytes[i..], tag) {
+        let start = i + rel;
+        match parse_element(bytes, start, tag) {
+            // Resume right after this element's own opening tag (not past
+            // its content) so nested same-name elements are still found.
+            Some((el, open_tag_end)) => {
+                i = open_tag_end;
+                out.push(el);
+            }
+            None => i = start + 1,
+        }
+    }
+    out
+}
+
+/// Find the first `<tag>` in `scope` whose opening tag carries `attr`.
+pub(crate) fn find_first_with_attr<'a>(
+    scope: &'a str,
+    tag: &str,
+    attr: &str,
+) -> Option<Element<'a>> {
+    find_all(scope, tag)
+        .into_iter()
+        .find(|el| el.attr(attr).is_some())
+}
+
+/// Byte offset of the next `<tag` occurrence in `haystack` at a real
+/// tag-name boundary (not a prefix match -- searching for `a` must skip
+/// `<article`).
+fn find_tag_open(haystack: &[u8], tag: &[u8]) -> Option<usize> {
+    let mut i = 0;
+    while let Some(rel) = find_byte(haystack, i, b'<') {
+        if match_open_name(haystack, rel, tag).is_some() {
+            return Some(rel);
+        }
+        i = rel + 1;
+    }
+    None
+}
+
+/// If `haystack[idx..]` is `<tag` at a real name boundary, the index right
+/// after the tag name.
+fn match_open_name(haystack: &[u8], idx: usize, tag: &[u8]) -> Option<usize> {
+    let name_start = idx + 1;
+    let name_end = name_start + tag.len();
+    if haystack.len() < name_end || !haystack[name_start..name_end].eq_ignore_ascii_case(tag) {
+        return None;
+    }
+    match haystack.get(name_end) {
+        Some(b) if b.is_ascii_whitespace() || *b == b'>' || *b == b'/' => Some(name_end),
+        _ => None,
+    }
+}
+
+/// If `haystack[idx..]` is `</tag` at a real name boundary, the index right
+/// after the tag name.
+fn match_close_name(haystack: &[u8], idx: usize, tag: &[u8]) -> Option<usize> {
+    if haystack.get(idx + 1) != Some(&b'/') {
+        return None;
+    }
+    let name_start = idx + 2;
+    let name_end = name_start + tag.len();
+    if haystack.len() < name_end || !haystack[name_start..name_end].eq_ignore_ascii_case(tag) {
+        return None;
+    }
+    match haystack.get(name_end) {
+        Some(b) if b.is_ascii_whitespace() || *b == b'>' => Some(name_end),
+        _ => None,
+    }
+}
+
+/// Parse one element starting at `haystack[tag_start..]` (a `<tag`
+/// boundary already confirmed by the caller via `find_tag_open`). Returns
+/// the element plus the offset right after its own opening tag.
+fn parse_element<'a>(
+    haystack: &'a [u8],
+    tag_start: usize,
+    tag: &[u8],
+) -> Option<(Element<'a>, usize)> {
+    let name_end = match_open_name(haystack, tag_start, tag)?;
+    let (open_tag, open_end, self_closing) = parse_open_tag(haystack, name_end)?;
+
+    if self_closing || is_void(tag) {
+        return Some((
+            Element {
+                open_tag,
+                inner: "",
+            },
+            open_end,
+        ));
+    }
+
+    let content_end = find_matching_close(haystack, open_end, tag);
+    let inner = std::str::from_utf8(&haystack[open_end..content_end])
+        .expect("span bounded by ASCII tag delimiters, always valid UTF-8");
+    Some((Element { open_tag, inner }, open_end))
+}
+
+/// Parse `<tagname ...>` / `<tagname .../>` starting right after the tag
+/// name (`from`). Returns (attribute text, index right after `>`, whether
+/// self-closing). Tolerant of `>` inside quoted attribute values.
+fn parse_open_tag(haystack: &[u8], from: usize) -> Option<(&[u8], usize, bool)> {
+    let mut i = from;
+    let mut quote: Option<u8> = None;
+    while i < haystack.len() {
+        let b = haystack[i];
+        match quote {
+            Some(q) if b == q => quote = None,
+            Some(_) => {}
+            None if b == b'"' || b == b'\'' => quote = Some(b),
+            None if b == b'>' => {
+                let self_closing = i > from && haystack[i - 1] == b'/';
+                let attrs_end = if self_closing { i - 1 } else { i };
+                return Some((&haystack[from..attrs_end], i + 1, self_closing));
+            }
+            None => {}
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Find where `tag`'s content ends: the matching `</tag>` (tracking nested
+/// same-name open tags), or the end of `haystack` if unclosed.
+fn find_matching_close(haystack: &[u8], from: usize, tag: &[u8]) -> usize {
+    let mut depth = 0usize;
+    let mut i = from;
+    while let Some(rel) = find_byte(haystack, i, b'<') {
+        if let Some(name_end) = match_close_name(haystack, rel, tag) {
+            if depth == 0 {
+                return rel;
+            }
+            depth -= 1;
+            i = find_byte(haystack, name_end, b'>')
+                .map(|g| g + 1)
+                .unwrap_or(haystack.len());
+            continue;
+        }
+        if let Some(name_end) = match_open_name(haystack, rel, tag)
+            && let Some((_, open_end, self_closing)) = parse_open_tag(haystack, name_end)
+        {
+            if !self_closing && !is_void(tag) {
+                depth += 1;
+            }
+            i = open_end;
+            continue;
+        }
+        i = rel + 1;
+    }
+    haystack.len()
+}
+
+/// Concatenate all text content within `html`, stripping tags/comments and
+/// decoding entities.
+fn strip_tags(html: &[u8]) -> String {
+    let mut out = String::with_capacity(html.len());
+    let mut i = 0;
+    while let Some(rel) = find_byte(html, i, b'<') {
+        out.push_str(&unescape(&html[i..rel]));
+        i = if html[rel..].starts_with(b"<!--") {
+            find(html, rel + 4, b"-->")
+                .map(|p| p + 3)
+                .unwrap_or(html.len())
+        } else {
+            skip_tag(html, rel + 1)
+        };
+    }
+    out.push_str(&unescape(&html[i..]));
+    out
+}
+
+/// Index right after the next unquoted `>` at or after `from` (tolerant of
+/// `>` inside quoted attribute values), or end of input if none.
+fn skip_tag(html: &[u8], from: usize) -> usize {
+    let mut i = from;
+    let mut quote: Option<u8> = None;
+    while i < html.len() {
+        let b = html[i];
+        match quote {
+            Some(q) if b == q => quote = None,
+            Some(_) => {}
+            None if b == b'"' || b == b'\'' => quote = Some(b),
+            None if b == b'>' => return i + 1,
+            None => {}
+        }
+        i += 1;
+    }
+    html.len()
+}
+
+fn find(haystack: &[u8], from: usize, needle: &[u8]) -> Option<usize> {
+    if from > haystack.len() {
+        return None;
+    }
+    haystack[from..]
+        .windows(needle.len())
+        .position(|w| w == needle)
+        .map(|p| p + from)
+}
+
+fn find_byte(haystack: &[u8], from: usize, byte: u8) -> Option<usize> {
+    if from > haystack.len() {
+        return None;
+    }
+    haystack[from..]
+        .iter()
+        .position(|&b| b == byte)
+        .map(|p| p + from)
+}
+
+/// Find an attribute's value within a start tag's raw bytes (after the tag
+/// name). Handles both `"` and `'` quoting; requires a whitespace boundary
+/// before the attribute name so e.g. `xhref` doesn't match a lookup for
+/// `href`.
+fn find_attr(tag_bytes: &[u8], attr: &[u8]) -> Option<String> {
+    let mut i = 0;
+    while i < tag_bytes.len() {
+        if tag_bytes[i..].starts_with(attr) {
+            let boundary_ok = i == 0 || tag_bytes[i - 1].is_ascii_whitespace();
+            if boundary_ok {
+                let mut j = i + attr.len();
+                while tag_bytes.get(j).is_some_and(u8::is_ascii_whitespace) {
+                    j += 1;
+                }
+                if tag_bytes.get(j) == Some(&b'=') {
+                    j += 1;
+                    while tag_bytes.get(j).is_some_and(u8::is_ascii_whitespace) {
+                        j += 1;
+                    }
+                    if let Some(&quote) = tag_bytes.get(j)
+                        && (quote == b'"' || quote == b'\'')
+                        && let Some(end) = find_byte(tag_bytes, j + 1, quote)
+                    {
+                        return Some(unescape(&tag_bytes[j + 1..end]));
+                    }
+                }
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Decode the 5 predefined XML/HTML entities and numeric character
+/// references (`&#NN;` / `&#xHH;`). Unrecognized or malformed entities are
+/// left as a literal `&` rather than erroring -- scraped HTML in the wild
+/// is inconsistent here (mirrors `feeds::parser::unescape`).
+fn unescape(raw: &[u8]) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let mut i = 0;
+    loop {
+        match find_byte(raw, i, b'&') {
+            Some(amp) => {
+                out.push_str(&String::from_utf8_lossy(&raw[i..amp]));
+                let decoded = find_byte(raw, amp, b';')
+                    .filter(|&semi| semi - amp <= 10)
+                    .and_then(|semi| decode_entity(&raw[amp + 1..semi]).map(|ch| (ch, semi)));
+                match decoded {
+                    Some((ch, semi)) => {
+                        out.push(ch);
+                        i = semi + 1;
+                    }
+                    None => {
+                        out.push('&');
+                        i = amp + 1;
+                    }
+                }
+            }
+            None => {
+                out.push_str(&String::from_utf8_lossy(&raw[i..]));
+                break;
+            }
+        }
+    }
+    out
+}
+
+fn decode_entity(entity: &[u8]) -> Option<char> {
+    match entity {
+        b"amp" => Some('&'),
+        b"lt" => Some('<'),
+        b"gt" => Some('>'),
+        b"quot" => Some('"'),
+        b"apos" => Some('\''),
+        _ if entity.starts_with(b"#x") || entity.starts_with(b"#X") => {
+            let hex = std::str::from_utf8(&entity[2..]).ok()?;
+            u32::from_str_radix(hex, 16).ok().and_then(char::from_u32)
+        }
+        _ if entity.starts_with(b"#") => {
+            let dec = std::str::from_utf8(&entity[1..]).ok()?;
+            dec.parse::<u32>().ok().and_then(char::from_u32)
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finds_table_rows_and_cells() {
+        let html = r#"
+            <table>
+              <tr><th>Country</th><th>Suffix</th></tr>
+              <tr><td>Japan</td><td>.T</td></tr>
+              <tr><td>Hong Kong</td><td>.HK</td></tr>
+            </table>
+        "#;
+        let table = find_first(html, "table").unwrap();
+        let rows = find_all(table.inner, "tr");
+        assert_eq!(rows.len(), 3);
+
+        let data_rows: Vec<_> = rows
+            .iter()
+            .map(|r| find_all(r.inner, "td"))
+            .filter(|cells| cells.len() == 2)
+            .collect();
+        assert_eq!(data_rows.len(), 2);
+        assert_eq!(data_rows[0][0].text(), "Japan");
+        assert_eq!(data_rows[0][1].text(), ".T");
+    }
+
+    #[test]
+    fn finds_all_nested_divs() {
+        let html = r#"<div id="outer"><div id="inner">x</div></div>"#;
+        let divs = find_all(html, "div");
+        assert_eq!(divs.len(), 2);
+        assert_eq!(divs[0].attr("id").as_deref(), Some("outer"));
+        assert_eq!(divs[1].attr("id").as_deref(), Some("inner"));
+    }
+
+    #[test]
+    fn chained_descendant_lookup() {
+        let html = r#"<div><h3><a href="/news/1">Fed holds rates</a></h3></div>"#;
+        let item = find_first(html, "div").unwrap();
+        let title = find_first(item.inner, "h3")
+            .and_then(|h3| find_first(h3.inner, "a"))
+            .unwrap();
+        assert_eq!(title.text(), "Fed holds rates");
+        assert_eq!(title.attr("href").as_deref(), Some("/news/1"));
+    }
+
+    #[test]
+    fn find_first_with_attr_matches_presence_not_value() {
+        let html = r#"<div>text</div><div title="14 hours ago - Reuters">meta</div>"#;
+        let el = find_first_with_attr(html, "div", "title").unwrap();
+        assert_eq!(el.text(), "meta");
+    }
+
+    #[test]
+    fn void_elements_have_no_content() {
+        let html = r#"<div><img src="/a.png"><p>after</p></div>"#;
+        let item = find_first(html, "div").unwrap();
+        let img = find_first(item.inner, "img").unwrap();
+        assert_eq!(img.attr("src").as_deref(), Some("/a.png"));
+        assert_eq!(img.inner, "");
+    }
+
+    #[test]
+    fn self_closing_img_also_works() {
+        let html = r#"<img src="/a.png"/>"#;
+        let img = find_first(html, "img").unwrap();
+        assert_eq!(img.attr("src").as_deref(), Some("/a.png"));
+    }
+
+    #[test]
+    fn text_strips_nested_tags_and_decodes_entities() {
+        let html = r#"<td>AT&amp;T <b>Inc</b>.</td>"#;
+        let cell = find_first(html, "td").unwrap();
+        assert_eq!(cell.text(), "AT&T Inc.");
+    }
+
+    #[test]
+    fn greater_than_inside_quoted_attr_does_not_end_tag_early() {
+        let html = r#"<div title="a > b">ok</div>"#;
+        let el = find_first(html, "div").unwrap();
+        assert_eq!(el.attr("title").as_deref(), Some("a > b"));
+        assert_eq!(el.text(), "ok");
+    }
+
+    #[test]
+    fn unclosed_tag_is_tolerated_not_an_error() {
+        let html = r#"<div><p>trailing content, no closing div"#;
+        let el = find_first(html, "div").unwrap();
+        assert!(el.inner.contains("trailing content"));
+    }
+
+    #[test]
+    fn attribute_name_boundary_is_respected() {
+        let html = r#"<div xhref="wrong" href="right">x</div>"#;
+        let el = find_first(html, "div").unwrap();
+        assert_eq!(el.attr("href").as_deref(), Some("right"));
+    }
+
+    #[test]
+    fn no_match_returns_none() {
+        assert!(find_first("<div>no table here</div>", "table").is_none());
+        assert!(find_all("<div>no rows</div>", "tr").is_empty());
+    }
+}

--- a/src/scrapers/mod.rs
+++ b/src/scrapers/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! This module contains scrapers for sources that don't provide official APIs.
 
+mod html;
 pub(crate) mod stockanalysis;
 pub(crate) mod yahoo_earnings;
 pub(crate) mod yahoo_exchanges;

--- a/src/scrapers/stockanalysis.rs
+++ b/src/scrapers/stockanalysis.rs
@@ -4,7 +4,7 @@
 
 use crate::error::{FinanceError, Result};
 use crate::models::corporate::news::News;
-use scraper::{Html, Selector};
+use crate::scrapers::html;
 use std::collections::HashMap;
 use std::sync::LazyLock;
 use tracing::info;
@@ -70,13 +70,6 @@ static EXCHANGE_MAPPING: LazyLock<HashMap<&'static str, &'static str>> = LazyLoc
     ])
 });
 
-/// CSS selectors for `parse_news` — parsed once and reused across every call.
-static ALL_DIVS_SEL: LazyLock<Selector> = LazyLock::new(|| Selector::parse("div").unwrap());
-static IMG_SEL: LazyLock<Selector> = LazyLock::new(|| Selector::parse("img").unwrap());
-static TITLE_SEL: LazyLock<Selector> = LazyLock::new(|| Selector::parse("h3 a").unwrap());
-static SOURCE_TIME_SEL: LazyLock<Selector> =
-    LazyLock::new(|| Selector::parse("div[title]").unwrap());
-
 /// Build a reqwest client with the StockAnalysis user agent.
 fn build_client() -> Result<reqwest::Client> {
     Ok(reqwest::Client::builder()
@@ -118,35 +111,31 @@ fn build_symbol_urls(symbol: &str) -> Vec<String> {
 }
 
 /// Parse news articles from HTML content
-fn parse_news(html: &str) -> Result<Vec<News>> {
-    let document = Html::parse_document(html);
-
+fn parse_news(document: &str) -> Result<Vec<News>> {
     // Find all divs that contain the news item structure:
     // - h3 with a link (title)
     // - div with title attribute (source/time)
     let mut news_list = Vec::new();
     let mut seen_titles = std::collections::HashSet::new();
 
-    for item in document.select(&ALL_DIVS_SEL) {
-        let title_elem = item.select(&TITLE_SEL).next();
-        let source_time_elem = item.select(&SOURCE_TIME_SEL).next();
+    for item in html::find_all(document, "div") {
+        let title_elem =
+            html::find_first(item.inner, "h3").and_then(|h3| html::find_first(h3.inner, "a"));
+        let source_time_elem = html::find_first_with_attr(item.inner, "div", "title");
 
         if let (Some(title_el), Some(source_time_el)) = (title_elem, source_time_elem) {
-            let title = title_el.text().collect::<String>().trim().to_string();
-            let link = title_el.value().attr("href").unwrap_or("").to_string();
+            let title = title_el.text().trim().to_string();
+            let link = title_el.attr("href").unwrap_or_default();
 
             // Skip if missing essential fields or already seen (dedup)
             if title.is_empty() || link.is_empty() || !seen_titles.insert(title.clone()) {
                 continue;
             }
 
-            let source_time_text = source_time_el.text().collect::<String>();
-            let img = item
-                .select(&IMG_SEL)
-                .next()
-                .and_then(|e| e.value().attr("src"))
-                .unwrap_or("")
-                .to_string();
+            let source_time_text = source_time_el.text();
+            let img = html::find_first(item.inner, "img")
+                .and_then(|e| e.attr("src"))
+                .unwrap_or_default();
 
             // Parse "14 hours ago - Seeking Alpha" format
             let (time, source) = if let Some(pos) = source_time_text.find(" - ") {
@@ -247,6 +236,50 @@ mod tests {
         let urls = build_symbol_urls("VOD.L");
         assert_eq!(urls.len(), 1);
         assert!(urls[0].contains("quote/lon/VOD"));
+    }
+
+    #[test]
+    fn parses_news_offline() {
+        let html = r#"
+            <div class="feed">
+              <div class="item">
+                <img src="/logo1.png">
+                <h3><a href="/news/fed-holds-rates">Fed holds rates steady</a></h3>
+                <div title="2026-07-09">14 hours ago - Reuters</div>
+              </div>
+              <div class="item">
+                <img src="/logo2.png">
+                <h3><a href="/news/earnings-beat">Earnings beat expectations</a></h3>
+                <div title="2026-07-08">2 days ago - Bloomberg</div>
+              </div>
+              <div class="not-a-news-item">just some other div</div>
+            </div>
+        "#;
+
+        let news = parse_news(html).unwrap();
+        assert_eq!(news.len(), 2);
+        assert_eq!(news[0].title, "Fed holds rates steady");
+        assert_eq!(news[0].link, "/news/fed-holds-rates");
+        assert_eq!(news[0].source, "Reuters");
+        assert_eq!(news[0].time, "14 hours ago");
+        assert_eq!(news[0].img, "/logo1.png");
+    }
+
+    #[test]
+    fn parse_news_dedupes_repeated_titles() {
+        let html = r#"
+            <div>
+              <h3><a href="/news/1">Same headline</a></h3>
+              <div title="x">1 hour ago - Source</div>
+            </div>
+            <div>
+              <h3><a href="/news/1-repost">Same headline</a></h3>
+              <div title="y">2 hours ago - Source</div>
+            </div>
+        "#;
+
+        let news = parse_news(html).unwrap();
+        assert_eq!(news.len(), 1);
     }
 
     #[tokio::test]

--- a/src/scrapers/yahoo_exchanges.rs
+++ b/src/scrapers/yahoo_exchanges.rs
@@ -5,7 +5,7 @@
 
 use crate::error::{FinanceError, Result};
 use crate::models::market::exchanges::Exchange;
-use scraper::{Html, Selector};
+use crate::scrapers::html;
 use tracing::info;
 
 const EXCHANGES_URL: &str = "https://help.yahoo.com/kb/finance-for-web/SLN2310.html";
@@ -35,27 +35,8 @@ pub async fn scrape_exchanges() -> Result<Vec<Exchange>> {
 }
 
 /// Parse the exchanges HTML table.
-fn parse_exchanges_html(html: &str) -> Result<Vec<Exchange>> {
-    let document = Html::parse_document(html);
-
-    let table_selector =
-        Selector::parse("table").map_err(|_| FinanceError::ResponseStructureError {
-            field: "table".to_string(),
-            context: "Failed to parse table selector".to_string(),
-        })?;
-
-    let row_selector = Selector::parse("tr").map_err(|_| FinanceError::ResponseStructureError {
-        field: "tr".to_string(),
-        context: "Failed to parse row selector".to_string(),
-    })?;
-
-    let cell_selector =
-        Selector::parse("td").map_err(|_| FinanceError::ResponseStructureError {
-            field: "td".to_string(),
-            context: "Failed to parse cell selector".to_string(),
-        })?;
-
-    let table = document.select(&table_selector).next().ok_or_else(|| {
+fn parse_exchanges_html(document: &str) -> Result<Vec<Exchange>> {
+    let table = html::find_first(document, "table").ok_or_else(|| {
         FinanceError::ResponseStructureError {
             field: "table".to_string(),
             context: "No table found in exchanges page".to_string(),
@@ -64,19 +45,19 @@ fn parse_exchanges_html(html: &str) -> Result<Vec<Exchange>> {
 
     let mut exchanges = Vec::new();
 
-    for row in table.select(&row_selector) {
-        let cells: Vec<_> = row.select(&cell_selector).collect();
+    for row in html::find_all(table.inner, "tr") {
+        let cells = html::find_all(row.inner, "td");
 
         // Skip header rows (they use <th> not <td>)
         if cells.len() != 5 {
             continue;
         }
 
-        let country = cells[0].text().collect::<String>().trim().to_string();
-        let market = cells[1].text().collect::<String>().trim().to_string();
-        let suffix = cells[2].text().collect::<String>().trim().to_string();
-        let delay = cells[3].text().collect::<String>().trim().to_string();
-        let data_provider = cells[4].text().collect::<String>().trim().to_string();
+        let country = cells[0].text().trim().to_string();
+        let market = cells[1].text().trim().to_string();
+        let suffix = cells[2].text().trim().to_string();
+        let delay = cells[3].text().trim().to_string();
+        let data_provider = cells[4].text().trim().to_string();
 
         exchanges.push(Exchange {
             country,
@@ -101,6 +82,30 @@ fn parse_exchanges_html(html: &str) -> Result<Vec<Exchange>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parses_exchanges_table_offline() {
+        let html = r#"
+            <html><body>
+            <table>
+              <tr><th>Country</th><th>Market</th><th>Suffix</th><th>Delay</th><th>Provider</th></tr>
+              <tr><td>United States of America</td><td>NASDAQ</td><td></td><td>Real-time</td><td>Nasdaq</td></tr>
+              <tr><td>Japan</td><td>Tokyo Stock Exchange</td><td>.T</td><td>20 min</td><td>Tokyo</td></tr>
+            </table>
+            </body></html>
+        "#;
+
+        let exchanges = parse_exchanges_html(html).unwrap();
+        assert_eq!(exchanges.len(), 2);
+        assert_eq!(exchanges[0].country, "United States of America");
+        assert_eq!(exchanges[1].suffix, ".T");
+    }
+
+    #[test]
+    fn errors_when_no_table_present() {
+        let result = parse_exchanges_html("<html><body>no table here</body></html>");
+        assert!(result.is_err());
+    }
 
     #[tokio::test]
     #[ignore] // Requires network access


### PR DESCRIPTION
## Description
Removes three dependencies that were either unused or pulled in far more transitive weight than the code actually needed: `indicatif`, `governor`, and `scraper`. Also bumps two transitive dependencies to resolve 3 RUSTSEC advisories found while re-auditing this branch.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Removed `indicatif` from `finance-query-cli` (declared, never used anywhere in the CLI source)
- Replaced `governor` in `server/src/rate_limit.rs` with a small hand rolled token bucket behind a `Mutex`. It was pulling in 50 transitive crates for a single global, non-keyed counter, none of governor's keyed/multi-tenant machinery was exercised
- Replaced `scraper` with a new minimal hand rolled HTML element matcher (`src/scrapers/html.rs`), same approach as the earlier feed-rs to hand rolled RSS parser move. It was pulling in 56 transitive crates (html5ever, selectors, cssparser) for 7 trivial selector calls across `src/scrapers/yahoo_exchanges.rs` and `src/scrapers/stockanalysis.rs`
- Added offline unit tests for both rewritten scrapers (previously only network gated integration tests existed) plus 11 unit tests for the new HTML matcher
- Bumped `cxx` 1.0.194 -> 1.0.197 (fixes RUSTSEC-2026-0202, unsound) and `tauri-winrt-notification` 0.7.2 -> 0.7.3 (a patch release that backported the same native `windows`-API rewrite as its 0.8.0 major bump, dropping `quick-xml` entirely; fixes RUSTSEC-2026-0194 and RUSTSEC-2026-0195). `cargo audit` now reports 0 vulnerabilities. No manifest changes, lockfile only.
- Fixed two doc staleness bugs from the first commit: `server/README.md` still said "Governor-based" rate limiting, and `RateLimitConfig::requests_per_minute`'s doc comment said "per IP" though the limiter is global

## Breaking Changes
None. Internal only, no public API changes.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All tests pass (`cargo test`)

Ran the server locally (`make serve`) and compared `/v2/exchanges`, `/v2/news`, and `/v2/news/AAPL` against production (finance-query.com): output was identical in both cases. Verified the new rate limiter with a tight `RATE_LIMIT_PER_MINUTE` override: burst is allowed up to capacity, then 429s with a correct `Retry-After` header and JSON body, and refills correctly over time. Independently re-verified the security bumps with `cargo audit --json` (0 vulnerabilities) and a full `cargo check --workspace --features full` plus `--features translation-offline` (the cxx/ct2rs FFI path).

## Documentation
- [x] Code documentation updated (doc comments)
- [x] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues
Closes #236