### PR TITLE
fix: parse Polygon index-value websocket events

### DIFF
--- a/src/adapters/polygon/websocket.rs
+++ b/src/adapters/polygon/websocket.rs
@@ -134,6 +134,21 @@ pub struct StreamAggregate {
     pub z: Option<u64>,
 }
 
+/// A real-time index value message (`indices` cluster).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct StreamIndexValue {
+    /// Event type (e.g., `"V"`).
+    pub ev: Option<String>,
+    /// Index ticker (e.g., `"I:SPX"`). Sent as `T`, not `sym`, on this cluster.
+    #[serde(rename = "T")]
+    pub ticker: Option<String>,
+    /// Index value.
+    pub val: Option<f64>,
+    /// Timestamp (milliseconds).
+    pub t: Option<i64>,
+}
+
 /// A parsed WebSocket message from Polygon.
 #[derive(Debug, Clone)]
 pub enum PolygonMessage {
@@ -143,6 +158,8 @@ pub enum PolygonMessage {
     Quote(StreamQuote),
     /// Aggregate bar (per-second or per-minute).
     Aggregate(StreamAggregate),
+    /// Index value (`indices` cluster).
+    IndexValue(StreamIndexValue),
     /// Status/control message (auth, subscription confirmations).
     Status(serde_json::Value),
     /// Unknown/unparsed message.
@@ -170,6 +187,7 @@ impl PolygonStreamBuilder {
     /// - `Q.*` — Quotes (e.g., `"Q.AAPL"`)
     /// - `A.*` — Per-second aggregates (e.g., `"A.AAPL"`)
     /// - `AM.*` — Per-minute aggregates (e.g., `"AM.AAPL"`)
+    /// - `V.*` — Index values, `indices` cluster only (e.g., `"V.I:SPX"`)
     pub fn subscribe(mut self, channels: &[&str]) -> Self {
         self.subscriptions
             .extend(channels.iter().map(|s| s.to_string()));
@@ -309,6 +327,11 @@ fn parse_message(text: &str) -> PolygonMessage {
                     return PolygonMessage::Aggregate(agg);
                 }
             }
+            "V" => {
+                if let Ok(value) = serde_json::from_value(event) {
+                    return PolygonMessage::IndexValue(value);
+                }
+            }
             "status" => {
                 return PolygonMessage::Status(event);
             }
@@ -361,6 +384,26 @@ mod tests {
             }
             other => panic!("Expected Aggregate, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn test_parse_index_value_message() {
+        let msg = r#"[{"ev":"V","val":3988.5,"T":"I:SPX","t":1678220098130}]"#;
+        match parse_message(msg) {
+            PolygonMessage::IndexValue(v) => {
+                assert_eq!(v.ev.as_deref(), Some("V"));
+                assert_eq!(v.ticker.as_deref(), Some("I:SPX"));
+                assert!((v.val.unwrap() - 3988.5).abs() < 0.01);
+                assert_eq!(v.t, Some(1678220098130));
+            }
+            other => panic!("Expected IndexValue, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_index_value_not_dropped_as_unknown() {
+        let msg = r#"[{"ev":"V","val":3988.5,"T":"I:SPX","t":1678220098130}]"#;
+        assert!(!matches!(parse_message(msg), PolygonMessage::Unknown(_)));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Polygon's `indices` cluster emits an index-value event (`ev: "V"`) that `parse_message` never matched, so every one of those events fell through to `PolygonMessage::Unknown` and was discarded. This adds the missing event type.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes

- `src/adapters/polygon/websocket.rs`: add `StreamIndexValue` DTO — `ev`, `ticker`, `val`, `t`. The `indices` cluster sends the ticker as `T` rather than `sym` like every other cluster, so the field is `#[serde(rename = "T")] pub ticker` (a bare `T` field would trip `non_snake_case` under `-D warnings`).
- Add a `PolygonMessage::IndexValue` variant and the corresponding `"V"` arm in `parse_message`.
- Document the `V.*` channel prefix on `PolygonStreamBuilder::subscribe`, whose doc comment previously listed only `T`/`Q`/`A`/`AM`.

Schema verified against Polygon's [indices value docs](https://polygon.io/docs/websocket/indices/value) and the `IndexValue` struct in the official [polygon-io/client-go](https://pkg.go.dev/github.com/polygon-io/client-go/websocket/models) models — both agree on `ev` / `val` / `T` / `t`.

## Breaking Changes

None. `PolygonMessage` is reachable only through `pub(crate) mod adapters` → `pub(crate) mod polygon` → `pub(crate) mod websocket`, so the new variant is not part of the public API surface. There are no matches on `PolygonMessage` anywhere outside its defining module, so nothing needed updating for the added variant.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] All tests pass (`cargo test`)

Two tests added, both using the verbatim sample payload from Polygon's docs:
- `test_parse_index_value_message` — asserts every field round-trips, including that `T` maps onto `ticker`.
- `test_index_value_not_dropped_as_unknown` — pins the specific regression in #246.

Both were confirmed to fail with the `"V"` arm removed (`Expected IndexValue, got Unknown("[{\"ev\":\"V\",...}]")`) and pass with it restored, so they genuinely guard the fix rather than passing vacuously. Full library suite: 902 passed, 0 failed.

## Documentation
- [x] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy`)
- [x] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues
Closes #246
