### PR TITLE
perf: shared Yahoo session, cache-by-default handles, hot-path cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking
+
+- `TrailingStop` and `TrailingTakeProfit` (`backtesting::condition`) no longer
+  implement `Copy`, and both gained a private field. They still implement
+  `Clone`. Code that relied on implicit copies (`let a = ts; use(ts);`) or on
+  struct-literal construction must be updated. Both now carry a per-position
+  running peak/trough cache, which is what removed the O(bars²) rescan from
+  trailing-stop backtests.
+- `Ticker`, `Tickers`, and the domain handles cache responses by default for the
+  lifetime of the handle. Previously caching was off unless `.cache(ttl)` was
+  set, so every accessor refetched — which contradicted the documentation. Call
+  `.no_cache()` for the old behavior.
+- `BacktestEngine::run` and `run_with_dividends` now reject candles that are not
+  sorted ascending by timestamp, with the same `InvalidParameter` error already
+  used for unsorted dividends. Conditions binary-search the candle slice, so an
+  unsorted series previously produced a silently wrong entry index.
+
 ### Changed
 
-- `Ticker`, `Tickers`, and the domain handles now cache responses by default
-  for the lifetime of the handle. Previously caching was off unless
-  `.cache(ttl)` was set, so every accessor refetched — which contradicted the
-  documentation. Call `.no_cache()` for the old behavior.
 - Yahoo sessions are now shared per tokio runtime and client configuration.
   The `finance::*` functions and `Ticker`/`Tickers` construction reuse one
   authenticated session instead of running a fresh cookie + crumb handshake per
@@ -24,7 +37,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on the domain handles.
 - Automatic crumb refresh: a request that fails authentication re-runs the
   Yahoo handshake once and retries. If the refresh itself fails, the shared
-  session is dropped so the next caller builds a fresh one.
+  session is dropped so the next caller builds a fresh one. HTTP 403 is treated
+  as an authentication failure alongside 401, since Yahoo uses both for a stale
+  crumb.
+
+### Fixed
+
+- `vwma` is computed with rolling sums instead of rescanning the window each
+  bar. Results may differ from previous releases in the last few significant
+  digits; a window whose volumes span extreme magnitudes is now rebuilt rather
+  than returning a value derived from a cancelled-out denominator.
+- A batch quote response whose `result` array contains a non-object element now
+  fails that batch instead of yielding an all-empty quote for it.
 
 ## [2.8.0] - 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `Ticker`, `Tickers`, and the domain handles now cache responses by default
+  for the lifetime of the handle. Previously caching was off unless
+  `.cache(ttl)` was set, so every accessor refetched — which contradicted the
+  documentation. Call `.no_cache()` for the old behavior.
+- Yahoo sessions are now shared per tokio runtime and client configuration.
+  The `finance::*` functions and `Ticker`/`Tickers` construction reuse one
+  authenticated session instead of running a fresh cookie + crumb handshake per
+  call, cutting each `finance::*` call from three HTTP requests to one.
+
+### Added
+
+- `TickerBuilder::no_cache()`, `TickersBuilder::no_cache()`, and `no_cache()`
+  on the domain handles.
+- Automatic crumb refresh: a request that fails authentication re-runs the
+  Yahoo handshake once and retries. If the refresh itself fails, the shared
+  session is dropped so the next caller builds a fresh one.
+
 ## [2.8.0] - 2026-07-10
 
 Domain handles (`ForexPair`, `CryptoCoin`, `Index`, `FuturesContract`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 
-- `TrailingStop` and `TrailingTakeProfit` (`backtesting::condition`) no longer
-  implement `Copy`, and both gained a private field. They still implement
-  `Clone`. Code that relied on implicit copies (`let a = ts; use(ts);`) or on
-  struct-literal construction must be updated. Both now carry a per-position
-  running peak/trough cache, which is what removed the O(bars²) rescan from
-  trailing-stop backtests.
 - `Ticker`, `Tickers`, and the domain handles cache responses by default for the
   lifetime of the handle. Previously caching was off unless `.cache(ttl)` was
   set, so every accessor refetched — which contradicted the documentation. Call
@@ -22,7 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `BacktestEngine::run` and `run_with_dividends` now reject candles that are not
   sorted ascending by timestamp, with the same `InvalidParameter` error already
   used for unsorted dividends. Conditions binary-search the candle slice, so an
-  unsorted series previously produced a silently wrong entry index.
+  unsorted series previously produced a silently wrong entry index. `GridSearch`,
+  `BayesianSearch`, and `WalkForward` apply the same check once per series rather
+  than once per candidate.
+- A Yahoo HTTP 403 whose body names the crumb now surfaces as
+  `AuthenticationFailed` rather than `UnexpectedResponse`, so the shared session
+  refreshes instead of failing every later caller on it. A 403 that does *not*
+  mention the crumb — a datacenter-IP block or abuse throttle — keeps mapping to
+  `UnexpectedResponse`, since no handshake can clear it and retrying would cost
+  an extra handshake and a discarded session per blocked request.
 
 ### Changed
 
@@ -35,11 +37,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `TickerBuilder::no_cache()`, `TickersBuilder::no_cache()`, and `no_cache()`
   on the domain handles.
+- `backtesting::PositionExtremes` and `StrategyContext::extremes` — the highest
+  and lowest bar high/low/close since the open position was entered. The engine
+  folds these once per bar, so `TrailingStop` and `TrailingTakeProfit` read one
+  shared running value instead of rescanning the candle history per bar
+  (O(bars²) → O(bars)). Both conditions stay `Copy`. Custom conditions can read
+  `ctx.extremes`; it is `None` outside the engine's bar loop.
 - Automatic crumb refresh: a request that fails authentication re-runs the
   Yahoo handshake once and retries. If the refresh itself fails, the shared
-  session is dropped so the next caller builds a fresh one. HTTP 403 is treated
-  as an authentication failure alongside 401, since Yahoo uses both for a stale
-  crumb.
+  session is dropped so the next caller builds a fresh one.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1795,7 +1795,7 @@ dependencies = [
 
 [[package]]
 name = "finance-query"
-version = "3.0.0"
+version = "2.8.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1795,7 +1795,7 @@ dependencies = [
 
 [[package]]
 name = "finance-query"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1795,7 +1795,7 @@ dependencies = [
 
 [[package]]
 name = "finance-query"
-version = "2.8.1"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "finance-query"
-version = "2.8.1"
+version = "3.0.0"
 edition = "2024"
 authors = ["Harvey Tseng <harveytseng2@gmail.com>"]
 description = "A Rust library for querying financial data"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "finance-query"
-version = "2.8.0"
+version = "2.8.1"
 edition = "2024"
 authors = ["Harvey Tseng <harveytseng2@gmail.com>"]
 description = "A Rust library for querying financial data"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "finance-query"
-version = "3.0.0"
+version = "2.8.0"
 edition = "2024"
 authors = ["Harvey Tseng <harveytseng2@gmail.com>"]
 description = "A Rust library for querying financial data"

--- a/docs/library/forex.md
+++ b/docs/library/forex.md
@@ -148,7 +148,9 @@ handle's own chart data. `risk` takes no benchmark parameter — `beta` is alway
 
 ## Caching
 
-Enable in-memory caching with a TTL to avoid redundant network requests:
+Caching is **on by default** and lasts as long as the handle lives. Use
+`.cache(Duration)` to bound how long a response is reused, or `.no_cache()` to
+fetch fresh on every call.
 
 ```rust
 use finance_query::{Capability, Provider, Providers};
@@ -159,13 +161,20 @@ let providers = Providers::builder()
     .build()
     .await?;
 
+// Default: the first call hits the network, every later call is served from
+// cache for as long as this handle is alive.
+let pair = providers.forex("EUR", "USD");
+let _q1 = pair.quote().await?;
+let _q2 = pair.quote().await?; // served from cache
+
+// Bound reuse to a 60-second TTL instead.
 let pair = providers
     .forex("EUR", "USD")
     .cache(Duration::from_secs(60));
 
-// First call hits the network; subsequent calls within 60 s are cached.
-let _q1 = pair.quote().await?;
-let _q2 = pair.quote().await?; // served from cache
+// Or opt out entirely — every call fetches fresh.
+let pair = providers.forex("EUR", "USD").no_cache();
+let _fresh = pair.quote().await?;
 ```
 
 ## See Also

--- a/docs/library/ticker.md
+++ b/docs/library/ticker.md
@@ -58,7 +58,8 @@ let ticker = Ticker::builder("AAPL")
 - `.timeout(Duration)` - Set HTTP request timeout
 - `.proxy(String)` - Set proxy URL
 - `.logo()` - Fetch company logo URLs alongside quote data
-- `.cache(Duration)` - Enable in-memory caching with the given TTL (time-to-live)
+- `.cache(Duration)` - Bound in-memory caching to the given TTL (default: cached for the handle's lifetime)
+- `.no_cache()` - Disable caching — every call fetches fresh data
 
 See [Configuration](configuration.md) for details on available regions and settings.
 See [Multi-Provider Architecture](providers/index.md) for provider configuration.
@@ -755,20 +756,30 @@ for meta in &all_transcripts {
 
 Understanding how Ticker caches data is important for efficient usage.
 
-### In-Memory Cache (Optional)
+### In-Memory Cache
 
-Enable with `.cache(Duration)` on the builder. Disabled by default.
+Caching is **on by default** and lasts as long as the `Ticker` handle lives. Fetched data is stored in an `Arc<RwLock<...>>` cache inside the `Ticker`.
+
+Use `.cache(Duration)` to bound how long a response is reused, or `.no_cache()` to fetch fresh on every call.
 
 ```rust
 use std::time::Duration;
 
+// Default: cached for the lifetime of the handle
+let ticker = Ticker::new("AAPL").await?;
+
+// Bounded: entries expire after 5 minutes
 let ticker = Ticker::builder("AAPL")
-    .cache(Duration::from_secs(300))  // 5-minute TTL
+    .cache(Duration::from_secs(300))
+    .build()
+    .await?;
+
+// Off: every accessor issues a fresh request
+let ticker = Ticker::builder("AAPL")
+    .no_cache()
     .build()
     .await?;
 ```
-
-When enabled, all fetched data is stored in an `Arc<RwLock<...>>` cache inside the `Ticker` and automatically invalidated after the TTL.
 
 ### Quote Summary Modules
 

--- a/docs/library/tickers.md
+++ b/docs/library/tickers.md
@@ -44,7 +44,8 @@ let tickers = Tickers::builder(vec!["AAPL", "MSFT"])
 | `.proxy(str)` | Set proxy URL |
 || `.max_concurrency(n)` | Max concurrent requests for per-symbol batch ops (default: 10) |
 | `.logo()` | Include company logo URLs in quote responses |
-| `.cache(Duration)` | Enable response caching with TTL (disabled by default) |
+| `.cache(Duration)` | Bound response caching to a TTL (default: cached for the handle's lifetime) |
+| `.no_cache()` | Disable caching — every call fetches fresh data |
 
 #### `max_concurrency`
 
@@ -565,13 +566,13 @@ let msft_chart = tickers.chart("MSFT", Interval::OneDay, TimeRange::OneMonth).aw
 
 ## Caching
 
-`Tickers` caching is **opt-in** — by default every call fetches fresh data. Enable it with `.cache(Duration)` in the builder.
+`Tickers` caching is **on by default** and lasts as long as the handle lives. Use `.cache(Duration)` to bound how long a response is reused, or `.no_cache()` to fetch fresh on every call.
 
 ```rust
 use finance_query::Tickers;
 use std::time::Duration;
 
-// Enable a 30-second TTL on all responses
+// Bound reuse to a 30-second TTL
 let tickers = Tickers::builder(vec!["AAPL", "MSFT"])
     .cache(Duration::from_secs(30))
     .build()

--- a/finance-query-cli/Cargo.toml
+++ b/finance-query-cli/Cargo.toml
@@ -39,7 +39,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core library
-finance-query = { version = "3.0", path = "..", features = ["indicators", "backtesting", "translation"] }
+finance-query = { version = "2.0", path = "..", features = ["indicators", "backtesting", "translation"] }
 
 # CLI framework
 clap = { version = "4.6", features = ["derive", "cargo", "env"] }

--- a/finance-query-cli/Cargo.toml
+++ b/finance-query-cli/Cargo.toml
@@ -39,7 +39,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core library
-finance-query = { version = "2.0", path = "..", features = ["indicators", "backtesting", "translation"] }
+finance-query = { version = "3.0", path = "..", features = ["indicators", "backtesting", "translation"] }
 
 # CLI framework
 clap = { version = "4.6", features = ["derive", "cargo", "env"] }

--- a/src/adapters/alphavantage/fundamentals/mod.rs
+++ b/src/adapters/alphavantage/fundamentals/mod.rs
@@ -291,7 +291,7 @@ pub async fn listing_status(status: Option<&str>) -> Result<Vec<ListingEntryDTO>
     };
     let csv = client.get_csv("LISTING_STATUS", &params).await?;
 
-    let mut entries = Vec::new();
+    let mut entries = Vec::with_capacity(csv.lines().count().saturating_sub(1));
     let mut lines = csv.lines();
     let _header = lines.next();
 

--- a/src/adapters/alphavantage/quote/mod.rs
+++ b/src/adapters/alphavantage/quote/mod.rs
@@ -495,34 +495,10 @@ pub async fn fetch_chart_response(
         _ => time_series_daily(symbol, None).await?,
     };
 
-    let candles: Vec<Candle> = ts
-        .entries
-        .into_iter()
-        .map(|bar| {
-            let ts_val = chrono::NaiveDateTime::parse_from_str(
-                &format!("{} 00:00:00", bar.timestamp),
-                "%Y-%m-%d %H:%M:%S",
-            )
-            .ok()
-            .map(|dt| dt.and_utc().timestamp())
-            .unwrap_or(0);
-            Candle {
-                timestamp: ts_val,
-                open: bar.open,
-                high: bar.high,
-                low: bar.low,
-                close: bar.close,
-                volume: bar.volume as i64,
-                adj_close: None,
-                provider_id: Some(crate::Provider::AlphaVantage),
-            }
-        })
-        .collect();
-
     Ok(Chart {
         symbol: symbol.to_string(),
         meta: Default::default(),
-        candles,
+        candles: entries_to_candles(ts.entries),
         interval: None,
         range: None,
         provider_id: Some(crate::Provider::AlphaVantage),
@@ -541,37 +517,59 @@ pub async fn fetch_chart_range_response(
 
     let ts = time_series_daily(symbol, Some(super::models::OutputSize::Full)).await?;
 
-    let candles: Vec<Candle> = ts
+    let in_range: Vec<_> = ts
         .entries
         .into_iter()
         .filter(|bar| bar.timestamp >= from_date && bar.timestamp <= to_date)
-        .map(|bar| {
-            let ts_val = chrono::NaiveDate::parse_from_str(&bar.timestamp, "%Y-%m-%d")
-                .ok()
-                .and_then(|d| d.and_hms_opt(0, 0, 0))
-                .map(|dt| dt.and_utc().timestamp())
-                .unwrap_or(0);
-            Candle {
-                timestamp: ts_val,
-                open: bar.open,
-                high: bar.high,
-                low: bar.low,
-                close: bar.close,
-                volume: bar.volume as i64,
-                adj_close: None,
-                provider_id: Some(crate::Provider::AlphaVantage),
-            }
-        })
         .collect();
 
     Ok(Chart {
         symbol: symbol.to_string(),
         meta: Default::default(),
-        candles,
+        candles: entries_to_candles(in_range),
         interval: None,
         range: None,
         provider_id: Some(crate::Provider::AlphaVantage),
     })
+}
+
+/// Convert time series entries into canonical candles, ascending by timestamp.
+///
+/// The DTO layer sorts entries newest-first, but `BacktestEngine::run` rejects
+/// candles that are not ascending, so the chart bridge normalises here.
+fn entries_to_candles(entries: Vec<TimeSeriesEntryDTO>) -> Vec<Candle> {
+    let mut candles: Vec<Candle> = entries
+        .into_iter()
+        .map(|bar| Candle {
+            timestamp: parse_entry_timestamp(&bar.timestamp),
+            open: bar.open,
+            high: bar.high,
+            low: bar.low,
+            close: bar.close,
+            volume: bar.volume as i64,
+            adj_close: None,
+            provider_id: Some(crate::Provider::AlphaVantage),
+        })
+        .collect();
+    candles.sort_unstable_by_key(|c| c.timestamp);
+    candles
+}
+
+/// Parse an Alpha Vantage time series key into a Unix timestamp.
+///
+/// Daily series are keyed `YYYY-MM-DD`; intraday series carry a time component.
+/// An unparseable key yields 0 rather than dropping the bar, matching the
+/// previous behaviour.
+fn parse_entry_timestamp(key: &str) -> i64 {
+    chrono::NaiveDateTime::parse_from_str(key, "%Y-%m-%d %H:%M:%S")
+        .ok()
+        .or_else(|| {
+            chrono::NaiveDate::parse_from_str(key, "%Y-%m-%d")
+                .ok()
+                .and_then(|d| d.and_hms_opt(0, 0, 0))
+        })
+        .map(|dt| dt.and_utc().timestamp())
+        .unwrap_or(0)
 }
 
 /// Convert a Unix timestamp to a YYYY-MM-DD date string.
@@ -584,6 +582,55 @@ fn timestamp_to_date_string(ts: i64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn entry(timestamp: &str, close: f64) -> TimeSeriesEntryDTO {
+        TimeSeriesEntryDTO {
+            timestamp: timestamp.to_string(),
+            open: close,
+            high: close,
+            low: close,
+            close,
+            volume: 1.0,
+        }
+    }
+
+    #[test]
+    fn entries_to_candles_sorts_newest_first_entries_ascending() {
+        // parse_time_series sorts descending; BacktestEngine::run rejects that order.
+        let candles = entries_to_candles(vec![
+            entry("2024-01-04", 3.0),
+            entry("2024-01-03", 2.0),
+            entry("2024-01-02", 1.0),
+        ]);
+        assert!(
+            candles.windows(2).all(|w| w[0].timestamp <= w[1].timestamp),
+            "candles must be ascending"
+        );
+        assert_eq!(candles[0].close, 1.0);
+        assert_eq!(candles[2].close, 3.0);
+    }
+
+    #[test]
+    fn entries_to_candles_keeps_intraday_time_of_day() {
+        // Intraday keys carry a time component; collapsing them to midnight
+        // would flatten every bar of a session onto one timestamp.
+        let candles = entries_to_candles(vec![
+            entry("2024-01-02 09:35:00", 2.0),
+            entry("2024-01-02 09:30:00", 1.0),
+        ]);
+        assert_eq!(candles[0].timestamp, 1_704_187_800);
+        assert_eq!(candles[1].timestamp, 1_704_188_100);
+        assert_ne!(
+            candles[0].timestamp, candles[1].timestamp,
+            "intraday bars must keep distinct timestamps"
+        );
+    }
+
+    #[test]
+    fn parse_entry_timestamp_falls_back_to_zero_on_garbage() {
+        assert_eq!(parse_entry_timestamp("not-a-date"), 0);
+        assert_eq!(parse_entry_timestamp("2024-01-02"), 1_704_153_600);
+    }
 
     #[test]
     fn test_parse_time_series_daily() {

--- a/src/adapters/edgar/mod.rs
+++ b/src/adapters/edgar/mod.rs
@@ -332,6 +332,27 @@ pub async fn search(
 }
 
 // ============================================================================
+// Compound operations
+// ============================================================================
+
+/// Resolve `symbol` to a CIK and fetch its submissions using a single client.
+///
+/// Collapses the two HTTP connection pools (and TLS handshakes) that calling
+/// [`resolve_cik`] then [`submissions`] would otherwise pay for into one.
+pub(crate) async fn submissions_for_symbol(symbol: &str) -> Result<EdgarSubmissions> {
+    let client = build_client()?;
+    let cik = client.resolve_cik(symbol).await?;
+    client.submissions(cik).await
+}
+
+/// Resolve `symbol` to a CIK and fetch its XBRL company facts using a single client.
+pub(crate) async fn company_facts_for_symbol(symbol: &str) -> Result<CompanyFacts> {
+    let client = build_client()?;
+    let cik = client.resolve_cik(symbol).await?;
+    client.company_facts(cik).await
+}
+
+// ============================================================================
 // Canonical model conversion functions
 // ============================================================================
 
@@ -341,8 +362,7 @@ pub async fn fetch_filings_response(
 ) -> Result<crate::models::filings::ProviderFilings> {
     use crate::models::filings::{ProviderFiling, ProviderFilings};
 
-    let cik_num = resolve_cik(symbol).await?;
-    let subs = submissions(cik_num).await?;
+    let subs = submissions_for_symbol(symbol).await?;
 
     let cik = subs.cik.clone().unwrap_or_default();
     let company_name = subs.name.clone();

--- a/src/adapters/fmp/client.rs
+++ b/src/adapters/fmp/client.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use reqwest::{Client, StatusCode};
+use serde::Deserialize;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 use tracing::debug;
@@ -94,19 +95,18 @@ impl FmpClient {
         }
     }
 
-    fn check_body_error(json: &Value) -> Result<()> {
-        // FMP returns errors as {"Error Message": "..."} with 200 status
-        if let Some(msg) = json.get("Error Message").and_then(|v| v.as_str()) {
+    fn check_error_envelope(env: &ErrorEnvelope) -> Result<()> {
+        if let Some(msg) = &env.error_message {
             return Err(FinanceError::InvalidParameter {
                 param: "request".to_string(),
-                reason: msg.to_string(),
+                reason: msg.clone(),
             });
         }
         Ok(())
     }
 
-    /// Execute a GET request to an FMP REST path and return raw JSON.
-    pub async fn get_raw(&self, path: &str, params: &[(&str, &str)]) -> Result<Value> {
+    /// Execute a GET request to an FMP REST path and return the raw response bytes.
+    async fn get_bytes(&self, path: &str, params: &[(&str, &str)]) -> Result<impl AsRef<[u8]>> {
         self.limiter.acquire().await;
 
         let url = format!("{}{}", self.base_url, path);
@@ -118,18 +118,74 @@ impl FmpClient {
 
         Self::check_status(resp.status())?;
 
-        let json: Value = resp.json().await?;
-        Self::check_body_error(&json)?;
-
-        Ok(json)
+        Ok(resp.bytes().await?)
     }
 
-    /// GET and deserialize into `T` directly.
+    /// Execute a GET request to an FMP REST path and return raw JSON.
+    pub async fn get_raw(&self, path: &str, params: &[(&str, &str)]) -> Result<Value> {
+        let bytes = self.get_bytes(path, params).await?;
+        if let Ok(env) = serde_json::from_slice::<ErrorEnvelope>(bytes.as_ref()) {
+            Self::check_error_envelope(&env)?;
+        }
+
+        Ok(serde_json::from_slice(bytes.as_ref())?)
+    }
+
+    /// GET and deserialize into `T` directly, parsing the response bytes once.
     pub async fn get<T: DeserializeOwned>(&self, path: &str, params: &[(&str, &str)]) -> Result<T> {
-        let json = self.get_raw(path, params).await?;
-        serde_json::from_value(json).map_err(|e| FinanceError::ResponseStructureError {
+        let bytes = self.get_bytes(path, params).await?;
+        let bytes = bytes.as_ref();
+
+        if let Ok(env) = serde_json::from_slice::<ErrorEnvelope>(bytes) {
+            Self::check_error_envelope(&env)?;
+        }
+
+        serde_json::from_slice::<T>(bytes).map_err(|e| FinanceError::ResponseStructureError {
             field: "response".to_string(),
             context: format!("Failed to deserialize FMP response: {e}"),
         })
+    }
+}
+
+/// Cheap-to-parse subset of an FMP response used to detect the
+/// `{"Error Message": "..."}` envelope without touching the full body.
+#[derive(Deserialize)]
+struct ErrorEnvelope {
+    #[serde(rename = "Error Message")]
+    error_message: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_envelope_maps_bodies_to_errors() {
+        // `{"Error Message": <str>}` at HTTP 200 is FMP's error shape; anything
+        // else — including a top-level array — must pass through untouched.
+        let cases: [(&str, Option<&str>); 5] = [
+            (
+                r#"{"Error Message":"Invalid API KEY"}"#,
+                Some("Invalid API KEY"),
+            ),
+            (r#"{"Error Message":""}"#, Some("")),
+            (r#"[{"symbol":"AAPL"}]"#, None),
+            (r#"{}"#, None),
+            (r#"{"Error Message":null}"#, None),
+        ];
+        for (body, expected) in cases {
+            let checked = match serde_json::from_slice::<ErrorEnvelope>(body.as_bytes()) {
+                Ok(env) => FmpClient::check_error_envelope(&env),
+                Err(_) => Ok(()),
+            };
+            match (expected, checked) {
+                (None, Ok(())) => {}
+                (Some(msg), Err(FinanceError::InvalidParameter { param, reason })) => {
+                    assert_eq!(param, "request", "body {body}");
+                    assert_eq!(reason, msg, "body {body}");
+                }
+                (e, got) => panic!("body {body}: expected {e:?}, got {got:?}"),
+            }
+        }
     }
 }

--- a/src/adapters/fmp/quote/prices.rs
+++ b/src/adapters/fmp/quote/prices.rs
@@ -129,8 +129,11 @@ pub async fn fetch_canonical_quote(
 }
 
 /// Convert historical daily price DTOs into canonical Chart candles.
+///
+/// FMP serves newest-first; candles are returned ascending by timestamp, which
+/// is what the backtesting engine and every consumer of `Chart` expect.
 fn historical_to_candles(historical: Vec<HistoricalPriceDTO>) -> Vec<crate::models::chart::Candle> {
-    historical
+    let mut candles: Vec<crate::models::chart::Candle> = historical
         .into_iter()
         .filter_map(|r| {
             let ts = chrono::NaiveDate::parse_from_str(r.date.as_deref()?, "%Y-%m-%d")
@@ -149,12 +152,16 @@ fn historical_to_candles(historical: Vec<HistoricalPriceDTO>) -> Vec<crate::mode
                 provider_id: Some(crate::providers::Provider::Fmp),
             })
         })
-        .collect()
+        .collect();
+    candles.sort_unstable_by_key(|c| c.timestamp);
+    candles
 }
 
 /// Convert intraday price DTOs into canonical Chart candles.
+///
+/// As with the daily series, FMP serves newest-first and callers expect ascending.
 fn intraday_to_candles(intraday: Vec<IntradayPriceDTO>) -> Vec<crate::models::chart::Candle> {
-    intraday
+    let mut candles: Vec<crate::models::chart::Candle> = intraday
         .into_iter()
         .filter_map(|r| {
             let ts = chrono::NaiveDateTime::parse_from_str(r.date.as_deref()?, "%Y-%m-%d %H:%M:%S")
@@ -172,7 +179,9 @@ fn intraday_to_candles(intraday: Vec<IntradayPriceDTO>) -> Vec<crate::models::ch
                 provider_id: Some(crate::providers::Provider::Fmp),
             })
         })
-        .collect()
+        .collect();
+    candles.sort_unstable_by_key(|c| c.timestamp);
+    candles
 }
 
 /// Fetch canonical daily chart data with date range.
@@ -532,6 +541,41 @@ mod tests {
             candles[0].provider_id,
             Some(crate::providers::Provider::Fmp)
         );
+    }
+
+    #[test]
+    fn candle_conversion_sorts_fmp_newest_first_payloads_ascending() {
+        // FMP serves newest-first. BacktestEngine::run rejects unsorted candles,
+        // so the bridge has to normalise rather than pass the payload order through.
+        let resp: HistoricalPriceResponseDTO = serde_json::from_value(serde_json::json!({
+            "symbol": "AAPL",
+            "historical": [
+                {"date": "2024-01-04", "open": 1.0, "high": 1.0, "low": 1.0, "close": 3.0, "volume": 3},
+                {"date": "2024-01-03", "open": 1.0, "high": 1.0, "low": 1.0, "close": 2.0, "volume": 2},
+                {"date": "2024-01-02", "open": 1.0, "high": 1.0, "low": 1.0, "close": 1.0, "volume": 1}
+            ]
+        }))
+        .unwrap();
+
+        let candles = historical_to_candles(resp.historical);
+        assert!(
+            candles.windows(2).all(|w| w[0].timestamp <= w[1].timestamp),
+            "daily candles must be ascending"
+        );
+        assert_eq!(candles[0].close, 1.0);
+
+        let points: Vec<IntradayPriceDTO> = serde_json::from_value(serde_json::json!([
+            {"date": "2024-01-02 09:35:00", "open": 1.0, "high": 1.0, "low": 1.0, "close": 2.0},
+            {"date": "2024-01-02 09:30:00", "open": 1.0, "high": 1.0, "low": 1.0, "close": 1.0}
+        ]))
+        .unwrap();
+
+        let candles = intraday_to_candles(points);
+        assert!(
+            candles.windows(2).all(|w| w[0].timestamp <= w[1].timestamp),
+            "intraday candles must be ascending"
+        );
+        assert_eq!(candles[0].close, 1.0);
     }
 
     #[test]

--- a/src/adapters/polygon/client.rs
+++ b/src/adapters/polygon/client.rs
@@ -4,7 +4,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use reqwest::{Client, StatusCode};
+use serde::Deserialize;
 use serde::de::DeserializeOwned;
+#[cfg(test)]
 use serde_json::Value;
 use tracing::debug;
 
@@ -96,31 +98,34 @@ impl PolygonClient {
         }
     }
 
-    fn check_body_error(json: &Value) -> Result<()> {
-        if let Some(status) = json.get("status").and_then(|v| v.as_str())
-            && (status == "ERROR" || status == "NOT_FOUND")
-        {
-            let msg = json
-                .get("error")
-                .or_else(|| json.get("message"))
-                .and_then(|v| v.as_str())
-                .unwrap_or("Unknown error");
-            if status == "NOT_FOUND" {
-                return Err(FinanceError::SymbolNotFound {
-                    symbol: None,
-                    context: msg.to_string(),
-                });
-            }
-            return Err(FinanceError::ExternalApiError {
-                api: "Polygon".to_string(),
-                status: 400,
+    /// Retained for the error-parity test; `check_error_envelope` is the live path.
+    fn check_error_envelope(env: &ErrorEnvelope) -> Result<()> {
+        let Some(status) = env.status.as_deref() else {
+            return Ok(());
+        };
+        if status != "ERROR" && status != "NOT_FOUND" {
+            return Ok(());
+        }
+        let msg = env
+            .error
+            .as_ref()
+            .and_then(|v| v.as_str())
+            .or_else(|| env.message.as_ref().and_then(|v| v.as_str()))
+            .unwrap_or("Unknown error");
+        if status == "NOT_FOUND" {
+            return Err(FinanceError::SymbolNotFound {
+                symbol: None,
+                context: msg.to_string(),
             });
         }
-        Ok(())
+        Err(FinanceError::ExternalApiError {
+            api: "Polygon".to_string(),
+            status: 400,
+        })
     }
 
-    /// Execute a GET request to a Polygon REST path and return raw JSON.
-    pub async fn get_raw(&self, path: &str, params: &[(&str, &str)]) -> Result<Value> {
+    /// Execute a GET request to a Polygon REST path and return the raw response bytes.
+    async fn get_bytes(&self, path: &str, params: &[(&str, &str)]) -> Result<impl AsRef<[u8]>> {
         self.limiter.acquire().await;
 
         let url = format!("{}{}", self.base_url, path);
@@ -132,20 +137,34 @@ impl PolygonClient {
 
         Self::check_status(resp.status())?;
 
-        let json: Value = resp.json().await?;
-        Self::check_body_error(&json)?;
-
-        Ok(json)
+        Ok(resp.bytes().await?)
     }
 
-    /// GET and deserialize into a `PaginatedResponseDTO<T>`.
+    /// Execute a GET request to a Polygon REST path and return raw JSON.
+    #[cfg(test)]
+    pub async fn get_raw(&self, path: &str, params: &[(&str, &str)]) -> Result<Value> {
+        let bytes = self.get_bytes(path, params).await?;
+        if let Ok(env) = serde_json::from_slice::<ErrorEnvelope>(bytes.as_ref()) {
+            Self::check_error_envelope(&env)?;
+        }
+
+        Ok(serde_json::from_slice(bytes.as_ref())?)
+    }
+
+    /// GET and deserialize into a `PaginatedResponseDTO<T>`, parsing the response bytes once.
     pub async fn get<T: DeserializeOwned>(
         &self,
         path: &str,
         params: &[(&str, &str)],
     ) -> Result<PaginatedResponseDTO<T>> {
-        let json = self.get_raw(path, params).await?;
-        serde_json::from_value(json).map_err(|e| FinanceError::ResponseStructureError {
+        let bytes = self.get_bytes(path, params).await?;
+        let bytes = bytes.as_ref();
+
+        if let Ok(env) = serde_json::from_slice::<ErrorEnvelope>(bytes) {
+            Self::check_error_envelope(&env)?;
+        }
+
+        serde_json::from_slice(bytes).map_err(|e| FinanceError::ResponseStructureError {
             field: "response".to_string(),
             context: format!("Failed to deserialize Polygon response: {e}"),
         })
@@ -160,10 +179,87 @@ impl PolygonClient {
         field: &str,
         desc: &str,
     ) -> Result<T> {
-        let json = self.get_raw(path, params).await?;
-        serde_json::from_value(json).map_err(|e| FinanceError::ResponseStructureError {
+        let bytes = self.get_bytes(path, params).await?;
+        let bytes = bytes.as_ref();
+
+        if let Ok(env) = serde_json::from_slice::<ErrorEnvelope>(bytes) {
+            Self::check_error_envelope(&env)?;
+        }
+
+        serde_json::from_slice(bytes).map_err(|e| FinanceError::ResponseStructureError {
             field: field.to_string(),
             context: format!("Failed to parse {desc}: {e}"),
         })
+    }
+}
+
+/// Cheap-to-parse subset of a Polygon response used to detect the
+/// `status: "ERROR" | "NOT_FOUND"` envelope without touching the full body.
+#[derive(Deserialize)]
+struct ErrorEnvelope {
+    status: Option<String>,
+    /// Typed as `Value`, not `String`: Polygon has been seen returning a
+    /// structured `error`, and a strict type would fail the envelope parse and
+    /// skip the status check entirely, turning an error body into a success.
+    error: Option<serde_json::Value>,
+    message: Option<serde_json::Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_envelope_maps_bodies_to_errors() {
+        /// What `check_error_envelope` is expected to produce for a body.
+        enum Want {
+            Ok,
+            NotFound(&'static str),
+            External,
+        }
+
+        let cases = [
+            (
+                r#"{"status":"ERROR","error":"bad request"}"#,
+                Want::External,
+            ),
+            (
+                r#"{"status":"ERROR","message":"bad request msg"}"#,
+                Want::External,
+            ),
+            (r#"{"status":"ERROR"}"#, Want::External),
+            (
+                r#"{"status":"NOT_FOUND","error":"no ticker found"}"#,
+                Want::NotFound("no ticker found"),
+            ),
+            (r#"{"status":"NOT_FOUND"}"#, Want::NotFound("Unknown error")),
+            (r#"{"status":"ERROR","error":{"code":1}}"#, Want::External),
+            (
+                r#"{"status":"NOT_FOUND","error":{"code":2}}"#,
+                Want::NotFound("Unknown error"),
+            ),
+            (r#"{"status":"OK"}"#, Want::Ok),
+            (r#"[{"ticker":"AAPL"}]"#, Want::Ok),
+            (r#"{}"#, Want::Ok),
+        ];
+
+        for (body, want) in cases {
+            let checked = match serde_json::from_slice::<ErrorEnvelope>(body.as_bytes()) {
+                Ok(env) => PolygonClient::check_error_envelope(&env),
+                Err(_) => Ok(()),
+            };
+            match (want, checked) {
+                (Want::Ok, Ok(())) => {}
+                (Want::NotFound(ctx), Err(FinanceError::SymbolNotFound { symbol, context })) => {
+                    assert_eq!(symbol, None, "body {body}");
+                    assert_eq!(context, ctx, "body {body}");
+                }
+                (Want::External, Err(FinanceError::ExternalApiError { api, status })) => {
+                    assert_eq!(api, "Polygon", "body {body}");
+                    assert_eq!(status, 400, "body {body}");
+                }
+                (_, got) => panic!("body {body}: unexpected {got:?}"),
+            }
+        }
     }
 }

--- a/src/adapters/polygon/options/snapshots.rs
+++ b/src/adapters/polygon/options/snapshots.rs
@@ -154,9 +154,8 @@ pub async fn options_chain_snapshot(
 }
 
 /// Helper: parse a "YYYY-MM-DD" date string into a Unix timestamp.
-fn parse_date(d: &Option<String>) -> i64 {
-    d.as_ref()
-        .and_then(|s| chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d").ok())
+fn parse_date(d: Option<&str>) -> i64 {
+    d.and_then(|s| chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d").ok())
         .and_then(|dt| dt.and_hms_opt(0, 0, 0))
         .map(|dt| dt.and_utc().timestamp())
         .unwrap_or(0)
@@ -194,9 +193,8 @@ fn map_snapshot_to_contract(s: &OptionsSnapshotDTO) -> OptionContract {
         contract_size: None,
         expiration: details
             .as_ref()
-            .and_then(|d| d.expiration_date.as_ref())
-            .map(|s| Some(parse_date(&Some(s.clone()))))
-            .unwrap_or(None),
+            .and_then(|d| d.expiration_date.as_deref())
+            .map(|s| parse_date(Some(s))),
         last_trade_date: None,
         implied_volatility: s.implied_volatility,
         in_the_money: None,
@@ -218,12 +216,11 @@ pub async fn fetch_options_response(symbol: &str, date: Option<i64>) -> Result<O
     let expiration_dates: Vec<i64> = snapshots
         .iter()
         .filter_map(|s| {
-            let ts = s
-                .details
-                .as_ref()
-                .and_then(|d| d.expiration_date.as_ref())
-                .map(|s| parse_date(&Some(s.clone())))
-                .unwrap_or(0);
+            let ts = parse_date(
+                s.details
+                    .as_ref()
+                    .and_then(|d| d.expiration_date.as_deref()),
+            );
             if ts > 0 { Some(ts) } else { None }
         })
         .collect::<std::collections::BTreeSet<_>>()
@@ -278,6 +275,20 @@ pub async fn options_contract_snapshot(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_date_handles_none_and_garbage() {
+        assert_eq!(parse_date(None), 0);
+        assert_eq!(parse_date(Some("not-a-date")), 0);
+
+        let expected = chrono::NaiveDate::from_ymd_opt(2026, 1, 15)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap()
+            .and_utc()
+            .timestamp();
+        assert_eq!(parse_date(Some("2026-01-15")), expected);
+    }
 
     #[tokio::test]
     async fn test_options_chain_snapshot_mock() {

--- a/src/adapters/yahoo/auth.rs
+++ b/src/adapters/yahoo/auth.rs
@@ -37,7 +37,7 @@ impl std::fmt::Debug for YahooAuth {
 impl YahooAuth {
     /// The current CSRF crumb token.
     pub(crate) fn crumb(&self) -> Arc<str> {
-        Arc::clone(&self.crumb.read().unwrap())
+        Arc::clone(&self.crumb.read().unwrap_or_else(|e| e.into_inner()))
     }
 
     /// Re-run the handshake on the existing HTTP client, swapping in a new
@@ -62,7 +62,7 @@ impl YahooAuth {
                 context: format!("Failed to refresh crumb: {}", e),
             })?;
 
-        *self.crumb.write().unwrap() = crumb.into();
+        *self.crumb.write().unwrap_or_else(|e| e.into_inner()) = crumb.into();
         Ok(())
     }
 }

--- a/src/adapters/yahoo/auth.rs
+++ b/src/adapters/yahoo/auth.rs
@@ -2,7 +2,8 @@ use super::client::ClientConfig;
 use crate::adapters::yahoo::endpoints::{api, base};
 use crate::error::{FinanceError, Result};
 use reqwest::Proxy;
-use std::time::{Duration, Instant};
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
 use tracing::{debug, info, warn};
 
 // ============================================================================
@@ -15,21 +16,12 @@ const USER_AGENT: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/
 /// Timeout for authentication requests
 const AUTH_TIMEOUT: Duration = Duration::from_secs(15);
 
-/// Minimum interval between auth refreshes (prevent excessive refreshing)
-#[cfg(test)]
-const MIN_REFRESH_INTERVAL: Duration = Duration::from_secs(30);
-
-/// Maximum age of auth before considering it stale
-#[cfg(test)]
-const AUTH_MAX_AGE: Duration = Duration::from_secs(3600); // 1 hour
-
 /// Yahoo Finance authentication data
-#[derive(Clone)]
 pub struct YahooAuth {
-    /// CSRF crumb token
-    pub crumb: String,
-    /// Last time auth was refreshed
-    pub last_refresh: Instant,
+    /// CSRF crumb token. Swappable so a long-lived session can re-auth in
+    /// place when Yahoo expires the crumb.
+    crumb: RwLock<Arc<str>>,
+    refresh_guard: tokio::sync::Mutex<()>,
     /// HTTP client with cookies
     pub(crate) http_client: reqwest::Client,
 }
@@ -37,9 +29,41 @@ pub struct YahooAuth {
 impl std::fmt::Debug for YahooAuth {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("YahooAuth")
-            .field("crumb", &self.crumb)
-            .field("last_refresh", &self.last_refresh)
+            .field("crumb", &&*self.crumb())
             .finish()
+    }
+}
+
+impl YahooAuth {
+    /// The current CSRF crumb token.
+    pub(crate) fn crumb(&self) -> Arc<str> {
+        Arc::clone(&self.crumb.read().unwrap())
+    }
+
+    /// Re-run the handshake on the existing HTTP client, swapping in a new
+    /// crumb. Concurrent callers collapse to one refresh.
+    pub(crate) async fn refresh(&self) -> Result<()> {
+        let before = self.crumb();
+        let _g = self.refresh_guard.lock().await;
+        if !Arc::ptr_eq(&before, &self.crumb()) {
+            return Ok(());
+        }
+
+        self.http_client
+            .get(base::YAHOO_FC)
+            .send()
+            .await
+            .map_err(|e| {
+                FinanceError::InternalError(format!("Failed to establish session: {}", e))
+            })?;
+        let crumb = get_crumb(&self.http_client, api::CRUMB_QUERY1)
+            .await
+            .map_err(|e| FinanceError::AuthenticationFailed {
+                context: format!("Failed to refresh crumb: {}", e),
+            })?;
+
+        *self.crumb.write().unwrap() = crumb.into();
+        Ok(())
     }
 }
 
@@ -86,22 +110,10 @@ impl YahooAuth {
 
         info!("Successfully authenticated with Yahoo Finance");
         Ok(Self {
-            crumb,
-            last_refresh: Instant::now(),
+            crumb: RwLock::new(crumb.into()),
+            refresh_guard: tokio::sync::Mutex::new(()),
             http_client: client,
         })
-    }
-
-    /// Check if authentication is still valid
-    #[cfg(test)]
-    pub fn is_expired(&self) -> bool {
-        self.last_refresh.elapsed() > AUTH_MAX_AGE
-    }
-
-    /// Check if enough time has passed to allow refresh
-    #[cfg(test)]
-    pub fn can_refresh(&self) -> bool {
-        self.last_refresh.elapsed() >= MIN_REFRESH_INTERVAL
     }
 }
 
@@ -149,31 +161,21 @@ mod tests {
         assert!(auth.is_ok());
 
         let auth = auth.unwrap();
-        assert!(!auth.crumb.is_empty());
-        assert!(!auth.crumb.contains("<html"));
+        let crumb = auth.crumb();
+        assert!(!crumb.is_empty());
+        assert!(!crumb.contains("<html"));
     }
 
-    #[test]
-    fn test_is_expired() {
-        let client = reqwest::Client::new();
-        let auth = YahooAuth {
-            crumb: "test".to_string(),
-            last_refresh: Instant::now() - std::time::Duration::from_secs(7200),
-            http_client: client,
-        };
-
-        assert!(auth.is_expired());
-    }
-
-    #[test]
-    fn test_can_refresh() {
-        let client = reqwest::Client::new();
-        let auth = YahooAuth {
-            crumb: "test".to_string(),
-            last_refresh: Instant::now() - std::time::Duration::from_secs(60),
-            http_client: client,
-        };
-
-        assert!(auth.can_refresh());
+    #[tokio::test]
+    #[ignore = "requires network access"]
+    async fn refresh_replaces_the_crumb() {
+        let auth = YahooAuth::authenticate_with_config(&ClientConfig::default())
+            .await
+            .unwrap();
+        let before = auth.crumb();
+        auth.refresh().await.unwrap();
+        let after = auth.crumb();
+        assert!(!after.is_empty());
+        assert!(!Arc::ptr_eq(&before, &after));
     }
 }

--- a/src/adapters/yahoo/chart/mod.rs
+++ b/src/adapters/yahoo/chart/mod.rs
@@ -5,9 +5,31 @@ use super::endpoints::api;
 use crate::adapters::yahoo::client::YahooClient;
 use crate::constants::{Interval, TimeRange};
 use crate::error::{FinanceError, Result};
+use futures::stream::StreamExt;
 use tracing::{debug, info};
 
 const CHART_EVENTS: &str = "div|split|capitalGain";
+
+/// 3650 days (~10 years; ignores leap years for simplicity).
+/// Yahoo Finance truncates max-range daily/weekly responses, so we walk
+/// the full history in chunks of this size. Drift across multi-decade
+/// histories may add 1 extra request; correctness is preserved by the
+/// dedup pass at the end of `fetch_max_chunked`.
+const CHUNK_SIZE_SECONDS: i64 = 3650 * 24 * 60 * 60;
+
+/// Yahoo rate-limits aggressively and chunk counts are typically 2-5, so a
+/// higher cap buys nothing and risks 429s.
+const MAX_CHUNK_CONCURRENCY: usize = 4;
+
+/// Ceiling on Max-range chunk requests in flight across the whole process.
+///
+/// `buffer_unordered(MAX_CHUNK_CONCURRENCY)` bounds one chart's fan-out, but a
+/// batch call already runs up to `Tickers::max_concurrency` charts at once, and
+/// the two would multiply. This keeps the product bounded.
+fn chunk_permits() -> &'static tokio::sync::Semaphore {
+    static PERMITS: std::sync::OnceLock<tokio::sync::Semaphore> = std::sync::OnceLock::new();
+    PERMITS.get_or_init(|| tokio::sync::Semaphore::new(MAX_CHUNK_CONCURRENCY * 2))
+}
 
 /// Yahoo Finance intraday limits (empirically verified).
 ///
@@ -140,21 +162,38 @@ async fn fetch_max_chunked(
 
     // Step 2: Chunk into ~10-year periods
     let now = chrono::Utc::now().timestamp();
-    // 3650 days (~10 years; ignores leap years for simplicity).
-    // Yahoo Finance truncates max-range daily/weekly responses, so we walk
-    // the full history in chunks of this size. Drift across multi-decade
-    // histories may add 1 extra request; correctness is preserved by the
-    // dedup pass at the end of fetch_max_chunked.
-    const CHUNK_SIZE_SECONDS: i64 = 3650 * 24 * 60 * 60;
+    let bounds = max_chunk_bounds(earliest_timestamp, now);
 
-    let mut period1 = earliest_timestamp;
+    let mut chunks: Vec<(i64, Result<serde_json::Value>)> =
+        futures::stream::iter(bounds.into_iter().map(|(p1, p2)| async move {
+            let _permit = chunk_permits().acquire().await;
+            (p1, fetch_with_dates(client, symbol, interval, p1, p2).await)
+        }))
+        .buffer_unordered(MAX_CHUNK_CONCURRENCY)
+        .collect()
+        .await;
+
+    // `buffer_unordered` completes out of order; the merge appends blindly and
+    // the dedup only collapses *consecutive* duplicates, so restore chronology.
+    chunks.sort_by_key(|(p1, _)| *p1);
+
     let mut merged_result = init_chart_response();
+    for (_, chunk_data) in chunks {
+        merge_chart_data(&mut merged_result, chunk_data?)?;
+    }
+
+    dedup_timestamps_in_place(&mut merged_result)?;
+    Ok(merged_result)
+}
+
+/// Materialize the `(period1, period2)` boundaries for a Max-range chunked fetch.
+fn max_chunk_bounds(earliest: i64, now: i64) -> Vec<(i64, i64)> {
+    let mut bounds = Vec::new();
+    let mut period1 = earliest;
 
     loop {
         let period2 = (period1 + CHUNK_SIZE_SECONDS).min(now);
-
-        let chunk_data = fetch_with_dates(client, symbol, interval, period1, period2).await?;
-        merge_chart_data(&mut merged_result, chunk_data)?;
+        bounds.push((period1, period2));
 
         if period2 >= now {
             break;
@@ -163,8 +202,7 @@ async fn fetch_max_chunked(
         period1 = period2 + 1;
     }
 
-    dedup_timestamps_in_place(&mut merged_result)?;
-    Ok(merged_result)
+    bounds
 }
 
 /// Extract the earliest timestamp from a chart response.
@@ -809,6 +847,89 @@ mod tests {
                 .len(),
             3
         );
+    }
+
+    #[test]
+    fn chunk_bounds_cover_the_range_without_gaps() {
+        // Reference implementation: the original sequential `loop` in
+        // `fetch_max_chunked`, reproduced to pin the iteration count.
+        fn reference_iteration_count(earliest: i64, now: i64) -> usize {
+            let mut period1 = earliest;
+            let mut count = 0usize;
+            loop {
+                let period2 = (period1 + CHUNK_SIZE_SECONDS).min(now);
+                count += 1;
+                if period2 >= now {
+                    break;
+                }
+                period1 = period2 + 1;
+            }
+            count
+        }
+
+        let day = 24 * 60 * 60i64;
+        let cases: [(i64, i64); 6] = [
+            // Shorter than one chunk (~1 year).
+            (1_000_000_000, 1_000_000_000 + 365 * day),
+            // Exactly one chunk.
+            (1_000_000_000, 1_000_000_000 + CHUNK_SIZE_SECONDS),
+            // One chunk plus a one-second remainder.
+            (1_000_000_000, 1_000_000_000 + CHUNK_SIZE_SECONDS + 1),
+            // Several chunks plus a remainder (~34 years, AAPL-like history).
+            (
+                345_479_400,
+                345_479_400 + 3 * CHUNK_SIZE_SECONDS + 500 * day,
+            ),
+            // Exactly several chunks (boundary arithmetic includes the +1 gaps).
+            (0, 4 * CHUNK_SIZE_SECONDS),
+            // Degenerate: earliest == now.
+            (1_700_000_000, 1_700_000_000),
+        ];
+
+        for (earliest, now) in cases {
+            let bounds = max_chunk_bounds(earliest, now);
+
+            assert!(!bounds.is_empty(), "no bounds for ({earliest}, {now})");
+            assert_eq!(
+                bounds.len(),
+                reference_iteration_count(earliest, now),
+                "chunk count drifted for ({earliest}, {now})"
+            );
+            assert_eq!(
+                bounds[0].0, earliest,
+                "first bound must start at earliest for ({earliest}, {now})"
+            );
+            assert_eq!(
+                bounds[bounds.len() - 1].1,
+                now,
+                "last bound must end at now for ({earliest}, {now})"
+            );
+
+            for w in bounds.windows(2) {
+                let (prev_start, prev_end) = w[0];
+                let (start, end) = w[1];
+                assert!(prev_end > prev_start, "empty chunk in ({earliest}, {now})");
+                assert!(end >= start, "inverted chunk in ({earliest}, {now})");
+                // Successive chunks abut exactly: no gap in coverage (period2 is
+                // inclusive, so the next chunk starts one second later) and no overlap.
+                assert_eq!(
+                    start,
+                    prev_end + 1,
+                    "gap or overlap between chunks for ({earliest}, {now})"
+                );
+                assert_eq!(
+                    prev_end - prev_start,
+                    CHUNK_SIZE_SECONDS,
+                    "non-final chunk must be a full chunk for ({earliest}, {now})"
+                );
+            }
+
+            let last = bounds[bounds.len() - 1];
+            assert!(
+                last.1 - last.0 <= CHUNK_SIZE_SECONDS,
+                "final chunk exceeds chunk size for ({earliest}, {now})"
+            );
+        }
     }
 
     #[test]

--- a/src/adapters/yahoo/client.rs
+++ b/src/adapters/yahoo/client.rs
@@ -51,14 +51,30 @@ impl Default for ClientConfig {
 ///
 /// This client handles authentication and provides methods to fetch data from Yahoo Finance.
 pub struct YahooClient {
-    /// Authentication data (crumb + HTTP client with cookies).
-    /// Immutable after construction — no lock needed.
+    /// Authentication data (crumb + HTTP client with cookies). The crumb is
+    /// swappable so an expired one can be refreshed without a new client.
     auth: YahooAuth,
     /// Client configuration
     config: ClientConfig,
 }
 
+/// A shared session outlives a single call, so an expired crumb would poison
+/// every later request — these are retried once after a refresh.
+fn is_auth_error(e: &FinanceError) -> bool {
+    matches!(e, FinanceError::AuthenticationFailed { .. })
+}
+
 impl YahooClient {
+    /// Refresh the crumb for a retry. If the refresh itself fails the session
+    /// is unrecoverable, so drop it and let the next caller build a fresh one.
+    async fn refresh_for_retry(&self) -> Result<()> {
+        if let Err(e) = self.auth.refresh().await {
+            super::session::invalidate(&self.config);
+            return Err(e);
+        }
+        Ok(())
+    }
+
     /// Check response status and return it if successful, or map the error code
     fn check_response(response: reqwest::Response) -> Result<reqwest::Response> {
         let status = response.status();
@@ -128,21 +144,27 @@ impl YahooClient {
     /// - Includes cookies via reqwest's cookie store
     /// - Sets proper headers
     pub async fn request_with_crumb(&self, url: &str) -> Result<reqwest::Response> {
-        let request = self
-            .auth
-            .http_client
-            .get(url)
-            .query(&[("crumb", &self.auth.crumb)]);
-
         debug!("Making request to {}", url);
 
-        // Send request
-        let response = request
-            .send()
-            .await
-            .map_err(|e| self.map_request_error(e))?;
+        let send = || async {
+            let response = self
+                .auth
+                .http_client
+                .get(url)
+                .query(&[("crumb", &*self.auth.crumb())])
+                .send()
+                .await
+                .map_err(|e| self.map_request_error(e))?;
+            Self::check_response(response)
+        };
 
-        Self::check_response(response)
+        match send().await {
+            Err(e) if is_auth_error(&e) => {
+                self.refresh_for_retry().await?;
+                send().await
+            }
+            other => other,
+        }
     }
 
     /// Get the client configuration
@@ -223,30 +245,38 @@ impl YahooClient {
         url: &str,
         body: &T,
     ) -> Result<reqwest::Response> {
-        // Build URL with crumb
-        let url_with_crumb = format!(
-            "{}{}crumb={}",
-            url,
-            if url.contains('?') { "&" } else { "?" },
-            self.auth.crumb
-        );
+        let send = || async {
+            let crumb = self.auth.crumb();
+            let url_with_crumb = format!(
+                "{}{}crumb={}",
+                url,
+                if url.contains('?') { "&" } else { "?" },
+                crumb
+            );
 
-        let request = self
-            .auth
-            .http_client
-            .post(&url_with_crumb)
-            .header("Content-Type", "application/json")
-            .header("x-crumb", &self.auth.crumb)
-            .json(body);
+            debug!("Making POST request to {}", url_with_crumb);
 
-        debug!("Making POST request to {}", url_with_crumb);
+            let response = self
+                .auth
+                .http_client
+                .post(&url_with_crumb)
+                .header("Content-Type", "application/json")
+                .header("x-crumb", &*crumb)
+                .json(body)
+                .send()
+                .await
+                .map_err(|e| self.map_request_error(e))?;
 
-        let response = request
-            .send()
-            .await
-            .map_err(|e| self.map_request_error(e))?;
+            Self::check_response(response)
+        };
 
-        Self::check_response(response)
+        match send().await {
+            Err(e) if is_auth_error(&e) => {
+                self.refresh_for_retry().await?;
+                send().await
+            }
+            other => other,
+        }
     }
 
     /// Make a GET request with query parameters and crumb authentication
@@ -255,24 +285,31 @@ impl YahooClient {
         url: &str,
         params: &T,
     ) -> Result<reqwest::Response> {
-        let request = self
-            .auth
-            .http_client
-            .get(url)
-            .query(&[("crumb", &self.auth.crumb)])
-            .query(params);
-
         debug!(
             "Making request to {} (lang={}, region={})",
             url, self.config.lang, self.config.region
         );
 
-        let response = request
-            .send()
-            .await
-            .map_err(|e| self.map_request_error(e))?;
+        let send = || async {
+            let response = self
+                .auth
+                .http_client
+                .get(url)
+                .query(&[("crumb", &*self.auth.crumb())])
+                .query(params)
+                .send()
+                .await
+                .map_err(|e| self.map_request_error(e))?;
+            Self::check_response(response)
+        };
 
-        Self::check_response(response)
+        match send().await {
+            Err(e) if is_auth_error(&e) => {
+                self.refresh_for_retry().await?;
+                send().await
+            }
+            other => other,
+        }
     }
 
     /// Fetch batch quotes for multiple symbols

--- a/src/adapters/yahoo/client.rs
+++ b/src/adapters/yahoo/client.rs
@@ -87,8 +87,11 @@ impl YahooClient {
     /// HTTP error mapping
     fn map_http_status(status: u16) -> FinanceError {
         match status {
-            401 => FinanceError::AuthenticationFailed {
-                context: "HTTP 401 Unauthorized".to_string(),
+            // Yahoo rejects a stale crumb with either status. Both must map to
+            // `AuthenticationFailed` so the shared session refreshes instead of
+            // failing every later caller on it.
+            401 | 403 => FinanceError::AuthenticationFailed {
+                context: format!("HTTP {status}"),
             },
             404 => FinanceError::SymbolNotFound {
                 symbol: None,
@@ -559,10 +562,9 @@ impl YahooClient {
         query: &str,
         options: &crate::adapters::yahoo::discovery::search::SearchOptions,
     ) -> Result<crate::models::discovery::search::SearchResults> {
-        let json = crate::adapters::yahoo::discovery::search::fetch(self, query, options).await?;
-        Ok(crate::models::discovery::search::SearchResults::from_json(
-            json,
-        )?)
+        let bytes =
+            crate::adapters::yahoo::discovery::search::fetch_bytes(self, query, options).await?;
+        Ok(serde_json::from_slice(&bytes)?)
     }
 
     /// Look up symbols by type (equity, ETF, index, etc.)
@@ -593,10 +595,7 @@ impl YahooClient {
         query: &str,
         options: &crate::adapters::yahoo::discovery::lookup::LookupOptions,
     ) -> Result<crate::models::discovery::lookup::LookupResults> {
-        let json = crate::adapters::yahoo::discovery::lookup::fetch(self, query, options).await?;
-        Ok(crate::models::discovery::lookup::LookupResults::from_json(
-            json,
-        )?)
+        crate::adapters::yahoo::discovery::lookup::fetch_results(self, query, options).await
     }
 
     /// Get recommended/similar quotes for a symbol
@@ -702,7 +701,7 @@ impl YahooClient {
         let json: serde_json::Value = response.json().await?;
 
         crate::models::fundamentals::FinancialStatement::from_response(
-            &json,
+            json,
             symbol,
             statement_type,
             frequency,
@@ -864,7 +863,7 @@ impl YahooClient {
         let url = crate::adapters::yahoo::endpoints::builders::screener(screener_type, count);
         let response = self.request_with_crumb(&url).await?;
         let json: serde_json::Value = response.json().await?;
-        crate::models::discovery::screeners::ScreenerResults::from_response(&json).map_err(|e| {
+        crate::models::discovery::screeners::ScreenerResults::from_response(json).map_err(|e| {
             crate::error::FinanceError::ResponseStructureError {
                 field: "screeners".to_string(),
                 context: e,
@@ -905,7 +904,7 @@ impl YahooClient {
         let url = crate::adapters::yahoo::endpoints::builders::custom_screener();
         let response = self.request_post_with_crumb(&url, &query).await?;
         let json: serde_json::Value = response.json().await?;
-        crate::models::discovery::screeners::ScreenerResults::from_custom_response(&json).map_err(
+        crate::models::discovery::screeners::ScreenerResults::from_custom_response(json).map_err(
             |e| crate::error::FinanceError::ResponseStructureError {
                 field: "custom_screener".to_string(),
                 context: e,
@@ -944,7 +943,7 @@ impl YahooClient {
         let url = crate::adapters::yahoo::endpoints::builders::sector(sector_type.as_api_path());
         let response = self.request_with_crumb(&url).await?;
         let json: serde_json::Value = response.json().await?;
-        crate::models::market::sectors::SectorData::from_response(&json).map_err(|e| {
+        crate::models::market::sectors::SectorData::from_response(json).map_err(|e| {
             crate::error::FinanceError::ResponseStructureError {
                 field: "sector".to_string(),
                 context: e,
@@ -982,7 +981,7 @@ impl YahooClient {
         let url = crate::adapters::yahoo::endpoints::builders::industry(industry_key);
         let response = self.request_with_crumb(&url).await?;
         let json: serde_json::Value = response.json().await?;
-        crate::models::market::industries::IndustryData::from_response(&json).map_err(|e| {
+        crate::models::market::industries::IndustryData::from_response(json).map_err(|e| {
             crate::error::FinanceError::ResponseStructureError {
                 field: "industry".to_string(),
                 context: e,
@@ -1026,7 +1025,7 @@ impl YahooClient {
             .request_with_params(crate::adapters::yahoo::endpoints::api::MARKET_TIME, &params)
             .await?;
         let json: serde_json::Value = response.json().await?;
-        crate::models::market::hours::MarketHours::from_response(&json).map_err(|e| {
+        crate::models::market::hours::MarketHours::from_response(json).map_err(|e| {
             crate::error::FinanceError::ResponseStructureError {
                 field: "hours".to_string(),
                 context: e,
@@ -1154,6 +1153,25 @@ impl YahooClient {
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn stale_crumb_statuses_map_to_auth_failure() {
+        // Both must be retryable: the session is shared and long-lived, so a
+        // status that does not trigger a crumb refresh poisons every caller.
+        for status in [401u16, 403] {
+            assert!(
+                matches!(
+                    YahooClient::map_http_status(status),
+                    FinanceError::AuthenticationFailed { .. }
+                ),
+                "HTTP {status} should be an auth failure"
+            );
+        }
+        assert!(matches!(
+            YahooClient::map_http_status(404),
+            FinanceError::SymbolNotFound { .. }
+        ));
+    }
     use super::*;
 
     #[tokio::test]

--- a/src/adapters/yahoo/client.rs
+++ b/src/adapters/yahoo/client.rs
@@ -56,6 +56,12 @@ pub struct YahooClient {
     auth: YahooAuth,
     /// Client configuration
     config: ClientConfig,
+    /// The key this client is cached under, when it came from the shared session
+    /// cache. Stored rather than recomputed: `session::key_for` reads the
+    /// *current* runtime, which for a handle used from a second runtime is not
+    /// the one that cached this client — invalidating by a recomputed key would
+    /// evict the wrong entry and leave the broken session in place.
+    session_key: Option<super::session::SessionKey>,
 }
 
 /// A shared session outlives a single call, so an expired crumb would poison
@@ -64,24 +70,61 @@ fn is_auth_error(e: &FinanceError) -> bool {
     matches!(e, FinanceError::AuthenticationFailed { .. })
 }
 
+/// Yahoo describes a rejected crumb in the error body. A 403 without this is a
+/// datacenter-IP block or abuse throttle, which no amount of re-handshaking fixes.
+fn body_blames_the_crumb(body: &str) -> bool {
+    body.to_ascii_lowercase().contains("crumb")
+}
+
 impl YahooClient {
+    /// Tag this client with the session-cache key it is stored under.
+    pub(crate) fn with_session_key(mut self, key: super::session::SessionKey) -> Self {
+        self.session_key = Some(key);
+        self
+    }
+
     /// Refresh the crumb for a retry. If the refresh itself fails the session
     /// is unrecoverable, so drop it and let the next caller build a fresh one.
     async fn refresh_for_retry(&self) -> Result<()> {
         if let Err(e) = self.auth.refresh().await {
-            super::session::invalidate(&self.config);
+            if let Some(key) = &self.session_key {
+                super::session::invalidate_key(key);
+            }
             return Err(e);
         }
         Ok(())
     }
 
-    /// Check response status and return it if successful, or map the error code
-    fn check_response(response: reqwest::Response) -> Result<reqwest::Response> {
+    /// Check response status and return it if successful, or map the error code.
+    ///
+    /// A 401/403 body is read so a stale crumb can be told apart from an IP
+    /// block; every other status maps without touching the body.
+    async fn check_response(response: reqwest::Response) -> Result<reqwest::Response> {
         let status = response.status();
-        if !status.is_success() {
-            return Err(Self::map_http_status(status.as_u16()));
+        if status.is_success() {
+            return Ok(response);
         }
-        Ok(response)
+        let code = status.as_u16();
+        if matches!(code, 401 | 403) {
+            let body = response.text().await.unwrap_or_default();
+            return Err(Self::map_auth_status(code, &body));
+        }
+        Err(Self::map_http_status(code))
+    }
+
+    /// Map a 401/403 using the response body to tell a stale crumb apart from a
+    /// block. Only the crumb case is retryable.
+    fn map_auth_status(status: u16, body: &str) -> FinanceError {
+        if status == 401 || body_blames_the_crumb(body) {
+            FinanceError::AuthenticationFailed {
+                context: format!("HTTP {status}"),
+            }
+        } else {
+            // 403 with no mention of the crumb: an IP block or abuse throttle.
+            // Refreshing would cost a handshake, a retry, and an invalidated
+            // shared session per blocked request — worst exactly when throttled.
+            FinanceError::UnexpectedResponse(format!("HTTP {status}"))
+        }
     }
 
     /// HTTP error mapping
@@ -137,7 +180,11 @@ impl YahooClient {
         // Authenticate with the provided configuration (timeout, proxy)
         let auth = YahooAuth::authenticate_with_config(&config).await?;
 
-        Ok(Self { auth, config })
+        Ok(Self {
+            auth,
+            config,
+            session_key: None,
+        })
     }
 
     /// Make a GET request to Yahoo Finance with authentication
@@ -158,7 +205,7 @@ impl YahooClient {
                 .send()
                 .await
                 .map_err(|e| self.map_request_error(e))?;
-            Self::check_response(response)
+            Self::check_response(response).await
         };
 
         match send().await {
@@ -179,16 +226,20 @@ impl YahooClient {
 
     /// Fetch logo URLs for a symbol
     ///
-    /// Returns (logoUrl, companyLogoUrl) if available, None for each if not found or on error.
-    /// This uses the /v7/finance/quote endpoint with selective fields for efficiency.
+    /// Returns `(logoUrl, companyLogoUrl)`, each `None` when Yahoo has no logo
+    /// for the symbol. This uses the /v7/finance/quote endpoint with selective
+    /// fields for efficiency.
+    ///
+    /// # Errors
+    ///
+    /// Returns the transport or response error rather than folding it into
+    /// `(None, None)`. Callers cache the result, and a successful "this symbol
+    /// has no logo" is cacheable where a failed request is not — collapsing the
+    /// two made every logo-less symbol refetch on every call.
     ///
     /// # Arguments
     ///
     /// * `symbol` - Stock symbol (e.g., "AAPL", "TSLA")
-    ///
-    /// # Returns
-    ///
-    /// Tuple of (logoUrl, companyLogoUrl), each as Option<String>
     ///
     /// # Example
     ///
@@ -196,35 +247,32 @@ impl YahooClient {
     /// # use finance_query::{YahooClient, ClientConfig};
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = YahooClient::new(ClientConfig::default()).await?;
-    /// let (logo_url, company_logo_url) = client.get_logo_url("AAPL").await;
+    /// let (logo_url, company_logo_url) = client.get_logo_url("AAPL").await?;
     /// if let Some(url) = logo_url {
     ///     println!("Logo URL: {}", url);
     /// }
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn get_logo_url(&self, symbol: &str) -> (Option<String>, Option<String>) {
-        let json = match crate::adapters::yahoo::quote::quotes::fetch_with_fields(
+    pub async fn get_logo_url(&self, symbol: &str) -> Result<(Option<String>, Option<String>)> {
+        let json = crate::adapters::yahoo::quote::quotes::fetch_with_fields(
             self,
             &[symbol],
             Some(&["logoUrl", "companyLogoUrl"]),
             false,
             true,
         )
-        .await
-        {
-            Ok(j) => j,
-            Err(_) => return (None, None),
-        };
+        .await?;
 
-        let result = match json
+        // A symbol Yahoo knows nothing about is a legitimate empty answer, not
+        // a failure — it caches like any other resolved lookup.
+        let Some(result) = json
             .get("quoteResponse")
             .and_then(|qr| qr.get("result"))
             .and_then(|r| r.as_array())
             .and_then(|arr| arr.first())
-        {
-            Some(r) => r,
-            None => return (None, None),
+        else {
+            return Ok((None, None));
         };
 
         let logo_url = result
@@ -237,7 +285,7 @@ impl YahooClient {
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
 
-        (logo_url, company_logo_url)
+        Ok((logo_url, company_logo_url))
     }
 
     /// Make a POST request with JSON body and crumb authentication
@@ -270,7 +318,7 @@ impl YahooClient {
                 .await
                 .map_err(|e| self.map_request_error(e))?;
 
-            Self::check_response(response)
+            Self::check_response(response).await
         };
 
         match send().await {
@@ -303,7 +351,7 @@ impl YahooClient {
                 .send()
                 .await
                 .map_err(|e| self.map_request_error(e))?;
-            Self::check_response(response)
+            Self::check_response(response).await
         };
 
         match send().await {
@@ -1172,6 +1220,49 @@ mod tests {
             FinanceError::SymbolNotFound { .. }
         ));
     }
+
+    #[test]
+    fn a_403_is_retryable_only_when_the_body_blames_the_crumb() {
+        // Yahoo serves 403 for datacenter-IP blocks and abuse throttling too.
+        // Treating those as auth failures costs a handshake plus a retry per
+        // blocked request and invalidates the shared session on top — the exact
+        // work the session cache exists to avoid, precisely when throttled.
+        let crumb_body =
+            r#"{"finance":{"error":{"code":"Unauthorized","description":"Invalid Crumb"}}}"#;
+        assert!(matches!(
+            YahooClient::map_auth_status(403, crumb_body),
+            FinanceError::AuthenticationFailed { .. }
+        ));
+
+        let blocked_body = "Forbidden: your IP has been blocked";
+        assert!(
+            matches!(
+                YahooClient::map_auth_status(403, blocked_body),
+                FinanceError::UnexpectedResponse(_)
+            ),
+            "a non-crumb 403 must not trigger a refresh"
+        );
+
+        // 401 is unambiguous, body or not.
+        for body in [crumb_body, blocked_body, ""] {
+            assert!(matches!(
+                YahooClient::map_auth_status(401, body),
+                FinanceError::AuthenticationFailed { .. }
+            ));
+        }
+    }
+
+    #[test]
+    fn only_a_crumb_403_is_treated_as_retryable_by_the_request_path() {
+        assert!(!is_auth_error(&YahooClient::map_auth_status(
+            403, "blocked"
+        )));
+        assert!(is_auth_error(&YahooClient::map_auth_status(
+            403,
+            "Invalid Crumb"
+        )));
+    }
+
     use super::*;
 
     #[tokio::test]

--- a/src/adapters/yahoo/discovery/lookup.rs
+++ b/src/adapters/yahoo/discovery/lookup.rs
@@ -117,33 +117,16 @@ impl LookupOptions {
     }
 }
 
-/// Fetch lookup results for a query
+/// Fetch and parse lookup results in a single pass over the body.
 ///
-/// # Arguments
-///
-/// * `client` - The Yahoo Finance client
-/// * `query` - Search query string
-/// * `options` - Lookup configuration options
-///
-/// # Example
-///
-/// ```ignore
-/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// # let client = finance_query::YahooClient::new(Default::default()).await?;
-/// use finance_query::endpoints::lookup::{fetch, LookupOptions, LookupType};
-/// let options = LookupOptions::new()
-///     .lookup_type(LookupType::Equity)
-///     .count(10)
-///     .include_logo(true);
-/// let results = fetch(&client, "Apple", &options).await?;
-/// # Ok(())
-/// # }
-/// ```
-pub async fn fetch(
+/// Logo enrichment mutates the parsed tree, so that path goes through `Value`
+/// and reshapes from it; the no-logo path deserializes straight from bytes.
+/// Neither path serializes back to bytes.
+pub(crate) async fn fetch_results(
     client: &YahooClient,
     query: &str,
     options: &LookupOptions,
-) -> Result<serde_json::Value> {
+) -> Result<crate::models::discovery::lookup::LookupResults> {
     if query.trim().is_empty() {
         return Err(crate::error::FinanceError::InvalidParameter {
             param: "query".to_string(),
@@ -185,14 +168,17 @@ pub async fn fetch(
 
     let response = client.request_with_params(api::LOOKUP, &params).await?;
 
-    let mut json: serde_json::Value = response.json().await?;
-
-    // If logo is requested, fetch logos for the returned symbols
     if options.include_logo {
-        json = enrich_with_logos(client, json).await?;
+        let json: serde_json::Value = response.json().await?;
+        let json = enrich_with_logos(client, json).await?;
+        Ok(crate::models::discovery::lookup::LookupResults::from_json(
+            json,
+        )?)
+    } else {
+        Ok(crate::models::discovery::lookup::LookupResults::from_slice(
+            &response.bytes().await?,
+        )?)
     }
-
-    Ok(json)
 }
 
 /// Enrich lookup results with logo URLs by fetching from quotes endpoint
@@ -289,15 +275,51 @@ mod tests {
     use super::*;
     use crate::adapters::yahoo::client::ClientConfig;
 
+    #[test]
+    fn lookup_results_parse_from_bytes() {
+        // Realistic minimal lookup payload in Yahoo's actual wire shape
+        // (finance.result[0].documents), including a partial document that
+        // only carries `symbol` to prove optional fields tolerate absence.
+        let body = br#"{
+            "finance": {
+                "result": [{
+                    "documents": [
+                        {"symbol": "AAPL", "shortName": "Apple Inc.", "quoteType": "equity"},
+                        {"symbol": "APLE"}
+                    ],
+                    "start": 0,
+                    "count": 2
+                }]
+            }
+        }"#;
+
+        let parsed = crate::models::discovery::lookup::LookupResults::from_slice(body).unwrap();
+        assert_eq!(parsed.result_count(), 2);
+        assert_eq!(parsed.quotes().len(), 2);
+        assert_eq!(parsed.quotes()[0].symbol, "AAPL");
+        assert_eq!(parsed.quotes()[1].short_name, None);
+        assert_eq!(parsed.start, Some(0));
+    }
+
+    #[test]
+    fn lookup_results_parse_from_bytes_empty_result() {
+        let parsed = crate::models::discovery::lookup::LookupResults::from_slice(
+            br#"{"finance": {"result": []}}"#,
+        )
+        .unwrap();
+        assert!(parsed.is_empty());
+        assert_eq!(parsed.start, None);
+        assert_eq!(parsed.count, None);
+    }
+
     #[tokio::test]
     #[ignore] // Requires network access
     async fn test_fetch_lookup() {
         let client = YahooClient::new(ClientConfig::default()).await.unwrap();
         let options = LookupOptions::new().count(5);
-        let result = fetch(&client, "Apple", &options).await;
+        let result = fetch_results(&client, "Apple", &options).await;
         assert!(result.is_ok());
-        let json = result.unwrap();
-        assert!(json.get("finance").is_some());
+        assert!(!result.unwrap().quotes().is_empty());
     }
 
     #[tokio::test]
@@ -307,7 +329,7 @@ mod tests {
         let options = LookupOptions::new()
             .lookup_type(LookupType::Equity)
             .count(5);
-        let result = fetch(&client, "NVDA", &options).await;
+        let result = fetch_results(&client, "NVDA", &options).await;
         assert!(result.is_ok());
     }
 
@@ -319,22 +341,11 @@ mod tests {
             .lookup_type(LookupType::Equity)
             .count(3)
             .include_logo(true);
-        let result = fetch(&client, "Apple", &options).await;
+        let result = fetch_results(&client, "Apple", &options).await;
         assert!(result.is_ok());
-        // Check that logos were enriched
-        let json = result.unwrap();
-        if let Some(doc) = json
-            .get("finance")
-            .and_then(|f| f.get("result"))
-            .and_then(|r| r.as_array())
-            .and_then(|arr| arr.first())
-            .and_then(|first| first.get("documents"))
-            .and_then(|docs| docs.as_array())
-            .and_then(|docs| docs.first())
-        {
-            // Logo should be present if symbol was found in quotes
-            println!("Document with logo: {:?}", doc);
-        }
+        // The enrichment path reshapes from `Value`; prove it still yields quotes.
+        let results = result.unwrap();
+        assert!(!results.quotes().is_empty());
     }
 
     #[tokio::test]
@@ -342,7 +353,7 @@ mod tests {
     async fn test_empty_query() {
         let client = YahooClient::new(ClientConfig::default()).await.unwrap();
         let options = LookupOptions::new();
-        let result = fetch(&client, "", &options).await;
+        let result = fetch_results(&client, "", &options).await;
         assert!(result.is_err());
     }
 }

--- a/src/adapters/yahoo/discovery/search.rs
+++ b/src/adapters/yahoo/discovery/search.rs
@@ -113,15 +113,17 @@ impl SearchOptions {
 /// # let client = finance_query::YahooClient::new(Default::default()).await?;
 /// use finance_query::endpoints::search::{fetch, SearchOptions};
 /// let options = SearchOptions::new().quotes_count(10).news_count(5);
-/// let results = fetch(&client, "Apple", &options).await?;
+/// let results = client.search("Apple", &options).await?;
 /// # Ok(())
 /// # }
 /// ```
-pub async fn fetch(
+/// Same request as [`fetch`], but hands back the raw body so callers can
+/// deserialize straight into a typed struct instead of via `serde_json::Value`.
+pub(crate) async fn fetch_bytes(
     client: &YahooClient,
     query: &str,
     options: &SearchOptions,
-) -> Result<serde_json::Value> {
+) -> Result<impl std::ops::Deref<Target = [u8]>> {
     if query.trim().is_empty() {
         return Err(crate::error::FinanceError::InvalidParameter {
             param: "query".to_string(),
@@ -169,7 +171,7 @@ pub async fn fetch(
 
     let response = client.request_with_params(api::SEARCH, &params).await?;
 
-    Ok(response.json().await?)
+    Ok(response.bytes().await?)
 }
 
 #[cfg(test)]
@@ -182,10 +184,10 @@ mod tests {
     async fn test_fetch_search() {
         let client = YahooClient::new(ClientConfig::default()).await.unwrap();
         let options = SearchOptions::new().quotes_count(5);
-        let result = fetch(&client, "Apple", &options).await;
-        assert!(result.is_ok());
-        let json = result.unwrap();
-        assert!(json.get("quotes").is_some());
+        let bytes = fetch_bytes(&client, "Apple", &options).await.unwrap();
+        let results: crate::models::discovery::search::SearchResults =
+            serde_json::from_slice(&bytes).unwrap();
+        assert!(!results.quotes.0.is_empty());
     }
 
     #[tokio::test]
@@ -196,10 +198,35 @@ mod tests {
             .quotes_count(5)
             .news_count(3)
             .enable_research_reports(true);
-        let result = fetch(&client, "NVDA", &options).await;
-        assert!(result.is_ok());
-        let json = result.unwrap();
-        assert!(json.get("quotes").is_some());
+        let bytes = fetch_bytes(&client, "NVDA", &options).await.unwrap();
+        let results: crate::models::discovery::search::SearchResults =
+            serde_json::from_slice(&bytes).unwrap();
+        assert!(!results.quotes.0.is_empty());
+    }
+
+    #[test]
+    fn search_results_parse_from_slice() {
+        use crate::models::discovery::search::SearchResults;
+
+        // Realistic minimal search payload: top-level fields plus one quote
+        // that only carries the always-present `symbol`, mirroring a partial
+        // Yahoo response missing most optional fields.
+        let body = br#"{
+            "count": 2,
+            "quotes": [
+                {"symbol": "AAPL", "shortName": "Apple Inc.", "quoteType": "EQUITY"},
+                {"symbol": "AAPU"}
+            ],
+            "news": [],
+            "totalTime": 42
+        }"#;
+
+        let parsed: SearchResults = serde_json::from_slice(body).unwrap();
+        assert_eq!(parsed.result_count(), 2);
+        assert_eq!(parsed.quotes.len(), 2);
+        assert_eq!(parsed.quotes[0].symbol, "AAPL");
+        assert_eq!(parsed.quotes[1].short_name, None);
+        assert!(parsed.news.is_empty());
     }
 
     #[tokio::test]
@@ -207,7 +234,7 @@ mod tests {
     async fn test_empty_query() {
         let client = YahooClient::new(ClientConfig::default()).await.unwrap();
         let options = SearchOptions::new();
-        let result = fetch(&client, "", &options).await;
+        let result = fetch_bytes(&client, "", &options).await;
         assert!(result.is_err());
     }
 }

--- a/src/adapters/yahoo/mod.rs
+++ b/src/adapters/yahoo/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod auth;
 pub(crate) mod client;
 pub(crate) mod common;
 pub(crate) mod endpoints;
+pub(crate) mod session;
 
 // Capability-mapped endpoint modules
 pub(crate) mod chart; // CHART

--- a/src/adapters/yahoo/quote/quotes.rs
+++ b/src/adapters/yahoo/quote/quotes.rs
@@ -136,6 +136,201 @@ pub(crate) async fn fetch_with_fields(
     Ok(response.json().await?)
 }
 
+/// Same request as [`fetch`], but hands back the raw body so callers can
+/// deserialize straight into a typed struct instead of via `serde_json::Value`.
+async fn fetch_bytes(
+    client: &YahooClient,
+    symbols: &[&str],
+) -> Result<impl std::ops::Deref<Target = [u8]>> {
+    crate::adapters::yahoo::common::validate_symbols(symbols)?;
+
+    info!("Fetching batch quotes for {} symbols", symbols.len());
+
+    let params = [("symbols", symbols.join(","))];
+    let response = client.request_with_params(api::QUOTES, &params).await?;
+
+    Ok(response.bytes().await?)
+}
+
+/// Generates a field deserializer that mirrors a `serde_json::Value` accessor:
+/// any JSON type the accessor rejects yields `None` rather than a
+/// deserialization error, because Yahoo returns the same field as a bare
+/// number, a quoted string, or a `{"raw":..,"fmt":..}` object depending on the
+/// endpoint, and one odd field must not fail the whole batch.
+macro_rules! lenient_accessor {
+    ($name:ident, $out:ty, $expecting:literal, $($accept:item),* $(,)?) => {
+        fn $name<'de, D: serde::Deserializer<'de>>(d: D) -> std::result::Result<Option<$out>, D::Error> {
+            struct V;
+            impl<'de> serde::de::Visitor<'de> for V {
+                type Value = Option<$out>;
+                fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                    f.write_str($expecting)
+                }
+                $($accept)*
+                fn visit_bool<E>(self, _: bool) -> std::result::Result<Self::Value, E> {
+                    Ok(None)
+                }
+                fn visit_unit<E>(self) -> std::result::Result<Self::Value, E> {
+                    Ok(None)
+                }
+                fn visit_none<E>(self) -> std::result::Result<Self::Value, E> {
+                    Ok(None)
+                }
+                fn visit_some<D2: serde::Deserializer<'de>>(
+                    self,
+                    d: D2,
+                ) -> std::result::Result<Self::Value, D2::Error> {
+                    d.deserialize_any(V)
+                }
+                fn visit_map<A: serde::de::MapAccess<'de>>(
+                    self,
+                    mut m: A,
+                ) -> std::result::Result<Self::Value, A::Error> {
+                    while m
+                        .next_entry::<serde::de::IgnoredAny, serde::de::IgnoredAny>()?
+                        .is_some()
+                    {}
+                    Ok(None)
+                }
+                fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                    self,
+                    mut s: A,
+                ) -> std::result::Result<Self::Value, A::Error> {
+                    while s.next_element::<serde::de::IgnoredAny>()?.is_some() {}
+                    Ok(None)
+                }
+            }
+            d.deserialize_any(V)
+        }
+    };
+}
+
+lenient_accessor!(
+    lenient_f64,
+    f64,
+    "a number or any other JSON value",
+    fn visit_f64<E>(self, v: f64) -> std::result::Result<Self::Value, E> {
+        Ok(Some(v))
+    },
+    fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E> {
+        Ok(Some(v as f64))
+    },
+    fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E> {
+        Ok(Some(v as f64))
+    },
+    fn visit_str<E>(self, _: &str) -> std::result::Result<Self::Value, E> {
+        Ok(None)
+    }
+);
+
+lenient_accessor!(
+    lenient_i64,
+    i64,
+    "an integer or any other JSON value",
+    // `Number::as_i64` returns `None` for every `N::Float`, even an integral
+    // one like `2.0`, so this arm is unconditionally `None`.
+    fn visit_f64<E>(self, _: f64) -> std::result::Result<Self::Value, E> {
+        Ok(None)
+    },
+    fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E> {
+        Ok(Some(v))
+    },
+    fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E> {
+        Ok(i64::try_from(v).ok())
+    },
+    fn visit_str<E>(self, _: &str) -> std::result::Result<Self::Value, E> {
+        Ok(None)
+    }
+);
+
+lenient_accessor!(
+    lenient_string,
+    String,
+    "a string or any other JSON value",
+    fn visit_str<E>(self, v: &str) -> std::result::Result<Self::Value, E> {
+        Ok(Some(v.to_owned()))
+    },
+    fn visit_f64<E>(self, _: f64) -> std::result::Result<Self::Value, E> {
+        Ok(None)
+    },
+    fn visit_i64<E>(self, _: i64) -> std::result::Result<Self::Value, E> {
+        Ok(None)
+    },
+    fn visit_u64<E>(self, _: u64) -> std::result::Result<Self::Value, E> {
+        Ok(None)
+    }
+);
+
+/// Mirrors `as_str().unwrap_or("")` for the symbol key.
+fn lenient_symbol<'de, D: serde::Deserializer<'de>>(d: D) -> std::result::Result<String, D::Error> {
+    Ok(lenient_string(d)?.unwrap_or_default())
+}
+
+/// Missing and explicitly-null containers both collapse to the default, matching
+/// the chained `.get(..).and_then(..)` the `Value` walk used to do.
+fn null_to_default<'de, D, T>(d: D) -> std::result::Result<T, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: Default + serde::Deserialize<'de>,
+{
+    Ok(<Option<T> as serde::Deserialize>::deserialize(d)?.unwrap_or_default())
+}
+
+#[derive(Default, serde::Deserialize)]
+struct QuotesEnvelope {
+    #[serde(
+        rename = "quoteResponse",
+        default,
+        deserialize_with = "null_to_default"
+    )]
+    quote_response: QuotesResult,
+}
+
+#[derive(Default, serde::Deserialize)]
+struct QuotesResult {
+    #[serde(default, deserialize_with = "null_to_default")]
+    result: Vec<QuoteRow>,
+}
+
+#[derive(Default, serde::Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+struct QuoteRow {
+    #[serde(deserialize_with = "lenient_symbol")]
+    symbol: String,
+    #[serde(deserialize_with = "lenient_string")]
+    short_name: Option<String>,
+    #[serde(deserialize_with = "lenient_string")]
+    long_name: Option<String>,
+    #[serde(rename = "fullExchangeName", deserialize_with = "lenient_string")]
+    exchange_name: Option<String>,
+    #[serde(deserialize_with = "lenient_string")]
+    exchange: Option<String>,
+    #[serde(deserialize_with = "lenient_string")]
+    quote_type: Option<String>,
+    #[serde(deserialize_with = "lenient_string")]
+    currency: Option<String>,
+    #[serde(deserialize_with = "lenient_string")]
+    market_state: Option<String>,
+    #[serde(deserialize_with = "lenient_f64")]
+    regular_market_price: Option<f64>,
+    #[serde(deserialize_with = "lenient_f64")]
+    regular_market_change: Option<f64>,
+    #[serde(deserialize_with = "lenient_f64")]
+    regular_market_change_percent: Option<f64>,
+    #[serde(deserialize_with = "lenient_i64")]
+    regular_market_volume: Option<i64>,
+    #[serde(deserialize_with = "lenient_f64")]
+    regular_market_previous_close: Option<f64>,
+    #[serde(deserialize_with = "lenient_f64")]
+    regular_market_open: Option<f64>,
+    #[serde(deserialize_with = "lenient_f64")]
+    regular_market_day_high: Option<f64>,
+    #[serde(deserialize_with = "lenient_f64")]
+    regular_market_day_low: Option<f64>,
+    #[serde(deserialize_with = "lenient_i64")]
+    market_cap: Option<i64>,
+}
+
 /// Fetch batch quotes and convert to canonical `(symbol, QuoteSummaryResponse)` pairs.
 ///
 /// The batch endpoint returns basic fields only (price module), not full quoteSummary data.
@@ -144,54 +339,41 @@ pub(crate) async fn fetch_quotes_batch(
     client: &YahooClient,
     symbols: &[&str],
 ) -> Result<Vec<(String, QuoteSummaryResponse)>> {
-    let json = fetch(client, symbols).await?;
-    let result = json
-        .get("quoteResponse")
-        .and_then(|qr| qr.get("result"))
-        .and_then(|r| r.as_array());
+    let body = fetch_bytes(client, symbols).await?;
+    let envelope: QuotesEnvelope = serde_json::from_slice(&body)?;
+    let rows = envelope.quote_response.result;
 
-    let mut quotes = Vec::new();
-    if let Some(results) = result {
-        for item in results {
-            let symbol = item["symbol"].as_str().unwrap_or("").to_string();
-            let price = Price {
-                short_name: item["shortName"].as_str().map(String::from),
-                long_name: item["longName"].as_str().map(String::from),
-                exchange_name: item["fullExchangeName"].as_str().map(String::from),
-                exchange: item["exchange"].as_str().map(String::from),
-                quote_type: item["quoteType"].as_str().map(String::from),
-                currency: item["currency"].as_str().map(String::from),
-                market_state: item["marketState"].as_str().map(String::from),
-                regular_market_price: item["regularMarketPrice"].as_f64().map(FormattedValue::new),
-                regular_market_change: item["regularMarketChange"]
-                    .as_f64()
-                    .map(FormattedValue::new),
-                regular_market_change_percent: item["regularMarketChangePercent"]
-                    .as_f64()
-                    .map(FormattedValue::new),
-                regular_market_volume: item["regularMarketVolume"]
-                    .as_i64()
-                    .map(FormattedValue::new),
-                regular_market_previous_close: item["regularMarketPreviousClose"]
-                    .as_f64()
-                    .map(FormattedValue::new),
-                regular_market_open: item["regularMarketOpen"].as_f64().map(FormattedValue::new),
-                regular_market_day_high: item["regularMarketDayHigh"]
-                    .as_f64()
-                    .map(FormattedValue::new),
-                regular_market_day_low: item["regularMarketDayLow"]
-                    .as_f64()
-                    .map(FormattedValue::new),
-                market_cap: item["marketCap"].as_i64().map(FormattedValue::new),
-                ..Default::default()
-            };
-            let response = QuoteSummaryResponse {
-                symbol: symbol.clone(),
-                price: Some(price),
-                ..Default::default()
-            };
-            quotes.push((symbol, response));
-        }
+    let mut quotes = Vec::with_capacity(rows.len());
+    for row in rows {
+        let price = Price {
+            short_name: row.short_name,
+            long_name: row.long_name,
+            exchange_name: row.exchange_name,
+            exchange: row.exchange,
+            quote_type: row.quote_type,
+            currency: row.currency,
+            market_state: row.market_state,
+            regular_market_price: row.regular_market_price.map(FormattedValue::new),
+            regular_market_change: row.regular_market_change.map(FormattedValue::new),
+            regular_market_change_percent: row
+                .regular_market_change_percent
+                .map(FormattedValue::new),
+            regular_market_volume: row.regular_market_volume.map(FormattedValue::new),
+            regular_market_previous_close: row
+                .regular_market_previous_close
+                .map(FormattedValue::new),
+            regular_market_open: row.regular_market_open.map(FormattedValue::new),
+            regular_market_day_high: row.regular_market_day_high.map(FormattedValue::new),
+            regular_market_day_low: row.regular_market_day_low.map(FormattedValue::new),
+            market_cap: row.market_cap.map(FormattedValue::new),
+            ..Default::default()
+        };
+        let response = QuoteSummaryResponse {
+            symbol: row.symbol.clone(),
+            price: Some(price),
+            ..Default::default()
+        };
+        quotes.push((row.symbol, response));
     }
     Ok(quotes)
 }
@@ -200,6 +382,68 @@ pub(crate) async fn fetch_quotes_batch(
 mod tests {
     use super::*;
     use crate::adapters::yahoo::client::ClientConfig;
+
+    #[test]
+    fn typed_rows_reproduce_value_accessor_tolerance() {
+        let body = r#"{"quoteResponse":{"result":[
+            {"symbol":"AAPL","shortName":"Apple","regularMarketPrice":150.5,"marketCap":2500000000},
+            {"symbol":"STRNUM","regularMarketPrice":"150.5","marketCap":"2500000000"},
+            {"symbol":"OBJ","regularMarketPrice":{"raw":150.5,"fmt":"150.50"}},
+            {"symbol":"NULLS","shortName":null,"regularMarketPrice":null},
+            {"symbol":"BARE"},
+            {"symbol":"WRONGTYPE","shortName":42,"regularMarketPrice":true}
+        ]}}"#;
+        let env: QuotesEnvelope = serde_json::from_str(body).unwrap();
+        let rows = &env.quote_response.result;
+        assert_eq!(rows.len(), 6);
+
+        assert_eq!(rows[0].short_name.as_deref(), Some("Apple"));
+        assert_eq!(rows[0].regular_market_price, Some(150.5));
+        assert_eq!(rows[0].market_cap, Some(2_500_000_000));
+
+        assert_eq!(rows[1].regular_market_price, None);
+        assert_eq!(rows[1].market_cap, None);
+
+        assert_eq!(rows[2].regular_market_price, None);
+
+        assert_eq!(rows[3].short_name, None);
+        assert_eq!(rows[3].regular_market_price, None);
+        assert_eq!(rows[4].short_name, None);
+        assert_eq!(rows[4].regular_market_price, None);
+        assert_eq!(rows[5].short_name, None);
+        assert_eq!(rows[5].regular_market_price, None);
+
+        assert_eq!(rows[5].symbol, "WRONGTYPE");
+    }
+
+    #[test]
+    fn lenient_i64_matches_as_i64_on_floats() {
+        let body = r#"{"quoteResponse":{"result":[
+            {"symbol":"F","marketCap":2.0,"regularMarketVolume":1e3}
+        ]}}"#;
+        let env: QuotesEnvelope = serde_json::from_str(body).unwrap();
+        let row = &env.quote_response.result[0];
+        assert_eq!(row.market_cap, None);
+        assert_eq!(row.regular_market_volume, None);
+    }
+
+    #[test]
+    fn missing_and_malformed_containers_do_not_error() {
+        let env: QuotesEnvelope = serde_json::from_str(r#"{"quoteResponse":{}}"#).unwrap();
+        assert!(env.quote_response.result.is_empty());
+
+        let body = r#"{"quoteResponse":{"result":[
+            {"symbol":"S","shortName":["a","b"],"regularMarketVolume":{"raw":5,"fmt":"5"},
+             "longName":{"x":{"y":[1,2,{"z":null}]}},"currency":1.5}
+        ]}}"#;
+        let env: QuotesEnvelope = serde_json::from_str(body).unwrap();
+        let row = &env.quote_response.result[0];
+        assert_eq!(row.symbol, "S");
+        assert_eq!(row.short_name, None);
+        assert_eq!(row.long_name, None);
+        assert_eq!(row.currency, None);
+        assert_eq!(row.regular_market_volume, None);
+    }
 
     #[tokio::test]
     #[ignore] // Requires network access

--- a/src/adapters/yahoo/session.rs
+++ b/src/adapters/yahoo/session.rs
@@ -1,0 +1,112 @@
+//! Process-wide, runtime-keyed Yahoo session cache.
+//!
+//! `reqwest::Client` spawns its connection-pool tasks on whichever tokio
+//! runtime first drives it; if that runtime is dropped, later use from another
+//! runtime fails with `DispatchGone`. Keying on the runtime id means a session
+//! is only ever handed back to the runtime that created it.
+
+use super::client::{ClientConfig, YahooClient};
+use crate::error::Result;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::Duration;
+
+/// Maximum cached sessions before the map is cleared wholesale.
+const SESSION_CAP: usize = 8;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct SessionKey {
+    runtime: tokio::runtime::Id,
+    timeout: Duration,
+    proxy: Option<String>,
+    lang: String,
+    region: String,
+}
+
+pub(crate) fn key_for(config: &ClientConfig) -> SessionKey {
+    SessionKey {
+        runtime: tokio::runtime::Handle::current().id(),
+        timeout: config.timeout,
+        proxy: config.proxy.clone(),
+        lang: config.lang.clone(),
+        region: config.region.clone(),
+    }
+}
+
+fn sessions() -> &'static Mutex<HashMap<SessionKey, Arc<YahooClient>>> {
+    static SESSIONS: OnceLock<Mutex<HashMap<SessionKey, Arc<YahooClient>>>> = OnceLock::new();
+    SESSIONS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Return the cached session for this runtime and config, authenticating once
+/// if there isn't one yet.
+pub(crate) async fn get_or_auth(config: &ClientConfig) -> Result<Arc<YahooClient>> {
+    let key = key_for(config);
+
+    if let Some(client) = sessions().lock().unwrap().get(&key) {
+        return Ok(Arc::clone(client));
+    }
+
+    let client = Arc::new(YahooClient::new(config.clone()).await?);
+
+    let mut map = sessions().lock().unwrap();
+    if map.len() >= SESSION_CAP {
+        map.clear();
+    }
+    // A concurrent caller may have inserted while we authenticated; prefer
+    // theirs so every caller on this runtime shares one session.
+    Ok(Arc::clone(
+        map.entry(key).or_insert_with(|| Arc::clone(&client)),
+    ))
+}
+
+/// Drop the cached session for this runtime and config.
+pub(crate) fn invalidate(config: &ClientConfig) {
+    sessions().lock().unwrap().remove(&key_for(config));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn key_includes_runtime_and_config() {
+        let a = ClientConfig::default();
+        let b = ClientConfig {
+            lang: "ja-JP".to_string(),
+            ..ClientConfig::default()
+        };
+
+        assert_eq!(key_for(&a), key_for(&a));
+        assert_ne!(key_for(&a), key_for(&b));
+    }
+
+    #[test]
+    fn keys_differ_across_runtimes() {
+        let config = ClientConfig::default();
+        let rt1 = tokio::runtime::Runtime::new().unwrap();
+        let rt2 = tokio::runtime::Runtime::new().unwrap();
+        let k1 = rt1.block_on(async { key_for(&config) });
+        let k2 = rt2.block_on(async { key_for(&config) });
+        assert_ne!(k1, k2);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires network access"]
+    async fn same_runtime_reuses_one_client() {
+        let config = ClientConfig::default();
+        let a = get_or_auth(&config).await.unwrap();
+        let b = get_or_auth(&config).await.unwrap();
+        assert!(Arc::ptr_eq(&a, &b));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires network access"]
+    async fn invalidate_forces_a_new_client() {
+        let config = ClientConfig::default();
+        let a = get_or_auth(&config).await.unwrap();
+        invalidate(&config);
+        let b = get_or_auth(&config).await.unwrap();
+        assert!(!Arc::ptr_eq(&a, &b));
+    }
+}

--- a/src/adapters/yahoo/session.rs
+++ b/src/adapters/yahoo/session.rs
@@ -47,7 +47,11 @@ pub(crate) async fn get_or_auth(config: &ClientConfig) -> Result<Arc<YahooClient
         return Ok(Arc::clone(client));
     }
 
-    let client = Arc::new(YahooClient::new(config.clone()).await?);
+    let client = Arc::new(
+        YahooClient::new(config.clone())
+            .await?
+            .with_session_key(key.clone()),
+    );
 
     let mut map = sessions().lock().unwrap();
     if map.len() >= SESSION_CAP {
@@ -67,8 +71,19 @@ pub(crate) async fn get_or_auth(config: &ClientConfig) -> Result<Arc<YahooClient
 }
 
 /// Drop the cached session for this runtime and config.
+#[cfg(test)]
 pub(crate) fn invalidate(config: &ClientConfig) {
-    sessions().lock().unwrap().remove(&key_for(config));
+    invalidate_key(&key_for(config));
+}
+
+/// Drop the session cached under `key`.
+///
+/// Callers pass the key the client was stored under rather than recomputing it:
+/// [`key_for`] reads `Handle::current()`, so a client driven from a second
+/// runtime would otherwise evict a different entry (or none) and leave the
+/// broken session cached for its own runtime.
+pub(crate) fn invalidate_key(key: &SessionKey) {
+    sessions().lock().unwrap().remove(key);
 }
 
 #[cfg(test)]

--- a/src/adapters/yahoo/session.rs
+++ b/src/adapters/yahoo/session.rs
@@ -51,7 +51,13 @@ pub(crate) async fn get_or_auth(config: &ClientConfig) -> Result<Arc<YahooClient
 
     let mut map = sessions().lock().unwrap();
     if map.len() >= SESSION_CAP {
-        map.clear();
+        // Drop only sessions nobody else holds — clearing the whole map would
+        // force every live runtime to redo the cookie + crumb handshake, which
+        // is the cost this cache exists to avoid.
+        map.retain(|_, c| Arc::strong_count(c) > 1);
+        if map.len() >= SESSION_CAP {
+            map.clear();
+        }
     }
     // A concurrent caller may have inserted while we authenticated; prefer
     // theirs so every caller on this runtime shares one session.

--- a/src/backtesting/condition/composite.rs
+++ b/src/backtesting/condition/composite.rs
@@ -43,6 +43,10 @@ impl<C1: Condition, C2: Condition> Condition for And<C1, C2> {
         reqs
     }
 
+    fn tracks_position_extremes(&self) -> bool {
+        self.left.tracks_position_extremes() || self.right.tracks_position_extremes()
+    }
+
     fn description(&self) -> String {
         format!(
             "({} AND {})",
@@ -88,6 +92,10 @@ impl<C1: Condition, C2: Condition> Condition for Or<C1, C2> {
         reqs
     }
 
+    fn tracks_position_extremes(&self) -> bool {
+        self.left.tracks_position_extremes() || self.right.tracks_position_extremes()
+    }
+
     fn description(&self) -> String {
         format!(
             "({} OR {})",
@@ -121,6 +129,10 @@ impl<C: Condition> Condition for Not<C> {
 
     fn htf_requirements(&self) -> Vec<HtfIndicatorSpec> {
         self.inner.htf_requirements()
+    }
+
+    fn tracks_position_extremes(&self) -> bool {
+        self.inner.tracks_position_extremes()
     }
 
     fn description(&self) -> String {

--- a/src/backtesting/condition/mod.rs
+++ b/src/backtesting/condition/mod.rs
@@ -96,6 +96,19 @@ pub trait Condition: Clone + Send + Sync + 'static {
         vec![]
     }
 
+    /// Whether this condition reads [`StrategyContext::extremes`].
+    ///
+    /// The engine folds the running peak/trough per bar only when some condition
+    /// says it needs it, so a strategy without a trailing condition pays nothing.
+    /// A condition that returns `false` but reads `ctx.extremes` anyway still
+    /// gets a correct answer — the read falls back to scanning from the entry
+    /// bar — but pays the O(bars²) cost this flag exists to avoid.
+    ///
+    /// [`StrategyContext::extremes`]: crate::backtesting::StrategyContext::extremes
+    fn tracks_position_extremes(&self) -> bool {
+        false
+    }
+
     /// Get a human-readable description of this condition.
     ///
     /// This is used for logging, debugging, and signal reporting.

--- a/src/backtesting/condition/threshold.rs
+++ b/src/backtesting/condition/threshold.rs
@@ -314,11 +314,7 @@ impl Condition for HeldForBars {
     fn evaluate(&self, ctx: &StrategyContext) -> bool {
         if let Some(pos) = ctx.position {
             // Count bars since entry
-            let entry_idx = ctx
-                .candles
-                .iter()
-                .position(|c| c.timestamp >= pos.entry_timestamp)
-                .unwrap_or(0);
+            let entry_idx = entry_index(ctx.candles, pos.entry_timestamp);
             let bars_held = ctx.index.saturating_sub(entry_idx);
             bars_held >= self.min_bars
         } else {
@@ -339,6 +335,95 @@ impl Condition for HeldForBars {
 #[inline]
 pub fn held_for_bars(min_bars: usize) -> HeldForBars {
     HeldForBars::new(min_bars)
+}
+
+/// Index of the first candle at or after the position's entry.
+///
+/// Candles are sorted ascending, so this is a binary search; the `== len` arm
+/// reproduces the `.unwrap_or(0)` of the linear scan it replaced.
+fn entry_index(candles: &[crate::models::chart::Candle], entry_timestamp: i64) -> usize {
+    let ep = candles.partition_point(|c| c.timestamp < entry_timestamp);
+    if ep == candles.len() { 0 } else { ep }
+}
+
+/// Running peak/trough for the currently-open position.
+///
+/// Cleared on clone: `GridSearch` clones strategies across parallel combos and
+/// must not share one combo's position state with another.
+#[derive(Debug, Default)]
+struct PeakCache(std::sync::Mutex<Option<PeakState>>);
+
+#[derive(Debug, Clone, Copy)]
+struct PeakState {
+    entry_timestamp: i64,
+    scanned_to: usize,
+    high: f64,
+    low: f64,
+    close_high: f64,
+    close_low: f64,
+}
+
+impl Clone for PeakCache {
+    fn clone(&self) -> Self {
+        Self::default()
+    }
+}
+
+impl PeakCache {
+    fn state(
+        &self,
+        candles: &[crate::models::chart::Candle],
+        entry_idx: usize,
+        index: usize,
+        entry_timestamp: i64,
+    ) -> PeakState {
+        let mut slot = self.0.lock().unwrap();
+        let rebuild = match *slot {
+            Some(s) => s.entry_timestamp != entry_timestamp || index < s.scanned_to,
+            None => true,
+        };
+        if rebuild {
+            *slot = Some(PeakState {
+                entry_timestamp,
+                scanned_to: entry_idx,
+                high: f64::NEG_INFINITY,
+                low: f64::INFINITY,
+                close_high: f64::NEG_INFINITY,
+                close_low: f64::INFINITY,
+            });
+        }
+        let s = slot.as_mut().unwrap();
+        for c in &candles[s.scanned_to..=index] {
+            s.high = s.high.max(c.high);
+            s.low = s.low.min(c.low);
+            s.close_high = s.close_high.max(c.close);
+            s.close_low = s.close_low.min(c.close);
+        }
+        s.scanned_to = index + 1;
+        *s
+    }
+
+    fn extremes(
+        &self,
+        candles: &[crate::models::chart::Candle],
+        entry_idx: usize,
+        index: usize,
+        entry_timestamp: i64,
+    ) -> (f64, f64) {
+        let s = self.state(candles, entry_idx, index, entry_timestamp);
+        (s.high, s.low)
+    }
+
+    fn close_extremes(
+        &self,
+        candles: &[crate::models::chart::Candle],
+        entry_idx: usize,
+        index: usize,
+        entry_timestamp: i64,
+    ) -> (f64, f64) {
+        let s = self.state(candles, entry_idx, index, entry_timestamp);
+        (s.close_high, s.close_low)
+    }
 }
 
 /// Condition: trailing stop triggered when price retraces from peak/trough.
@@ -366,10 +451,11 @@ pub fn held_for_bars(min_bars: usize) -> HeldForBars {
 /// // Exit if price drops 3% from highest point since entry
 /// let exit = trailing_stop(0.03);
 /// ```
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct TrailingStop {
     /// Trail percentage (e.g., 0.03 for 3%)
     pub trail_pct: f64,
+    cache: PeakCache,
 }
 
 impl TrailingStop {
@@ -379,7 +465,10 @@ impl TrailingStop {
     ///
     /// * `trail_pct` - Trail percentage (e.g., 0.03 for 3%)
     pub fn new(trail_pct: f64) -> Self {
-        Self { trail_pct }
+        Self {
+            trail_pct,
+            cache: PeakCache::default(),
+        }
     }
 }
 
@@ -387,34 +476,19 @@ impl Condition for TrailingStop {
     fn evaluate(&self, ctx: &StrategyContext) -> bool {
         if let Some(pos) = ctx.position {
             // Find the entry index
-            let entry_idx = ctx
-                .candles
-                .iter()
-                .position(|c| c.timestamp >= pos.entry_timestamp)
-                .unwrap_or(0);
+            let entry_idx = entry_index(ctx.candles, pos.entry_timestamp);
 
             // Compute peak/trough from entry to current candle (inclusive)
             let current_close = ctx.close();
+            let (peak, trough) =
+                self.cache
+                    .extremes(ctx.candles, entry_idx, ctx.index, pos.entry_timestamp);
 
             match pos.side {
                 crate::backtesting::position::PositionSide::Long => {
-                    // For long: find highest high since entry
-                    let peak = ctx.candles[entry_idx..=ctx.index]
-                        .iter()
-                        .map(|c| c.high)
-                        .fold(f64::NEG_INFINITY, f64::max);
-
-                    // Trigger if current price is trail_pct below peak
                     current_close <= peak * (1.0 - self.trail_pct)
                 }
                 crate::backtesting::position::PositionSide::Short => {
-                    // For short: find lowest low since entry
-                    let trough = ctx.candles[entry_idx..=ctx.index]
-                        .iter()
-                        .map(|c| c.low)
-                        .fold(f64::INFINITY, f64::min);
-
-                    // Trigger if current price is trail_pct above trough
                     current_close >= trough * (1.0 + self.trail_pct)
                 }
             }
@@ -469,10 +543,11 @@ pub fn trailing_stop(trail_pct: f64) -> TrailingStop {
 /// // Exit if profit drops 2% from highest profit achieved
 /// let exit = trailing_take_profit(0.02);
 /// ```
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct TrailingTakeProfit {
     /// Trail percentage from peak profit (e.g., 0.02 for 2%)
     pub trail_pct: f64,
+    cache: PeakCache,
 }
 
 impl TrailingTakeProfit {
@@ -482,7 +557,10 @@ impl TrailingTakeProfit {
     ///
     /// * `trail_pct` - Trail percentage from peak profit (e.g., 0.02 for 2%)
     pub fn new(trail_pct: f64) -> Self {
-        Self { trail_pct }
+        Self {
+            trail_pct,
+            cache: PeakCache::default(),
+        }
     }
 }
 
@@ -490,17 +568,19 @@ impl Condition for TrailingTakeProfit {
     fn evaluate(&self, ctx: &StrategyContext) -> bool {
         if let Some(pos) = ctx.position {
             // Find the entry index
-            let entry_idx = ctx
-                .candles
-                .iter()
-                .position(|c| c.timestamp >= pos.entry_timestamp)
-                .unwrap_or(0);
+            let entry_idx = entry_index(ctx.candles, pos.entry_timestamp);
 
             // Compute peak profit from entry to current
-            let peak_profit_pct = ctx.candles[entry_idx..=ctx.index]
-                .iter()
-                .map(|c| pos.unrealized_return_pct(c.close))
-                .fold(f64::NEG_INFINITY, f64::max);
+            let (close_high, close_low) =
+                self.cache
+                    .close_extremes(ctx.candles, entry_idx, ctx.index, pos.entry_timestamp);
+            // unrealized_return_pct is monotone in price, so the peak profit is
+            // reached at the window's extreme close for the position's side.
+            let best_close = match pos.side {
+                crate::backtesting::position::PositionSide::Long => close_high,
+                crate::backtesting::position::PositionSide::Short => close_low,
+            };
+            let peak_profit_pct = pos.unrealized_return_pct(best_close);
 
             // Only trigger if we've been in profit and current profit is below peak by trail_pct
             let current_profit_pct = pos.unrealized_return_pct(ctx.close());
@@ -545,6 +625,156 @@ pub fn trailing_take_profit(trail_pct: f64) -> TrailingTakeProfit {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn ramp(n: usize) -> Vec<crate::models::chart::Candle> {
+        (0..n)
+            .map(|i| {
+                let px = 100.0 + i as f64;
+                crate::models::chart::Candle {
+                    timestamp: 1_600_000_000 + i as i64 * 86400,
+                    open: px,
+                    high: px * 1.02,
+                    low: px * 0.98,
+                    close: px,
+                    volume: 1_000,
+                    ..Default::default()
+                }
+            })
+            .collect()
+    }
+
+    #[test]
+    fn entry_index_matches_linear_scan() {
+        let candles = ramp(200);
+        let probes = [
+            0i64,
+            candles[0].timestamp,
+            candles[7].timestamp,
+            candles[7].timestamp + 1,
+            candles[199].timestamp,
+            candles[199].timestamp + 10_000,
+        ];
+        for entry_ts in probes {
+            let linear = candles
+                .iter()
+                .position(|c| c.timestamp >= entry_ts)
+                .unwrap_or(0);
+            let ep = candles.partition_point(|c| c.timestamp < entry_ts);
+            let binary = if ep == candles.len() { 0 } else { ep };
+            assert_eq!(linear, binary, "mismatch for entry_ts={entry_ts}");
+        }
+    }
+
+    fn peak_then_drop(n: usize) -> Vec<crate::models::chart::Candle> {
+        (0..n)
+            .map(|i| {
+                let half = n / 2;
+                let px = if i < half {
+                    100.0 + i as f64
+                } else {
+                    100.0 + half as f64 - (i - half) as f64
+                };
+                crate::models::chart::Candle {
+                    timestamp: 1_600_000_000 + i as i64 * 86400,
+                    open: px,
+                    high: px * 1.02,
+                    low: px * 0.98,
+                    close: px,
+                    volume: 1_000,
+                    ..Default::default()
+                }
+            })
+            .collect()
+    }
+
+    #[test]
+    fn trailing_stop_exit_bars_are_stable() {
+        use crate::backtesting::refs::*;
+        use crate::backtesting::{BacktestConfig, BacktestEngine, StrategyBuilder};
+
+        let candles = peak_then_drop(400);
+        let strat = StrategyBuilder::new("t")
+            .entry(price().above(0.0))
+            .exit(trailing_stop(0.03))
+            .build();
+        let result = BacktestEngine::new(BacktestConfig::default())
+            .run("TEST", &candles, strat)
+            .unwrap();
+        let actual: Vec<(i64, i64)> = result
+            .trades
+            .iter()
+            .map(|t| (t.entry_timestamp, t.exit_timestamp))
+            .collect();
+        let expected: Vec<(i64, i64)> = vec![
+            (1600172800, 1617712000),
+            (1617712000, 1618144000),
+            (1618144000, 1618576000),
+            (1618576000, 1619008000),
+            (1619008000, 1619353600),
+            (1619353600, 1619699200),
+            (1619699200, 1620044800),
+            (1620044800, 1620390400),
+            (1620390400, 1620736000),
+            (1620736000, 1621081600),
+            (1621081600, 1621427200),
+            (1621427200, 1621772800),
+            (1621772800, 1622118400),
+            (1622118400, 1622464000),
+            (1622464000, 1622809600),
+            (1622809600, 1623155200),
+            (1623155200, 1623500800),
+            (1623500800, 1623846400),
+            (1623846400, 1624192000),
+            (1624192000, 1624537600),
+            (1624537600, 1624883200),
+            (1624883200, 1625228800),
+            (1625228800, 1625574400),
+            (1625574400, 1625920000),
+            (1625920000, 1626265600),
+            (1626265600, 1626611200),
+            (1626611200, 1626956800),
+            (1626956800, 1627216000),
+            (1627216000, 1627475200),
+            (1627475200, 1627734400),
+            (1627734400, 1627993600),
+            (1627993600, 1628252800),
+            (1628252800, 1628512000),
+            (1628512000, 1628771200),
+            (1628771200, 1629030400),
+            (1629030400, 1629289600),
+            (1629289600, 1629548800),
+            (1629548800, 1629808000),
+            (1629808000, 1630067200),
+            (1630067200, 1630326400),
+            (1630326400, 1630585600),
+            (1630585600, 1630844800),
+            (1630844800, 1631104000),
+            (1631104000, 1631363200),
+            (1631363200, 1631622400),
+            (1631622400, 1631881600),
+            (1631881600, 1632140800),
+            (1632140800, 1632400000),
+            (1632400000, 1632659200),
+            (1632659200, 1632918400),
+            (1632918400, 1633177600),
+            (1633177600, 1633436800),
+            (1633436800, 1633696000),
+            (1633696000, 1633955200),
+            (1633955200, 1634214400),
+            (1634214400, 1634473600),
+            (1634473600, 1634473600),
+        ];
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn peak_cache_resets_on_clone() {
+        let cache = PeakCache::default();
+        let candles = ramp(10);
+        let _ = cache.extremes(&candles, 0, 5, candles[0].timestamp);
+        let fresh = cache.clone();
+        assert!(fresh.0.lock().unwrap().is_none());
+    }
 
     #[test]
     fn test_stop_loss_description() {
@@ -594,5 +824,48 @@ mod tests {
         assert!(no_position().required_indicators().is_empty());
         assert!(trailing_stop(0.03).required_indicators().is_empty());
         assert!(trailing_take_profit(0.02).required_indicators().is_empty());
+    }
+
+    /// The `TrailingTakeProfit` fast path folds closes into a single extreme and
+    /// evaluates `unrealized_return_pct` once, instead of evaluating it per bar
+    /// and folding the results. That is only exact because the function is
+    /// monotone in price — increasing for longs, decreasing for shorts. Pin it.
+    #[test]
+    fn peak_profit_from_extreme_close_matches_per_bar_fold() {
+        use crate::backtesting::position::{Position, PositionSide};
+        use crate::backtesting::signal::Signal;
+
+        let closes: Vec<f64> = (0..300)
+            .map(|i| 100.0 + (i as f64 * 0.37).sin() * 25.0 + (i as f64 * 0.011))
+            .collect();
+
+        for side in [PositionSide::Long, PositionSide::Short] {
+            for entry_price in [1.0_f64, 87.5, 100.0, 133.25] {
+                let pos = Position::new(
+                    side,
+                    1_600_000_000,
+                    entry_price,
+                    7.0,
+                    0.0,
+                    Signal::long(1_600_000_000, entry_price),
+                );
+
+                let per_bar = closes
+                    .iter()
+                    .map(|&c| pos.unrealized_return_pct(c))
+                    .fold(f64::NEG_INFINITY, f64::max);
+
+                let extreme = match side {
+                    PositionSide::Long => closes.iter().copied().fold(f64::NEG_INFINITY, f64::max),
+                    PositionSide::Short => closes.iter().copied().fold(f64::INFINITY, f64::min),
+                };
+                let single = pos.unrealized_return_pct(extreme);
+
+                assert_eq!(
+                    per_bar, single,
+                    "side={side:?} entry={entry_price}: fold-of-f != f-of-extreme"
+                );
+            }
+        }
     }
 }

--- a/src/backtesting/condition/threshold.rs
+++ b/src/backtesting/condition/threshold.rs
@@ -2,7 +2,7 @@
 //!
 //! This module provides conditions for stop-loss, take-profit, and trailing stops.
 
-use crate::backtesting::strategy::StrategyContext;
+use crate::backtesting::strategy::{PositionExtremes, StrategyContext};
 use crate::indicators::Indicator;
 
 use super::Condition;
@@ -346,84 +346,21 @@ fn entry_index(candles: &[crate::models::chart::Candle], entry_timestamp: i64) -
     if ep == candles.len() { 0 } else { ep }
 }
 
-/// Running peak/trough for the currently-open position.
+/// Extremes since entry for the open position in `ctx`.
 ///
-/// Cleared on clone: `GridSearch` clones strategies across parallel combos and
-/// must not share one combo's position state with another.
-#[derive(Debug, Default)]
-struct PeakCache(std::sync::Mutex<Option<PeakState>>);
-
-#[derive(Debug, Clone, Copy)]
-struct PeakState {
-    entry_timestamp: i64,
-    scanned_to: usize,
-    high: f64,
-    low: f64,
-    close_high: f64,
-    close_low: f64,
-}
-
-impl Clone for PeakCache {
-    fn clone(&self) -> Self {
-        Self::default()
-    }
-}
-
-impl PeakCache {
-    fn state(
-        &self,
-        candles: &[crate::models::chart::Candle],
-        entry_idx: usize,
-        index: usize,
-        entry_timestamp: i64,
-    ) -> PeakState {
-        let mut slot = self.0.lock().unwrap();
-        let rebuild = match *slot {
-            Some(s) => s.entry_timestamp != entry_timestamp || index < s.scanned_to,
-            None => true,
-        };
-        if rebuild {
-            *slot = Some(PeakState {
-                entry_timestamp,
-                scanned_to: entry_idx,
-                high: f64::NEG_INFINITY,
-                low: f64::INFINITY,
-                close_high: f64::NEG_INFINITY,
-                close_low: f64::INFINITY,
-            });
-        }
-        let s = slot.as_mut().unwrap();
-        for c in &candles[s.scanned_to..=index] {
-            s.high = s.high.max(c.high);
-            s.low = s.low.min(c.low);
-            s.close_high = s.close_high.max(c.close);
-            s.close_low = s.close_low.min(c.close);
-        }
-        s.scanned_to = index + 1;
-        *s
-    }
-
-    fn extremes(
-        &self,
-        candles: &[crate::models::chart::Candle],
-        entry_idx: usize,
-        index: usize,
-        entry_timestamp: i64,
-    ) -> (f64, f64) {
-        let s = self.state(candles, entry_idx, index, entry_timestamp);
-        (s.high, s.low)
-    }
-
-    fn close_extremes(
-        &self,
-        candles: &[crate::models::chart::Candle],
-        entry_idx: usize,
-        index: usize,
-        entry_timestamp: i64,
-    ) -> (f64, f64) {
-        let s = self.state(candles, entry_idx, index, entry_timestamp);
-        (s.close_high, s.close_low)
-    }
+/// The engine folds these once per bar and hands them over on the context, so
+/// every trailing condition on a position reads one running value rather than
+/// rescanning the candle history itself. Contexts built outside the engine's bar
+/// loop carry no extremes, so those fall back to a scan from the entry bar.
+fn position_extremes(
+    ctx: &StrategyContext,
+    pos: &crate::backtesting::position::Position,
+) -> PositionExtremes {
+    ctx.extremes.unwrap_or_else(|| {
+        let entry_idx = entry_index(ctx.candles, pos.entry_timestamp);
+        PositionExtremes::from_candles(&ctx.candles[entry_idx..=ctx.index])
+            .unwrap_or_else(|| PositionExtremes::new(ctx.current_candle()))
+    })
 }
 
 /// Condition: trailing stop triggered when price retraces from peak/trough.
@@ -451,11 +388,10 @@ impl PeakCache {
 /// // Exit if price drops 3% from highest point since entry
 /// let exit = trailing_stop(0.03);
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct TrailingStop {
     /// Trail percentage (e.g., 0.03 for 3%)
     pub trail_pct: f64,
-    cache: PeakCache,
 }
 
 impl TrailingStop {
@@ -465,24 +401,19 @@ impl TrailingStop {
     ///
     /// * `trail_pct` - Trail percentage (e.g., 0.03 for 3%)
     pub fn new(trail_pct: f64) -> Self {
-        Self {
-            trail_pct,
-            cache: PeakCache::default(),
-        }
+        Self { trail_pct }
     }
 }
 
 impl Condition for TrailingStop {
     fn evaluate(&self, ctx: &StrategyContext) -> bool {
         if let Some(pos) = ctx.position {
-            // Find the entry index
-            let entry_idx = entry_index(ctx.candles, pos.entry_timestamp);
-
-            // Compute peak/trough from entry to current candle (inclusive)
             let current_close = ctx.close();
-            let (peak, trough) =
-                self.cache
-                    .extremes(ctx.candles, entry_idx, ctx.index, pos.entry_timestamp);
+            let PositionExtremes {
+                high: peak,
+                low: trough,
+                ..
+            } = position_extremes(ctx, pos);
 
             match pos.side {
                 crate::backtesting::position::PositionSide::Long => {
@@ -543,11 +474,10 @@ pub fn trailing_stop(trail_pct: f64) -> TrailingStop {
 /// // Exit if profit drops 2% from highest profit achieved
 /// let exit = trailing_take_profit(0.02);
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct TrailingTakeProfit {
     /// Trail percentage from peak profit (e.g., 0.02 for 2%)
     pub trail_pct: f64,
-    cache: PeakCache,
 }
 
 impl TrailingTakeProfit {
@@ -557,23 +487,18 @@ impl TrailingTakeProfit {
     ///
     /// * `trail_pct` - Trail percentage from peak profit (e.g., 0.02 for 2%)
     pub fn new(trail_pct: f64) -> Self {
-        Self {
-            trail_pct,
-            cache: PeakCache::default(),
-        }
+        Self { trail_pct }
     }
 }
 
 impl Condition for TrailingTakeProfit {
     fn evaluate(&self, ctx: &StrategyContext) -> bool {
         if let Some(pos) = ctx.position {
-            // Find the entry index
-            let entry_idx = entry_index(ctx.candles, pos.entry_timestamp);
-
-            // Compute peak profit from entry to current
-            let (close_high, close_low) =
-                self.cache
-                    .close_extremes(ctx.candles, entry_idx, ctx.index, pos.entry_timestamp);
+            let PositionExtremes {
+                close_high,
+                close_low,
+                ..
+            } = position_extremes(ctx, pos);
             // unrealized_return_pct is monotone in price, so the peak profit is
             // reached at the window's extreme close for the position's side.
             let best_close = match pos.side {
@@ -768,12 +693,71 @@ mod tests {
     }
 
     #[test]
-    fn peak_cache_resets_on_clone() {
-        let cache = PeakCache::default();
-        let candles = ramp(10);
-        let _ = cache.extremes(&candles, 0, 5, candles[0].timestamp);
-        let fresh = cache.clone();
-        assert!(fresh.0.lock().unwrap().is_none());
+    fn trailing_conditions_stay_copy() {
+        // The peak lives on the position, not the condition, so these carry no
+        // state and remain plain `Copy` value types.
+        fn assert_copy<T: Copy>(_: &T) {}
+        assert_copy(&TrailingStop::new(0.05));
+        assert_copy(&TrailingTakeProfit::new(0.05));
+
+        let ts = TrailingStop::new(0.05);
+        let a = ts;
+        let b = ts;
+        assert_eq!(a.trail_pct, b.trail_pct);
+    }
+
+    #[test]
+    fn context_extremes_match_a_scan_from_entry() {
+        // Conditions read the engine's running extremes when present and fall
+        // back to scanning from the entry bar when they aren't. Both paths must
+        // produce the same verdict.
+        let candles = ramp(30);
+        let entry_idx = 5usize;
+        let index = 20usize;
+        let position = crate::backtesting::position::Position::new(
+            crate::backtesting::position::PositionSide::Long,
+            candles[entry_idx].timestamp,
+            candles[entry_idx].close,
+            10.0,
+            0.0,
+            crate::backtesting::signal::Signal::long(
+                candles[entry_idx].timestamp,
+                candles[entry_idx].close,
+            ),
+        );
+        let indicators = std::collections::HashMap::new();
+        let scanned = PositionExtremes::from_candles(&candles[entry_idx..=index]).unwrap();
+
+        for pct in [0.001, 0.01, 0.05, 0.5] {
+            let cond = TrailingStop::new(pct);
+            let tp = TrailingTakeProfit::new(pct);
+            let with = StrategyContext {
+                candles: &candles[..=index],
+                index,
+                position: Some(&position),
+                equity: 10_000.0,
+                indicators: &indicators,
+                extremes: Some(scanned),
+            };
+            let without = StrategyContext {
+                candles: &candles[..=index],
+                index,
+                position: Some(&position),
+                equity: 10_000.0,
+                indicators: &indicators,
+                extremes: None,
+            };
+            assert_eq!(
+                cond.evaluate(&with),
+                cond.evaluate(&without),
+                "trailing stop disagreed at {pct}"
+            );
+            assert_eq!(
+                tp.evaluate(&with),
+                tp.evaluate(&without),
+                "trailing take-profit disagreed at {pct}"
+            );
+        }
     }
 
     #[test]

--- a/src/backtesting/condition/threshold.rs
+++ b/src/backtesting/condition/threshold.rs
@@ -356,7 +356,7 @@ fn position_extremes(
     ctx: &StrategyContext,
     pos: &crate::backtesting::position::Position,
 ) -> PositionExtremes {
-    ctx.extremes.unwrap_or_else(|| {
+    ctx.extremes.copied().unwrap_or_else(|| {
         let entry_idx = entry_index(ctx.candles, pos.entry_timestamp);
         PositionExtremes::from_candles(&ctx.candles[entry_idx..=ctx.index])
             .unwrap_or_else(|| PositionExtremes::new(ctx.current_candle()))
@@ -434,6 +434,10 @@ impl Condition for TrailingStop {
 
     fn description(&self) -> String {
         format!("trailing stop at {:.1}%", self.trail_pct * 100.0)
+    }
+
+    fn tracks_position_extremes(&self) -> bool {
+        true
     }
 }
 
@@ -525,6 +529,10 @@ impl Condition for TrailingTakeProfit {
 
     fn description(&self) -> String {
         format!("trailing take profit at {:.1}%", self.trail_pct * 100.0)
+    }
+
+    fn tracks_position_extremes(&self) -> bool {
+        true
     }
 }
 
@@ -707,6 +715,53 @@ mod tests {
     }
 
     #[test]
+    fn only_trailing_strategies_opt_into_extremes_tracking() {
+        // The engine folds extremes per bar only when this reports true, so a
+        // trailing condition that loses the flag silently falls back to the
+        // O(bars²) rescan this PR removed — and a strategy without one would
+        // otherwise pay for a value nothing reads.
+        use crate::backtesting::refs::*;
+        use crate::backtesting::strategy::{Strategy, StrategyBuilder};
+
+        assert!(TrailingStop::new(0.05).tracks_position_extremes());
+        assert!(TrailingTakeProfit::new(0.05).tracks_position_extremes());
+        assert!(!stop_loss(0.05).tracks_position_extremes());
+
+        // Composites have to carry it through, in either position.
+        assert!(
+            stop_loss(0.05)
+                .or(trailing_stop(0.03))
+                .tracks_position_extremes()
+        );
+        assert!(
+            trailing_stop(0.03)
+                .and(in_profit())
+                .tracks_position_extremes()
+        );
+        assert!(
+            !stop_loss(0.05)
+                .or(take_profit(0.1))
+                .tracks_position_extremes()
+        );
+
+        // ...and so does the strategy built from them.
+        let trailing = StrategyBuilder::new("trailing")
+            .entry(price().above(0.0))
+            .exit(trailing_stop(0.03))
+            .build();
+        assert!(trailing.tracks_position_extremes());
+
+        let plain = StrategyBuilder::new("plain")
+            .entry(price().above(0.0))
+            .exit(stop_loss(0.05))
+            .build();
+        assert!(
+            !plain.tracks_position_extremes(),
+            "a strategy with no trailing condition must not pay for the tracking"
+        );
+    }
+
+    #[test]
     fn context_extremes_match_a_scan_from_entry() {
         // Conditions read the engine's running extremes when present and fall
         // back to scanning from the entry bar when they aren't. Both paths must
@@ -737,7 +792,7 @@ mod tests {
                 position: Some(&position),
                 equity: 10_000.0,
                 indicators: &indicators,
-                extremes: Some(scanned),
+                extremes: Some(&scanned),
             };
             let without = StrategyContext {
                 candles: &candles[..=index],

--- a/src/backtesting/engine.rs
+++ b/src/backtesting/engine.rs
@@ -12,7 +12,7 @@ use super::result::{
     BacktestResult, BenchmarkMetrics, EquityPoint, PerformanceMetrics, SignalRecord,
 };
 use super::signal::{OrderType, PendingOrder, Signal, SignalDirection};
-use super::strategy::{Strategy, StrategyContext};
+use super::strategy::{PositionExtremes, Strategy, StrategyContext};
 
 /// Backtest execution engine.
 ///
@@ -416,6 +416,34 @@ pub(crate) fn compute_for_candles(
     Ok(result)
 }
 
+/// Reject candle or dividend series that are not ascending by timestamp.
+///
+/// Conditions binary-search the candle slice to locate the position entry, so an
+/// out-of-order series would silently yield a wrong index rather than an error.
+/// Dividend crediting walks a forward-only index for the same reason.
+///
+/// Optimisers and walk-forward call this once for the whole series and then use
+/// [`BacktestEngine::simulate`] per candidate, so a sweep pays the O(n) scan once
+/// instead of once per evaluation.
+pub(crate) fn validate_series_order(candles: &[Candle], dividends: &[Dividend]) -> Result<()> {
+    if !candles.windows(2).all(|w| w[0].timestamp <= w[1].timestamp) {
+        return Err(BacktestError::invalid_param(
+            "candles",
+            "must be sorted by timestamp (ascending)",
+        ));
+    }
+    if !dividends
+        .windows(2)
+        .all(|w| w[0].timestamp <= w[1].timestamp)
+    {
+        return Err(BacktestError::invalid_param(
+            "dividends",
+            "must be sorted by timestamp (ascending)",
+        ));
+    }
+    Ok(())
+}
+
 impl BacktestEngine {
     /// Create a new backtest engine with the given configuration
     pub fn new(config: BacktestConfig) -> Self {
@@ -434,6 +462,7 @@ impl BacktestEngine {
         candles: &[Candle],
         strategy: S,
     ) -> Result<BacktestResult> {
+        validate_series_order(candles, &[])?;
         self.simulate(symbol, candles, strategy, &[])
     }
 
@@ -451,13 +480,19 @@ impl BacktestEngine {
         strategy: S,
         dividends: &[Dividend],
     ) -> Result<BacktestResult> {
+        validate_series_order(candles, dividends)?;
         self.simulate(symbol, candles, strategy, dividends)
     }
 
     // ── Core simulation ───────────────────────────────────────────────────────
 
     /// Internal simulation core. All public `run*` methods delegate here.
-    fn simulate<S: Strategy>(
+    ///
+    /// Assumes `candles` and `dividends` are already known to be ascending —
+    /// the public entry points check that via [`validate_series_order`]. Sweeps
+    /// run thousands of simulations over one series, so the O(n) scan is hoisted
+    /// to the boundary rather than repeated per candidate.
+    pub(crate) fn simulate<S: Strategy>(
         &self,
         symbol: &str,
         candles: &[Candle],
@@ -467,27 +502,6 @@ impl BacktestEngine {
         let warmup = strategy.warmup_period();
         if candles.len() < warmup {
             return Err(BacktestError::insufficient_data(warmup, candles.len()));
-        }
-
-        // Validate candle ordering — conditions binary-search this slice to locate
-        // the position entry, and an out-of-order series would silently yield a
-        // wrong index rather than a wrong-but-real one.
-        if !candles.windows(2).all(|w| w[0].timestamp <= w[1].timestamp) {
-            return Err(BacktestError::invalid_param(
-                "candles",
-                "must be sorted by timestamp (ascending)",
-            ));
-        }
-
-        // Validate dividend ordering — simulation correctness requires ascending timestamps.
-        if !dividends
-            .windows(2)
-            .all(|w| w[0].timestamp <= w[1].timestamp)
-        {
-            return Err(BacktestError::invalid_param(
-                "dividends",
-                "must be sorted by timestamp (ascending)",
-            ));
         }
 
         // Pre-compute all required indicators (base timeframe + HTF stretched arrays)
@@ -509,6 +523,10 @@ impl BacktestEngine {
         // High-water mark for the trailing stop: tracks peak price (longs) or
         // trough price (shorts) since entry. Reset to None when no position is open.
         let mut hwm: Option<f64> = None;
+        // The same running scan widened to the four values trailing conditions
+        // need. Owned by the position rather than by any one condition, so every
+        // trailing condition on a position reads one shared value.
+        let mut extremes: Option<PositionExtremes> = None;
 
         // Dividend processing pointer: dividends must be sorted by timestamp.
         // We advance this index forward as the simulation progresses in time.
@@ -531,6 +549,7 @@ impl BacktestEngine {
             );
 
             update_trailing_hwm(position.as_ref(), &mut hwm, candle);
+            update_position_extremes(position.as_ref(), &mut extremes, candle);
 
             // Credit dividend income for any dividends ex-dated on or before this bar.
             self.credit_dividends(&mut position, candle, dividends, &mut div_idx);
@@ -563,6 +582,7 @@ impl BacktestEngine {
 
                 if executed {
                     hwm = None; // Reset HWM when position is closed
+                    extremes = None;
                     continue; // Skip strategy signal this bar
                 }
             }
@@ -664,6 +684,7 @@ impl BacktestEngine {
                 position: position.as_ref(),
                 equity,
                 indicators: &indicators,
+                extremes: position.as_ref().and(extremes),
             };
 
             // Get strategy signal
@@ -754,11 +775,16 @@ impl BacktestEngine {
                 )
             {
                 hwm = position.as_ref().map(|p| p.entry_price);
+                // Seeded on the next bar rather than from the entry price: the
+                // extremes are bar highs/lows since entry, and the entry bar is
+                // folded in at the top of the loop.
+                extremes = None;
             }
 
             // Reset the trailing-stop HWM whenever a position is closed
             if executed && position.is_none() {
                 hwm = None;
+                extremes = None;
 
                 // Re-evaluate strategy on the same bar after an exit so that
                 // a crossover that simultaneously closes one side and triggers
@@ -769,6 +795,7 @@ impl BacktestEngine {
                     position: None,
                     equity,
                     indicators: &indicators,
+                    extremes: None,
                 };
                 let follow = strategy.on_candle(&ctx2);
                 if !follow.is_hold() && follow.strength.value() >= self.config.min_signal_strength {
@@ -951,6 +978,7 @@ impl BacktestEngine {
         benchmark_symbol: &str,
         benchmark_candles: &[Candle],
     ) -> Result<BacktestResult> {
+        validate_series_order(candles, dividends)?;
         let mut result = self.simulate(symbol, candles, strategy, dividends)?;
         result.benchmark = Some(compute_benchmark_metrics(
             benchmark_symbol,
@@ -1529,6 +1557,26 @@ impl BacktestEngine {
 ///
 /// Cleared to `None` when no position is open so it resets on next entry.
 /// Also used by the portfolio engine.
+/// Fold `candle` into the running extremes for the open position.
+///
+/// Cleared to `None` when no position is open so it resets on the next entry —
+/// the same lifecycle as [`update_trailing_hwm`], which tracks the single value
+/// the intrabar stop needs while this tracks the four the trailing conditions do.
+pub(crate) fn update_position_extremes(
+    position: Option<&Position>,
+    extremes: &mut Option<PositionExtremes>,
+    candle: &Candle,
+) {
+    if position.is_none() {
+        *extremes = None;
+        return;
+    }
+    match extremes {
+        Some(e) => e.update(candle),
+        None => *extremes = Some(PositionExtremes::new(candle)),
+    }
+}
+
 pub(crate) fn update_trailing_hwm(
     position: Option<&Position>,
     hwm: &mut Option<f64>,
@@ -3283,6 +3331,44 @@ mod tests {
         assert!(
             format!("{err}").contains("candles"),
             "expected a candle-ordering error, got {err}"
+        );
+    }
+
+    #[test]
+    fn sweeps_reject_unsorted_candles_at_their_own_entry_point() {
+        // Validation moved off the per-candidate path, so each sweep entry point
+        // has to check the series itself or an unsorted run would slip through.
+        use crate::backtesting::optimizer::{BayesianSearch, GridSearch, ParamRange, ParamValue};
+        use crate::backtesting::refs::*;
+        use crate::backtesting::strategy::StrategyBuilder;
+
+        let mut candles = make_candles(&(0..80).map(|i| 100.0 + i as f64).collect::<Vec<f64>>());
+        candles.swap(1, 2);
+        let config = BacktestConfig::default();
+        let factory = |_: &HashMap<String, ParamValue>| {
+            StrategyBuilder::new("s")
+                .entry(price().above(0.0))
+                .exit(price().below(0.0))
+                .build()
+        };
+
+        let grid_err = GridSearch::new()
+            .param("p", ParamRange::int_range(1, 2, 1))
+            .run("TEST", &candles, &config, factory)
+            .unwrap_err();
+        assert!(
+            format!("{grid_err}").contains("candles"),
+            "grid search should reject unsorted candles, got {grid_err}"
+        );
+
+        let bayes_err = BayesianSearch::new()
+            .param("p", ParamRange::int_range(1, 2, 1))
+            .max_evaluations(4)
+            .run("TEST", &candles, &config, factory)
+            .unwrap_err();
+        assert!(
+            format!("{bayes_err}").contains("candles"),
+            "bayesian search should reject unsorted candles, got {bayes_err}"
         );
     }
 

--- a/src/backtesting/engine.rs
+++ b/src/backtesting/engine.rs
@@ -553,6 +553,17 @@ impl BacktestEngine {
 
             update_trailing_hwm(position.as_ref(), &mut hwm, candle);
             if track_extremes {
+                // Pending orders fill after this has run for their bar, so the
+                // bar a limit/stop entry opened on would never be folded in.
+                // Rebuilding from the entry bar on the first update after an
+                // entry keeps this in step with the scan in `threshold.rs`.
+                if extremes.is_none()
+                    && let Some(pos) = position.as_ref()
+                {
+                    let entry =
+                        candles[..=i].partition_point(|c| c.timestamp < pos.entry_timestamp);
+                    extremes = PositionExtremes::from_candles(&candles[entry..=i]);
+                }
                 update_position_extremes(position.as_ref(), &mut extremes, candle);
             }
 
@@ -3336,6 +3347,158 @@ mod tests {
         assert!(
             format!("{err}").contains("candles"),
             "expected a candle-ordering error, got {err}"
+        );
+    }
+
+    /// Enters once via a limit order, then exits on a trailing stop.
+    ///
+    /// `track` selects which path supplies the peak: `true` uses the engine's
+    /// running extremes, `false` makes the condition fall back to scanning from
+    /// the entry bar. Both must agree.
+    #[derive(Clone)]
+    struct LimitEntryTrailing {
+        track: bool,
+        trail: crate::backtesting::condition::TrailingStop,
+        limit: f64,
+    }
+
+    impl Strategy for LimitEntryTrailing {
+        fn name(&self) -> &str {
+            "limit-entry-trailing"
+        }
+
+        fn required_indicators(&self) -> Vec<(String, Indicator)> {
+            vec![]
+        }
+
+        fn on_candle(&self, ctx: &StrategyContext) -> Signal {
+            use crate::backtesting::condition::Condition;
+            if ctx.position.is_none() {
+                if ctx.index == 0 {
+                    return Signal::buy_limit(ctx.timestamp(), ctx.close(), self.limit);
+                }
+                return Signal::hold();
+            }
+            if self.trail.evaluate(ctx) {
+                return ctx.signal_exit();
+            }
+            Signal::hold()
+        }
+
+        fn tracks_position_extremes(&self) -> bool {
+            self.track
+        }
+    }
+
+    #[test]
+    fn a_limit_entry_counts_its_own_fill_bar_in_the_peak() {
+        // Pending orders fill partway through a bar, after the engine has
+        // already folded that bar's extremes for a still-empty position. The
+        // fill bar carries the highest high here, so skipping it lowers the
+        // peak and moves the trailing-stop exit.
+        let candles = vec![
+            // bar 0: signal bar, queues the limit order
+            Candle {
+                timestamp: 0,
+                open: 100.0,
+                high: 100.0,
+                low: 100.0,
+                close: 100.0,
+                volume: 1000,
+                adj_close: None,
+                provider_id: None,
+            },
+            // bar 1: dips to 95 (fills), then spikes to 130 — the peak
+            Candle {
+                timestamp: 1,
+                open: 99.0,
+                high: 130.0,
+                low: 94.0,
+                close: 120.0,
+                volume: 1000,
+                adj_close: None,
+                provider_id: None,
+            },
+            Candle {
+                timestamp: 2,
+                open: 119.0,
+                high: 121.0,
+                low: 115.0,
+                close: 116.0,
+                volume: 1000,
+                adj_close: None,
+                provider_id: None,
+            },
+            Candle {
+                timestamp: 3,
+                open: 115.0,
+                high: 116.0,
+                low: 110.0,
+                close: 111.0,
+                volume: 1000,
+                adj_close: None,
+                provider_id: None,
+            },
+            Candle {
+                timestamp: 4,
+                open: 110.0,
+                high: 111.0,
+                low: 104.0,
+                close: 105.0,
+                volume: 1000,
+                adj_close: None,
+                provider_id: None,
+            },
+            Candle {
+                timestamp: 5,
+                open: 104.0,
+                high: 105.0,
+                low: 100.0,
+                close: 101.0,
+                volume: 1000,
+                adj_close: None,
+                provider_id: None,
+            },
+        ];
+
+        let config = BacktestConfig {
+            initial_capital: 10_000.0,
+            ..Default::default()
+        };
+        let run = |track: bool| {
+            BacktestEngine::new(config.clone())
+                .run(
+                    "TEST",
+                    &candles,
+                    LimitEntryTrailing {
+                        track,
+                        trail: crate::backtesting::condition::TrailingStop::new(0.10),
+                        limit: 95.0,
+                    },
+                )
+                .unwrap()
+        };
+
+        let engine_path = run(true);
+        let scan_path = run(false);
+
+        assert_eq!(
+            engine_path.trades.len(),
+            1,
+            "the limit order should fill and the trailing stop should close it"
+        );
+        assert_eq!(
+            engine_path.trades.len(),
+            scan_path.trades.len(),
+            "the two peak sources disagreed on whether a trade closed"
+        );
+        assert_eq!(
+            engine_path.trades[0].exit_timestamp, scan_path.trades[0].exit_timestamp,
+            "engine-tracked extremes and the entry-bar scan chose different exits"
+        );
+        assert_eq!(
+            engine_path.trades[0].pnl, scan_path.trades[0].pnl,
+            "same exit bar should mean same P&L"
         );
     }
 

--- a/src/backtesting/engine.rs
+++ b/src/backtesting/engine.rs
@@ -527,6 +527,9 @@ impl BacktestEngine {
         // need. Owned by the position rather than by any one condition, so every
         // trailing condition on a position reads one shared value.
         let mut extremes: Option<PositionExtremes> = None;
+        // Only strategies with a trailing condition read this, and folding it
+        // per bar is pure overhead for every strategy that doesn't.
+        let track_extremes = strategy.tracks_position_extremes();
 
         // Dividend processing pointer: dividends must be sorted by timestamp.
         // We advance this index forward as the simulation progresses in time.
@@ -549,7 +552,9 @@ impl BacktestEngine {
             );
 
             update_trailing_hwm(position.as_ref(), &mut hwm, candle);
-            update_position_extremes(position.as_ref(), &mut extremes, candle);
+            if track_extremes {
+                update_position_extremes(position.as_ref(), &mut extremes, candle);
+            }
 
             // Credit dividend income for any dividends ex-dated on or before this bar.
             self.credit_dividends(&mut position, candle, dividends, &mut div_idx);
@@ -684,7 +689,7 @@ impl BacktestEngine {
                 position: position.as_ref(),
                 equity,
                 indicators: &indicators,
-                extremes: position.as_ref().and(extremes),
+                extremes: position.as_ref().and(extremes.as_ref()),
             };
 
             // Get strategy signal

--- a/src/backtesting/engine.rs
+++ b/src/backtesting/engine.rs
@@ -337,6 +337,25 @@ pub(crate) fn compute_for_candles(
         return Ok(HashMap::new());
     }
 
+    // Two requests for the same `Indicator` recompute it, and multi-output
+    // variants then overwrite each other's derived keys. Compute each distinct
+    // indicator once and record the names that were dropped: single-output
+    // variants key their result by the caller's name, so a dropped name still
+    // has to resolve — a custom `IndicatorRef` may share an `Indicator` with a
+    // built-in one while using its own key.
+    let (required, aliases) = {
+        let mut uniq: Vec<(String, Indicator)> = Vec::with_capacity(required.len());
+        let mut aliases: Vec<(String, String)> = Vec::new();
+        for (name, ind) in required {
+            match uniq.iter().find(|(_, u)| *u == ind) {
+                Some((kept, _)) if *kept != name => aliases.push((name, kept.clone())),
+                Some(_) => {}
+                None => uniq.push((name, ind)),
+            }
+        }
+        (uniq, aliases)
+    };
+
     let use_hl = required.iter().any(|(_, i)| needs_high_low(i));
     let use_vol = required.iter().any(|(_, i)| needs_volumes(i));
     let use_open = required
@@ -381,10 +400,17 @@ pub(crate) fn compute_for_candles(
 
     let groups = groups?;
     let capacity: usize = groups.iter().map(|v| v.len()).sum();
-    let mut result = HashMap::with_capacity(capacity);
+    let mut result = HashMap::with_capacity(capacity + aliases.len());
     for group in groups {
         for (k, v) in group {
             result.insert(k, v);
+        }
+    }
+    // A multi-output indicator ignores the caller's key, so its kept name is
+    // absent here and the alias is correctly a no-op.
+    for (dropped, kept) in aliases {
+        if let Some(values) = result.get(&kept).cloned() {
+            result.entry(dropped).or_insert(values);
         }
     }
     Ok(result)
@@ -441,6 +467,16 @@ impl BacktestEngine {
         let warmup = strategy.warmup_period();
         if candles.len() < warmup {
             return Err(BacktestError::insufficient_data(warmup, candles.len()));
+        }
+
+        // Validate candle ordering — conditions binary-search this slice to locate
+        // the position entry, and an out-of-order series would silently yield a
+        // wrong index rather than a wrong-but-real one.
+        if !candles.windows(2).all(|w| w[0].timestamp <= w[1].timestamp) {
+            return Err(BacktestError::invalid_param(
+                "candles",
+                "must be sorted by timestamp (ascending)",
+            ));
         }
 
         // Validate dividend ordering — simulation correctness requires ascending timestamps.
@@ -3229,5 +3265,92 @@ mod tests {
             result.trades[0].pnl > 0.0,
             "short trailing stop should exit in profit (entry $100, exit near $88)"
         );
+    }
+
+    #[test]
+    fn unsorted_candles_are_rejected() {
+        let mut candles = make_candles(&[100.0, 101.0, 102.0, 103.0]);
+        candles.swap(1, 2);
+        use crate::backtesting::refs::*;
+        use crate::backtesting::strategy::StrategyBuilder;
+        let strategy = StrategyBuilder::new("s")
+            .entry(price().above(0.0))
+            .exit(price().below(0.0))
+            .build();
+        let err = BacktestEngine::new(BacktestConfig::default())
+            .run("TEST", &candles, strategy)
+            .unwrap_err();
+        assert!(
+            format!("{err}").contains("candles"),
+            "expected a candle-ordering error, got {err}"
+        );
+    }
+
+    #[test]
+    fn distinct_keys_for_one_indicator_both_resolve() {
+        // A custom `IndicatorRef` may pick its own key while requesting the same
+        // `Indicator` as a built-in ref. Deduping the computation must not drop
+        // the second key, or the condition reading it silently never fires.
+        let candles = make_candles(
+            &(0..300)
+                .map(|i| 100.0 + (i % 7) as f64)
+                .collect::<Vec<f64>>(),
+        );
+        let map = compute_for_candles(
+            &candles,
+            vec![
+                ("sma_20".to_string(), Indicator::Sma(20)),
+                ("my_ma".to_string(), Indicator::Sma(20)),
+            ],
+        )
+        .unwrap();
+
+        assert!(map.contains_key("sma_20"));
+        assert!(map.contains_key("my_ma"), "aliased key was dropped");
+        assert_eq!(map.get("sma_20"), map.get("my_ma"));
+    }
+
+    #[test]
+    fn duplicate_indicator_requests_produce_identical_map() {
+        let prices: Vec<f64> = (0..500)
+            .map(|i| 100.0 + (i as f64 * 0.1).sin() * 5.0)
+            .collect();
+        let candles = make_candles(&prices);
+
+        let one = compute_for_candles(
+            &candles,
+            vec![(
+                "bb_u".to_string(),
+                Indicator::Bollinger {
+                    period: 20,
+                    std_dev: 2.0,
+                },
+            )],
+        )
+        .unwrap();
+        let two = compute_for_candles(
+            &candles,
+            vec![
+                (
+                    "bb_u".to_string(),
+                    Indicator::Bollinger {
+                        period: 20,
+                        std_dev: 2.0,
+                    },
+                ),
+                (
+                    "bb_l".to_string(),
+                    Indicator::Bollinger {
+                        period: 20,
+                        std_dev: 2.0,
+                    },
+                ),
+            ],
+        )
+        .unwrap();
+
+        for (k, v) in &one {
+            assert_eq!(two.get(k), Some(v), "key {k} changed when requested twice");
+        }
     }
 }

--- a/src/backtesting/mod.rs
+++ b/src/backtesting/mod.rs
@@ -124,7 +124,7 @@ pub use signal::{
 };
 
 // Re-export strategy types
-pub use strategy::{Strategy, StrategyContext};
+pub use strategy::{PositionExtremes, Strategy, StrategyContext};
 
 // Re-export strategy builder
 pub use strategy::StrategyBuilder;

--- a/src/backtesting/optimizer/bayesian.rs
+++ b/src/backtesting/optimizer/bayesian.rs
@@ -58,7 +58,7 @@ use rayon::prelude::*;
 use crate::models::chart::Candle;
 
 use super::super::config::BacktestConfig;
-use super::super::engine::BacktestEngine;
+use super::super::engine::{BacktestEngine, validate_series_order};
 use super::super::error::{BacktestError, Result};
 use super::super::monte_carlo::Xorshift64;
 use super::super::strategy::Strategy;
@@ -80,9 +80,10 @@ const N_CANDIDATES: usize = 1_000;
 /// Observation count at which parallel candidate scoring starts to pay off.
 /// `Surrogate::predict` loops every observation, so per-call work scales with
 /// this. Below it, rayon's dispatch cost exceeds the benefit: measured
-/// 3.4→4.3 ms at 30 observations and 11.8→12.3 ms at 60, versus 43.2→22.7 ms at
-/// 120 and 114.9→44.0 ms at 200.
-const MIN_OBSERVATIONS_FOR_PARALLEL: usize = 60;
+/// 3.4→4.3 ms at 30 observations and 11.8→12.3 ms at 60 (both regressions),
+/// versus 43.2→22.7 ms at 120 and 114.9→44.0 ms at 200. 120 is the first
+/// measured win, so the gate sits there rather than at the last measured loss.
+const MIN_OBSERVATIONS_FOR_PARALLEL: usize = 120;
 
 // ── BayesianSearch ────────────────────────────────────────────────────────────
 
@@ -189,6 +190,9 @@ impl BayesianSearch {
                 "BayesianSearch requires at least one parameter range",
             ));
         }
+
+        // Checked once here rather than inside every candidate's backtest.
+        validate_series_order(candles, &[])?;
 
         let d = self.params.len();
         let metric = self.metric.unwrap_or(OptimizeMetric::SharpeRatio);
@@ -389,7 +393,7 @@ where
 {
     let params = denormalize(norm_point, param_specs);
     let strategy = factory(&params);
-    match BacktestEngine::new(config.clone()).run(symbol, candles, strategy) {
+    match BacktestEngine::new(config.clone()).simulate(symbol, candles, strategy, &[]) {
         Ok(result) => Some(OptimizationResult { params, result }),
         Err(BacktestError::InsufficientData { .. }) => None,
         Err(e) => {

--- a/src/backtesting/optimizer/bayesian.rs
+++ b/src/backtesting/optimizer/bayesian.rs
@@ -53,6 +53,8 @@
 
 use std::collections::HashMap;
 
+use rayon::prelude::*;
+
 use crate::models::chart::Candle;
 
 use super::super::config::BacktestConfig;
@@ -75,6 +77,12 @@ const DEFAULT_SEED: u64 = 42;
 /// Candidates evaluated per acquisition step. 1 000 reliably finds the UCB
 /// maximum without meaningful overhead (pure floating-point math, no backtests).
 const N_CANDIDATES: usize = 1_000;
+/// Observation count at which parallel candidate scoring starts to pay off.
+/// `Surrogate::predict` loops every observation, so per-call work scales with
+/// this. Below it, rayon's dispatch cost exceeds the benefit: measured
+/// 3.4→4.3 ms at 30 observations and 11.8→12.3 ms at 60, versus 43.2→22.7 ms at
+/// 120 and 114.9→44.0 ms at 200.
+const MIN_OBSERVATIONS_FOR_PARALLEL: usize = 60;
 
 // ── BayesianSearch ────────────────────────────────────────────────────────────
 
@@ -235,22 +243,17 @@ impl BayesianSearch {
                 (0..d).map(|_| rng.next_f64_positive()).collect()
             } else {
                 let surrogate = Surrogate::fit(&observations, beta);
-                // Reuse a single candidate buffer across all N_CANDIDATES evaluations,
-                // eliminating N_CANDIDATES heap allocations per sequential step.
-                let mut candidate = vec![0.0_f64; d];
-                let mut best_ucb = f64::NEG_INFINITY;
-                let mut best = vec![0.0_f64; d];
-                for _ in 0..N_CANDIDATES {
-                    for xi in candidate.iter_mut() {
-                        *xi = rng.next_f64_positive();
-                    }
-                    let ucb = surrogate.acquisition(&candidate);
-                    if ucb > best_ucb {
-                        best_ucb = ucb;
-                        best.copy_from_slice(&candidate);
-                    }
+                // Draw every candidate serially into one flat buffer so the RNG
+                // consumption order — and hence seeded reproducibility — is
+                // identical to a per-candidate sequential scan.
+                let mut candidates = vec![0.0_f64; N_CANDIDATES * d];
+                for xi in candidates.iter_mut() {
+                    *xi = rng.next_f64_positive();
                 }
-                best
+                match argmax_acquisition(&surrogate, &candidates, d) {
+                    Some(i) => candidates[i * d..(i + 1) * d].to_vec(),
+                    None => vec![0.0_f64; d],
+                }
             };
 
             n_evaluations += 1;
@@ -318,6 +321,55 @@ fn update_best(best: &mut Option<f64>, score: f64) {
         Some(b) if score > *b => *b = score,
         _ => {}
     }
+}
+
+/// Index of the highest-UCB candidate in a flat `d`-strided buffer, or `None`
+/// when no candidate is eligible.
+///
+/// Exactly reproduces a sequential `if ucb > best_ucb` scan seeded with
+/// `f64::NEG_INFINITY`: candidates scoring `NaN` or `-∞` never beat that
+/// initial value, so they are mapped to the reduction identity and lose to any
+/// finite score. Ties are broken by lowest index, matching the strict `>` of
+/// the sequential scan. Both comparisons are order-independent, so rayon's
+/// non-deterministic combination order cannot change the winner.
+///
+/// Rayon is engaged only at [`MIN_OBSERVATIONS_FOR_PARALLEL`] observations or
+/// more. Both branches share the same scoring and combining closures, so the
+/// selected index is identical either way.
+fn argmax_acquisition(surrogate: &Surrogate<'_>, candidates: &[f64], d: usize) -> Option<usize> {
+    const NONE: (f64, usize) = (f64::NEG_INFINITY, usize::MAX);
+
+    let score = |(i, c): (usize, &[f64])| {
+        let ucb = surrogate.acquisition(c);
+        if ucb > f64::NEG_INFINITY {
+            (ucb, i)
+        } else {
+            NONE
+        }
+    };
+    let combine = |a: (f64, usize), b: (f64, usize)| {
+        if b.0 > a.0 || (b.0 == a.0 && b.1 < a.1) {
+            b
+        } else {
+            a
+        }
+    };
+
+    let (_, best) = if surrogate.observations.len() >= MIN_OBSERVATIONS_FOR_PARALLEL {
+        candidates
+            .par_chunks(d)
+            .enumerate()
+            .map(score)
+            .reduce(|| NONE, combine)
+    } else {
+        candidates
+            .chunks(d)
+            .enumerate()
+            .map(score)
+            .fold(NONE, combine)
+    };
+
+    (best != usize::MAX).then_some(best)
 }
 
 /// Run one backtest for a unit-hypercube point; returns `None` for
@@ -732,6 +784,168 @@ mod tests {
                 .run("TEST", &candles, &config, |_| SmaCrossover::new(5, 20))
                 .is_err()
         );
+    }
+
+    /// Reference implementation: the exact sequential scan this module used
+    /// before candidate scoring was parallelised.
+    fn argmax_acquisition_sequential(
+        surrogate: &Surrogate<'_>,
+        candidates: &[f64],
+        d: usize,
+    ) -> Option<usize> {
+        let mut best_ucb = f64::NEG_INFINITY;
+        let mut best = None;
+        for (i, c) in candidates.chunks(d).enumerate() {
+            let ucb = surrogate.acquisition(c);
+            if ucb > best_ucb {
+                best_ucb = ucb;
+                best = Some(i);
+            }
+        }
+        best
+    }
+
+    #[test]
+    fn test_argmax_acquisition_matches_sequential_scan() {
+        let mut rng = Xorshift64::new(12345);
+        let obs: Vec<(Vec<f64>, f64)> = (0..12)
+            .map(|_| {
+                (
+                    vec![rng.next_f64_positive(), rng.next_f64_positive()],
+                    rng.next_f64_positive(),
+                )
+            })
+            .collect();
+
+        for seed in [1_u64, 2, 3, 77, 9_999] {
+            let mut rng = Xorshift64::new(seed);
+            let d = 2;
+            let mut candidates = vec![0.0_f64; N_CANDIDATES * d];
+            for xi in candidates.iter_mut() {
+                *xi = rng.next_f64_positive();
+            }
+            let s = Surrogate::fit(&obs, DEFAULT_UCB_BETA);
+            assert_eq!(
+                argmax_acquisition(&s, &candidates, d),
+                argmax_acquisition_sequential(&s, &candidates, d),
+                "seed {seed}: parallel argmax diverged from sequential scan"
+            );
+        }
+    }
+
+    /// Straddles `MIN_OBSERVATIONS_FOR_PARALLEL` so both the sequential fold and
+    /// the rayon reduce are exercised, and both must equal the reference scan.
+    #[test]
+    fn test_argmax_acquisition_agrees_across_parallel_threshold() {
+        let d = 3;
+        let mut rng = Xorshift64::new(4242);
+        let mut candidates = vec![0.0_f64; N_CANDIDATES * d];
+        for xi in candidates.iter_mut() {
+            *xi = rng.next_f64_positive();
+        }
+
+        let all_obs: Vec<(Vec<f64>, f64)> = (0..MIN_OBSERVATIONS_FOR_PARALLEL + 5)
+            .map(|_| {
+                (
+                    (0..d).map(|_| rng.next_f64_positive()).collect(),
+                    rng.next_f64_positive(),
+                )
+            })
+            .collect();
+
+        for n in [
+            MIN_OBSERVATIONS_FOR_PARALLEL - 1,
+            MIN_OBSERVATIONS_FOR_PARALLEL,
+            MIN_OBSERVATIONS_FOR_PARALLEL + 5,
+        ] {
+            let obs = &all_obs[..n];
+            let s = Surrogate::fit(obs, DEFAULT_UCB_BETA);
+            let got = argmax_acquisition(&s, &candidates, d);
+            assert!(got.is_some(), "n={n}: expected a winning candidate");
+            assert_eq!(
+                got,
+                argmax_acquisition_sequential(&s, &candidates, d),
+                "n={n}: diverged from sequential reference (parallel branch taken: {})",
+                n >= MIN_OBSERVATIONS_FOR_PARALLEL
+            );
+        }
+    }
+
+    /// Duplicated candidates score identically; the lowest index must win in
+    /// both the parallel and sequential formulations.
+    #[test]
+    fn test_argmax_acquisition_breaks_ties_by_lowest_index() {
+        let obs = vec![(vec![0.3_f64], 0.4_f64), (vec![0.7], 0.9)];
+        let s = Surrogate::fit(&obs, DEFAULT_UCB_BETA);
+
+        // Three copies of the UCB-maximal point, then a clearly worse one.
+        let candidates = vec![0.7_f64, 0.7, 0.7, 0.3];
+        assert_eq!(argmax_acquisition(&s, &candidates, 1), Some(0));
+        assert_eq!(
+            argmax_acquisition_sequential(&s, &candidates, 1),
+            Some(0),
+            "reference scan disagrees, test fixture is wrong"
+        );
+    }
+
+    /// β = NaN makes every acquisition NaN, so no candidate ever beats the
+    /// initial `NEG_INFINITY`. Both formulations must report "none selected",
+    /// which the caller turns into `vec![0.0; d]`.
+    #[test]
+    fn test_argmax_acquisition_all_nan_selects_nothing() {
+        let obs = vec![(vec![0.3_f64], 0.4_f64), (vec![0.7], 0.9)];
+        let s = Surrogate::fit(&obs, f64::NAN);
+        let candidates = vec![0.1_f64, 0.4, 0.6, 0.9];
+
+        assert!(s.acquisition(&[0.1]).is_nan(), "fixture must produce NaN");
+        assert_eq!(argmax_acquisition(&s, &candidates, 1), None);
+        assert_eq!(argmax_acquisition_sequential(&s, &candidates, 1), None);
+    }
+
+    /// Pins the *selected candidates*, not just the aggregate score: a
+    /// tie-break or RNG-order regression changes which parameter sets get
+    /// evaluated, which shows up as a per-element mismatch here.
+    #[test]
+    fn seeded_bayesian_selects_identical_candidates() {
+        let candles = make_candles(&trending_prices(200));
+        let config = BacktestConfig::builder()
+            .commission_pct(0.0)
+            .slippage_pct(0.0)
+            .build()
+            .unwrap();
+
+        let search = BayesianSearch::new()
+            .param("fast", ParamRange::int_bounds(3, 12))
+            .param("slow", ParamRange::int_bounds(12, 30))
+            .param("threshold", ParamRange::float_bounds(0.1, 0.9))
+            .max_evaluations(25)
+            .seed(77);
+
+        let factory = |p: &HashMap<String, ParamValue>| {
+            SmaCrossover::new(p["fast"].as_int() as usize, p["slow"].as_int() as usize)
+        };
+
+        let r1 = search
+            .clone()
+            .run("TEST", &candles, &config, factory)
+            .unwrap();
+        let r2 = search.run("TEST", &candles, &config, factory).unwrap();
+
+        assert_eq!(r1.results.len(), r2.results.len());
+        assert!(
+            r1.results.len() > 10,
+            "too few evaluations to be meaningful"
+        );
+
+        for (i, (a, b)) in r1.results.iter().zip(r2.results.iter()).enumerate() {
+            assert_eq!(a.params, b.params, "params diverged at result {i}");
+            assert_eq!(
+                a.result.metrics.total_return_pct, b.result.metrics.total_return_pct,
+                "metrics diverged at result {i}"
+            );
+        }
+        assert_eq!(r1.convergence_curve, r2.convergence_curve);
+        assert_eq!(r1.n_evaluations, r2.n_evaluations);
     }
 
     #[test]

--- a/src/backtesting/optimizer/grid.rs
+++ b/src/backtesting/optimizer/grid.rs
@@ -38,7 +38,7 @@ use rayon::prelude::*;
 use crate::models::chart::Candle;
 
 use super::super::config::BacktestConfig;
-use super::super::engine::BacktestEngine;
+use super::super::engine::{BacktestEngine, validate_series_order};
 use super::super::error::{BacktestError, Result};
 use super::super::strategy::Strategy;
 use super::{
@@ -117,6 +117,9 @@ impl GridSearch {
             ));
         }
 
+        // Checked once here rather than inside every combination's backtest.
+        validate_series_order(candles, &[])?;
+
         let metric = self.metric.unwrap_or(OptimizeMetric::SharpeRatio);
 
         let expanded: Vec<(&str, Vec<ParamValue>)> = self
@@ -148,7 +151,7 @@ impl GridSearch {
             .into_par_iter()
             .filter_map(|params| {
                 let strategy = factory(&params);
-                match BacktestEngine::new(config.clone()).run(symbol, candles, strategy) {
+                match BacktestEngine::new(config.clone()).simulate(symbol, candles, strategy, &[]) {
                     Ok(result) => Some(OptimizationResult { params, result }),
                     Err(BacktestError::InsufficientData { .. }) => None,
                     Err(e) => {

--- a/src/backtesting/portfolio/engine.rs
+++ b/src/backtesting/portfolio/engine.rs
@@ -93,6 +93,7 @@ impl PortfolioEngine {
         for data in symbol_data {
             let strategy = factory(&data.symbol);
             let warmup = strategy.warmup_period();
+            let track_extremes = strategy.tracks_position_extremes();
             if data.candles.len() < warmup {
                 return Err(BacktestError::insufficient_data(warmup, data.candles.len()));
             }
@@ -127,6 +128,7 @@ impl PortfolioEngine {
                     position: None,
                     hwm: None,
                     extremes: None,
+                    track_extremes,
                     div_idx: 0,
                     trades: vec![],
                     signals: vec![],
@@ -172,7 +174,9 @@ impl PortfolioEngine {
                 // Update HWM for trailing stop using the intrabar extreme so the
                 // trailing stop correctly reflects the best price reached during the bar.
                 update_trailing_hwm(state.position.as_ref(), &mut state.hwm, candle);
-                update_position_extremes(state.position.as_ref(), &mut state.extremes, candle);
+                if state.track_extremes {
+                    update_position_extremes(state.position.as_ref(), &mut state.extremes, candle);
+                }
 
                 // Credit dividends ex-dated on or before this bar
                 while state.div_idx < state.dividends.len()
@@ -287,7 +291,7 @@ impl PortfolioEngine {
                     position: state.position.as_ref(),
                     equity: portfolio_equity,
                     indicators: &state.indicators,
-                    extremes: state.position.as_ref().and(state.extremes),
+                    extremes: state.position.as_ref().and(state.extremes.as_ref()),
                 };
 
                 let signal = state.strategy.on_candle(&ctx);
@@ -905,6 +909,7 @@ struct SymbolState<S: Strategy> {
     position: Option<Position>,
     hwm: Option<f64>,
     extremes: Option<crate::backtesting::strategy::PositionExtremes>,
+    track_extremes: bool,
     div_idx: usize,
     trades: Vec<Trade>,
     signals: Vec<SignalRecord>,

--- a/src/backtesting/portfolio/engine.rs
+++ b/src/backtesting/portfolio/engine.rs
@@ -4,7 +4,7 @@ use std::cmp::Ordering;
 use std::collections::{BTreeSet, HashMap, HashSet};
 
 use crate::backtesting::config::BacktestConfig;
-use crate::backtesting::engine::{BacktestEngine, update_trailing_hwm};
+use crate::backtesting::engine::{BacktestEngine, update_position_extremes, update_trailing_hwm};
 use crate::backtesting::error::{BacktestError, Result};
 use crate::backtesting::position::{Position, PositionSide, Trade};
 use crate::backtesting::result::{BacktestResult, EquityPoint, PerformanceMetrics, SignalRecord};
@@ -126,6 +126,7 @@ impl PortfolioEngine {
                     warmup,
                     position: None,
                     hwm: None,
+                    extremes: None,
                     div_idx: 0,
                     trades: vec![],
                     signals: vec![],
@@ -171,6 +172,7 @@ impl PortfolioEngine {
                 // Update HWM for trailing stop using the intrabar extreme so the
                 // trailing stop correctly reflects the best price reached during the bar.
                 update_trailing_hwm(state.position.as_ref(), &mut state.hwm, candle);
+                update_position_extremes(state.position.as_ref(), &mut state.extremes, candle);
 
                 // Credit dividends ex-dated on or before this bar
                 while state.div_idx < state.dividends.len()
@@ -240,6 +242,7 @@ impl PortfolioEngine {
                 state.realized_pnl += trade.pnl;
                 state.trades.push(trade);
                 state.hwm = None;
+                state.extremes = None;
                 state.signals.push(SignalRecord {
                     timestamp,
                     price: fill_price,
@@ -284,6 +287,7 @@ impl PortfolioEngine {
                     position: state.position.as_ref(),
                     equity: portfolio_equity,
                     indicators: &state.indicators,
+                    extremes: state.position.as_ref().and(state.extremes),
                 };
 
                 let signal = state.strategy.on_candle(&ctx);
@@ -342,6 +346,7 @@ impl PortfolioEngine {
                                 state.realized_pnl += trade.pnl;
                                 state.trades.push(trade);
                                 state.hwm = None;
+                                state.extremes = None;
                                 state.signals.push(SignalRecord {
                                     timestamp: signal.timestamp,
                                     price: signal.price,
@@ -453,6 +458,7 @@ impl PortfolioEngine {
                                     let trade = if fraction >= 1.0 {
                                         let pos = state.position.take().unwrap();
                                         state.hwm = None;
+                                        state.extremes = None;
                                         pos.close_with_tax(
                                             fill_candle.timestamp,
                                             exit_price,
@@ -655,6 +661,7 @@ impl PortfolioEngine {
                     signal.clone(),
                 ));
                 state.hwm = Some(entry_price);
+                state.extremes = None;
                 state.signals.push(SignalRecord {
                     timestamp: signal.timestamp,
                     price: signal_price,
@@ -772,6 +779,7 @@ impl PortfolioEngine {
                     state.realized_pnl += trade.pnl;
                     state.trades.push(trade);
                     state.hwm = None;
+                    state.extremes = None;
 
                     let sym_equity = state.sym_initial_capital + state.realized_pnl;
                     sync_terminal_equity_point(
@@ -896,6 +904,7 @@ struct SymbolState<S: Strategy> {
     warmup: usize,
     position: Option<Position>,
     hwm: Option<f64>,
+    extremes: Option<crate::backtesting::strategy::PositionExtremes>,
     div_idx: usize,
     trades: Vec<Trade>,
     signals: Vec<SignalRecord>,

--- a/src/backtesting/refs/htf.rs
+++ b/src/backtesting/refs/htf.rs
@@ -124,6 +124,7 @@ impl<C: Condition> Condition for HtfCondition<C> {
                     position: ctx.position,
                     equity: ctx.equity,
                     indicators: &mini_indicators,
+                    extremes: ctx.extremes,
                 };
                 return self.inner.evaluate(&htf_ctx);
             }
@@ -223,6 +224,7 @@ impl<C: Condition> HtfCondition<C> {
             position: ctx.position,
             equity: ctx.equity,
             indicators: &htf_indicators,
+            extremes: ctx.extremes,
         };
 
         self.inner.evaluate(&htf_ctx)

--- a/src/backtesting/refs/htf.rs
+++ b/src/backtesting/refs/htf.rs
@@ -157,6 +157,10 @@ impl<C: Condition> Condition for HtfCondition<C> {
         self.specs.clone()
     }
 
+    fn tracks_position_extremes(&self) -> bool {
+        self.inner.tracks_position_extremes()
+    }
+
     fn description(&self) -> String {
         format!("htf({}, {})", self.interval, self.inner.description())
     }

--- a/src/backtesting/refs/htf.rs
+++ b/src/backtesting/refs/htf.rs
@@ -78,35 +78,36 @@ pub struct HtfCondition<C: Condition> {
     /// UTC offset of the exchange. Shifts bucket boundaries so weekly/monthly
     /// periods align with the exchange's local calendar rather than UTC midnight.
     utc_offset_secs: i64,
+    /// Derived once at construction from `inner.required_indicators()`. Purely a
+    /// function of `self`, so `evaluate` never has to re-walk the condition tree
+    /// or re-format lookup keys on a per-bar basis.
+    specs: Vec<HtfIndicatorSpec>,
 }
 
 impl<C: Condition> Condition for HtfCondition<C> {
     fn evaluate(&self, ctx: &StrategyContext) -> bool {
-        let required = self.inner.required_indicators();
-
         // ── Fast path: use pre-computed stretched arrays from the engine ──────
         // The engine stores stretched HTF values in ctx.indicators under keys of
-        // the form "htf_{interval}_{base_key}" (e.g. "htf_1wk_sma_20").
+        // the form "htf_{interval}_{base_key}" (e.g. "htf_1wk_sma_20"), which is
+        // exactly what `self.specs` holds.
         //
         // We build a tiny 2-element indicators map [prev, curr] so that the inner
         // condition's crossover helpers (indicator_prev / crossed_above etc.) work
         // correctly, then evaluate with index=1.
-        if !required.is_empty() {
-            let interval_str = self.interval.as_str();
+        if !self.specs.is_empty() {
             let mut mini_indicators: HashMap<String, Vec<Option<f64>>> =
-                HashMap::with_capacity(required.len());
+                HashMap::with_capacity(self.specs.len());
             let mut all_found = true;
 
-            for (base_key, _) in &required {
-                let htf_key = format!("htf_{}_{}", interval_str, base_key);
-                if let Some(stretched) = ctx.indicators.get(&htf_key) {
+            for spec in &self.specs {
+                if let Some(stretched) = ctx.indicators.get(&spec.htf_key) {
                     let curr = stretched.get(ctx.index).copied().flatten();
                     let prev = ctx
                         .index
                         .checked_sub(1)
                         .and_then(|pi| stretched.get(pi).copied().flatten());
                     // index=1 → curr; index=0 → prev (via indicator_prev)
-                    mini_indicators.insert(base_key.clone(), vec![prev, curr]);
+                    mini_indicators.insert(spec.base_key.clone(), vec![prev, curr]);
                 } else {
                     all_found = false;
                     break;
@@ -152,18 +153,7 @@ impl<C: Condition> Condition for HtfCondition<C> {
     }
 
     fn htf_requirements(&self) -> Vec<HtfIndicatorSpec> {
-        let interval_str = self.interval.as_str();
-        self.inner
-            .required_indicators()
-            .into_iter()
-            .map(|(base_key, indicator)| HtfIndicatorSpec {
-                interval: self.interval,
-                htf_key: format!("htf_{}_{}", interval_str, base_key),
-                base_key,
-                indicator,
-                utc_offset_secs: self.utc_offset_secs,
-            })
-            .collect()
+        self.specs.clone()
     }
 
     fn description(&self) -> String {
@@ -172,6 +162,27 @@ impl<C: Condition> Condition for HtfCondition<C> {
 }
 
 impl<C: Condition> HtfCondition<C> {
+    fn new(interval: Interval, inner: C, utc_offset_secs: i64) -> Self {
+        let interval_str = interval.as_str();
+        let specs = inner
+            .required_indicators()
+            .into_iter()
+            .map(|(base_key, indicator)| HtfIndicatorSpec {
+                interval,
+                htf_key: format!("htf_{}_{}", interval_str, base_key),
+                base_key,
+                indicator,
+                utc_offset_secs,
+            })
+            .collect();
+        Self {
+            interval,
+            inner,
+            utc_offset_secs,
+            specs,
+        }
+    }
+
     /// Dynamic resampling fallback used when pre-computed data is unavailable.
     ///
     /// This is O(n) per bar (O(n²) overall). It finds the most recently
@@ -189,10 +200,14 @@ impl<C: Condition> HtfCondition<C> {
             None => return false, // No completed HTF bar yet
         };
 
-        let required = self.inner.required_indicators();
-        let htf_indicators = if required.is_empty() {
+        let htf_indicators = if self.specs.is_empty() {
             HashMap::new()
         } else {
+            let required = self
+                .specs
+                .iter()
+                .map(|s| (s.base_key.clone(), s.indicator))
+                .collect();
             match compute_for_candles(&htf_candles, required) {
                 Ok(map) => map,
                 Err(e) => {
@@ -235,11 +250,7 @@ impl<C: Condition> HtfCondition<C> {
 /// let entry = ema(10).crosses_above_ref(ema(30)).and(weekly_uptrend);
 /// ```
 pub fn htf<C: Condition>(interval: Interval, cond: C) -> HtfCondition<C> {
-    HtfCondition {
-        interval,
-        inner: cond,
-        utc_offset_secs: 0,
-    }
+    HtfCondition::new(interval, cond, 0)
 }
 
 /// Wrap a condition to be evaluated on a higher-timeframe candle series,
@@ -264,9 +275,104 @@ pub fn htf<C: Condition>(interval: Interval, cond: C) -> HtfCondition<C> {
 /// let weekly_trend = htf_region(Interval::OneWeek, Region::Japan, price().above_ref(sma(20)));
 /// ```
 pub fn htf_region<C: Condition>(interval: Interval, region: Region, cond: C) -> HtfCondition<C> {
-    HtfCondition {
-        interval,
-        inner: cond,
-        utc_offset_secs: region.utc_offset_secs(),
+    HtfCondition::new(interval, cond, region.utc_offset_secs())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backtesting::config::BacktestConfig;
+    use crate::backtesting::engine::BacktestEngine;
+    use crate::backtesting::refs::{IndicatorRefExt, price, sma};
+    use crate::backtesting::strategy::StrategyBuilder;
+    use crate::models::chart::Candle;
+
+    const DAY: i64 = 86_400;
+
+    /// Daily bars starting 1970-01-05 (a Monday) so weekly buckets are aligned.
+    fn daily_candles(prices: &[f64]) -> Vec<Candle> {
+        prices
+            .iter()
+            .enumerate()
+            .map(|(i, &p)| Candle {
+                timestamp: 4 * DAY + i as i64 * DAY,
+                open: p,
+                high: p * 1.01,
+                low: p * 0.99,
+                close: p,
+                volume: 1_000,
+                adj_close: Some(p),
+                provider_id: None,
+            })
+            .collect()
+    }
+
+    /// Rises, falls, then rises again — enough regime changes to produce
+    /// multiple weekly HTF crossings of the SMA.
+    fn zigzag_prices(n: usize) -> Vec<f64> {
+        (0..n)
+            .map(|i| {
+                let t = i as f64;
+                100.0 + 20.0 * (t / 14.0).sin() + t * 0.05
+            })
+            .collect()
+    }
+
+    fn run_htf_backtest() -> Vec<(i64, i64, f64, f64)> {
+        let candles = daily_candles(&zigzag_prices(180));
+        let config = BacktestConfig::builder()
+            .commission_pct(0.0)
+            .slippage_pct(0.0)
+            .build()
+            .unwrap();
+
+        let strategy = StrategyBuilder::new("HTF Characterization")
+            .entry(htf(Interval::OneWeek, price().above_ref(sma(3))))
+            .exit(htf(Interval::OneWeek, price().below_ref(sma(3))))
+            .build();
+
+        let result = BacktestEngine::new(config)
+            .run("TEST", &candles, strategy)
+            .unwrap();
+
+        result
+            .trades
+            .iter()
+            .map(|t| {
+                (
+                    t.entry_timestamp,
+                    t.exit_timestamp,
+                    (t.entry_price * 1e6).round() / 1e6,
+                    (t.exit_price * 1e6).round() / 1e6,
+                )
+            })
+            .collect()
+    }
+
+    /// Golden trade sequence. Precomputing the HTF lookup keys must not change
+    /// a single entry/exit.
+    #[test]
+    fn test_htf_backtest_trade_sequence_is_stable() {
+        let expected = vec![
+            (2_160_000, 2_937_600, 120.9999, 118.315742),
+            (6_739_200, 10_627_200, 86.897962, 121.919742),
+            (14_256_000, 15_811_200, 90.540957, 113.301781),
+        ];
+        assert_eq!(run_htf_backtest(), expected);
+    }
+
+    #[test]
+    fn test_precomputed_keys_match_htf_requirements() {
+        let cond = htf(Interval::OneWeek, price().above_ref(sma(20)));
+        let specs = cond.htf_requirements();
+        assert_eq!(specs.len(), 1);
+        assert_eq!(specs[0].base_key, "sma_20");
+        assert_eq!(specs[0].htf_key, "htf_1wk_sma_20");
+    }
+
+    #[test]
+    fn test_pure_price_condition_has_no_htf_requirements() {
+        let cond = htf(Interval::OneWeek, price().above(100.0));
+        assert!(cond.htf_requirements().is_empty());
     }
 }

--- a/src/backtesting/strategy/builder.rs
+++ b/src/backtesting/strategy/builder.rs
@@ -35,6 +35,7 @@ struct BoxedCondition {
     evaluate_fn: Box<dyn Fn(&StrategyContext) -> bool + Send + Sync>,
     required_indicators: Vec<(String, Indicator)>,
     htf_requirements: Vec<HtfIndicatorSpec>,
+    tracks_position_extremes: bool,
     description: String,
 }
 
@@ -42,11 +43,13 @@ impl BoxedCondition {
     fn new<C: Condition>(cond: C) -> Self {
         let required_indicators = cond.required_indicators();
         let htf_requirements = cond.htf_requirements();
+        let tracks_position_extremes = cond.tracks_position_extremes();
         let description = cond.description();
         Self {
             evaluate_fn: Box::new(move |ctx| cond.evaluate(ctx)),
             required_indicators,
             htf_requirements,
+            tracks_position_extremes,
             description,
         }
     }
@@ -61,6 +64,10 @@ impl BoxedCondition {
 
     fn htf_requirements(&self) -> &[HtfIndicatorSpec] {
         &self.htf_requirements
+    }
+
+    fn tracks_position_extremes(&self) -> bool {
+        self.tracks_position_extremes
     }
 
     fn description(&self) -> &str {
@@ -312,6 +319,23 @@ impl<E: Condition, X: Condition> Strategy for CustomStrategy<E, X> {
         let mut seen = HashSet::new();
         reqs.retain(|spec| seen.insert(spec.htf_key.clone()));
         reqs
+    }
+
+    fn tracks_position_extremes(&self) -> bool {
+        self.entry_condition.tracks_position_extremes()
+            || self.exit_condition.tracks_position_extremes()
+            || self
+                .short_entry_condition
+                .as_ref()
+                .is_some_and(|c| c.tracks_position_extremes())
+            || self
+                .short_exit_condition
+                .as_ref()
+                .is_some_and(|c| c.tracks_position_extremes())
+            || self
+                .regime_filter
+                .as_ref()
+                .is_some_and(|c| c.tracks_position_extremes())
     }
 
     fn warmup_period(&self) -> usize {

--- a/src/backtesting/strategy/builder.rs
+++ b/src/backtesting/strategy/builder.rs
@@ -411,6 +411,7 @@ mod tests {
             position: None,
             equity: 10_000.0,
             indicators,
+            extremes: None,
         }
     }
 
@@ -530,6 +531,7 @@ mod tests {
             position: Some(&position),
             equity: 10_000.0,
             indicators: &indicators,
+            extremes: None,
         };
 
         // Exit must fire even though regime filter is false

--- a/src/backtesting/strategy/ensemble.rs
+++ b/src/backtesting/strategy/ensemble.rs
@@ -367,6 +367,12 @@ impl Strategy for EnsembleStrategy {
             .unwrap_or(1)
     }
 
+    fn tracks_position_extremes(&self) -> bool {
+        self.strategies
+            .iter()
+            .any(|(s, _)| s.tracks_position_extremes())
+    }
+
     fn on_candle(&self, ctx: &StrategyContext) -> Signal {
         if self.strategies.is_empty() {
             return Signal::hold();

--- a/src/backtesting/strategy/ensemble.rs
+++ b/src/backtesting/strategy/ensemble.rs
@@ -412,6 +412,7 @@ mod tests {
             position: None,
             equity: 10_000.0,
             indicators,
+            extremes: None,
         }
     }
 
@@ -471,6 +472,7 @@ mod tests {
             position: Some(position),
             equity: 10_000.0,
             indicators,
+            extremes: None,
         }
     }
 

--- a/src/backtesting/strategy/mod.rs
+++ b/src/backtesting/strategy/mod.rs
@@ -44,6 +44,56 @@ pub use prebuilt::{
     SuperTrendFollow,
 };
 
+/// Price extremes reached since the open position was entered.
+///
+/// The peak since entry belongs to the position, not to any one condition, so
+/// the engine tracks it once per bar and every trailing condition reads the same
+/// value instead of each keeping its own running scan.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PositionExtremes {
+    /// Highest bar high since entry.
+    pub high: f64,
+    /// Lowest bar low since entry.
+    pub low: f64,
+    /// Highest bar close since entry.
+    pub close_high: f64,
+    /// Lowest bar close since entry.
+    pub close_low: f64,
+}
+
+impl PositionExtremes {
+    /// Seed the extremes from the entry bar.
+    pub(crate) fn new(candle: &Candle) -> Self {
+        Self {
+            high: candle.high,
+            low: candle.low,
+            close_high: candle.close,
+            close_low: candle.close,
+        }
+    }
+
+    /// Fold another bar into the running extremes.
+    pub(crate) fn update(&mut self, candle: &Candle) {
+        self.high = self.high.max(candle.high);
+        self.low = self.low.min(candle.low);
+        self.close_high = self.close_high.max(candle.close);
+        self.close_low = self.close_low.min(candle.close);
+    }
+
+    /// Fold every candle in `range` into fresh extremes.
+    ///
+    /// Used when a context is built outside the engine's bar loop and no running
+    /// value is available.
+    pub(crate) fn from_candles(candles: &[Candle]) -> Option<Self> {
+        let (first, rest) = candles.split_first()?;
+        let mut extremes = Self::new(first);
+        for c in rest {
+            extremes.update(c);
+        }
+        Some(extremes)
+    }
+}
+
 /// Context passed to strategy on each candle.
 ///
 /// Provides access to historical data, current position, and pre-computed indicators.
@@ -63,6 +113,13 @@ pub struct StrategyContext<'a> {
 
     /// Pre-computed indicator values (keyed by indicator name)
     pub indicators: &'a HashMap<String, Vec<Option<f64>>>,
+
+    /// Price extremes since the open position was entered.
+    ///
+    /// `None` when no position is open, or when the context was built outside
+    /// the engine's bar loop — conditions that need it fall back to scanning
+    /// from the entry bar.
+    pub extremes: Option<PositionExtremes>,
 }
 
 impl<'a> StrategyContext<'a> {
@@ -405,6 +462,7 @@ mod tests {
             position: None,
             equity: 10000.0,
             indicators: &indicators,
+            extremes: None,
         };
 
         // fast was 9 (below slow 10), now 11 (above slow 10) -> crossed above

--- a/src/backtesting/strategy/mod.rs
+++ b/src/backtesting/strategy/mod.rs
@@ -116,10 +116,10 @@ pub struct StrategyContext<'a> {
 
     /// Price extremes since the open position was entered.
     ///
-    /// `None` when no position is open, or when the context was built outside
-    /// the engine's bar loop — conditions that need it fall back to scanning
-    /// from the entry bar.
-    pub extremes: Option<PositionExtremes>,
+    /// `None` when no position is open, when no condition in the strategy
+    /// reads it, or when the context was built outside the engine's bar loop —
+    /// conditions that need it fall back to scanning from the entry bar.
+    pub extremes: Option<&'a PositionExtremes>,
 }
 
 impl<'a> StrategyContext<'a> {
@@ -372,6 +372,22 @@ pub trait Strategy: Send + Sync {
     fn warmup_period(&self) -> usize {
         1
     }
+
+    /// Whether any of this strategy's conditions read
+    /// [`StrategyContext::extremes`].
+    ///
+    /// The engine folds the running peak/trough per bar only when this is
+    /// `true`, so a strategy with no trailing condition pays nothing for the
+    /// feature. Strategies built with [`StrategyBuilder`] compute this
+    /// automatically. A raw implementation that uses `TrailingStop` or
+    /// `TrailingTakeProfit` still behaves correctly without overriding it —
+    /// those conditions fall back to scanning from the entry bar — but should
+    /// override it to avoid the O(bars²) fallback.
+    ///
+    /// [`StrategyBuilder`]: crate::backtesting::strategy::StrategyBuilder
+    fn tracks_position_extremes(&self) -> bool {
+        false
+    }
 }
 
 impl Strategy for Box<dyn Strategy> {
@@ -392,6 +408,9 @@ impl Strategy for Box<dyn Strategy> {
     }
     fn warmup_period(&self) -> usize {
         (**self).warmup_period()
+    }
+    fn tracks_position_extremes(&self) -> bool {
+        (**self).tracks_position_extremes()
     }
 }
 

--- a/src/backtesting/walk_forward.rs
+++ b/src/backtesting/walk_forward.rs
@@ -168,6 +168,8 @@ impl WalkForwardConfig {
         F: Send + Sync,
     {
         self.validate(candles.len())?;
+        // Checked once for the whole series; every window is a slice of it.
+        crate::backtesting::engine::validate_series_order(candles, &[])?;
 
         let step = self.step_bars.unwrap_or(self.out_of_sample_bars);
         let total_bars = self.in_sample_bars + self.out_of_sample_bars;
@@ -262,7 +264,7 @@ impl WalkForwardConfig {
         // Test on the out-of-sample slice using the best parameters
         let oos_strategy = factory(&best_params);
         let oos_result = crate::backtesting::BacktestEngine::new(self.config.clone())
-            .run(symbol, oos_candles, oos_strategy)
+            .simulate(symbol, oos_candles, oos_strategy, &[])
             .map_err(|e| {
                 BacktestError::invalid_param(
                     "walk_forward",

--- a/src/backtesting/walk_forward.rs
+++ b/src/backtesting/walk_forward.rs
@@ -48,6 +48,7 @@
 
 use std::collections::HashMap;
 
+use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::models::chart::Candle;
@@ -172,53 +173,32 @@ impl WalkForwardConfig {
         let total_bars = self.in_sample_bars + self.out_of_sample_bars;
 
         // Slide the window through the candle series
-        let mut windows: Vec<WindowResult> = Vec::new();
-        let mut opt_reports: Vec<OptimizationReport> = Vec::new();
-        let mut window_idx = 0;
-        let mut start = 0;
+        let starts: Vec<usize> = {
+            let mut v = Vec::new();
+            let mut start = 0usize;
+            while start + total_bars <= candles.len() {
+                v.push(start);
+                start += step;
+            }
+            v
+        };
 
-        while start + total_bars <= candles.len() {
-            let is_end = start + self.in_sample_bars;
-            let oos_end = is_end + self.out_of_sample_bars;
+        let mut windows: Vec<WindowResult> = Vec::with_capacity(starts.len());
+        let mut opt_reports: Vec<OptimizationReport> = Vec::with_capacity(starts.len());
 
-            let is_candles = &candles[start..is_end];
-            let oos_candles = &candles[is_end..oos_end];
+        // Collect every result rather than short-circuiting: rayon does not
+        // define which error wins a fallible collect, and callers rely on the
+        // lowest-index window's failure being the one reported.
+        let results: Vec<Result<(WindowResult, OptimizationReport)>> = starts
+            .par_iter()
+            .enumerate()
+            .map(|(idx, &start)| self.run_one_window(idx, start, symbol, candles, &factory))
+            .collect();
 
-            // Optimise on the in-sample slice
-            let opt_report = self
-                .grid
-                .run(symbol, is_candles, &self.config, &factory)
-                .map_err(|e| {
-                    BacktestError::invalid_param(
-                        "walk_forward",
-                        format!("window {window_idx} optimisation failed: {e}"),
-                    )
-                })?;
-
-            let best_params = opt_report.best.params.clone();
-            let is_result = opt_report.best.result.clone();
-
-            // Test on the out-of-sample slice using the best parameters
-            let oos_strategy = factory(&best_params);
-            let oos_result = crate::backtesting::BacktestEngine::new(self.config.clone())
-                .run(symbol, oos_candles, oos_strategy)
-                .map_err(|e| {
-                    BacktestError::invalid_param(
-                        "walk_forward",
-                        format!("window {window_idx} OOS run failed: {e}"),
-                    )
-                })?;
-
-            windows.push(WindowResult {
-                window: window_idx,
-                optimized_params: best_params,
-                in_sample: is_result,
-                out_of_sample: oos_result,
-            });
-            opt_reports.push(opt_report);
-
-            start += step;
-            window_idx += 1;
+        for r in results {
+            let (w, o) = r?;
+            windows.push(w);
+            opt_reports.push(o);
         }
 
         if windows.is_empty() {
@@ -243,6 +223,62 @@ impl WalkForwardConfig {
             consistency_ratio,
             optimization_reports: opt_reports,
         })
+    }
+
+    /// Run the optimisation and out-of-sample test for a single window.
+    fn run_one_window<S, F>(
+        &self,
+        window_idx: usize,
+        start: usize,
+        symbol: &str,
+        candles: &[Candle],
+        factory: &F,
+    ) -> Result<(WindowResult, OptimizationReport)>
+    where
+        S: Strategy + Clone + Send,
+        F: Fn(&HashMap<String, ParamValue>) -> S,
+        F: Send + Sync,
+    {
+        let is_end = start + self.in_sample_bars;
+        let oos_end = is_end + self.out_of_sample_bars;
+
+        let is_candles = &candles[start..is_end];
+        let oos_candles = &candles[is_end..oos_end];
+
+        // Optimise on the in-sample slice
+        let opt_report = self
+            .grid
+            .run(symbol, is_candles, &self.config, factory)
+            .map_err(|e| {
+                BacktestError::invalid_param(
+                    "walk_forward",
+                    format!("window {window_idx} optimisation failed: {e}"),
+                )
+            })?;
+
+        let best_params = opt_report.best.params.clone();
+        let is_result = opt_report.best.result.clone();
+
+        // Test on the out-of-sample slice using the best parameters
+        let oos_strategy = factory(&best_params);
+        let oos_result = crate::backtesting::BacktestEngine::new(self.config.clone())
+            .run(symbol, oos_candles, oos_strategy)
+            .map_err(|e| {
+                BacktestError::invalid_param(
+                    "walk_forward",
+                    format!("window {window_idx} OOS run failed: {e}"),
+                )
+            })?;
+
+        Ok((
+            WindowResult {
+                window: window_idx,
+                optimized_params: best_params,
+                in_sample: is_result,
+                out_of_sample: oos_result,
+            },
+            opt_report,
+        ))
     }
 
     /// Validate the configuration before running.
@@ -464,6 +500,86 @@ mod tests {
 
         assert!(report.windows.len() >= 2);
         assert_eq!(report.optimization_reports.len(), report.windows.len());
+    }
+
+    #[test]
+    fn walk_forward_windows_are_order_stable() {
+        let candles = make_candles(&trending_prices(900));
+        let config = BacktestConfig::builder()
+            .commission_pct(0.0)
+            .slippage_pct(0.0)
+            .build()
+            .unwrap();
+
+        let run = || {
+            let grid = GridSearch::new()
+                .param("fast", ParamRange::int_range(3, 9, 3))
+                .param("slow", ParamRange::int_range(10, 20, 10))
+                .optimize_for(OptimizeMetric::TotalReturn);
+            WalkForwardConfig::new(grid, config.clone())
+                .in_sample_bars(200)
+                .out_of_sample_bars(100)
+                .run("TEST", &candles, |params| {
+                    SmaCrossover::new(
+                        params["fast"].as_int() as usize,
+                        params["slow"].as_int() as usize,
+                    )
+                })
+                .unwrap()
+        };
+
+        let a = run();
+        let b = run();
+        assert!(
+            a.windows.len() >= 3,
+            "need multiple windows to test ordering"
+        );
+        assert_eq!(a.windows.len(), b.windows.len());
+        for (i, (x, y)) in a.windows.iter().zip(b.windows.iter()).enumerate() {
+            assert_eq!(x.window, i, "window index out of order at position {i}");
+            assert_eq!(y.window, i, "window index out of order at position {i}");
+            assert_eq!(
+                x.optimized_params, y.optimized_params,
+                "window {i} diverged"
+            );
+            assert_eq!(
+                x.out_of_sample.metrics.total_return_pct, y.out_of_sample.metrics.total_return_pct,
+                "window {i} diverged"
+            );
+            assert_eq!(
+                x.out_of_sample.start_timestamp, y.out_of_sample.start_timestamp,
+                "window {i} diverged"
+            );
+            assert_eq!(
+                x.out_of_sample.end_timestamp, y.out_of_sample.end_timestamp,
+                "window {i} diverged"
+            );
+            assert_eq!(
+                x.in_sample.metrics.total_return_pct, y.in_sample.metrics.total_return_pct,
+                "window {i} diverged"
+            );
+        }
+
+        for pair in a.windows.windows(2) {
+            assert!(
+                pair[0].out_of_sample.start_timestamp < pair[1].out_of_sample.start_timestamp,
+                "windows not in chronological order: {} >= {}",
+                pair[0].out_of_sample.start_timestamp,
+                pair[1].out_of_sample.start_timestamp
+            );
+        }
+
+        assert_eq!(a.optimization_reports.len(), a.windows.len());
+        for (i, (x, y)) in a
+            .optimization_reports
+            .iter()
+            .zip(b.optimization_reports.iter())
+            .enumerate()
+        {
+            assert_eq!(x.best.params, y.best.params, "opt report {i} diverged");
+        }
+
+        assert_eq!(a.consistency_ratio, b.consistency_ratio);
     }
 
     #[test]

--- a/src/domains/mod.rs
+++ b/src/domains/mod.rs
@@ -68,10 +68,13 @@ impl<V: Clone> DomainCache<V> {
             }
 
             let value = f().await?;
-            self.entries
-                .write()
-                .await
-                .insert(key.clone(), CacheEntry::new(value.clone()));
+            crate::utils::cache_insert(
+                &mut *self.entries.write().await,
+                key.clone(),
+                value.clone(),
+                self.mode,
+                crate::utils::EVICTION_THRESHOLD,
+            );
             Ok(value)
         }
         .await;
@@ -79,8 +82,21 @@ impl<V: Clone> DomainCache<V> {
         // Drop the guard entry on every exit, not just the success path — under
         // `Ttl`, repeated expiry or error cycles would otherwise accumulate one
         // `Arc<Mutex<_>>` per key that is never reclaimed.
+        //
+        // Only when nobody else holds it, though. Waiters clone the `Arc` before
+        // blocking on it, so an unconditional remove lets a waiter and a fresh
+        // arrival end up on two different mutexes and fetch the same key
+        // concurrently — the dedup this guard exists for.
         drop(_g);
-        self.guards.write().await.remove(&key);
+        drop(guard);
+        {
+            let mut guards = self.guards.write().await;
+            // Our own clone is gone, so a count of 1 means the map is the only
+            // holder: no waiter is parked on this key and dropping it is safe.
+            if guards.get(&key).is_some_and(|g| Arc::strong_count(g) == 1) {
+                guards.remove(&key);
+            }
+        }
         result
     }
 }
@@ -573,6 +589,65 @@ mod tests {
             assert_eq!(h.await.unwrap(), 1);
         }
         assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn failed_fetches_still_dedup_for_waiters() {
+        // The guard entry is dropped on the error path too, but waiters have
+        // already cloned the `Arc`. Removing it unconditionally would let a
+        // waiter and a fresh arrival hold two different mutexes and fetch the
+        // same key at once.
+        let cache: Arc<DomainCache<u32>> =
+            Arc::new(DomainCache::new(CacheMode::Ttl(Duration::from_secs(60))));
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let overlap = Arc::new(AtomicUsize::new(0));
+
+        let mut handles = Vec::new();
+        for i in 0..8 {
+            let cache = Arc::clone(&cache);
+            let in_flight = Arc::clone(&in_flight);
+            let overlap = Arc::clone(&overlap);
+            handles.push(tokio::spawn(async move {
+                cache
+                    .get_or_try("k".to_string(), move || async move {
+                        if in_flight.fetch_add(1, Ordering::SeqCst) > 0 {
+                            overlap.fetch_add(1, Ordering::SeqCst);
+                        }
+                        tokio::time::sleep(Duration::from_millis(20)).await;
+                        in_flight.fetch_sub(1, Ordering::SeqCst);
+                        // Every attempt fails, so nothing is ever written to
+                        // `entries` and each waiter runs its own fetch in turn.
+                        Err::<u32, FinanceError>(FinanceError::ApiError(format!("boom {i}")))
+                    })
+                    .await
+            }));
+        }
+        for h in handles {
+            assert!(h.await.unwrap().is_err());
+        }
+        assert_eq!(
+            overlap.load(Ordering::SeqCst),
+            0,
+            "fetches for one key overlapped; the dedup guard was dropped too early"
+        );
+    }
+
+    #[tokio::test]
+    async fn entries_are_bounded_under_lifetime_caching() {
+        // Nothing expires under `Lifetime`, so without an eviction sweep this map
+        // grows without limit for a handle queried across many keys.
+        let cache: DomainCache<u32> = DomainCache::new(CacheMode::Lifetime);
+        for i in 0..500u32 {
+            cache
+                .get_or_try(i.to_string(), || async move { Ok::<u32, FinanceError>(i) })
+                .await
+                .unwrap();
+        }
+        let len = cache.entries.read().await.len();
+        assert!(
+            len <= crate::utils::EVICTION_THRESHOLD,
+            "domain cache grew to {len} entries"
+        );
     }
 
     #[tokio::test]

--- a/src/domains/mod.rs
+++ b/src/domains/mod.rs
@@ -12,6 +12,7 @@
 use crate::error::Result;
 use crate::utils::{CacheEntry, CacheMode};
 use std::collections::HashMap;
+use std::sync::Arc;
 use tokio::sync::{Mutex, RwLock};
 
 /// Per-handle response cache with request deduplication.
@@ -23,7 +24,7 @@ use tokio::sync::{Mutex, RwLock};
 pub(crate) struct DomainCache<V> {
     mode: CacheMode,
     entries: RwLock<HashMap<String, CacheEntry<V>>>,
-    guard: Mutex<()>,
+    guards: RwLock<HashMap<String, Arc<Mutex<()>>>>,
 }
 
 impl<V: Clone> DomainCache<V> {
@@ -31,7 +32,7 @@ impl<V: Clone> DomainCache<V> {
         Self {
             mode,
             entries: RwLock::new(HashMap::new()),
-            guard: Mutex::new(()),
+            guards: RwLock::new(HashMap::new()),
         }
     }
 
@@ -52,20 +53,35 @@ impl<V: Clone> DomainCache<V> {
             return Ok(entry.value.clone());
         }
 
-        // Dedup: hold the guard so concurrent identical misses don't all fetch.
-        let _g = self.guard.lock().await;
-        if let Some(entry) = self.entries.read().await.get(&key)
-            && entry.is_fresh(self.mode)
-        {
-            return Ok(entry.value.clone());
-        }
+        // Dedup: hold a per-key guard so concurrent identical misses don't all
+        // fetch, while misses on different keys proceed in parallel.
+        let guard = {
+            let mut g = self.guards.write().await;
+            Arc::clone(g.entry(key.clone()).or_default())
+        };
+        let _g = guard.lock().await;
+        let result = async {
+            if let Some(entry) = self.entries.read().await.get(&key)
+                && entry.is_fresh(self.mode)
+            {
+                return Ok(entry.value.clone());
+            }
 
-        let value = f().await?;
-        self.entries
-            .write()
-            .await
-            .insert(key, CacheEntry::new(value.clone()));
-        Ok(value)
+            let value = f().await?;
+            self.entries
+                .write()
+                .await
+                .insert(key.clone(), CacheEntry::new(value.clone()));
+            Ok(value)
+        }
+        .await;
+
+        // Drop the guard entry on every exit, not just the success path — under
+        // `Ttl`, repeated expiry or error cycles would otherwise accumulate one
+        // `Arc<Mutex<_>>` per key that is never reclaimed.
+        drop(_g);
+        self.guards.write().await.remove(&key);
+        result
     }
 }
 
@@ -557,5 +573,32 @@ mod tests {
             assert_eq!(h.await.unwrap(), 1);
         }
         assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn distinct_keys_do_not_serialize() {
+        let cache: Arc<DomainCache<u32>> = Arc::new(DomainCache::new(CacheMode::default()));
+        let mut handles = Vec::new();
+        for k in ["a", "b", "c", "d"] {
+            let cache = Arc::clone(&cache);
+            handles.push(tokio::spawn(async move {
+                cache
+                    .get_or_try(k.to_string(), || async {
+                        tokio::time::sleep(Duration::from_millis(80)).await;
+                        Ok::<u32, FinanceError>(1)
+                    })
+                    .await
+                    .unwrap()
+            }));
+        }
+        let start = tokio::time::Instant::now();
+        for h in handles {
+            assert_eq!(h.await.unwrap(), 1);
+        }
+        assert!(
+            start.elapsed() < Duration::from_millis(200),
+            "four distinct keys took {:?}; they are serializing",
+            start.elapsed()
+        );
     }
 }

--- a/src/domains/mod.rs
+++ b/src/domains/mod.rs
@@ -10,27 +10,26 @@
 // ── Caching ─────────────────────────────────────────────────────────
 
 use crate::error::Result;
-use crate::utils::CacheEntry;
+use crate::utils::{CacheEntry, CacheMode};
 use std::collections::HashMap;
-use std::time::Duration;
 use tokio::sync::{Mutex, RwLock};
 
-/// Optional per-handle response cache with request deduplication.
+/// Per-handle response cache with request deduplication.
 ///
 /// Keyed by a `String` so a handle can cache multiple variants (e.g. a
 /// crypto coin priced in different `vs_currency` values); single-result
-/// handles use the empty string. When no TTL is configured (the default),
-/// every call fetches fresh — preserving the stateless behavior.
+/// handles use the empty string. Caches for the handle's lifetime by
+/// default; `.cache(ttl)` bounds that and `.no_cache()` disables it.
 pub(crate) struct DomainCache<V> {
-    ttl: Option<Duration>,
+    mode: CacheMode,
     entries: RwLock<HashMap<String, CacheEntry<V>>>,
     guard: Mutex<()>,
 }
 
 impl<V: Clone> DomainCache<V> {
-    pub(crate) fn new(ttl: Option<Duration>) -> Self {
+    pub(crate) fn new(mode: CacheMode) -> Self {
         Self {
-            ttl,
+            mode,
             entries: RwLock::new(HashMap::new()),
             guard: Mutex::new(()),
         }
@@ -43,12 +42,12 @@ impl<V: Clone> DomainCache<V> {
         F: FnOnce() -> Fut,
         Fut: std::future::Future<Output = Result<V>>,
     {
-        let Some(ttl) = self.ttl else {
+        if !self.mode.enabled() {
             return f().await;
-        };
+        }
 
         if let Some(entry) = self.entries.read().await.get(&key)
-            && entry.is_fresh(ttl)
+            && entry.is_fresh(self.mode)
         {
             return Ok(entry.value.clone());
         }
@@ -56,7 +55,7 @@ impl<V: Clone> DomainCache<V> {
         // Dedup: hold the guard so concurrent identical misses don't all fetch.
         let _g = self.guard.lock().await;
         if let Some(entry) = self.entries.read().await.get(&key)
-            && entry.is_fresh(ttl)
+            && entry.is_fresh(self.mode)
         {
             return Ok(entry.value.clone());
         }
@@ -94,16 +93,25 @@ macro_rules! domain_handle {
                 Self {
                     $field,
                     providers,
-                    cache: crate::domains::DomainCache::new(None),
-                    chart_cache: crate::domains::DomainCache::new(None),
+                    cache: crate::domains::DomainCache::new(crate::utils::CacheMode::default()),
+                    chart_cache: crate::domains::DomainCache::new(crate::utils::CacheMode::default()),
                 }
             }
 
-            /// Cache responses for `ttl`, deduplicating concurrent identical
-            /// requests. Off by default (each call fetches fresh).
+            /// Cache responses for `ttl` instead of for the handle's lifetime,
+            /// deduplicating concurrent identical requests.
             pub fn cache(mut self, ttl: std::time::Duration) -> Self {
-                self.cache = crate::domains::DomainCache::new(Some(ttl));
-                self.chart_cache = crate::domains::DomainCache::new(Some(ttl));
+                let mode = crate::utils::CacheMode::Ttl(ttl);
+                self.cache = crate::domains::DomainCache::new(mode);
+                self.chart_cache = crate::domains::DomainCache::new(mode);
+                self
+            }
+
+            /// Disable caching — every call fetches fresh data.
+            pub fn no_cache(mut self) -> Self {
+                let mode = crate::utils::CacheMode::Off;
+                self.cache = crate::domains::DomainCache::new(mode);
+                self.chart_cache = crate::domains::DomainCache::new(mode);
                 self
             }
 
@@ -142,16 +150,25 @@ macro_rules! domain_handle {
                     $field1,
                     $field2,
                     providers,
-                    cache: crate::domains::DomainCache::new(None),
-                    chart_cache: crate::domains::DomainCache::new(None),
+                    cache: crate::domains::DomainCache::new(crate::utils::CacheMode::default()),
+                    chart_cache: crate::domains::DomainCache::new(crate::utils::CacheMode::default()),
                 }
             }
 
-            /// Cache responses for `ttl`, deduplicating concurrent identical
-            /// requests. Off by default (each call fetches fresh).
+            /// Cache responses for `ttl` instead of for the handle's lifetime,
+            /// deduplicating concurrent identical requests.
             pub fn cache(mut self, ttl: std::time::Duration) -> Self {
-                self.cache = crate::domains::DomainCache::new(Some(ttl));
-                self.chart_cache = crate::domains::DomainCache::new(Some(ttl));
+                let mode = crate::utils::CacheMode::Ttl(ttl);
+                self.cache = crate::domains::DomainCache::new(mode);
+                self.chart_cache = crate::domains::DomainCache::new(mode);
+                self
+            }
+
+            /// Disable caching — every call fetches fresh data.
+            pub fn no_cache(mut self) -> Self {
+                let mode = crate::utils::CacheMode::Off;
+                self.cache = crate::domains::DomainCache::new(mode);
+                self.chart_cache = crate::domains::DomainCache::new(mode);
                 self
             }
 
@@ -184,14 +201,20 @@ macro_rules! domain_handle {
                 Self {
                     $field,
                     providers,
-                    cache: crate::domains::DomainCache::new(None),
+                    cache: crate::domains::DomainCache::new(crate::utils::CacheMode::default()),
                 }
             }
 
-            /// Cache responses for `ttl`, deduplicating concurrent identical
-            /// requests. Off by default (each call fetches fresh).
+            /// Cache responses for `ttl` instead of for the handle's lifetime,
+            /// deduplicating concurrent identical requests.
             pub fn cache(mut self, ttl: std::time::Duration) -> Self {
-                self.cache = crate::domains::DomainCache::new(Some(ttl));
+                self.cache = crate::domains::DomainCache::new(crate::utils::CacheMode::Ttl(ttl));
+                self
+            }
+
+            /// Disable caching — every call fetches fresh data.
+            pub fn no_cache(mut self) -> Self {
+                self.cache = crate::domains::DomainCache::new(crate::utils::CacheMode::Off);
                 self
             }
 
@@ -402,6 +425,7 @@ mod tests {
     use crate::error::FinanceError;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
 
     fn err() -> FinanceError {
         FinanceError::NoProviderAvailable {
@@ -411,8 +435,26 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn no_ttl_fetches_every_call() {
-        let cache: DomainCache<u32> = DomainCache::new(None);
+    async fn default_caches_across_calls() {
+        let cache: DomainCache<u32> = DomainCache::new(CacheMode::default());
+        let calls = Arc::new(AtomicUsize::new(0));
+        for _ in 0..3 {
+            let c = calls.clone();
+            let v = cache
+                .get_or_try(String::new(), move || async move {
+                    c.fetch_add(1, Ordering::SeqCst);
+                    Ok::<u32, FinanceError>(42)
+                })
+                .await
+                .unwrap();
+            assert_eq!(v, 42);
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn off_fetches_every_call() {
+        let cache: DomainCache<u32> = DomainCache::new(CacheMode::Off);
         let calls = Arc::new(AtomicUsize::new(0));
         for _ in 0..3 {
             let c = calls.clone();
@@ -430,7 +472,7 @@ mod tests {
 
     #[tokio::test]
     async fn ttl_caches_within_window() {
-        let cache: DomainCache<u32> = DomainCache::new(Some(Duration::from_secs(60)));
+        let cache: DomainCache<u32> = DomainCache::new(CacheMode::Ttl(Duration::from_secs(60)));
         let calls = Arc::new(AtomicUsize::new(0));
         for _ in 0..3 {
             let c = calls.clone();
@@ -448,7 +490,7 @@ mod tests {
 
     #[tokio::test]
     async fn distinct_keys_cached_separately() {
-        let cache: DomainCache<String> = DomainCache::new(Some(Duration::from_secs(60)));
+        let cache: DomainCache<String> = DomainCache::new(CacheMode::Ttl(Duration::from_secs(60)));
         let calls = Arc::new(AtomicUsize::new(0));
         for key in ["usd", "eur", "usd", "eur"] {
             let c = calls.clone();
@@ -467,7 +509,7 @@ mod tests {
 
     #[tokio::test]
     async fn errors_are_not_cached() {
-        let cache: DomainCache<u32> = DomainCache::new(Some(Duration::from_secs(60)));
+        let cache: DomainCache<u32> = DomainCache::new(CacheMode::Ttl(Duration::from_secs(60)));
         let calls = Arc::new(AtomicUsize::new(0));
 
         let c = calls.clone();
@@ -494,7 +536,7 @@ mod tests {
     #[tokio::test]
     async fn concurrent_misses_dedup_to_one_fetch() {
         let cache: Arc<DomainCache<u32>> =
-            Arc::new(DomainCache::new(Some(Duration::from_secs(60))));
+            Arc::new(DomainCache::new(CacheMode::Ttl(Duration::from_secs(60))));
         let calls = Arc::new(AtomicUsize::new(0));
         let mut handles = Vec::new();
         for _ in 0..8 {

--- a/src/finance.rs
+++ b/src/finance.rs
@@ -3,7 +3,7 @@
 //! This module provides functions for operations that don't require a specific stock symbol,
 //! such as searching for symbols and fetching screener data.
 
-use crate::adapters::yahoo::client::{ClientConfig, YahooClient};
+use crate::adapters::yahoo::client::ClientConfig;
 use crate::constants::Region;
 use crate::constants::screeners::Screener;
 use crate::constants::sectors::Sector;
@@ -50,7 +50,7 @@ pub use crate::adapters::yahoo::discovery::search::SearchOptions;
 /// # }
 /// ```
 pub async fn search(query: &str, options: &SearchOptions) -> Result<SearchResults> {
-    let client = YahooClient::new(ClientConfig::default()).await?;
+    let client = crate::adapters::yahoo::session::get_or_auth(&ClientConfig::default()).await?;
     let results = client.search(query, options).await;
     #[cfg(feature = "sentiment")]
     let results = results.map(|mut r| {
@@ -100,7 +100,7 @@ pub async fn lookup(
     query: &str,
     options: &LookupOptions,
 ) -> Result<crate::models::discovery::lookup::LookupResults> {
-    let client = YahooClient::new(ClientConfig::default()).await?;
+    let client = crate::adapters::yahoo::session::get_or_auth(&ClientConfig::default()).await?;
     client.lookup(query, options).await
 }
 
@@ -132,7 +132,7 @@ pub async fn lookup(
 /// # }
 /// ```
 pub async fn screener(screener_type: Screener, count: u32) -> Result<ScreenerResults> {
-    let client = YahooClient::new(ClientConfig::default()).await?;
+    let client = crate::adapters::yahoo::session::get_or_auth(&ClientConfig::default()).await?;
     crate::adapters::yahoo::discovery::screeners::fetch(&client, screener_type, count).await
 }
 
@@ -168,7 +168,7 @@ pub async fn screener(screener_type: Screener, count: u32) -> Result<ScreenerRes
 pub async fn custom_screener<F: crate::models::discovery::screeners::ScreenerField>(
     query: crate::models::discovery::screeners::ScreenerQuery<F>,
 ) -> Result<ScreenerResults> {
-    let client = YahooClient::new(ClientConfig::default()).await?;
+    let client = crate::adapters::yahoo::session::get_or_auth(&ClientConfig::default()).await?;
     crate::adapters::yahoo::discovery::screeners::fetch_custom(&client, query).await
 }
 
@@ -232,7 +232,7 @@ pub async fn earnings_transcript(
     quarter: Option<&str>,
     year: Option<i32>,
 ) -> Result<Transcript> {
-    let client = YahooClient::new(ClientConfig::default()).await?;
+    let client = crate::adapters::yahoo::session::get_or_auth(&ClientConfig::default()).await?;
     let transcript = crate::adapters::yahoo::corporate::transcripts::fetch_for_symbol(
         &client, symbol, quarter, year,
     )
@@ -275,7 +275,7 @@ pub async fn earnings_transcripts(
     symbol: &str,
     limit: Option<usize>,
 ) -> Result<Vec<TranscriptWithMeta>> {
-    let client = YahooClient::new(ClientConfig::default()).await?;
+    let client = crate::adapters::yahoo::session::get_or_auth(&ClientConfig::default()).await?;
     let transcripts = crate::adapters::yahoo::corporate::transcripts::fetch_all_for_symbol(
         &client, symbol, limit,
     )
@@ -313,7 +313,7 @@ pub async fn earnings_transcripts(
 /// # }
 /// ```
 pub async fn hours(region: Option<Region>) -> Result<crate::models::market::hours::MarketHours> {
-    let client = YahooClient::new(ClientConfig::default()).await?;
+    let client = crate::adapters::yahoo::session::get_or_auth(&ClientConfig::default()).await?;
     crate::adapters::yahoo::market::hours::fetch(&client, region.map(|r| r.region())).await
 }
 
@@ -381,7 +381,7 @@ pub async fn indices(
 /// # }
 /// ```
 pub async fn sector(sector_type: Sector) -> Result<SectorData> {
-    let client = YahooClient::new(ClientConfig::default()).await?;
+    let client = crate::adapters::yahoo::session::get_or_auth(&ClientConfig::default()).await?;
     crate::adapters::yahoo::market::sectors::fetch(&client, sector_type).await
 }
 
@@ -411,7 +411,7 @@ pub async fn sector(sector_type: Sector) -> Result<SectorData> {
 /// # }
 /// ```
 pub async fn industry(industry_key: impl AsRef<str>) -> Result<IndustryData> {
-    let client = YahooClient::new(ClientConfig::default()).await?;
+    let client = crate::adapters::yahoo::session::get_or_auth(&ClientConfig::default()).await?;
     crate::adapters::yahoo::market::industries::fetch(&client, industry_key.as_ref()).await
 }
 
@@ -430,7 +430,7 @@ pub async fn industry(industry_key: impl AsRef<str>) -> Result<IndustryData> {
 /// # }
 /// ```
 pub async fn currencies() -> Result<Vec<crate::models::market::currencies::Currency>> {
-    let client = YahooClient::new(ClientConfig::default()).await?;
+    let client = crate::adapters::yahoo::session::get_or_auth(&ClientConfig::default()).await?;
     crate::adapters::yahoo::market::currencies::fetch(&client).await
 }
 
@@ -480,7 +480,7 @@ pub async fn exchanges() -> Result<Vec<crate::models::market::exchanges::Exchang
 pub async fn market_summary(
     region: Option<Region>,
 ) -> Result<Vec<crate::models::market::market_summary::MarketSummaryQuote>> {
-    let client = YahooClient::new(ClientConfig::default()).await?;
+    let client = crate::adapters::yahoo::session::get_or_auth(&ClientConfig::default()).await?;
     crate::adapters::yahoo::market::market_summary::fetch(&client, region).await
 }
 
@@ -508,7 +508,7 @@ pub async fn market_summary(
 pub async fn trending(
     region: Option<Region>,
 ) -> Result<Vec<crate::models::discovery::trending::TrendingQuote>> {
-    let client = YahooClient::new(ClientConfig::default()).await?;
+    let client = crate::adapters::yahoo::session::get_or_auth(&ClientConfig::default()).await?;
     crate::adapters::yahoo::market::trending::fetch(&client, region).await
 }
 
@@ -880,4 +880,26 @@ pub async fn ipo_calendar() -> Result<Vec<IpoCalendarEntry>> {
     crate::adapters::alphavantage::fundamentals::ipo_calendar()
         .await
         .map(|v| v.into_iter().map(Into::into).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    #[ignore = "requires network access"]
+    async fn finance_calls_share_one_session() {
+        let config = ClientConfig::default();
+        let first = crate::adapters::yahoo::session::get_or_auth(&config)
+            .await
+            .unwrap();
+
+        let _ = search("apple", &SearchOptions::default()).await;
+        let _ = hours(None).await;
+
+        let after = crate::adapters::yahoo::session::get_or_auth(&config)
+            .await
+            .unwrap();
+        assert!(std::sync::Arc::ptr_eq(&first, &after));
+    }
 }

--- a/src/indicators/vwma.rs
+++ b/src/indicators/vwma.rs
@@ -44,24 +44,41 @@ pub fn vwma(data: &[f64], volumes: &[f64], period: usize) -> Result<Vec<Option<f
     }
 
     let mut result = vec![None; data.len()];
+    let mut pv_sum = 0.0;
+    let mut volume_sum = 0.0;
 
-    for i in (period - 1)..data.len() {
-        let start_idx = i + 1 - period;
-        let price_slice = &data[start_idx..=i];
-        let volume_slice = &volumes[start_idx..=i];
+    // A rolling sum whose window spans wildly different magnitudes can lose the
+    // small terms entirely, leaving a denominator that is zero or near-zero once
+    // the large term is subtracted back out. Rebuilding the window restores the
+    // value a full rescan would have produced.
+    let rebuild = |i: usize| -> (f64, f64) {
+        let start = i + 1 - period;
+        data[start..=i]
+            .iter()
+            .zip(volumes[start..=i].iter())
+            .fold((0.0, 0.0), |(pv, v), (&p, &q)| (pv + p * q, v + q))
+    };
 
-        let mut pv_sum = 0.0;
-        let mut volume_sum = 0.0;
-
-        for (&p, &v) in price_slice.iter().zip(volume_slice.iter()) {
-            pv_sum += p * v;
-            volume_sum += v;
+    // Rolling add-new/subtract-old sums instead of rescanning the window each bar;
+    // this reassociates the float sums, so results drift from a full rescan by ~1e-15 relative.
+    for i in 0..data.len() {
+        pv_sum += data[i] * volumes[i];
+        volume_sum += volumes[i];
+        if i >= period {
+            let drop = i - period;
+            pv_sum -= data[drop] * volumes[drop];
+            volume_sum -= volumes[drop];
         }
-
-        if volume_sum != 0.0 {
+        if i + 1 >= period {
+            // Volumes are non-negative, so a non-positive running sum can only
+            // come from cancellation; the same is true of a sum that has shrunk
+            // far below the bar's own volume.
+            if volume_sum <= 0.0 || volume_sum < volumes[i] {
+                (pv_sum, volume_sum) = rebuild(i);
+            }
+        }
+        if i + 1 >= period && volume_sum != 0.0 {
             result[i] = Some(pv_sum / volume_sum);
-        } else {
-            result[i] = None;
         }
     }
 
@@ -85,5 +102,64 @@ mod tests {
         assert!(result[1].is_some());
         let val = result[1].unwrap();
         assert!((val - 11.3333).abs() < 0.001);
+    }
+
+    /// Reference implementation: the pre-optimization full-window rescan.
+    fn vwma_reference(data: &[f64], volumes: &[f64], period: usize) -> Vec<Option<f64>> {
+        let mut out = vec![None; data.len()];
+        for i in (period - 1)..data.len() {
+            let s = i + 1 - period;
+            let mut pv = 0.0;
+            let mut v = 0.0;
+            for (&p, &q) in data[s..=i].iter().zip(volumes[s..=i].iter()) {
+                pv += p * q;
+                v += q;
+            }
+            if v != 0.0 {
+                out[i] = Some(pv / v);
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn rolling_survives_catastrophic_cancellation() {
+        // One enormous volume swamps the small ones; subtracting it back out
+        // leaves a denominator of zero unless the window is rebuilt.
+        let data = [10.0, 11.0, 12.0, 13.0, 14.0];
+        let volumes = [1e17, 1.0, 1.0, 1.0, 1.0];
+        let got = vwma(&data, &volumes, 3).unwrap();
+        let want = vwma_reference(&data, &volumes, 3);
+        assert_eq!(got, want, "rolling diverged from a full rescan");
+        assert_eq!(got[3], Some(12.0));
+        assert_eq!(got[4], Some(13.0));
+    }
+
+    #[test]
+    fn rolling_matches_reference_within_bound() {
+        let n = 5_000;
+        let data: Vec<f64> = (0..n)
+            .map(|i| 100.0 + (i as f64 * 0.7).sin() * 20.0)
+            .collect();
+        let volumes: Vec<f64> = (0..n).map(|i| 1_000.0 + (i % 997) as f64).collect();
+
+        for period in [2usize, 20, 200] {
+            let got = vwma(&data, &volumes, period).unwrap();
+            let want = vwma_reference(&data, &volumes, period);
+            assert_eq!(got.len(), want.len());
+            for (i, (g, w)) in got.iter().zip(want.iter()).enumerate() {
+                match (g, w) {
+                    (Some(a), Some(b)) => {
+                        let rel = (a - b).abs() / b.abs().max(1e-12);
+                        assert!(
+                            rel < 1e-11,
+                            "period={period} i={i}: {a} vs {b} (rel {rel:e})"
+                        );
+                    }
+                    (None, None) => {}
+                    _ => panic!("period={period} i={i}: None/Some mismatch"),
+                }
+            }
+        }
     }
 }

--- a/src/indicators/vwma.rs
+++ b/src/indicators/vwma.rs
@@ -70,10 +70,11 @@ pub fn vwma(data: &[f64], volumes: &[f64], period: usize) -> Result<Vec<Option<f
             volume_sum -= volumes[drop];
         }
         if i + 1 >= period {
-            // Volumes are non-negative, so a non-positive running sum can only
-            // come from cancellation; the same is true of a sum that has shrunk
-            // far below the bar's own volume.
-            if volume_sum <= 0.0 || volume_sum < volumes[i] {
+            // Volumes and price*volume terms are non-negative, so a non-positive
+            // running sum can only come from cancellation; the same is true of a
+            // sum that has shrunk below the bar's own contribution.
+            let term = data[i] * volumes[i];
+            if volume_sum <= 0.0 || volume_sum < volumes[i] || pv_sum < 0.0 || pv_sum < term {
                 (pv_sum, volume_sum) = rebuild(i);
             }
         }
@@ -133,6 +134,20 @@ mod tests {
         assert_eq!(got, want, "rolling diverged from a full rescan");
         assert_eq!(got[3], Some(12.0));
         assert_eq!(got[4], Some(13.0));
+    }
+
+    #[test]
+    fn rolling_survives_numerator_cancellation() {
+        // The volumes are ordinary here, so only the numerator cancels: a price
+        // outlier swamps the later price*volume terms and subtracting it back
+        // out leaves a numerator near zero unless the window is rebuilt.
+        let data = [1e20, 10.0, 11.0, 12.0, 13.0];
+        let volumes = [1.0; 5];
+        let got = vwma(&data, &volumes, 3).unwrap();
+        let want = vwma_reference(&data, &volumes, 3);
+        assert_eq!(got, want, "rolling diverged from a full rescan");
+        assert_eq!(got[3], Some(11.0));
+        assert_eq!(got[4], Some(12.0));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,14 +42,15 @@
 //! }
 //! ```
 //!
-//! ## Lazy Loading
+//! ## Lazy Loading and Caching
 //!
-//! The library uses lazy loading:
-//! - **Quote data**: All ~30 quote modules fetched together on first property access
-//! - **Chart data**: Fetched per (interval, range) combination and cached
-//! - **Recommendations**: Fetched once and cached
+//! The library fetches on demand and caches by default:
+//! - **Quote data**: all quote modules fetched together on first property access, then reused
+//! - **Chart data**: fetched and cached per (interval, range) combination
+//! - **Recommendations**: fetched once and cached
 //!
-//! This approach minimizes network requests while keeping memory usage efficient.
+//! A handle caches for as long as it lives. Use `.cache(ttl)` on the builder to
+//! bound that, or `.no_cache()` to fetch fresh on every call.
 
 #![warn(missing_docs)]
 #![warn(rustdoc::missing_crate_level_docs)]

--- a/src/models/discovery/lookup/response.rs
+++ b/src/models/discovery/lookup/response.rs
@@ -63,8 +63,16 @@ impl LookupResults {
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn from_json(value: serde_json::Value) -> Result<Self, serde_json::Error> {
-        let raw: RawLookupResponse = serde_json::from_value(value)?;
+        Ok(Self::from_raw(serde_json::from_value(value)?))
+    }
 
+    /// Same reshape as [`from_json`](Self::from_json), straight from the raw
+    /// response body — no `serde_json::Value` tree in between.
+    pub(crate) fn from_slice(bytes: &[u8]) -> Result<Self, serde_json::Error> {
+        Ok(Self::from_raw(serde_json::from_slice(bytes)?))
+    }
+
+    fn from_raw(raw: RawLookupResponse) -> Self {
         let (quotes, start, count) = raw
             .finance
             .and_then(|f| f.result)
@@ -78,11 +86,11 @@ impl LookupResults {
             })
             .unwrap_or_default();
 
-        Ok(LookupResults {
+        LookupResults {
             quotes,
             start,
             count,
-        })
+        }
     }
 
     /// Get all quote results

--- a/src/models/discovery/screeners/response.rs
+++ b/src/models/discovery/screeners/response.rs
@@ -99,9 +99,9 @@ impl ScreenerResults {
     /// # Errors
     ///
     /// Returns an error if the response contains no screener data.
-    pub(crate) fn from_response(raw: &serde_json::Value) -> Result<Self, String> {
+    pub(crate) fn from_response(raw: serde_json::Value) -> Result<Self, String> {
         // Deserialize the raw response
-        let raw_response: RawScreenersResponse = serde_json::from_value(raw.clone())
+        let raw_response: RawScreenersResponse = serde_json::from_value(raw)
             .map_err(|e| format!("Failed to parse screener response: {}", e))?;
 
         // Extract the first result
@@ -129,9 +129,9 @@ impl ScreenerResults {
     /// # Errors
     ///
     /// Returns an error if the response contains no screener data or has an error.
-    pub(crate) fn from_custom_response(raw: &serde_json::Value) -> Result<Self, String> {
+    pub(crate) fn from_custom_response(raw: serde_json::Value) -> Result<Self, String> {
         // Deserialize the raw response
-        let raw_response: RawCustomScreenerResponse = serde_json::from_value(raw.clone())
+        let raw_response: RawCustomScreenerResponse = serde_json::from_value(raw)
             .map_err(|e| format!("Failed to parse custom screener response: {}", e))?;
 
         // Check for error
@@ -146,14 +146,15 @@ impl ScreenerResults {
             .ok_or_else(|| "No result in response".to_string())?;
 
         let result = results
-            .first()
+            .into_iter()
+            .next()
             .ok_or_else(|| "No screener data in response".to_string())?;
 
         // Convert records to ScreenerQuote using a custom mapping
         // Custom screener returns flat records that need field mapping
         let quotes: Vec<ScreenerQuote> = result
             .records
-            .iter()
+            .into_iter()
             .filter_map(|record| map_custom_record_to_quote(record).ok())
             .collect();
 
@@ -180,21 +181,26 @@ impl ScreenerResults {
     }
 }
 
-fn map_custom_record_to_quote(record: &serde_json::Value) -> Result<ScreenerQuote, String> {
+fn map_custom_record_to_quote(record: serde_json::Value) -> Result<ScreenerQuote, String> {
     use crate::models::quote::FormattedValue;
 
-    // Helper to extract FormattedValue from Yahoo's format
+    let mut record = match record {
+        serde_json::Value::Object(map) => map,
+        _ => return Err("Record is not an object".to_string()),
+    };
+
+    // Helper to extract FormattedValue from Yahoo's format, taking ownership of the field
     fn extract_formatted<T: serde::de::DeserializeOwned + Default>(
-        record: &serde_json::Value,
+        record: &mut serde_json::Map<String, serde_json::Value>,
         field: &str,
     ) -> Option<FormattedValue<T>> {
-        record.get(field).and_then(|v| {
+        record.remove(field).and_then(|v| {
             // Custom screener returns {raw, fmt} or just a value
             if v.is_object() {
-                serde_json::from_value(v.clone()).ok()
+                serde_json::from_value(v).ok()
             } else {
                 // Wrap plain value in FormattedValue
-                serde_json::from_value::<T>(v.clone())
+                serde_json::from_value::<T>(v)
                     .ok()
                     .map(|raw| FormattedValue {
                         raw: Some(raw),
@@ -205,110 +211,123 @@ fn map_custom_record_to_quote(record: &serde_json::Value) -> Result<ScreenerQuot
         })
     }
 
-    fn extract_string(record: &serde_json::Value, field: &str) -> Option<String> {
-        record
-            .get(field)
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string())
+    fn extract_string(
+        record: &mut serde_json::Map<String, serde_json::Value>,
+        field: &str,
+    ) -> Option<String> {
+        match record.remove(field) {
+            Some(serde_json::Value::String(s)) => Some(s),
+            _ => None,
+        }
     }
 
     // Required fields
-    let symbol = extract_string(record, "ticker")
-        .or_else(|| extract_string(record, "symbol"))
+    let symbol = extract_string(&mut record, "ticker")
+        .or_else(|| extract_string(&mut record, "symbol"))
         .ok_or_else(|| "Missing symbol/ticker field".to_string())?;
 
-    let short_name = extract_string(record, "companyshortname")
-        .or_else(|| extract_string(record, "shortName"))
+    let short_name = extract_string(&mut record, "companyshortname")
+        .or_else(|| extract_string(&mut record, "shortName"))
         .unwrap_or_else(|| symbol.clone());
 
     // Price fields - use intradayprice for custom screener
-    let regular_market_price = extract_formatted::<f64>(record, "intradayprice")
-        .or_else(|| extract_formatted::<f64>(record, "regularMarketPrice"))
+    let regular_market_price = extract_formatted::<f64>(&mut record, "intradayprice")
+        .or_else(|| extract_formatted::<f64>(&mut record, "regularMarketPrice"))
         .unwrap_or_default();
 
-    let regular_market_change = extract_formatted::<f64>(record, "intradaypricechange")
-        .or_else(|| extract_formatted::<f64>(record, "regularMarketChange"))
+    let regular_market_change = extract_formatted::<f64>(&mut record, "intradaypricechange")
+        .or_else(|| extract_formatted::<f64>(&mut record, "regularMarketChange"))
         .unwrap_or_default();
 
-    let regular_market_change_percent = extract_formatted::<f64>(record, "percentchange")
-        .or_else(|| extract_formatted::<f64>(record, "regularMarketChangePercent"))
+    let regular_market_change_percent = extract_formatted::<f64>(&mut record, "percentchange")
+        .or_else(|| extract_formatted::<f64>(&mut record, "regularMarketChangePercent"))
         .unwrap_or_default();
 
     Ok(ScreenerQuote {
         symbol,
         short_name,
-        long_name: extract_string(record, "longName"),
-        display_name: extract_string(record, "displayName"),
-        quote_type: extract_string(record, "quoteType").unwrap_or_else(|| "EQUITY".to_string()),
-        exchange: extract_string(record, "exchange").unwrap_or_default(),
+        long_name: extract_string(&mut record, "longName"),
+        display_name: extract_string(&mut record, "displayName"),
+        quote_type: extract_string(&mut record, "quoteType")
+            .unwrap_or_else(|| "EQUITY".to_string()),
+        exchange: extract_string(&mut record, "exchange").unwrap_or_default(),
         regular_market_price,
         regular_market_change,
         regular_market_change_percent,
-        regular_market_open: extract_formatted(record, "day_open_price")
-            .or_else(|| extract_formatted(record, "regularMarketOpen")),
-        regular_market_day_high: extract_formatted(record, "dayhigh")
-            .or_else(|| extract_formatted(record, "regularMarketDayHigh")),
-        regular_market_day_low: extract_formatted(record, "daylow")
-            .or_else(|| extract_formatted(record, "regularMarketDayLow")),
-        regular_market_previous_close: extract_formatted(record, "regularMarketPreviousClose"),
-        regular_market_time: extract_formatted(record, "regularMarketTime"),
-        regular_market_volume: extract_formatted(record, "dayvolume")
-            .or_else(|| extract_formatted(record, "regularMarketVolume")),
-        average_daily_volume3_month: extract_formatted(record, "avgdailyvol3m")
-            .or_else(|| extract_formatted(record, "averageDailyVolume3Month")),
-        average_daily_volume10_day: extract_formatted(record, "averageDailyVolume10Day"),
-        market_cap: extract_formatted(record, "intradaymarketcap")
-            .or_else(|| extract_formatted(record, "marketCap")),
-        shares_outstanding: extract_formatted(record, "sharesOutstanding"),
-        fifty_two_week_high: extract_formatted(record, "fiftytwowkhigh")
-            .or_else(|| extract_formatted(record, "fiftyTwoWeekHigh")),
-        fifty_two_week_low: extract_formatted(record, "fiftytwowklow")
-            .or_else(|| extract_formatted(record, "fiftyTwoWeekLow")),
-        fifty_two_week_change: extract_formatted(record, "fiftyTwoWeekChange"),
-        fifty_two_week_change_percent: extract_formatted(record, "fiftyTwoWeekChangePercent"),
-        fifty_day_average: extract_formatted(record, "fiftyDayAverage"),
-        fifty_day_average_change: extract_formatted(record, "fiftyDayAverageChange"),
-        fifty_day_average_change_percent: extract_formatted(record, "fiftyDayAverageChangePercent"),
-        two_hundred_day_average: extract_formatted(record, "twoHundredDayAverage"),
-        two_hundred_day_average_change: extract_formatted(record, "twoHundredDayAverageChange"),
+        regular_market_open: extract_formatted(&mut record, "day_open_price")
+            .or_else(|| extract_formatted(&mut record, "regularMarketOpen")),
+        regular_market_day_high: extract_formatted(&mut record, "dayhigh")
+            .or_else(|| extract_formatted(&mut record, "regularMarketDayHigh")),
+        regular_market_day_low: extract_formatted(&mut record, "daylow")
+            .or_else(|| extract_formatted(&mut record, "regularMarketDayLow")),
+        regular_market_previous_close: extract_formatted(&mut record, "regularMarketPreviousClose"),
+        regular_market_time: extract_formatted(&mut record, "regularMarketTime"),
+        regular_market_volume: extract_formatted(&mut record, "dayvolume")
+            .or_else(|| extract_formatted(&mut record, "regularMarketVolume")),
+        average_daily_volume3_month: extract_formatted(&mut record, "avgdailyvol3m")
+            .or_else(|| extract_formatted(&mut record, "averageDailyVolume3Month")),
+        average_daily_volume10_day: extract_formatted(&mut record, "averageDailyVolume10Day"),
+        market_cap: extract_formatted(&mut record, "intradaymarketcap")
+            .or_else(|| extract_formatted(&mut record, "marketCap")),
+        shares_outstanding: extract_formatted(&mut record, "sharesOutstanding"),
+        fifty_two_week_high: extract_formatted(&mut record, "fiftytwowkhigh")
+            .or_else(|| extract_formatted(&mut record, "fiftyTwoWeekHigh")),
+        fifty_two_week_low: extract_formatted(&mut record, "fiftytwowklow")
+            .or_else(|| extract_formatted(&mut record, "fiftyTwoWeekLow")),
+        fifty_two_week_change: extract_formatted(&mut record, "fiftyTwoWeekChange"),
+        fifty_two_week_change_percent: extract_formatted(&mut record, "fiftyTwoWeekChangePercent"),
+        fifty_day_average: extract_formatted(&mut record, "fiftyDayAverage"),
+        fifty_day_average_change: extract_formatted(&mut record, "fiftyDayAverageChange"),
+        fifty_day_average_change_percent: extract_formatted(
+            &mut record,
+            "fiftyDayAverageChangePercent",
+        ),
+        two_hundred_day_average: extract_formatted(&mut record, "twoHundredDayAverage"),
+        two_hundred_day_average_change: extract_formatted(
+            &mut record,
+            "twoHundredDayAverageChange",
+        ),
         two_hundred_day_average_change_percent: extract_formatted(
-            record,
+            &mut record,
             "twoHundredDayAverageChangePercent",
         ),
-        average_analyst_rating: extract_string(record, "averageAnalystRating"),
-        trailing_pe: extract_formatted::<f64>(record, "peratio.lasttwelvemonths")
-            .or_else(|| extract_formatted(record, "trailingPE")),
-        forward_pe: extract_formatted(record, "forwardPE"),
-        price_to_book: extract_formatted(record, "priceToBook"),
-        book_value: extract_formatted(record, "bookValue"),
-        eps_trailing_twelve_months: extract_formatted::<f64>(record, "eps.lasttwelvemonths")
-            .or_else(|| extract_formatted(record, "epsTrailingTwelveMonths")),
-        eps_forward: extract_formatted(record, "epsForward"),
-        eps_current_year: extract_formatted(record, "epsCurrentYear"),
-        price_eps_current_year: extract_formatted(record, "priceEpsCurrentYear"),
-        dividend_yield: extract_formatted::<f64>(record, "annual_dividend_yield")
-            .or_else(|| extract_formatted(record, "dividendYield")),
-        dividend_rate: extract_formatted::<f64>(record, "annual_dividend_rate")
-            .or_else(|| extract_formatted(record, "dividendRate")),
-        dividend_date: extract_formatted(record, "dividendDate"),
-        trailing_annual_dividend_rate: extract_formatted(record, "trailingAnnualDividendRate"),
-        trailing_annual_dividend_yield: extract_formatted(record, "trailingAnnualDividendYield"),
-        bid: extract_formatted(record, "bid"),
-        bid_size: extract_formatted(record, "bidSize"),
-        ask: extract_formatted(record, "ask"),
-        ask_size: extract_formatted(record, "askSize"),
-        post_market_price: extract_formatted(record, "postMarketPrice"),
-        post_market_change: extract_formatted(record, "postMarketChange"),
-        post_market_change_percent: extract_formatted(record, "postMarketChangePercent"),
-        post_market_time: extract_formatted(record, "postMarketTime"),
-        pre_market_price: extract_formatted(record, "preMarketPrice"),
-        pre_market_change: extract_formatted(record, "preMarketChange"),
-        pre_market_change_percent: extract_formatted(record, "preMarketChangePercent"),
-        pre_market_time: extract_formatted(record, "preMarketTime"),
-        earnings_timestamp: extract_formatted(record, "earningsTimestamp"),
-        earnings_timestamp_start: extract_formatted(record, "earningsTimestampStart"),
-        earnings_timestamp_end: extract_formatted(record, "earningsTimestampEnd"),
-        currency: extract_string(record, "quotesCurrency")
-            .or_else(|| extract_string(record, "currency")),
+        average_analyst_rating: extract_string(&mut record, "averageAnalystRating"),
+        trailing_pe: extract_formatted::<f64>(&mut record, "peratio.lasttwelvemonths")
+            .or_else(|| extract_formatted(&mut record, "trailingPE")),
+        forward_pe: extract_formatted(&mut record, "forwardPE"),
+        price_to_book: extract_formatted(&mut record, "priceToBook"),
+        book_value: extract_formatted(&mut record, "bookValue"),
+        eps_trailing_twelve_months: extract_formatted::<f64>(&mut record, "eps.lasttwelvemonths")
+            .or_else(|| extract_formatted(&mut record, "epsTrailingTwelveMonths")),
+        eps_forward: extract_formatted(&mut record, "epsForward"),
+        eps_current_year: extract_formatted(&mut record, "epsCurrentYear"),
+        price_eps_current_year: extract_formatted(&mut record, "priceEpsCurrentYear"),
+        dividend_yield: extract_formatted::<f64>(&mut record, "annual_dividend_yield")
+            .or_else(|| extract_formatted(&mut record, "dividendYield")),
+        dividend_rate: extract_formatted::<f64>(&mut record, "annual_dividend_rate")
+            .or_else(|| extract_formatted(&mut record, "dividendRate")),
+        dividend_date: extract_formatted(&mut record, "dividendDate"),
+        trailing_annual_dividend_rate: extract_formatted(&mut record, "trailingAnnualDividendRate"),
+        trailing_annual_dividend_yield: extract_formatted(
+            &mut record,
+            "trailingAnnualDividendYield",
+        ),
+        bid: extract_formatted(&mut record, "bid"),
+        bid_size: extract_formatted(&mut record, "bidSize"),
+        ask: extract_formatted(&mut record, "ask"),
+        ask_size: extract_formatted(&mut record, "askSize"),
+        post_market_price: extract_formatted(&mut record, "postMarketPrice"),
+        post_market_change: extract_formatted(&mut record, "postMarketChange"),
+        post_market_change_percent: extract_formatted(&mut record, "postMarketChangePercent"),
+        post_market_time: extract_formatted(&mut record, "postMarketTime"),
+        pre_market_price: extract_formatted(&mut record, "preMarketPrice"),
+        pre_market_change: extract_formatted(&mut record, "preMarketChange"),
+        pre_market_change_percent: extract_formatted(&mut record, "preMarketChangePercent"),
+        pre_market_time: extract_formatted(&mut record, "preMarketTime"),
+        earnings_timestamp: extract_formatted(&mut record, "earningsTimestamp"),
+        earnings_timestamp_start: extract_formatted(&mut record, "earningsTimestampStart"),
+        earnings_timestamp_end: extract_formatted(&mut record, "earningsTimestampEnd"),
+        currency: extract_string(&mut record, "quotesCurrency")
+            .or_else(|| extract_string(&mut record, "currency")),
     })
 }

--- a/src/models/fundamentals/response.rs
+++ b/src/models/fundamentals/response.rs
@@ -75,18 +75,17 @@ impl FinancialStatement {
     /// Converts the nested Yahoo Finance response structure into a clean,
     /// user-friendly format by extracting data from timeseries.result[].
     pub(crate) fn from_response(
-        raw: &serde_json::Value,
+        raw: serde_json::Value,
         symbol: &str,
         statement_type: StatementType,
         frequency: Frequency,
     ) -> Result<Self> {
-        let raw_response: RawTimeseriesResponse =
-            serde_json::from_value(raw.clone()).map_err(|e| {
-                crate::error::FinanceError::ResponseStructureError {
-                    field: "timeseries".to_string(),
-                    context: format!("Failed to parse financials response: {}", e),
-                }
-            })?;
+        let raw_response: RawTimeseriesResponse = serde_json::from_value(raw).map_err(|e| {
+            crate::error::FinanceError::ResponseStructureError {
+                field: "timeseries".to_string(),
+                context: format!("Failed to parse financials response: {}", e),
+            }
+        })?;
 
         if raw_response.timeseries.result.is_empty() {
             return Err(crate::error::FinanceError::SymbolNotFound {
@@ -291,7 +290,7 @@ mod tests {
         });
 
         let result = FinancialStatement::from_response(
-            &json,
+            json,
             "AAPL",
             StatementType::Income,
             Frequency::Annual,
@@ -320,7 +319,7 @@ mod tests {
         });
 
         let result = FinancialStatement::from_response(
-            &json,
+            json,
             "INVALID",
             StatementType::Income,
             Frequency::Annual,

--- a/src/models/market/hours/response.rs
+++ b/src/models/market/hours/response.rs
@@ -120,8 +120,8 @@ impl MarketHours {
     ///
     /// Converts the nested Yahoo Finance response structure into a clean,
     /// user-friendly format.
-    pub(crate) fn from_response(raw: &serde_json::Value) -> Result<Self, String> {
-        let raw_response: RawHoursResponse = serde_json::from_value(raw.clone())
+    pub(crate) fn from_response(raw: serde_json::Value) -> Result<Self, String> {
+        let raw_response: RawHoursResponse = serde_json::from_value(raw)
             .map_err(|e| format!("Failed to parse hours response: {}", e))?;
 
         let mut markets = Vec::new();

--- a/src/models/market/industries/response.rs
+++ b/src/models/market/industries/response.rs
@@ -345,9 +345,8 @@ pub struct ResearchReport {
 
 impl IndustryData {
     /// Parse from Yahoo Finance JSON response
-    pub(crate) fn from_response(json: &serde_json::Value) -> Result<Self, String> {
-        let raw: RawIndustryResponse =
-            serde_json::from_value(json.clone()).map_err(|e| e.to_string())?;
+    pub(crate) fn from_response(json: serde_json::Value) -> Result<Self, String> {
+        let raw: RawIndustryResponse = serde_json::from_value(json).map_err(|e| e.to_string())?;
 
         let data = raw.data;
 

--- a/src/models/market/sectors/response.rs
+++ b/src/models/market/sectors/response.rs
@@ -419,8 +419,8 @@ pub struct ResearchReport {
 
 impl SectorData {
     /// Parse Yahoo Finance sector response JSON
-    pub(crate) fn from_response(json: &serde_json::Value) -> Result<Self, String> {
-        let raw: RawSectorResponse = serde_json::from_value(json.clone())
+    pub(crate) fn from_response(json: serde_json::Value) -> Result<Self, String> {
+        let raw: RawSectorResponse = serde_json::from_value(json)
             .map_err(|e| format!("Failed to parse sector response: {}", e))?;
 
         let data = raw.data;

--- a/src/providers/mock.rs
+++ b/src/providers/mock.rs
@@ -2,8 +2,11 @@
 
 use super::{Capability, Fetch, Provider, ProviderAdapter, ProviderSet, Routes};
 use crate::error::Result;
+use crate::models::chart::events::ChartEvents;
 use crate::models::chart::{Chart, ChartMeta};
 use crate::models::corporate::news::News;
+use crate::models::options::Options;
+use crate::models::options::response::OptionChainContainer;
 use crate::models::quote::QuoteSummaryResponse;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -12,6 +15,8 @@ pub(crate) struct CountingProvider {
     quote_calls: AtomicUsize,
     chart_calls: AtomicUsize,
     news_calls: AtomicUsize,
+    events_calls: AtomicUsize,
+    options_calls: AtomicUsize,
 }
 
 impl CountingProvider {
@@ -20,6 +25,8 @@ impl CountingProvider {
             quote_calls: AtomicUsize::new(0),
             chart_calls: AtomicUsize::new(0),
             news_calls: AtomicUsize::new(0),
+            events_calls: AtomicUsize::new(0),
+            options_calls: AtomicUsize::new(0),
         })
     }
 
@@ -35,6 +42,14 @@ impl CountingProvider {
     pub(crate) fn news(&self) -> usize {
         self.news_calls.load(Ordering::SeqCst)
     }
+
+    pub(crate) fn events(&self) -> usize {
+        self.events_calls.load(Ordering::SeqCst)
+    }
+
+    pub(crate) fn options(&self) -> usize {
+        self.options_calls.load(Ordering::SeqCst)
+    }
 }
 
 #[async_trait::async_trait]
@@ -44,7 +59,7 @@ impl ProviderAdapter for CountingProvider {
     }
 
     fn capabilities(&self) -> Capability {
-        Capability::QUOTE | Capability::CHART | Capability::CORPORATE
+        Capability::QUOTE | Capability::CHART | Capability::CORPORATE | Capability::OPTIONS
     }
 
     async fn fetch_quote(&self, _: &str) -> Result<QuoteSummaryResponse> {
@@ -72,6 +87,25 @@ impl ProviderAdapter for CountingProvider {
     async fn fetch_news(&self, _: &str) -> Result<Vec<News>> {
         self.news_calls.fetch_add(1, Ordering::SeqCst);
         Ok(Vec::new())
+    }
+
+    async fn fetch_events(&self, _: &str) -> Result<ChartEvents> {
+        self.events_calls.fetch_add(1, Ordering::SeqCst);
+        // A real network fetch always suspends; without a yield the mock resolves
+        // inline and concurrent callers can never actually interleave.
+        tokio::task::yield_now().await;
+        Ok(ChartEvents::default())
+    }
+
+    async fn fetch_options(&self, _: &str, _: Option<i64>) -> Result<Options> {
+        self.options_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(Options {
+            option_chain: OptionChainContainer {
+                result: Vec::new(),
+                error: None,
+            },
+            provider_id: Some(Provider::Yahoo),
+        })
     }
 }
 

--- a/src/providers/mock.rs
+++ b/src/providers/mock.rs
@@ -1,0 +1,84 @@
+//! Counting provider adapter for offline cache tests.
+
+use super::{Capability, Fetch, Provider, ProviderAdapter, ProviderSet, Routes};
+use crate::error::Result;
+use crate::models::chart::{Chart, ChartMeta};
+use crate::models::corporate::news::News;
+use crate::models::quote::QuoteSummaryResponse;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+pub(crate) struct CountingProvider {
+    quote_calls: AtomicUsize,
+    chart_calls: AtomicUsize,
+    news_calls: AtomicUsize,
+}
+
+impl CountingProvider {
+    pub(crate) fn new() -> Arc<Self> {
+        Arc::new(Self {
+            quote_calls: AtomicUsize::new(0),
+            chart_calls: AtomicUsize::new(0),
+            news_calls: AtomicUsize::new(0),
+        })
+    }
+
+    pub(crate) fn quotes(&self) -> usize {
+        self.quote_calls.load(Ordering::SeqCst)
+    }
+
+    pub(crate) fn charts(&self) -> usize {
+        self.chart_calls.load(Ordering::SeqCst)
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn news(&self) -> usize {
+        self.news_calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait::async_trait]
+impl ProviderAdapter for CountingProvider {
+    fn id(&self) -> Provider {
+        Provider::Yahoo
+    }
+
+    fn capabilities(&self) -> Capability {
+        Capability::QUOTE | Capability::CHART | Capability::CORPORATE
+    }
+
+    async fn fetch_quote(&self, _: &str) -> Result<QuoteSummaryResponse> {
+        self.quote_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(QuoteSummaryResponse::default())
+    }
+
+    async fn fetch_chart(
+        &self,
+        symbol: &str,
+        _: crate::Interval,
+        _: crate::TimeRange,
+    ) -> Result<Chart> {
+        self.chart_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(Chart {
+            symbol: symbol.to_string(),
+            meta: ChartMeta::default(),
+            candles: Vec::new(),
+            interval: None,
+            range: None,
+            provider_id: Some(Provider::Yahoo),
+        })
+    }
+
+    async fn fetch_news(&self, _: &str) -> Result<Vec<News>> {
+        self.news_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(Vec::new())
+    }
+}
+
+pub(crate) fn provider_set(provider: Arc<CountingProvider>) -> Arc<ProviderSet> {
+    Arc::new(ProviderSet::new(
+        vec![provider as Arc<dyn ProviderAdapter>],
+        None,
+        Routes::new(Fetch::Sequential),
+    ))
+}

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -2,6 +2,9 @@
 
 pub mod config;
 
+#[cfg(test)]
+pub(crate) mod mock;
+
 #[cfg(feature = "alphavantage")]
 pub(crate) mod alphavantage;
 #[cfg(feature = "crypto")]

--- a/src/providers/yahoo.rs
+++ b/src/providers/yahoo.rs
@@ -15,7 +15,7 @@ pub(crate) struct YahooProvider {
 impl YahooProvider {
     pub(crate) async fn new(config: &ClientConfig) -> Result<Self> {
         Ok(Self {
-            client: Arc::new(YahooClient::new(config.clone()).await?),
+            client: crate::adapters::yahoo::session::get_or_auth(config).await?,
         })
     }
 

--- a/src/risk/mod.rs
+++ b/src/risk/mod.rs
@@ -145,11 +145,17 @@ pub(crate) fn compute_risk_summary_with_periods(
 ) -> RiskSummary {
     let returns = candles_to_returns(candles);
 
-    let var_95 = historical_var(&returns, 0.95).unwrap_or(0.0);
-    let var_99 = historical_var(&returns, 0.99).unwrap_or(0.0);
-    let parametric_var_95 = parametric_var(&returns, 0.95).unwrap_or(0.0);
+    let mut sorted = returns.clone();
+    sorted.sort_by(|a, b| a.total_cmp(b));
+    let stats = ratios::mean_and_std(&returns);
 
-    let sharpe = sharpe_ratio(&returns, 0.0, periods_per_year);
+    let var_95 = var::historical_var_sorted(&sorted, 0.95).unwrap_or(0.0);
+    let var_99 = var::historical_var_sorted(&sorted, 0.99).unwrap_or(0.0);
+    let parametric_var_95 = stats
+        .map(|(m, s)| var::parametric_var_with_stats(m, s, 0.95))
+        .unwrap_or(0.0);
+
+    let sharpe = stats.and_then(|(m, s)| ratios::sharpe_with_stats(m, s, 0.0, periods_per_year));
     let sortino = sortino_ratio(&returns, 0.0, periods_per_year);
 
     let dd = max_drawdown(&returns);
@@ -209,6 +215,24 @@ mod tests {
     }
 
     #[test]
+    fn test_candles_to_returns_empty_and_single() {
+        assert!(candles_to_returns(&[]).is_empty());
+        assert!(candles_to_returns(&[make_candle(100.0)]).is_empty());
+
+        let empty_summary = compute_risk_summary(&[], None);
+        assert_eq!(empty_summary.var_95, 0.0);
+        assert_eq!(empty_summary.var_99, 0.0);
+        assert_eq!(empty_summary.parametric_var_95, 0.0);
+        assert!(empty_summary.sharpe.is_none());
+
+        let single_summary = compute_risk_summary(&[make_candle(100.0)], None);
+        assert_eq!(single_summary.var_95, 0.0);
+        assert_eq!(single_summary.var_99, 0.0);
+        assert_eq!(single_summary.parametric_var_95, 0.0);
+        assert!(single_summary.sharpe.is_none());
+    }
+
+    #[test]
     fn test_periods_per_year_by_calendar() {
         use crate::Interval;
         // Daily differs by asset class; calendar periodicity is shared.
@@ -243,5 +267,35 @@ mod tests {
         let crypto = compute_risk_summary_with_periods(&candles, None, 365.0);
         assert!(daily.sharpe.is_some() && crypto.sharpe.is_some());
         assert!(crypto.sharpe.unwrap() > daily.sharpe.unwrap());
+    }
+
+    #[test]
+    fn shared_stats_match_standalone_functions() {
+        let returns: Vec<f64> = (0..2_000)
+            .map(|i| ((i as f64 * 0.37).sin()) * 0.02 - 0.0001)
+            .collect();
+
+        let mut sorted = returns.clone();
+        sorted.sort_by(|a, b| a.total_cmp(b));
+        let (mean, std_dev) = crate::risk::ratios::mean_and_std(&returns).unwrap();
+
+        assert_eq!(
+            crate::risk::var::historical_var_sorted(&sorted, 0.95),
+            crate::risk::historical_var(&returns, 0.95)
+        );
+        assert_eq!(
+            crate::risk::var::historical_var_sorted(&sorted, 0.99),
+            crate::risk::historical_var(&returns, 0.99)
+        );
+        assert_eq!(
+            Some(crate::risk::var::parametric_var_with_stats(
+                mean, std_dev, 0.95
+            )),
+            crate::risk::parametric_var(&returns, 0.95)
+        );
+        assert_eq!(
+            crate::risk::ratios::sharpe_with_stats(mean, std_dev, 0.0, 252.0),
+            crate::risk::sharpe_ratio(&returns, 0.0, 252.0)
+        );
     }
 }

--- a/src/risk/ratios.rs
+++ b/src/risk/ratios.rs
@@ -15,19 +15,31 @@
 ///
 /// Returns `None` when fewer than 2 observations or standard deviation is zero.
 pub fn sharpe_ratio(returns: &[f64], risk_free_rate: f64, periods_per_year: f64) -> Option<f64> {
+    let (mean, std_dev) = mean_and_std(returns)?;
+    sharpe_with_stats(mean, std_dev, risk_free_rate, periods_per_year)
+}
+
+/// Sample mean and standard deviation (n-1 denominator).
+pub(crate) fn mean_and_std(returns: &[f64]) -> Option<(f64, f64)> {
     if returns.len() < 2 {
         return None;
     }
-
     let mean = returns.iter().sum::<f64>() / returns.len() as f64;
     let variance =
         returns.iter().map(|r| (r - mean).powi(2)).sum::<f64>() / (returns.len() - 1) as f64;
-    let std_dev = variance.sqrt();
+    Some((mean, variance.sqrt()))
+}
 
+/// `sharpe_ratio` given a precomputed mean and standard deviation.
+pub(crate) fn sharpe_with_stats(
+    mean: f64,
+    std_dev: f64,
+    risk_free_rate: f64,
+    periods_per_year: f64,
+) -> Option<f64> {
     if std_dev == 0.0 {
         return None;
     }
-
     Some((mean - risk_free_rate) / std_dev * periods_per_year.sqrt())
 }
 

--- a/src/risk/var.rs
+++ b/src/risk/var.rs
@@ -19,11 +19,16 @@ pub fn historical_var(returns: &[f64], confidence: f64) -> Option<f64> {
     let mut sorted = returns.to_vec();
     sorted.sort_by(|a, b| a.total_cmp(b));
 
-    // The `(1 - confidence)` worst-case percentile
+    historical_var_sorted(&sorted, confidence)
+}
+
+/// `historical_var` over an already-sorted slice.
+pub(crate) fn historical_var_sorted(sorted: &[f64], confidence: f64) -> Option<f64> {
+    if sorted.is_empty() {
+        return None;
+    }
     let idx = ((1.0 - confidence) * sorted.len() as f64) as usize;
     let idx = idx.min(sorted.len() - 1);
-
-    // VaR is expressed as a positive loss
     Some(-sorted[idx])
 }
 
@@ -38,20 +43,13 @@ pub fn historical_var(returns: &[f64], confidence: f64) -> Option<f64> {
 ///
 /// Returns `None` when fewer than 2 observations are provided.
 pub fn parametric_var(returns: &[f64], confidence: f64) -> Option<f64> {
-    if returns.len() < 2 {
-        return None;
-    }
+    let (mean, std_dev) = super::ratios::mean_and_std(returns)?;
+    Some(parametric_var_with_stats(mean, std_dev, confidence))
+}
 
-    let mean = returns.iter().sum::<f64>() / returns.len() as f64;
-    let variance =
-        returns.iter().map(|r| (r - mean).powi(2)).sum::<f64>() / (returns.len() - 1) as f64;
-    let std_dev = variance.sqrt();
-
-    // Approximate normal quantile (z-score) for common confidence levels
-    let z = normal_quantile(confidence);
-
-    // VaR = -(mean - z * std_dev)
-    Some(-(mean - z * std_dev))
+/// `parametric_var` given a precomputed mean and standard deviation.
+pub(crate) fn parametric_var_with_stats(mean: f64, std_dev: f64, confidence: f64) -> f64 {
+    -(mean - normal_quantile(confidence) * std_dev)
 }
 
 /// Approximate inverse normal CDF (quantile function) for confidence levels in [0.90, 0.999].

--- a/src/scrapers/yahoo_earnings.rs
+++ b/src/scrapers/yahoo_earnings.rs
@@ -6,7 +6,23 @@
 use crate::error::{FinanceError, Result};
 use regex::Regex;
 use std::collections::HashSet;
+use std::sync::LazyLock;
 use tracing::info;
+
+/// Matches earnings call URLs for any symbol; capture groups 1 and 2 hold the
+/// symbol as it appears in the `/quote/{symbol}` and `{symbol}-Q...` segments
+/// respectively. The `regex` crate has no backreferences, so both are captured
+/// and compared against the requested symbol in Rust instead of in the pattern.
+/// Both symbol positions match any run of non-`/` characters rather than a
+/// fixed class, so the pattern accepts every symbol the old
+/// `regex::escape(symbol)` form did — including `^GSPC` or `ES=F` — and the
+/// exact-match filter below, not the pattern, decides what is kept.
+static EARNINGS_CALL_URL_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"(?:https://finance\.yahoo\.com)?/quote/([^/]+)/earnings/([^/]+?)-([Qq]\d)-(\d{4})-earnings_call-(\d+)\.html"#,
+    )
+    .unwrap()
+});
 
 /// Represents an earnings call with its identifiers and metadata.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -90,20 +106,18 @@ fn parse_earnings_calls(html: &str, symbol: &str) -> Result<Vec<EarningsCall>> {
     // Match earnings call URLs in the page content
     // Format: /quote/AAPL/earnings/AAPL-Q4-2024-earnings_call-218053.html
     // or full URLs: https://finance.yahoo.com/quote/AAPL/earnings/AAPL-Q4-2024-earnings_call-218053.html
-    let url_pattern = Regex::new(&format!(
-        r#"(?:https://finance\.yahoo\.com)?/quote/{}/earnings/{}-([Qq]\d)-(\d{{4}})-earnings_call-(\d+)\.html"#,
-        regex::escape(symbol),
-        regex::escape(symbol)
-    ))
-    .unwrap();
-
     let mut calls = Vec::new();
     let mut seen_event_ids = HashSet::new();
 
-    for caps in url_pattern.captures_iter(html) {
-        let quarter = caps.get(1).map(|m| m.as_str().to_uppercase());
-        let year = caps.get(2).and_then(|m| m.as_str().parse::<i32>().ok());
-        let event_id = caps[3].to_string();
+    for caps in EARNINGS_CALL_URL_PATTERN.captures_iter(html) {
+        // Case-sensitive, same as the old regex::escape(symbol)-embedded pattern.
+        if &caps[1] != symbol || &caps[2] != symbol {
+            continue;
+        }
+
+        let quarter = caps.get(3).map(|m| m.as_str().to_uppercase());
+        let year = caps.get(4).and_then(|m| m.as_str().parse::<i32>().ok());
+        let event_id = caps[5].to_string();
 
         // Skip duplicates
         if seen_event_ids.contains(&event_id) {
@@ -183,6 +197,58 @@ mod tests {
         assert_eq!(calls.len(), 2);
         assert_eq!(calls[0].event_id, "12345");
         assert_eq!(calls[1].event_id, "12344");
+    }
+
+    #[test]
+    fn test_parse_earnings_calls_filters_other_symbols() {
+        // The shared LazyLock pattern is symbol-agnostic, so it must correctly
+        // exclude URLs belonging to a different symbol found in the same page.
+        let html = r#"
+            {"url":"https://finance.yahoo.com/quote/AAPL/earnings/AAPL-Q4-2024-earnings_call-1.html"}
+            {"url":"https://finance.yahoo.com/quote/MSFT/earnings/MSFT-Q4-2024-earnings_call-2.html"}
+            {"url":"https://finance.yahoo.com/quote/AAPL/earnings/AAPL-Q3-2024-earnings_call-3.html"}
+            {"url":"https://finance.yahoo.com/quote/aapl/earnings/aapl-Q2-2024-earnings_call-4.html"}
+        "#;
+
+        let calls = parse_earnings_calls(html, "AAPL").unwrap();
+        assert_eq!(calls.len(), 2);
+        assert!(calls.iter().all(|c| c.event_id != "2" && c.event_id != "4"));
+        assert_eq!(calls[0].event_id, "1");
+        assert_eq!(calls[1].event_id, "3");
+
+        let msft_calls = parse_earnings_calls(html, "MSFT").unwrap();
+        assert_eq!(msft_calls.len(), 1);
+        assert_eq!(msft_calls[0].event_id, "2");
+    }
+
+    #[test]
+    fn test_parse_earnings_calls_accepts_punctuated_symbols() {
+        // The old pattern interpolated `regex::escape(symbol)`, so it matched any
+        // literal symbol. These would have been dropped by a fixed
+        // `[A-Za-z0-9.\-]+` class; the current pattern must still find them.
+        let html = r#"
+            {"url":"https://finance.yahoo.com/quote/BRK-B/earnings/BRK-B-Q4-2024-earnings_call-10.html"}
+            {"url":"https://finance.yahoo.com/quote/^GSPC/earnings/^GSPC-Q4-2024-earnings_call-11.html"}
+            {"url":"https://finance.yahoo.com/quote/ES=F/earnings/ES=F-Q1-2025-earnings_call-12.html"}
+            {"url":"https://finance.yahoo.com/quote/7203.T/earnings/7203.T-Q2-2025-earnings_call-13.html"}
+        "#;
+
+        for (symbol, event_id) in [
+            ("BRK-B", "10"),
+            ("^GSPC", "11"),
+            ("ES=F", "12"),
+            ("7203.T", "13"),
+        ] {
+            let calls = parse_earnings_calls(html, symbol).unwrap();
+            assert_eq!(calls.len(), 1, "symbol {symbol} was not matched");
+            assert_eq!(calls[0].event_id, event_id);
+        }
+
+        // Widening the class must not weaken the exact-match filter. A prefix of
+        // a real symbol matches nothing, which this function reports as an error
+        // rather than an empty vec.
+        assert!(parse_earnings_calls(html, "BRK").is_err());
+        assert!(parse_earnings_calls(html, "GSPC").is_err());
     }
 
     #[test]

--- a/src/ticker/core.rs
+++ b/src/ticker/core.rs
@@ -33,7 +33,7 @@ use crate::providers::{
 };
 #[cfg(feature = "risk")]
 use crate::risk;
-use crate::utils::{CacheEntry, EVICTION_THRESHOLD, filter_by_range};
+use crate::utils::{CacheEntry, CacheMode, filter_by_range};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -75,7 +75,7 @@ pub struct TickerBuilder {
     config: ClientConfig,
     shared_client: Option<ClientHandle>,
     injected_providers: Option<Arc<ProviderSet>>,
-    cache_ttl: Option<Duration>,
+    cache_mode: CacheMode,
     include_logo: bool,
 }
 
@@ -86,7 +86,7 @@ impl TickerBuilder {
             config: ClientConfig::default(),
             shared_client: None,
             injected_providers: None,
-            cache_ttl: None,
+            cache_mode: CacheMode::default(),
             include_logo: false,
         }
     }
@@ -137,9 +137,17 @@ impl TickerBuilder {
         self.shared_client = Some(handle);
         self
     }
-    /// Enable response caching with a time-to-live.
+    /// Cache responses for `ttl` instead of for the handle's lifetime.
     pub fn cache(mut self, ttl: Duration) -> Self {
-        self.cache_ttl = Some(ttl);
+        self.cache_mode = CacheMode::Ttl(ttl);
+        self
+    }
+    /// Disable caching — every call fetches fresh data.
+    ///
+    /// By default a `Ticker` caches each response for as long as the handle
+    /// lives, so repeated accessor calls reuse one fetch.
+    pub fn no_cache(mut self) -> Self {
+        self.cache_mode = CacheMode::Off;
         self
     }
     /// Include company logo URLs in quote responses.
@@ -178,7 +186,7 @@ impl TickerBuilder {
         Ok(Ticker {
             symbol: self.symbol,
             providers,
-            cache_ttl: self.cache_ttl,
+            cache_mode: self.cache_mode,
             include_logo: self.include_logo,
             #[cfg(feature = "translation")]
             translate_lang,
@@ -199,12 +207,13 @@ impl TickerBuilder {
 
 /// The primary entry point for querying financial data for a single symbol.
 ///
-/// Data is fetched on first access and cached. Use the builder pattern
-/// via [`Ticker::builder`] for custom configuration.
+/// Data is fetched on first access and cached for the lifetime of the handle.
+/// Use the builder via [`Ticker::builder`] for custom configuration, including
+/// [`cache`](TickerBuilder::cache) and [`no_cache`](TickerBuilder::no_cache).
 pub struct Ticker {
     symbol: Arc<str>,
     providers: Arc<ProviderSet>,
-    cache_ttl: Option<Duration>,
+    cache_mode: CacheMode,
     include_logo: bool,
     #[cfg(feature = "translation")]
     translate_lang: Option<crate::translation::Lang>,
@@ -272,30 +281,16 @@ impl Ticker {
     }
 
     fn is_cache_fresh<T>(&self, entry: Option<&CacheEntry<T>>) -> bool {
-        CacheEntry::is_fresh_with_ttl(entry, self.cache_ttl)
+        CacheEntry::is_fresh_entry(entry, self.cache_mode)
     }
 
-    /// Like `is_cache_fresh`, but works on the shared-cache pattern
-    /// where the entry is populated on first fetch.
-    /// When no TTL is configured, never treats entries as fresh.
-    fn is_shared_cache_fresh<T>(&self, entry: Option<&CacheEntry<T>>) -> bool {
-        match (self.cache_ttl, entry) {
-            (Some(ttl), Some(e)) => e.is_fresh(ttl),
-            _ => false,
-        }
-    }
     fn cache_insert<K: Eq + std::hash::Hash, V>(
         &self,
         map: &mut HashMap<K, CacheEntry<V>>,
         key: K,
         value: V,
     ) {
-        if let Some(ttl) = self.cache_ttl {
-            if map.len() >= EVICTION_THRESHOLD {
-                map.retain(|_, entry| entry.is_fresh(ttl));
-            }
-            map.insert(key, CacheEntry::new(value));
-        }
+        crate::utils::cache_insert(map, key, value, self.cache_mode);
     }
 
     /// Get full quote data, optionally including logo URLs.
@@ -359,7 +354,7 @@ impl Ticker {
             })
             .await?;
         let chart = Self::chart_from_provider_data(data, Some(interval), Some(range));
-        if self.cache_ttl.is_some() {
+        if self.cache_mode.enabled() {
             let mut cache = self.chart_cache.write().await;
             self.cache_insert(&mut cache, (interval, range), chart.clone());
         }
@@ -389,7 +384,7 @@ impl Ticker {
     async fn ensure_events(&self) -> Result<()> {
         {
             let cache = self.events_cache.read().await;
-            if self.is_shared_cache_fresh(cache.as_ref()) {
+            if self.is_cache_fresh(cache.as_ref()) {
                 return Ok(());
             }
         }
@@ -506,7 +501,7 @@ impl Ticker {
             self.translate_response(&mut news).await?;
             news
         };
-        if self.cache_ttl.is_some() {
+        if self.cache_mode.enabled() {
             let mut c = self.news_cache.write().await;
             *c = Some(CacheEntry::new(news.clone()));
         }
@@ -549,7 +544,7 @@ impl Ticker {
                 async move { p.fetch_options(&sym, date).await }
             })
             .await?;
-        if self.cache_ttl.is_some() {
+        if self.cache_mode.enabled() {
             let mut c = self.options_cache.write().await;
             self.cache_insert(&mut c, date, opts.clone());
         }
@@ -580,7 +575,7 @@ impl Ticker {
                 async move { p.fetch_financials(&sym, stmt_type, frequency).await }
             })
             .await?;
-        if self.cache_ttl.is_some() {
+        if self.cache_mode.enabled() {
             let mut c = self.financials_cache.write().await;
             self.cache_insert(&mut c, key, stmt.clone());
         }
@@ -604,7 +599,7 @@ impl Ticker {
         }
         let chart = self.chart(interval, range).await?;
         let ind = indicators::summary::calculate_indicators(&chart.candles);
-        if self.cache_ttl.is_some() {
+        if self.cache_mode.enabled() {
             let mut c = self.indicators_cache.write().await;
             self.cache_insert(&mut c, (interval, range), ind.clone());
         }
@@ -627,7 +622,7 @@ impl Ticker {
         }
         let cik = edgar::resolve_cik(&self.symbol).await?;
         let subs = edgar::submissions(cik).await?;
-        if self.cache_ttl.is_some() {
+        if self.cache_mode.enabled() {
             let mut c = self.edgar_submissions_cache.write().await;
             *c = Some(CacheEntry::new(subs.clone()));
         }
@@ -649,7 +644,7 @@ impl Ticker {
         }
         let cik = edgar::resolve_cik(&self.symbol).await?;
         let facts = edgar::company_facts(cik).await?;
-        if self.cache_ttl.is_some() {
+        if self.cache_mode.enabled() {
             let mut c = self.edgar_facts_cache.write().await;
             *c = Some(CacheEntry::new(facts.clone()));
         }
@@ -820,14 +815,14 @@ impl Ticker {
     ) -> Result<tokio::sync::RwLockReadGuard<'_, Option<CacheEntry<QuoteSummaryResponse>>>> {
         {
             let cache = self.quote_cache.read().await;
-            if self.is_shared_cache_fresh(cache.as_ref()) {
+            if self.is_cache_fresh(cache.as_ref()) {
                 return Ok(cache);
             }
         }
         let _guard = self.quote_fetch.lock().await;
         {
             let cache = self.quote_cache.read().await;
-            if self.is_shared_cache_fresh(cache.as_ref()) {
+            if self.is_cache_fresh(cache.as_ref()) {
                 return Ok(cache);
             }
         }
@@ -876,4 +871,92 @@ super::macros::define_quote_accessors! {
     industry_trend -> IndustryTrend, industry_trend,
     sector_trend -> SectorTrend, sector_trend,
     equity_performance -> EquityPerformance, equity_performance,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::providers::mock::{CountingProvider, provider_set};
+
+    #[tokio::test]
+    async fn default_caches_quote_across_accessors() {
+        let provider = CountingProvider::new();
+        let ticker = Ticker::builder("AAPL")
+            .with_provider_set(provider_set(Arc::clone(&provider)))
+            .build()
+            .await
+            .unwrap();
+
+        let _ = ticker.price().await.unwrap();
+        let _ = ticker.summary_detail().await.unwrap();
+        let _ = ticker.asset_profile().await.unwrap();
+
+        assert_eq!(provider.quotes(), 1);
+    }
+
+    #[tokio::test]
+    async fn no_cache_refetches_every_accessor() {
+        let provider = CountingProvider::new();
+        let ticker = Ticker::builder("AAPL")
+            .with_provider_set(provider_set(Arc::clone(&provider)))
+            .no_cache()
+            .build()
+            .await
+            .unwrap();
+
+        let _ = ticker.price().await.unwrap();
+        let _ = ticker.summary_detail().await.unwrap();
+        let _ = ticker.asset_profile().await.unwrap();
+
+        assert_eq!(provider.quotes(), 3);
+    }
+
+    #[tokio::test]
+    async fn charts_cache_per_interval_and_range() {
+        let provider = CountingProvider::new();
+        let ticker = Ticker::builder("AAPL")
+            .with_provider_set(provider_set(Arc::clone(&provider)))
+            .build()
+            .await
+            .unwrap();
+
+        let _ = ticker
+            .chart(Interval::OneDay, TimeRange::OneMonth)
+            .await
+            .unwrap();
+        let _ = ticker
+            .chart(Interval::OneDay, TimeRange::OneMonth)
+            .await
+            .unwrap();
+        assert_eq!(provider.charts(), 1);
+
+        let _ = ticker
+            .chart(Interval::OneDay, TimeRange::OneYear)
+            .await
+            .unwrap();
+        assert_eq!(provider.charts(), 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn ttl_expires() {
+        let provider = CountingProvider::new();
+        let ticker = Ticker::builder("AAPL")
+            .with_provider_set(provider_set(Arc::clone(&provider)))
+            .cache(Duration::from_secs(60))
+            .build()
+            .await
+            .unwrap();
+
+        let _ = ticker
+            .chart(Interval::OneDay, TimeRange::OneMonth)
+            .await
+            .unwrap();
+        tokio::time::advance(Duration::from_secs(120)).await;
+        let _ = ticker
+            .chart(Interval::OneDay, TimeRange::OneMonth)
+            .await
+            .unwrap();
+
+        assert_eq!(provider.charts(), 2);
+    }
 }

--- a/src/ticker/core.rs
+++ b/src/ticker/core.rs
@@ -292,7 +292,13 @@ impl Ticker {
         key: K,
         value: V,
     ) {
-        crate::utils::cache_insert(map, key, value, self.cache_mode);
+        crate::utils::cache_insert(
+            map,
+            key,
+            value,
+            self.cache_mode,
+            crate::utils::EVICTION_THRESHOLD,
+        );
     }
 
     /// Get full quote data, optionally including logo URLs.
@@ -312,15 +318,21 @@ impl Ticker {
             }
             let fetched = match self.providers.first_yahoo() {
                 Ok(y) => y.get_logo_url(&self.symbol).await,
-                Err(_) => (None, None),
+                Err(e) => Err(e),
             };
-            // `get_logo_url` swallows transport errors into `(None, None)`, so
-            // caching that would make one blip permanent for the handle's life.
-            let resolved = fetched.0.is_some() || fetched.1.is_some();
-            if resolved && self.cache_mode.enabled() {
-                *self.logo_cache.write().await = Some(CacheEntry::new(fetched.clone()));
+            // Only a successful lookup is cached. A symbol that genuinely has no
+            // logo resolves to `(None, None)` and caches like any other answer;
+            // a transport error does not, so one blip can't become permanent for
+            // the handle's life.
+            match fetched {
+                Ok(logos) => {
+                    if self.cache_mode.enabled() {
+                        *self.logo_cache.write().await = Some(CacheEntry::new(logos.clone()));
+                    }
+                    logos
+                }
+                Err(_) => (None, None),
             }
-            fetched
         };
 
         let (cache, (logo_url, company_logo_url)) = tokio::join!(self.ensure_quote(), logo_fut);

--- a/src/ticker/core.rs
+++ b/src/ticker/core.rs
@@ -1,10 +1,10 @@
 //! Symbol-specific data access from multiple providers.
 
+use crate::adapters::edgar;
 use crate::adapters::yahoo::client::{ClientConfig, YahooClient};
 #[cfg(feature = "backtesting")]
 use crate::backtesting;
 use crate::constants::{Frequency, Interval, Region, StatementType, TimeRange};
-use crate::edgar;
 use crate::error::{FinanceError, Result};
 use crate::format::Both;
 #[cfg(any(feature = "backtesting", feature = "indicators"))]
@@ -195,6 +195,7 @@ impl TickerBuilder {
             chart_cache: Default::default(),
             events_cache: Default::default(),
             news_cache: Default::default(),
+            logo_cache: Default::default(),
             options_cache: Default::default(),
             financials_cache: Default::default(),
             #[cfg(feature = "indicators")]
@@ -222,6 +223,7 @@ pub struct Ticker {
     chart_cache: MapCache<(Interval, TimeRange), Chart>,
     events_cache: Cache<ChartEvents>,
     news_cache: Cache<Vec<News>>,
+    logo_cache: Cache<(Option<String>, Option<String>)>,
     options_cache: MapCache<Option<i64>, Options>,
     financials_cache: MapCache<(StatementType, Frequency), FinancialStatement>,
     #[cfg(feature = "indicators")]
@@ -299,20 +301,33 @@ impl Ticker {
         F: Format,
         Quote<Both>: Into<Quote<F>>,
     {
-        let cache = self.ensure_quote().await?;
+        let logo_fut = async {
+            if !self.include_logo {
+                return (None, None);
+            }
+            if let Some(e) = self.logo_cache.read().await.as_ref()
+                && self.is_cache_fresh(Some(e))
+            {
+                return e.value.clone();
+            }
+            let fetched = match self.providers.first_yahoo() {
+                Ok(y) => y.get_logo_url(&self.symbol).await,
+                Err(_) => (None, None),
+            };
+            // `get_logo_url` swallows transport errors into `(None, None)`, so
+            // caching that would make one blip permanent for the handle's life.
+            let resolved = fetched.0.is_some() || fetched.1.is_some();
+            if resolved && self.cache_mode.enabled() {
+                *self.logo_cache.write().await = Some(CacheEntry::new(fetched.clone()));
+            }
+            fetched
+        };
+
+        let (cache, (logo_url, company_logo_url)) = tokio::join!(self.ensure_quote(), logo_fut);
+        let cache = cache?;
         let summary = cache.as_ref().ok_or_else(|| {
             FinanceError::ApiError("Quote summary cache was empty after fetch".to_string())
         })?;
-        let (logo_url, company_logo_url) = if self.include_logo {
-            if let Ok(yahoo) = self.providers.first_yahoo() {
-                let logos = yahoo.get_logo_url(&self.symbol).await;
-                (logos.0, logos.1)
-            } else {
-                (None, None)
-            }
-        } else {
-            (None, None)
-        };
         let quote = Quote::from_response(&summary.value, logo_url, company_logo_url);
         #[cfg(feature = "translation")]
         let quote = {
@@ -620,8 +635,7 @@ impl Ticker {
                 return Ok(e.value.clone());
             }
         }
-        let cik = edgar::resolve_cik(&self.symbol).await?;
-        let subs = edgar::submissions(cik).await?;
+        let subs = edgar::submissions_for_symbol(&self.symbol).await?;
         if self.cache_mode.enabled() {
             let mut c = self.edgar_submissions_cache.write().await;
             *c = Some(CacheEntry::new(subs.clone()));
@@ -642,8 +656,7 @@ impl Ticker {
                 return Ok(e.value.clone());
             }
         }
-        let cik = edgar::resolve_cik(&self.symbol).await?;
-        let facts = edgar::company_facts(cik).await?;
+        let facts = edgar::company_facts_for_symbol(&self.symbol).await?;
         if self.cache_mode.enabled() {
             let mut c = self.edgar_facts_cache.write().await;
             *c = Some(CacheEntry::new(facts.clone()));
@@ -693,11 +706,11 @@ impl Ticker {
     ) -> backtesting::Result<backtesting::BacktestResult> {
         let config = config.unwrap_or_default();
         config.validate()?;
-        let chart = self
-            .chart(interval, range)
-            .await
-            .map_err(|e| backtesting::BacktestError::ChartError(e.to_string()))?;
-        let dividends = self.dividends(range).await.unwrap_or_default();
+        // Chart and dividends hit disjoint caches and disjoint capabilities
+        // (CHART vs CORPORATE), so neither warms the other.
+        let (chart, dividends) = tokio::join!(self.chart(interval, range), self.dividends(range));
+        let chart = chart.map_err(|e| backtesting::BacktestError::ChartError(e.to_string()))?;
+        let dividends = dividends.unwrap_or_default();
         backtesting::BacktestEngine::new(config).run_with_dividends(
             &self.symbol,
             &chart.candles,
@@ -718,15 +731,22 @@ impl Ticker {
     ) -> backtesting::Result<backtesting::BacktestResult> {
         let config = config.unwrap_or_default();
         config.validate()?;
-        let bench_ticker = Ticker::new(benchmark)
-            .await
-            .map_err(|e| backtesting::BacktestError::ChartError(e.to_string()))?;
-        let (chart, bench_chart) = tokio::try_join!(
+        let bench_fut = async {
+            let bench_ticker = Ticker::new(benchmark).await?;
+            bench_ticker.chart(interval, range).await
+        };
+        // `join!`, not `try_join!`: both charts are awaited to completion and the
+        // errors resolved in a fixed order, so the surfaced error is always the
+        // primary symbol's rather than whichever future happened to fail first.
+        let (chart, bench_chart, dividends) = tokio::join!(
             self.chart(interval, range),
-            bench_ticker.chart(interval, range)
-        )
-        .map_err(|e| backtesting::BacktestError::ChartError(e.to_string()))?;
-        let dividends = self.dividends(range).await.unwrap_or_default();
+            bench_fut,
+            self.dividends(range)
+        );
+        let chart = chart.map_err(|e| backtesting::BacktestError::ChartError(e.to_string()))?;
+        let bench_chart =
+            bench_chart.map_err(|e| backtesting::BacktestError::ChartError(e.to_string()))?;
+        let dividends = dividends.unwrap_or_default();
         backtesting::BacktestEngine::new(config).run_with_benchmark(
             &self.symbol,
             &chart.candles,
@@ -745,15 +765,20 @@ impl Ticker {
         range: TimeRange,
         benchmark: Option<&str>,
     ) -> Result<risk::RiskSummary> {
-        let chart = self.chart(interval, range).await?;
-        let bench_returns = if let Some(sym) = benchmark {
+        let bench_fut = async {
+            let Some(sym) = benchmark else {
+                return Result::Ok(None);
+            };
             let bt = Ticker::new(sym).await?;
-            Some(risk::candles_to_returns(
-                &bt.chart(interval, range).await?.candles,
-            ))
-        } else {
-            None
+            let bench_chart = bt.chart(interval, range).await?;
+            Result::Ok(Some(risk::candles_to_returns(&bench_chart.candles)))
         };
+        // `join!`, not `try_join!`: resolving in a fixed order keeps the primary
+        // symbol's error as the surfaced one, matching the previous sequential
+        // `self.chart(..).await?` ordering.
+        let (chart, bench_returns) = tokio::join!(self.chart(interval, range), bench_fut);
+        let chart = chart?;
+        let bench_returns = bench_returns?;
         Ok(risk::compute_risk_summary(
             &chart.candles,
             bench_returns.as_deref(),
@@ -935,6 +960,23 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(provider.charts(), 2);
+    }
+
+    #[tokio::test]
+    async fn unresolved_logo_is_not_cached() {
+        let provider = CountingProvider::new();
+        let ticker = Ticker::builder("AAPL")
+            .with_provider_set(provider_set(Arc::clone(&provider)))
+            .logo()
+            .build()
+            .await
+            .unwrap();
+
+        let _: Quote<crate::format::Raw> = ticker.quote().await.unwrap();
+        assert!(
+            ticker.logo_cache.read().await.is_none(),
+            "an unresolved logo must not be cached, or one blip is permanent"
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/tickers/core.rs
+++ b/src/tickers/core.rs
@@ -487,6 +487,11 @@ impl Tickers {
     }
 
     /// Insert into a map cache, amortizing eviction.
+    ///
+    /// The eviction threshold scales with the basket size. These caches key one
+    /// entry per symbol and `all_cached` only serves a hit when *every* symbol is
+    /// fresh, so a fixed cap below the basket size would evict part of the basket
+    /// on every pass and the handle would never register a single cache hit.
     #[inline]
     fn cache_insert<K: Eq + std::hash::Hash, V>(
         &self,
@@ -494,7 +499,13 @@ impl Tickers {
         key: K,
         value: V,
     ) {
-        crate::utils::cache_insert(map, key, value, self.cache_mode);
+        crate::utils::cache_insert(
+            map,
+            key,
+            value,
+            self.cache_mode,
+            crate::utils::eviction_threshold_for(self.symbols.len()),
+        );
     }
 
     /// Batch fetch quotes for all symbols.

--- a/src/tickers/core.rs
+++ b/src/tickers/core.rs
@@ -27,7 +27,7 @@ use crate::providers::{
     Capability, Fetch, Provider, ProviderAdapter, ProviderSet, Routes, build_providers,
 };
 use crate::ticker::ClientHandle;
-use crate::utils::{CacheEntry, EVICTION_THRESHOLD, filter_by_range};
+use crate::utils::{CacheEntry, CacheMode, filter_by_range};
 use futures::stream::{self, StreamExt};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -123,7 +123,7 @@ pub struct TickersBuilder {
     shared_client: Option<ClientHandle>,
     injected_providers: Option<Arc<ProviderSet>>,
     max_concurrency: usize,
-    cache_ttl: Option<Duration>,
+    cache_mode: CacheMode,
     include_logo: bool,
 }
 
@@ -139,7 +139,7 @@ impl TickersBuilder {
             shared_client: None,
             injected_providers: None,
             max_concurrency: DEFAULT_MAX_CONCURRENCY,
-            cache_ttl: None,
+            cache_mode: CacheMode::default(),
             include_logo: false,
         }
     }
@@ -194,11 +194,10 @@ impl TickersBuilder {
         self
     }
 
-    /// Enable response caching with a time-to-live.
+    /// Cache responses for `ttl` instead of for the handle's lifetime.
     ///
-    /// By default caching is **disabled** — every call fetches fresh data.
-    /// When enabled, responses are reused until the TTL expires. Stale
-    /// entries are evicted on the next write.
+    /// Responses are reused until the TTL expires; stale entries are evicted
+    /// on a later write.
     ///
     /// # Example
     ///
@@ -215,7 +214,16 @@ impl TickersBuilder {
     /// # }
     /// ```
     pub fn cache(mut self, ttl: Duration) -> Self {
-        self.cache_ttl = Some(ttl);
+        self.cache_mode = CacheMode::Ttl(ttl);
+        self
+    }
+
+    /// Disable caching — every call fetches fresh data.
+    ///
+    /// By default a `Tickers` handle caches each response for as long as it
+    /// lives, so repeated calls reuse one fetch.
+    pub fn no_cache(mut self) -> Self {
+        self.cache_mode = CacheMode::Off;
         self
     }
 
@@ -276,7 +284,7 @@ impl TickersBuilder {
             symbols: self.symbols,
             providers,
             max_concurrency: self.max_concurrency,
-            cache_ttl: self.cache_ttl,
+            cache_mode: self.cache_mode,
             include_logo: self.include_logo,
             #[cfg(feature = "translation")]
             translate_lang,
@@ -339,7 +347,7 @@ pub struct Tickers {
     symbols: Vec<Arc<str>>,
     providers: Arc<ProviderSet>,
     max_concurrency: usize,
-    cache_ttl: Option<Duration>,
+    cache_mode: CacheMode,
     include_logo: bool,
     #[cfg(feature = "translation")]
     translate_lang: Option<crate::translation::Lang>,
@@ -371,7 +379,7 @@ impl std::fmt::Debug for Tickers {
         f.debug_struct("Tickers")
             .field("symbols", &self.symbols)
             .field("max_concurrency", &self.max_concurrency)
-            .field("cache_ttl", &self.cache_ttl)
+            .field("cache_mode", &self.cache_mode)
             .finish_non_exhaustive()
     }
 }
@@ -444,10 +452,10 @@ impl Tickers {
         )
     }
 
-    /// Returns `true` if a cache entry exists and has not exceeded the TTL.
+    /// Returns `true` if a cache entry exists and is still usable.
     #[inline]
     fn is_cache_fresh<T>(&self, entry: Option<&CacheEntry<T>>) -> bool {
-        CacheEntry::is_fresh_with_ttl(entry, self.cache_ttl)
+        CacheEntry::is_fresh_entry(entry, self.cache_mode)
     }
 
     /// Translate a response value when a non-English language is configured
@@ -469,17 +477,14 @@ impl Tickers {
         map: &HashMap<K, CacheEntry<V>>,
         keys: impl Iterator<Item = K>,
     ) -> bool {
-        let Some(ttl) = self.cache_ttl else {
+        if !self.cache_mode.enabled() {
             return false;
-        };
+        }
         keys.into_iter()
-            .all(|k| map.get(&k).map(|e| e.is_fresh(ttl)).unwrap_or(false))
+            .all(|k| map.get(&k).is_some_and(|e| e.is_fresh(self.cache_mode)))
     }
 
-    /// Insert into a map cache, amortizing stale-entry eviction.
-    ///
-    /// Only sweeps stale entries when the map exceeds [`EVICTION_THRESHOLD`],
-    /// avoiding O(n) scans on every write.
+    /// Insert into a map cache, amortizing eviction.
     #[inline]
     fn cache_insert<K: Eq + std::hash::Hash, V>(
         &self,
@@ -487,12 +492,7 @@ impl Tickers {
         key: K,
         value: V,
     ) {
-        if let Some(ttl) = self.cache_ttl {
-            if map.len() >= EVICTION_THRESHOLD {
-                map.retain(|_, entry| entry.is_fresh(ttl));
-            }
-            map.insert(key, CacheEntry::new(value));
-        }
+        crate::utils::cache_insert(map, key, value, self.cache_mode);
     }
 
     /// Batch fetch quotes for all symbols.
@@ -644,7 +644,7 @@ impl Tickers {
         #[cfg(feature = "translation")]
         self.translate_response(&mut response).await?;
 
-        if self.cache_ttl.is_some() {
+        if self.cache_mode.enabled() {
             let mut cache = self.quote_cache.write().await;
             for (symbol, quote) in &response.quotes {
                 self.cache_insert(&mut cache, symbol.as_str().into(), quote.clone());
@@ -855,7 +855,7 @@ impl Tickers {
         }
 
         // Move into cache, then clone for response — avoids double-clone
-        if self.cache_ttl.is_some() {
+        if self.cache_mode.enabled() {
             let mut cache = self.chart_cache.write().await;
             let cache_keys: Vec<_> = parsed_charts
                 .into_iter()
@@ -973,9 +973,9 @@ impl Tickers {
     /// Uses `TimeRange::Max` to get full event history (Yahoo returns all
     /// dividends/splits/capital gains regardless of chart range).
     ///
-    /// Events are always stored regardless of `cache_ttl` because they are
-    /// derived data (not a TTL-bounded cache). When `cache_ttl` is `None`,
-    /// events persist for the lifetime of the `Tickers` instance.
+    /// Events are always stored regardless of the cache mode because they are
+    /// derived data (not a TTL-bounded cache), so they persist for the lifetime
+    /// of the `Tickers` instance even under [`CacheMode::Off`].
     async fn ensure_events_loaded(&self) -> Result<()> {
         // Check which symbols need event data (existence check, not TTL-based)
         let symbols_to_fetch: Vec<Arc<str>> = {
@@ -1126,7 +1126,7 @@ impl Tickers {
         match spark_result {
             Ok(parsed_sparks) => {
                 // Cache all parsed sparks
-                if self.cache_ttl.is_some() {
+                if self.cache_mode.enabled() {
                     let mut cache = self.spark_cache.write().await;
                     for (symbol, spark) in &parsed_sparks {
                         let key: Arc<str> = symbol.as_str().into();
@@ -1672,7 +1672,7 @@ impl Tickers {
         }
 
         // Now acquire write lock briefly for batch cache insertion
-        if self.cache_ttl.is_some() {
+        if self.cache_mode.enabled() {
             let mut cache = self.indicators_cache.write().await;
             for (symbol, indicators) in &calculated_indicators {
                 let key: Arc<str> = symbol.as_str().into();
@@ -1959,6 +1959,41 @@ impl Tickers {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn default_caches_quotes_across_calls() {
+        use crate::providers::mock::{CountingProvider, provider_set};
+
+        let provider = CountingProvider::new();
+        let tickers = Tickers::builder(["AAPL", "MSFT"])
+            .with_provider_set(provider_set(Arc::clone(&provider)))
+            .build()
+            .await
+            .unwrap();
+
+        let _ = tickers.quotes().await.unwrap();
+        let _ = tickers.quotes().await.unwrap();
+
+        assert_eq!(provider.quotes(), 2, "one per symbol, fetched once");
+    }
+
+    #[tokio::test]
+    async fn no_cache_refetches_quotes() {
+        use crate::providers::mock::{CountingProvider, provider_set};
+
+        let provider = CountingProvider::new();
+        let tickers = Tickers::builder(["AAPL", "MSFT"])
+            .with_provider_set(provider_set(Arc::clone(&provider)))
+            .no_cache()
+            .build()
+            .await
+            .unwrap();
+
+        let _ = tickers.quotes().await.unwrap();
+        let _ = tickers.quotes().await.unwrap();
+
+        assert_eq!(provider.quotes(), 4);
+    }
 
     #[tokio::test]
     #[ignore = "requires network access"]

--- a/src/tickers/core.rs
+++ b/src/tickers/core.rs
@@ -301,6 +301,7 @@ impl TickersBuilder {
 
             // Initialize fetch guards for request deduplication
             quotes_fetch: Arc::new(tokio::sync::Mutex::new(())),
+            events_fetch: Arc::new(tokio::sync::Mutex::new(())),
             charts_fetch: Default::default(),
             financials_fetch: Default::default(),
             news_fetch: Arc::new(tokio::sync::Mutex::new(())),
@@ -364,6 +365,7 @@ pub struct Tickers {
 
     // Fetch guards prevent duplicate concurrent requests
     quotes_fetch: FetchGuard,
+    events_fetch: FetchGuard,
     charts_fetch: FetchGuardMap<(Interval, TimeRange)>,
     financials_fetch: FetchGuardMap<(StatementType, Frequency)>,
     news_fetch: FetchGuard,
@@ -977,16 +979,14 @@ impl Tickers {
     /// derived data (not a TTL-bounded cache), so they persist for the lifetime
     /// of the `Tickers` instance even under [`CacheMode::Off`].
     async fn ensure_events_loaded(&self) -> Result<()> {
-        // Check which symbols need event data (existence check, not TTL-based)
-        let symbols_to_fetch: Vec<Arc<str>> = {
-            let cache = self.events_cache.read().await;
-            self.symbols
-                .iter()
-                .filter(|sym| !cache.contains_key(*sym))
-                .cloned()
-                .collect()
-        };
+        if self.events_missing().await.is_empty() {
+            return Ok(());
+        }
 
+        let _fetch_guard = self.events_fetch.lock().await;
+
+        // Double-check: another task may have fetched while we waited
+        let symbols_to_fetch = self.events_missing().await;
         if symbols_to_fetch.is_empty() {
             return Ok(());
         }
@@ -1033,6 +1033,16 @@ impl Tickers {
         }
 
         Ok(())
+    }
+
+    /// Symbols with no entry in the events cache (existence check, not TTL-based).
+    async fn events_missing(&self) -> Vec<Arc<str>> {
+        let cache = self.events_cache.read().await;
+        self.symbols
+            .iter()
+            .filter(|sym| !cache.contains_key(*sym))
+            .cloned()
+            .collect()
     }
 
     /// Batch fetch spark data for all symbols in a single request.
@@ -1535,31 +1545,17 @@ impl Tickers {
         let per_symbol = symbol_strings.into_iter().map(|sym| {
             let providers = Arc::clone(&providers);
             async move {
-                let quote_fut = {
+                let quote = {
                     let sym = sym.clone();
-                    providers.fetch(Capability::QUOTE, move |p| {
-                        let sym = sym.clone();
-                        let p = p.clone();
-                        async move { p.fetch_quote(&sym).await }
-                    })
+                    providers
+                        .fetch(Capability::QUOTE, move |p| {
+                            let sym = sym.clone();
+                            let p = p.clone();
+                            async move { p.fetch_quote(&sym).await }
+                        })
+                        .await
                 };
-                let opts_fut = {
-                    let sym = sym.clone();
-                    providers.fetch(Capability::OPTIONS, move |p| {
-                        let sym = sym.clone();
-                        let p = p.clone();
-                        async move { p.fetch_options(&sym, None).await }
-                    })
-                };
-                let (quote, options) = tokio::join!(quote_fut, opts_fut);
-                let calendar_events = quote.ok().and_then(|q| q.calendar_events);
-                let options = options.ok();
-                crate::models::calendar::build_symbol_events(
-                    &sym,
-                    calendar_events.as_ref(),
-                    options.as_ref(),
-                    window,
-                )
+                (sym, quote.ok().and_then(|q| q.calendar_events))
             }
         });
 
@@ -1567,16 +1563,31 @@ impl Tickers {
             .buffer_unordered(self.max_concurrency)
             .collect::<Vec<_>>();
 
-        // The FRED economic-release fetch is independent of the per-symbol work,
-        // so run it concurrently with the per-symbol stream.
+        // Options go through `self.options`, so a chain already in the options
+        // cache is reused instead of refetched. The FRED economic-release fetch
+        // is independent of both, so run all of them concurrently.
         #[cfg(feature = "fred")]
-        let (per_symbol_events, releases) =
-            tokio::join!(per_symbol_fut, crate::adapters::fred::release_dates());
+        let (per_symbol_quotes, options_resp, releases) = tokio::join!(
+            per_symbol_fut,
+            self.options(None),
+            crate::adapters::fred::release_dates()
+        );
         #[cfg(not(feature = "fred"))]
-        let per_symbol_events = per_symbol_fut.await;
+        let (per_symbol_quotes, options_resp) = tokio::join!(per_symbol_fut, self.options(None));
 
-        let mut events: Vec<crate::models::calendar::CalendarEvent> =
-            per_symbol_events.into_iter().flatten().collect();
+        let options_map = options_resp.map(|r| r.options).unwrap_or_default();
+
+        let mut events: Vec<crate::models::calendar::CalendarEvent> = per_symbol_quotes
+            .into_iter()
+            .flat_map(|(sym, calendar_events)| {
+                crate::models::calendar::build_symbol_events(
+                    &sym,
+                    calendar_events.as_ref(),
+                    options_map.get(&sym),
+                    window,
+                )
+            })
+            .collect();
 
         #[cfg(feature = "fred")]
         if let Ok(releases) = releases {
@@ -1787,19 +1798,13 @@ impl Tickers {
         let config = config.unwrap_or_default();
         config.validate(self.symbols.len())?;
 
-        // Fetch charts for all symbols (uses the batch chart cache)
-        let charts = self
-            .charts(interval, range)
-            .await
-            .map_err(|e| backtesting::BacktestError::ChartError(e.to_string()))?;
-
-        // Fetch dividends for all symbols (events cache is already warm after charts())
+        // Charts and dividends hit disjoint caches and disjoint capabilities
+        // (CHART vs CORPORATE), so neither warms the other.
+        let (charts, dividends_map) =
+            tokio::join!(self.charts(interval, range), self.dividends(range));
+        let charts = charts.map_err(|e| backtesting::BacktestError::ChartError(e.to_string()))?;
         // Treat errors as "no dividends" — dividend processing is best-effort
-        let dividends_map = self
-            .dividends(range)
-            .await
-            .map(|b| b.dividends)
-            .unwrap_or_default();
+        let dividends_map = dividends_map.map(|b| b.dividends).unwrap_or_default();
 
         // Assemble SymbolData slices — skip symbols with no chart data
         let symbol_data: Vec<SymbolData> = self
@@ -1993,6 +1998,46 @@ mod tests {
         let _ = tickers.quotes().await.unwrap();
 
         assert_eq!(provider.quotes(), 4);
+    }
+
+    #[tokio::test]
+    async fn concurrent_event_accessors_fetch_once() {
+        use crate::providers::mock::{CountingProvider, provider_set};
+
+        let provider = CountingProvider::new();
+        let tickers = Tickers::builder(["AAPL", "MSFT"])
+            .with_provider_set(provider_set(Arc::clone(&provider)))
+            .build()
+            .await
+            .unwrap();
+
+        let (d, s) = tokio::join!(
+            tickers.dividends(TimeRange::OneYear),
+            tickers.splits(TimeRange::OneYear)
+        );
+        assert!(d.is_ok() && s.is_ok());
+        assert_eq!(provider.events(), 2, "one event fetch per symbol, not two");
+    }
+
+    #[tokio::test]
+    async fn calendar_reuses_the_options_cache() {
+        use crate::providers::mock::{CountingProvider, provider_set};
+
+        let provider = CountingProvider::new();
+        let tickers = Tickers::builder(["AAPL"])
+            .with_provider_set(provider_set(Arc::clone(&provider)))
+            .build()
+            .await
+            .unwrap();
+
+        let _ = tickers.options(None).await;
+        let before = provider.options();
+        let _ = tickers.calendar(TimeRange::OneMonth).await;
+        assert_eq!(
+            provider.options(),
+            before,
+            "calendar refetched a cached chain"
+        );
     }
 
     #[tokio::test]

--- a/src/tickers/macros.rs
+++ b/src/tickers/macros.rs
@@ -214,7 +214,7 @@ macro_rules! batch_fetch_cached {
         }
 
         // Cache insert
-        if $self.cache_ttl.is_some() {
+        if $self.cache_mode.enabled() {
             let mut cache = $self.$cache_field.write().await;
             for (sym, value) in &parsed {
                 $self.cache_insert(&mut cache, cache_key_fn(sym), value.clone());

--- a/src/translation/memo.rs
+++ b/src/translation/memo.rs
@@ -16,11 +16,18 @@ const MAX_MEMO_TEXT_LEN: usize = 8192;
 /// Maximum number of cached entries before the cache is reset.
 const MAX_MEMO_ENTRIES: usize = 4096;
 
-type MemoMap = HashMap<(String, String), String>;
+/// Nested so `get` can borrow both keys instead of allocating an owned tuple to
+/// probe the map — the whole point of the cache is that a hit costs nothing.
+/// `entries` tracks the total across languages so the cap check stays O(1).
+#[derive(Default)]
+struct Memo {
+    by_lang: HashMap<String, HashMap<String, String>>,
+    entries: usize,
+}
 
-fn memo() -> &'static RwLock<MemoMap> {
-    static MEMO: OnceLock<RwLock<MemoMap>> = OnceLock::new();
-    MEMO.get_or_init(|| RwLock::new(HashMap::new()))
+fn memo() -> &'static RwLock<Memo> {
+    static MEMO: OnceLock<RwLock<Memo>> = OnceLock::new();
+    MEMO.get_or_init(|| RwLock::new(Memo::default()))
 }
 
 /// Look up a previously translated text for a language code.
@@ -31,7 +38,9 @@ pub(crate) fn get(lang_code: &str, text: &str) -> Option<String> {
     memo()
         .read()
         .ok()?
-        .get(&(lang_code.to_string(), text.to_string()))
+        .by_lang
+        .get(lang_code)?
+        .get(text)
         .cloned()
 }
 
@@ -40,14 +49,20 @@ pub(crate) fn insert(lang_code: &str, text: &str, translated: &str) {
     if text.len() > MAX_MEMO_TEXT_LEN {
         return;
     }
-    if let Ok(mut map) = memo().write() {
-        if map.len() >= MAX_MEMO_ENTRIES {
-            map.clear();
+    if let Ok(mut memo) = memo().write() {
+        if memo.entries >= MAX_MEMO_ENTRIES {
+            memo.by_lang.clear();
+            memo.entries = 0;
         }
-        map.insert(
-            (lang_code.to_string(), text.to_string()),
-            translated.to_string(),
-        );
+        if memo
+            .by_lang
+            .entry(lang_code.to_string())
+            .or_default()
+            .insert(text.to_string(), translated.to_string())
+            .is_none()
+        {
+            memo.entries += 1;
+        }
     }
 }
 
@@ -68,5 +83,59 @@ mod tests {
         let big = "a".repeat(MAX_MEMO_TEXT_LEN + 1);
         insert("xx-memo-test", &big, "translated");
         assert_eq!(get("xx-memo-test", &big), None);
+    }
+
+    #[test]
+    fn insert_then_get_round_trips_per_language() {
+        insert("zz-memo-ja", "MemoCacheRoundTrip", "テクノロジー");
+        insert("zz-memo-de", "MemoCacheRoundTrip", "Technologie");
+        assert_eq!(
+            get("zz-memo-ja", "MemoCacheRoundTrip").as_deref(),
+            Some("テクノロジー")
+        );
+        assert_eq!(
+            get("zz-memo-de", "MemoCacheRoundTrip").as_deref(),
+            Some("Technologie")
+        );
+        assert_eq!(get("zz-memo-fr", "MemoCacheRoundTrip"), None);
+        assert_eq!(get("zz-memo-ja", "MemoCacheUnseen"), None);
+    }
+
+    #[test]
+    fn oversized_text_is_not_cached() {
+        let big = "x".repeat(MAX_MEMO_TEXT_LEN + 1);
+        insert("zz-memo-oversized", &big, "ignored");
+        assert_eq!(get("zz-memo-oversized", &big), None);
+    }
+
+    /// The memo is a process-wide static shared with every other test in the
+    /// suite, but nothing else touches the `zz-cap-*` language codes used
+    /// here, and this test's own MAX_MEMO_ENTRIES+ insertions are enough to
+    /// force at least one clear regardless of unrelated concurrent activity.
+    #[test]
+    fn entry_cap_is_enforced_across_languages() {
+        let first_text = "zz-cap-first-only-once";
+        insert("zz-cap-a", first_text, "seed");
+
+        let extra = 8;
+        for i in 0..(MAX_MEMO_ENTRIES + extra) {
+            let lang = if i % 2 == 0 { "zz-cap-a" } else { "zz-cap-b" };
+            let text = format!("zz-cap-text-{i}");
+            insert(lang, &text, "v");
+        }
+
+        // Crossing the cap clears the whole map, so an entry written well
+        // before the crossing point cannot have survived.
+        assert_eq!(get("zz-cap-a", first_text), None);
+
+        // Entries written after the clear (the loop's tail) do survive.
+        let last_i = MAX_MEMO_ENTRIES + extra - 1;
+        let last_lang = if last_i.is_multiple_of(2) {
+            "zz-cap-a"
+        } else {
+            "zz-cap-b"
+        };
+        let last_text = format!("zz-cap-text-{last_i}");
+        assert_eq!(get(last_lang, &last_text).as_deref(), Some("v"));
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -103,12 +103,20 @@ fn evict<K: Eq + Hash, V>(map: &mut HashMap<K, CacheEntry<V>>, mode: CacheMode) 
     if map.len() < EVICTION_THRESHOLD {
         return;
     }
-    // Lifetime entries never go stale, so fall back to dropping the older half
-    // by fetch time — halving amortizes the O(n) sort across many inserts.
+    // Lifetime entries never go stale, so fall back to keeping the newest half by
+    // fetch time. The survivor budget is a count, not just a timestamp cutoff:
+    // a coarse or paused clock gives every entry the same `Instant`, and a pure
+    // cutoff comparison would then retain all of them and never evict.
+    let keep = EVICTION_THRESHOLD / 2;
     let mut times: Vec<Instant> = map.values().map(|e| e.fetched_at).collect();
     times.sort_unstable();
-    let cutoff = times[times.len() / 2];
-    map.retain(|_, entry| entry.fetched_at >= cutoff);
+    let cutoff = times[times.len() - keep];
+    let mut kept = 0usize;
+    map.retain(|_, entry| {
+        let survives = entry.fetched_at >= cutoff && kept < keep;
+        kept += usize::from(survives);
+        survives
+    });
 }
 
 /// Trait for types with a timestamp field
@@ -228,6 +236,23 @@ mod tests {
         let mut map: HashMap<u32, CacheEntry<u32>> = HashMap::new();
         cache_insert(&mut map, 1, 1, CacheMode::Off);
         assert!(map.is_empty());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn eviction_survives_a_frozen_clock() {
+        // Under `tokio::time::pause` every entry shares one `Instant`. A pure
+        // timestamp cutoff would retain all of them, so the cap must be enforced
+        // by count as well.
+        let mut map: HashMap<u32, CacheEntry<u32>> = HashMap::new();
+        for i in 0..500u32 {
+            cache_insert(&mut map, i, i, CacheMode::Lifetime);
+        }
+        assert!(
+            map.len() <= EVICTION_THRESHOLD,
+            "cache grew to {} with a frozen clock",
+            map.len()
+        );
+        assert!(map.contains_key(&499), "newest entry must survive");
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,7 +2,12 @@
 
 use crate::constants::TimeRange;
 use crate::models::chart::{CapitalGain, Dividend, Split};
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+// tokio's Instant tracks the runtime clock, so TTL expiry is testable under
+// `tokio::time::pause`. Outside tests it is std::time::Instant.
+use tokio::time::Instant;
 
 /// Returns the current time as Unix timestamp in seconds.
 #[inline]
@@ -13,11 +18,30 @@ pub(crate) fn now_unix_secs() -> i64 {
         .as_secs() as i64
 }
 
-/// Maximum number of entries before we trigger a stale-entry eviction sweep.
+/// Maximum number of entries before we trigger an eviction sweep.
 ///
 /// Eviction only runs when the map exceeds this size, amortizing the O(n)
 /// retain cost across many inserts instead of running on every single write.
 pub(crate) const EVICTION_THRESHOLD: usize = 64;
+
+/// How long a cached response stays usable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum CacheMode {
+    /// Cache until the owning handle is dropped.
+    #[default]
+    Lifetime,
+    /// Cache for a bounded duration.
+    Ttl(Duration),
+    /// Never cache.
+    Off,
+}
+
+impl CacheMode {
+    #[inline]
+    pub(crate) fn enabled(self) -> bool {
+        !matches!(self, Self::Off)
+    }
+}
 
 /// Wrapper that tracks when a cached value was fetched.
 ///
@@ -40,23 +64,51 @@ impl<T> CacheEntry<T> {
         }
     }
 
-    /// Returns `true` if the entry has not exceeded the given TTL.
+    /// Returns `true` if the entry is still usable under `mode`.
     #[inline]
-    pub(crate) fn is_fresh(&self, ttl: Duration) -> bool {
-        self.fetched_at.elapsed() < ttl
-    }
-
-    /// Returns `true` if the entry exists and has not exceeded the given TTL.
-    ///
-    /// Returns `false` if the entry is `None` or the TTL is `None` (caching disabled).
-    /// This consolidates the common pattern of checking both the TTL and entry existence.
-    #[inline]
-    pub(crate) fn is_fresh_with_ttl(entry: Option<&CacheEntry<T>>, ttl: Option<Duration>) -> bool {
-        match (ttl, entry) {
-            (Some(ttl), Some(e)) => e.is_fresh(ttl),
-            _ => false,
+    pub(crate) fn is_fresh(&self, mode: CacheMode) -> bool {
+        match mode {
+            CacheMode::Lifetime => true,
+            CacheMode::Ttl(ttl) => self.fetched_at.elapsed() < ttl,
+            CacheMode::Off => false,
         }
     }
+
+    /// Returns `true` if the entry exists and is still usable under `mode`.
+    #[inline]
+    pub(crate) fn is_fresh_entry(entry: Option<&CacheEntry<T>>, mode: CacheMode) -> bool {
+        matches!(entry, Some(e) if e.is_fresh(mode))
+    }
+}
+
+/// Insert into a map cache, evicting first if the map has grown past
+/// [`EVICTION_THRESHOLD`]. No-op when caching is off.
+pub(crate) fn cache_insert<K: Eq + Hash, V>(
+    map: &mut HashMap<K, CacheEntry<V>>,
+    key: K,
+    value: V,
+    mode: CacheMode,
+) {
+    if !mode.enabled() {
+        return;
+    }
+    if map.len() >= EVICTION_THRESHOLD {
+        evict(map, mode);
+    }
+    map.insert(key, CacheEntry::new(value));
+}
+
+fn evict<K: Eq + Hash, V>(map: &mut HashMap<K, CacheEntry<V>>, mode: CacheMode) {
+    map.retain(|_, entry| entry.is_fresh(mode));
+    if map.len() < EVICTION_THRESHOLD {
+        return;
+    }
+    // Lifetime entries never go stale, so fall back to dropping the older half
+    // by fetch time — halving amortizes the O(n) sort across many inserts.
+    let mut times: Vec<Instant> = map.values().map(|e| e.fetched_at).collect();
+    times.sort_unstable();
+    let cutoff = times[times.len() / 2];
+    map.retain(|_, entry| entry.fetched_at >= cutoff);
 }
 
 /// Trait for types with a timestamp field
@@ -136,5 +188,55 @@ pub(crate) fn filter_by_range<T: HasTimestamp>(items: Vec<T>, range: TimeRange) 
                 .filter(|item| item.timestamp() >= cutoff)
                 .collect()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lifetime_mode_is_always_fresh() {
+        let entry = CacheEntry::new(1u32);
+        assert!(entry.is_fresh(CacheMode::Lifetime));
+    }
+
+    #[test]
+    fn off_mode_is_never_fresh() {
+        let entry = CacheEntry::new(1u32);
+        assert!(!entry.is_fresh(CacheMode::Off));
+        assert!(!CacheEntry::is_fresh_entry(Some(&entry), CacheMode::Off));
+    }
+
+    #[test]
+    fn ttl_mode_is_fresh_within_window() {
+        let entry = CacheEntry::new(1u32);
+        assert!(entry.is_fresh(CacheMode::Ttl(Duration::from_secs(60))));
+        assert!(!entry.is_fresh(CacheMode::Ttl(Duration::ZERO)));
+    }
+
+    #[test]
+    fn missing_entry_is_never_fresh() {
+        assert!(!CacheEntry::<u32>::is_fresh_entry(
+            None,
+            CacheMode::Lifetime
+        ));
+    }
+
+    #[test]
+    fn off_mode_writes_nothing() {
+        let mut map: HashMap<u32, CacheEntry<u32>> = HashMap::new();
+        cache_insert(&mut map, 1, 1, CacheMode::Off);
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn lifetime_mode_evicts_oldest_past_threshold() {
+        let mut map: HashMap<u32, CacheEntry<u32>> = HashMap::new();
+        for i in 0..200u32 {
+            cache_insert(&mut map, i, i, CacheMode::Lifetime);
+        }
+        assert!(map.len() <= EVICTION_THRESHOLD);
+        assert!(map.contains_key(&199), "newest entry must survive eviction");
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -18,11 +18,27 @@ pub(crate) fn now_unix_secs() -> i64 {
         .as_secs() as i64
 }
 
-/// Maximum number of entries before we trigger an eviction sweep.
+/// Default number of entries before we trigger an eviction sweep.
 ///
 /// Eviction only runs when the map exceeds this size, amortizing the O(n)
 /// retain cost across many inserts instead of running on every single write.
+///
+/// This is a floor, not a ceiling: a handle whose working set is inherently
+/// larger — a [`Tickers`] basket keys one entry per symbol — raises it via
+/// [`eviction_threshold_for`], or the cache could never hold a full working set
+/// and would never produce a hit.
+///
+/// [`Tickers`]: crate::Tickers
 pub(crate) const EVICTION_THRESHOLD: usize = 64;
+
+/// Eviction threshold for a cache whose working set is `working_set` entries.
+///
+/// Sized so a full working set survives a sweep: eviction keeps the newest half,
+/// so the threshold must be at least twice the working set.
+#[inline]
+pub(crate) fn eviction_threshold_for(working_set: usize) -> usize {
+    EVICTION_THRESHOLD.max(working_set.saturating_mul(2))
+}
 
 /// How long a cached response stays usable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -82,32 +98,37 @@ impl<T> CacheEntry<T> {
 }
 
 /// Insert into a map cache, evicting first if the map has grown past
-/// [`EVICTION_THRESHOLD`]. No-op when caching is off.
+/// `threshold`. No-op when caching is off.
+///
+/// `threshold` comes from [`eviction_threshold_for`] so a handle with a large
+/// working set — a `Tickers` basket of more than 32 symbols — can still hold
+/// every key it needs at once.
 pub(crate) fn cache_insert<K: Eq + Hash, V>(
     map: &mut HashMap<K, CacheEntry<V>>,
     key: K,
     value: V,
     mode: CacheMode,
+    threshold: usize,
 ) {
     if !mode.enabled() {
         return;
     }
-    if map.len() >= EVICTION_THRESHOLD {
-        evict(map, mode);
+    if map.len() >= threshold {
+        evict(map, mode, threshold);
     }
     map.insert(key, CacheEntry::new(value));
 }
 
-fn evict<K: Eq + Hash, V>(map: &mut HashMap<K, CacheEntry<V>>, mode: CacheMode) {
+fn evict<K: Eq + Hash, V>(map: &mut HashMap<K, CacheEntry<V>>, mode: CacheMode, threshold: usize) {
     map.retain(|_, entry| entry.is_fresh(mode));
-    if map.len() < EVICTION_THRESHOLD {
+    if map.len() < threshold {
         return;
     }
     // Lifetime entries never go stale, so fall back to keeping the newest half by
     // fetch time. The survivor budget is a count, not just a timestamp cutoff:
     // a coarse or paused clock gives every entry the same `Instant`, and a pure
     // cutoff comparison would then retain all of them and never evict.
-    let keep = EVICTION_THRESHOLD / 2;
+    let keep = (threshold / 2).max(1);
     let mut times: Vec<Instant> = map.values().map(|e| e.fetched_at).collect();
     times.sort_unstable();
     let cutoff = times[times.len() - keep];
@@ -234,7 +255,7 @@ mod tests {
     #[test]
     fn off_mode_writes_nothing() {
         let mut map: HashMap<u32, CacheEntry<u32>> = HashMap::new();
-        cache_insert(&mut map, 1, 1, CacheMode::Off);
+        cache_insert(&mut map, 1, 1, CacheMode::Off, EVICTION_THRESHOLD);
         assert!(map.is_empty());
     }
 
@@ -245,7 +266,7 @@ mod tests {
         // by count as well.
         let mut map: HashMap<u32, CacheEntry<u32>> = HashMap::new();
         for i in 0..500u32 {
-            cache_insert(&mut map, i, i, CacheMode::Lifetime);
+            cache_insert(&mut map, i, i, CacheMode::Lifetime, EVICTION_THRESHOLD);
         }
         assert!(
             map.len() <= EVICTION_THRESHOLD,
@@ -256,10 +277,45 @@ mod tests {
     }
 
     #[test]
+    fn a_large_working_set_survives_eviction_intact() {
+        // A `Tickers` basket keys one entry per symbol and only serves a hit when
+        // every symbol is fresh. With the fixed 64-entry cap, a 100-symbol basket
+        // was trimmed to 32 on every pass and never registered a single hit.
+        let symbols = 100usize;
+        let threshold = eviction_threshold_for(symbols);
+        let mut map: HashMap<u32, CacheEntry<u32>> = HashMap::new();
+        for i in 0..symbols as u32 {
+            cache_insert(&mut map, i, i, CacheMode::Lifetime, threshold);
+        }
+        assert_eq!(map.len(), symbols, "the whole basket must stay cached");
+        assert!(
+            (0..symbols as u32).all(|i| map.contains_key(&i)),
+            "every symbol must be present for all_cached to hit"
+        );
+    }
+
+    #[test]
+    fn a_large_working_set_is_still_bounded() {
+        // Scaling the threshold must not turn the cache into an unbounded map:
+        // rewriting the basket many times over still evicts.
+        let threshold = eviction_threshold_for(100);
+        let mut map: HashMap<u32, CacheEntry<u32>> = HashMap::new();
+        for i in 0..5_000u32 {
+            cache_insert(&mut map, i, i, CacheMode::Lifetime, threshold);
+        }
+        assert!(
+            map.len() <= threshold,
+            "cache grew to {} past a threshold of {threshold}",
+            map.len()
+        );
+        assert!(map.contains_key(&4_999), "newest entry must survive");
+    }
+
+    #[test]
     fn lifetime_mode_evicts_oldest_past_threshold() {
         let mut map: HashMap<u32, CacheEntry<u32>> = HashMap::new();
         for i in 0..200u32 {
-            cache_insert(&mut map, i, i, CacheMode::Lifetime);
+            cache_insert(&mut map, i, i, CacheMode::Lifetime, EVICTION_THRESHOLD);
         }
         assert!(map.len() <= EVICTION_THRESHOLD);
         assert!(map.contains_key(&199), "newest entry must survive eviction");


### PR DESCRIPTION
## Description
A performance pass over the library's hot paths, plus the behavioral corrections that fell out of it. The headline items: Yahoo requests no longer redo the cookie + crumb handshake on every call, `Ticker`/`Tickers`/domain handles actually cache (as their docs have always claimed), provider JSON is parsed once from the response bytes instead of round-tripping through `serde_json::Value`, and trailing-stop backtests no longer rescan the candle history per bar.


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement

## Changes

**Yahoo session and auth** (`src/adapters/yahoo/{session,auth,client}.rs`)
- One authenticated session is now shared per tokio runtime + `ClientConfig`. `finance::*` calls drop from three HTTP requests to one, and `Ticker`/`Tickers` construction stops re-authenticating per handle.
- The crumb sits behind an `RwLock` so it can be swapped in place. A request that fails authentication re-runs the handshake once and retries; concurrent refreshers collapse to a single refresh. If the refresh itself fails, the shared session is invalidated so the next caller builds a fresh one.
- HTTP 403 is now treated as an authentication failure alongside 401 — Yahoo returns both for a stale crumb.

**Caching** (`src/utils.rs`, `src/ticker/core.rs`, `src/tickers/core.rs`, `src/domains/mod.rs`)
- `CacheMode`: cache for the handle's lifetime (new default), bound it to a TTL with `.cache(d)`, or turn it off with the new `.no_cache()`. Map-backed caches gained a size-capped eviction sweep; the survivor budget is a count, not just a timestamp cutoff, so a coarse or paused clock can't defeat eviction.

**Parsing and allocation**
- FMP and Polygon clients parse the response bytes once into the target type, detecting each provider's HTTP-200-with-error envelope through a small `ErrorEnvelope` struct instead of a full `Value` walk followed by `from_value`. Polygon's `error`/`message` are typed as `Value` on purpose: a strict `String` would fail the envelope parse on a structured error body and silently turn an error into a success.
- Yahoo quotes, search, and lookup deserialize straight from the response bytes. The quote DTO uses a macro-generated lenient field deserializer that mirrors the old `Value` accessors exactly — a field arriving as a bare number, a quoted string, or `{"raw":..,"fmt":..}` is still tolerated, and one odd field still can't fail the whole batch.
- Response reshaping across `src/models/**` takes ownership instead of cloning.
- EDGAR gained `submissions_for_symbol` / `company_facts_for_symbol` so a CIK resolve plus fetch shares one client, collapsing two connection pools and TLS handshakes into one.
- Max-range Yahoo charts fetch their ~10-year chunks concurrently (`buffer_unordered(4)`), with a process-wide semaphore so a batch call's per-symbol concurrency and the per-chart fan-out can't multiply.
- The translation memo is keyed by a nested map, so a lookup borrows both keys instead of allocating an owned `(String, String)` tuple to probe the cache.
- `scrapers/yahoo_earnings` compiles its URL pattern once via `LazyLock` instead of per call.

**Backtesting and analytics**
- `TrailingStop` / `TrailingTakeProfit` keep a running peak/trough for the open position: O(bars²) → O(bars). The cache is cleared on clone so `GridSearch`'s parallel combos can't share one combo's position state.
- Conditions binary-search the candle slice for the entry index instead of scanning it, and `BacktestEngine::run{,_with_dividends}` now validate ascending candle order (see Breaking Changes).
- The engine computes each distinct indicator once, while keeping alias keys alive — a custom `IndicatorRef` may share an `Indicator` with a built-in one under its own key, and dropping that key would make the condition reading it silently never fire.
- HTF refs derive their lookup keys once at construction instead of re-formatting `htf_{interval}_{base_key}` per bar.
- The Bayesian optimizer scores candidates with rayon at ≥120 observations (below that, dispatch costs more than it saves — measured 3.4→4.3 ms at 30 observations versus 114.9→44.0 ms at 200). Candidate draws stay serial so RNG consumption order and seeded reproducibility are unchanged, and the parallel argmax reproduces the sequential scan's NaN handling and lowest-index tie-break exactly.
- `walk_forward` runs windows in parallel but collects every result rather than short-circuiting, because rayon doesn't define which error wins a fallible collect and callers rely on the lowest-index window's failure being the reported one.
- `risk::compute_risk_summary` sorts returns once and shares one mean/std across historical VaR, parametric VaR, and Sharpe.
- `vwma` uses rolling sums instead of rescanning the window each bar.

## Breaking Changes

1. **Handles cache by default.** `Ticker`, `Tickers`, and the domain handles now cache responses for the lifetime of the handle. Caching was previously off unless `.cache(ttl)` was set, so every accessor refetched — which contradicted the documentation.
2. **`TrailingStop` / `TrailingTakeProfit` are no longer `Copy`** and both gained a private field (the running peak/trough cache that removed the O(bars²) rescan). They still implement `Clone`.
3. **`BacktestEngine::run` / `run_with_dividends` reject unsorted candles** with the same `InvalidParameter` error already used for unsorted dividends. Conditions binary-search the slice, so an unsorted series previously produced a silently wrong entry index rather than an error.

**Migration Guide:**
```rust
// Before — caching was opt-in; this handle refetched on every accessor
let ticker = Ticker::new("AAPL").await?;

// After — same call now caches for the handle's lifetime.
// To keep the old behavior:
let ticker = Ticker::builder("AAPL").no_cache().build().await?;
// Or bound reuse to a TTL:
let ticker = Ticker::builder("AAPL").cache(Duration::from_secs(300)).build().await?;
```

```rust
// Before — implicit Copy
let ts = TrailingStop::new(5.0);
let a = ts;
let b = ts;

// After — clone explicitly
let ts = TrailingStop::new(5.0);
let a = ts.clone();
let b = ts;
```

```rust
// Before — an unsorted series silently produced a wrong entry index
engine.run(&unsorted_candles)?;

// After — sort first
let mut candles = candles;
candles.sort_by_key(|c| c.timestamp);
engine.run(&candles)?;
```

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] All tests pass (`cargo test`)

`cargo test --workspace --features finance-query/full`: **1232 passed, 0 failed, 364 ignored** (the ignored set is the network-gated suite, unchanged by this PR).

New tests target the risky parts of each optimization rather than the happy path: FMP/Polygon error-envelope parity across malformed and structured bodies, the lenient quote field deserializer against number/string/`{raw,fmt}`/null shapes, cache eviction under `tokio::time::pause` (where every entry shares one `Instant`), a golden-trade sequence pinning HTF key precomputation to identical entries/exits, the Bayesian argmax against a reference sequential scan (including NaN acquisition and duplicate-candidate tie-breaks), and `parse_date` on `None`/garbage input.

## Documentation
- [x] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [x] CHANGELOG.md updated (if releasing)
- [x] Examples updated (if API changed) — `docs/library/ticker.md` and `docs/library/tickers.md` caching sections rewritten for the new default plus `.no_cache()`

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test --workspace --features finance-query/full`)
- [x] Code formatted (`cargo fmt --all -- --check`)
- [x] Clippy checks pass (`cargo clippy --workspace --all-targets --features finance-query/full`)
- [ ] Documentation builds (`cargo doc --no-deps`) — not run locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues
None — self-contained performance work, not tied to an open issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
