### PR TITLE
fix: populate adjClose in Yahoo chart candles

### DIFF
--- a/src/adapters/yahoo/chart/mod.rs
+++ b/src/adapters/yahoo/chart/mod.rs
@@ -541,7 +541,7 @@ pub(crate) fn parse_chart_data(
             low: c.low,
             close: c.close,
             volume: c.volume.max(0),
-            adj_close: None,
+            adj_close: c.adj_close,
             provider_id: Some(Provider::Yahoo),
         })
         .collect();
@@ -930,6 +930,34 @@ mod tests {
                 "final chunk exceeds chunk size for ({earliest}, {now})"
             );
         }
+    }
+
+    #[test]
+    fn test_parse_chart_data_preserves_adj_close() {
+        let json = serde_json::json!({
+            "chart": {
+                "result": [{
+                    "meta": {"symbol": "AAPL", "currency": "USD"},
+                    "timestamp": [1609459200, 1609545600],
+                    "indicators": {
+                        "quote": [{
+                            "open": [130.0, 131.0],
+                            "high": [133.0, 134.0],
+                            "low": [129.0, 130.0],
+                            "close": [132.0, 133.0],
+                            "volume": [100000000, 90000000]
+                        }],
+                        "adjclose": [{
+                            "adjclose": [131.5, 132.5]
+                        }]
+                    }
+                }]
+            }
+        });
+
+        let chart = parse_chart_data(json, "AAPL").unwrap();
+        assert_eq!(chart.candles[0].adj_close, Some(131.5));
+        assert_eq!(chart.candles[1].adj_close, Some(132.5));
     }
 
     #[test]

--- a/src/adapters/yahoo/client.rs
+++ b/src/adapters/yahoo/client.rs
@@ -448,7 +448,7 @@ impl YahooClient {
                 low: c.low,
                 close: c.close,
                 volume: c.volume.max(0),
-                adj_close: None,
+                adj_close: c.adj_close,
                 provider_id: Some(crate::Provider::Yahoo),
             })
             .collect();
@@ -547,7 +547,7 @@ impl YahooClient {
                 low: c.low,
                 close: c.close,
                 volume: c.volume.max(0),
-                adj_close: None,
+                adj_close: c.adj_close,
                 provider_id: Some(crate::Provider::Yahoo),
             })
             .collect();


### PR DESCRIPTION
## Description
Fixes `adjClose` always being `null` on `/v2/chart` (and batch/GraphQL equivalents) when served from Yahoo, by no longer discarding the correctly-parsed adjusted-close value during conversion to the public `Candle` model.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- `src/adapters/yahoo/client.rs`: `get_chart` and `get_chart_range` now pass through `c.adj_close` instead of hardcoding `None`
- `src/adapters/yahoo/chart/mod.rs`: `parse_chart_data` (used by the batch/ticker cache and max-range chunked path) now passes through `c.adj_close`
- Added a regression unit test (`test_parse_chart_data_preserves_adj_close`) asserting `adj_close` survives `parse_chart_data`

## Breaking Changes
None.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] All tests pass (`cargo test`)

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues
Closes #287