### PR TITLE
feat: index constituents, short data, filing text, and market extras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `.constituent_changes()` list the current members and membership history of
   the S&P 500, Nasdaq 100, and Dow Jones (FMP; changes are S&P 500 only).
   `MajorIndex::from_symbol` maps common symbol spellings.
+- Short data on `Ticker`: `short_interest()`, `short_volume()`, and
+  `share_float()` via the `FUNDAMENTALS` route. The default Yahoo route
+  derives short interest (current + prior-month snapshots) and float from
+  key statistics keylessly; Polygon adds the full history and daily short
+  volume.
 - Three market-wide capabilities and handles on the Providers API (each needs
   at least one of the `fmp`/`polygon`/`alphavantage` features):
   `Capability::DISCOVERY` with `providers.discovery()` (symbol search,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,8 +59,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `providers.calendar().holidays()` — upcoming market holidays and early
   closes as a new `CalendarKind::MarketHoliday` (Polygon).
 - `providers.market().sector_performance_history(limit)` (FMP), and market
-  movers gained a second provider: Alpha Vantage now serves
-  `gainers()`/`losers()`/`most_active()` as a fallback route.
+  movers now work on the default keyless route: Yahoo serves
+  `gainers()`/`losers()`/`most_active()` derived from its predefined
+  screeners, with Alpha Vantage as a second keyed route. `providers.market()`
+  and the mover/sector models are available without any provider feature.
 - Three market-wide capabilities and handles on the Providers API (each needs
   at least one of the `fmp`/`polygon`/`alphavantage` features):
   `Capability::DISCOVERY` with `providers.discovery()` (symbol search,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Index constituents: `providers.index("^GSPC").constituents()` and
+  `.constituent_changes()` list the current members and membership history of
+  the S&P 500, Nasdaq 100, and Dow Jones (FMP; changes are S&P 500 only).
+  `MajorIndex::from_symbol` maps common symbol spellings.
 - Three market-wide capabilities and handles on the Providers API (each needs
   at least one of the `fmp`/`polygon`/`alphavantage` features):
   `Capability::DISCOVERY` with `providers.discovery()` (symbol search,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   derives short interest (current + prior-month snapshots) and float from
   key statistics keylessly; Polygon adds the full history and daily short
   volume.
+- Filing text: `providers.filings("AAPL").sections(accession, form)` returns
+  the sectioned 10-K/8-K text of a filing and `.risk_factors()` the extracted
+  risk factors (Polygon; EDGAR still serves metadata).
 - Three market-wide capabilities and handles on the Providers API (each needs
   at least one of the `fmp`/`polygon`/`alphavantage` features):
   `Capability::DISCOVERY` with `providers.discovery()` (symbol search,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Filing text: `providers.filings("AAPL").sections(accession, form)` returns
   the sectioned 10-K/8-K text of a filing and `.risk_factors()` the extracted
   risk factors (Polygon; EDGAR still serves metadata).
+- `Ticker::press_releases(limit)` — the company's own releases, distinct from
+  press coverage via `news()` (FMP).
+- `providers.calendar().holidays()` — upcoming market holidays and early
+  closes as a new `CalendarKind::MarketHoliday` (Polygon).
+- `providers.market().sector_performance_history(limit)` (FMP), and market
+  movers gained a second provider: Alpha Vantage now serves
+  `gainers()`/`losers()`/`most_active()` as a fallback route.
 - Three market-wide capabilities and handles on the Providers API (each needs
   at least one of the `fmp`/`polygon`/`alphavantage` features):
   `Capability::DISCOVERY` with `providers.discovery()` (symbol search,

--- a/docs/library/providers/index.md
+++ b/docs/library/providers/index.md
@@ -179,8 +179,8 @@ let mkt   = providers.market();      // → Market: sector performance, movers
 | `Commodity` | `.quote()` · `.chart(interval, range)` · `.history(range)` | `CommodityQuote` · `Chart` |
 | `Filings` | `.get()` · `.sections(accession, form)` · `.risk_factors()` | `ProviderFilings` · `Vec<FilingSection>` · `Vec<RiskFactor>` |
 | `Discovery` | `.search(query, limit)` · `.details(symbol)` · `.exchanges()` · `.screener(filters)` | `Vec<SymbolMatch>` · `SymbolDetails` · `Vec<ExchangeInfo>` · `Vec<ScreenerMatch>` |
-| `MarketCalendar` | `.earnings(from, to)` · `.ipos(..)` · `.dividends(..)` · `.splits(..)` · `.economic(..)` | `Vec<MarketCalendarEntry>` |
-| `Market` | `.sector_performance()` · `.sector_pe()` · `.industry_pe()` · `.gainers()` · `.losers()` · `.most_active()` | `Vec<SectorPerformance>` · `Vec<SectorPe>` · `Vec<IndustryPe>` · `Vec<MoverQuote>` |
+| `MarketCalendar` | `.earnings(from, to)` · `.ipos(..)` · `.dividends(..)` · `.splits(..)` · `.economic(..)` · `.holidays()` | `Vec<MarketCalendarEntry>` |
+| `Market` | `.sector_performance()` · `.sector_performance_history(limit)` · `.sector_pe()` · `.industry_pe()` · `.gainers()` · `.losers()` · `.most_active()` | `Vec<SectorPerformance>` · `Vec<SectorPerformanceHistory>` · `Vec<SectorPe>` · `Vec<IndustryPe>` · `Vec<MoverQuote>` |
 
 All chart-capable handles route through `Capability::CHART` (Yahoo by default) and cache per `(symbol, interval, range)` when `.cache(ttl)` is set. `history(range)` is sugar for `chart(range.default_interval(), range)`. The handle's identifier is passed to the chart route as-is, so it must be a chart-route symbol (e.g. `^GSPC`, `NQ=F`, `GC=F`); `CryptoCoin` builds `"{ID}-{VS}"` (e.g. `"BTC-USD"`), which resolves on Yahoo only for ticker-style ids.
 

--- a/docs/library/providers/index.md
+++ b/docs/library/providers/index.md
@@ -174,7 +174,7 @@ let mkt   = providers.market();      // → Market: sector performance, movers
 | `ForexPair` | `.quote()` · `.chart(interval, range)` · `.history(range)` | `ForexQuote` · `Chart` |
 | `CryptoCoin` | `.quote(vs_currency)` · `.chart(vs_currency, interval, range)` · `.history(vs_currency, range)` | `CryptoQuote` · `Chart` |
 | `EconomicIndicator` | `.series()` | `EconomicSeries` |
-| `Index` | `.quote()` · `.chart(interval, range)` · `.history(range)` | `IndexQuote` · `Chart` |
+| `Index` | `.quote()` · `.chart(interval, range)` · `.history(range)` · `.constituents()` · `.constituent_changes()` | `IndexQuote` · `Chart` · `Vec<IndexConstituent>` · `Vec<IndexConstituentChange>` |
 | `FuturesContract` | `.quote()` · `.chart(interval, range)` · `.history(range)` | `FuturesQuote` · `Chart` |
 | `Commodity` | `.quote()` · `.chart(interval, range)` · `.history(range)` | `CommodityQuote` · `Chart` |
 | `Filings` | `.get()` | `ProviderFilings` |

--- a/docs/library/providers/index.md
+++ b/docs/library/providers/index.md
@@ -158,8 +158,9 @@ let sec   = providers.filings("AAPL");                        // → Filings
 ```
 
 Three handles are market-wide rather than symbol-scoped, so their factories take
-no argument (each requires at least one of the `fmp`, `polygon`, or
-`alphavantage` features):
+no argument. `market()` is always available (movers are served keylessly from
+Yahoo's screeners); `discovery()` and `calendar()` require at least one of the
+`fmp`, `polygon`, or `alphavantage` features:
 
 ```rust,ignore
 let disco = providers.discovery();   // → Discovery: symbol search, reference data, screeners

--- a/docs/library/providers/index.md
+++ b/docs/library/providers/index.md
@@ -177,7 +177,7 @@ let mkt   = providers.market();      // → Market: sector performance, movers
 | `Index` | `.quote()` · `.chart(interval, range)` · `.history(range)` · `.constituents()` · `.constituent_changes()` | `IndexQuote` · `Chart` · `Vec<IndexConstituent>` · `Vec<IndexConstituentChange>` |
 | `FuturesContract` | `.quote()` · `.chart(interval, range)` · `.history(range)` | `FuturesQuote` · `Chart` |
 | `Commodity` | `.quote()` · `.chart(interval, range)` · `.history(range)` | `CommodityQuote` · `Chart` |
-| `Filings` | `.get()` | `ProviderFilings` |
+| `Filings` | `.get()` · `.sections(accession, form)` · `.risk_factors()` | `ProviderFilings` · `Vec<FilingSection>` · `Vec<RiskFactor>` |
 | `Discovery` | `.search(query, limit)` · `.details(symbol)` · `.exchanges()` · `.screener(filters)` | `Vec<SymbolMatch>` · `SymbolDetails` · `Vec<ExchangeInfo>` · `Vec<ScreenerMatch>` |
 | `MarketCalendar` | `.earnings(from, to)` · `.ipos(..)` · `.dividends(..)` · `.splits(..)` · `.economic(..)` | `Vec<MarketCalendarEntry>` |
 | `Market` | `.sector_performance()` · `.sector_pe()` · `.industry_pe()` · `.gainers()` · `.losers()` · `.most_active()` | `Vec<SectorPerformance>` · `Vec<SectorPe>` · `Vec<IndustryPe>` · `Vec<MoverQuote>` |

--- a/src/adapters/alphavantage/corporate/mod.rs
+++ b/src/adapters/alphavantage/corporate/mod.rs
@@ -134,7 +134,6 @@ pub async fn earnings_call_transcript(
 }
 
 /// Fetch top gainers, losers, and most actively traded tickers.
-#[allow(dead_code)] // unrouted: AV movers land with #300 (MarketProvider::fetch_market_movers)
 pub async fn top_gainers_losers() -> Result<TopMoversDTO> {
     let client = build_client()?;
     let json = client.get("TOP_GAINERS_LOSERS", &[]).await?;
@@ -270,5 +269,85 @@ fn parse_split_ratio(ratio: &str) -> (u32, u32) {
         (num, den)
     } else {
         (1, 1)
+    }
+}
+
+/// Fetch the canonical movers list for `direction`.
+///
+/// Alpha Vantage returns gainers, losers, and most-active in one response;
+/// the numbers arrive as strings (`"12.34"`, `"5.67%"`) and are parsed here.
+pub async fn fetch_market_movers_response(
+    direction: crate::models::market::performance::MoverDirection,
+) -> Result<Vec<crate::models::market::performance::MoverQuote>> {
+    Ok(movers_to_canonical(top_gainers_losers().await?, direction))
+}
+
+/// Select `direction`'s list and parse AV's stringly-typed numbers.
+fn movers_to_canonical(
+    movers: crate::adapters::alphavantage::models::TopMoversDTO,
+    direction: crate::models::market::performance::MoverDirection,
+) -> Vec<crate::models::market::performance::MoverQuote> {
+    use crate::models::market::performance::{MoverDirection, MoverQuote};
+
+    fn num(s: &str) -> Option<f64> {
+        s.trim().trim_end_matches('%').trim().parse().ok()
+    }
+
+    let list = match direction {
+        MoverDirection::Gainers => movers.top_gainers,
+        MoverDirection::Losers => movers.top_losers,
+        MoverDirection::MostActive => movers.most_actively_traded,
+    };
+    list.into_iter()
+        .map(|t| MoverQuote {
+            symbol: t.ticker,
+            name: None,
+            price: num(&t.price),
+            change: num(&t.change_amount),
+            change_percent: num(&t.change_percentage),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapters::alphavantage::models::{TopMoverTickerDTO, TopMoversDTO};
+    use crate::models::market::performance::MoverDirection;
+
+    fn movers() -> TopMoversDTO {
+        TopMoversDTO {
+            last_updated: "2026-08-01 16:00:00 US/Eastern".into(),
+            top_gainers: vec![TopMoverTickerDTO {
+                ticker: "AAA".into(),
+                price: "12.34".into(),
+                change_amount: "1.50".into(),
+                change_percentage: "13.85%".into(),
+                volume: "1000000".into(),
+            }],
+            top_losers: vec![TopMoverTickerDTO {
+                ticker: "BBB".into(),
+                price: "5.00".into(),
+                change_amount: "-0.55".into(),
+                change_percentage: "-9.91%".into(),
+                volume: "5".into(),
+            }],
+            most_actively_traded: vec![],
+        }
+    }
+
+    #[test]
+    fn movers_parse_string_numbers_per_direction() {
+        let g = movers_to_canonical(movers(), MoverDirection::Gainers);
+        assert_eq!(g.len(), 1);
+        assert_eq!(g[0].symbol, "AAA");
+        assert_eq!(g[0].price, Some(12.34));
+        assert_eq!(g[0].change, Some(1.50));
+        assert_eq!(g[0].change_percent, Some(13.85));
+
+        let l = movers_to_canonical(movers(), MoverDirection::Losers);
+        assert_eq!(l[0].change_percent, Some(-9.91));
+
+        assert!(movers_to_canonical(movers(), MoverDirection::MostActive).is_empty());
     }
 }

--- a/src/adapters/alphavantage/models.rs
+++ b/src/adapters/alphavantage/models.rs
@@ -378,7 +378,6 @@ pub struct EarningsCallTranscriptDTO {
 /// A top gainer, loser, or most actively traded ticker.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
-#[allow(dead_code)] // unrouted: AV movers land with #300
 pub struct TopMoverTickerDTO {
     /// Ticker symbol
     pub ticker: String,
@@ -395,7 +394,6 @@ pub struct TopMoverTickerDTO {
 /// Top gainers, losers, and most actively traded tickers.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
-#[allow(dead_code)] // unrouted: AV movers land with #300
 pub struct TopMoversDTO {
     /// Last updated timestamp
     pub last_updated: String,

--- a/src/adapters/fmp/corporate/news.rs
+++ b/src/adapters/fmp/corporate/news.rs
@@ -35,7 +35,6 @@ pub struct StockNewsDTO {
 /// Press release.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
-#[allow(dead_code)] // unrouted: press releases / category news land with #300
 pub struct PressReleaseDTO {
     /// Ticker symbol.
     pub symbol: Option<String>,
@@ -99,7 +98,6 @@ pub async fn stock_news(tickers: &str, limit: u32) -> Result<Vec<StockNewsDTO>> 
 }
 
 /// Fetch press releases for a symbol.
-#[allow(dead_code)] // unrouted: press releases / category news land with #300
 pub async fn press_releases(symbol: &str, limit: u32) -> Result<Vec<PressReleaseDTO>> {
     let client = build_client()?;
     let path = format!("/api/v3/press-releases/{}", encode_path_segment(symbol));
@@ -108,7 +106,7 @@ pub async fn press_releases(symbol: &str, limit: u32) -> Result<Vec<PressRelease
 }
 
 /// Fetch crypto news.
-#[allow(dead_code)] // unrouted: press releases / category news land with #300
+#[allow(dead_code)] // unrouted: category news deliberately deferred (#300 optional)
 pub async fn crypto_news(limit: u32) -> Result<Vec<StockNewsDTO>> {
     let client = build_client()?;
     let size_str = limit.to_string();
@@ -118,13 +116,30 @@ pub async fn crypto_news(limit: u32) -> Result<Vec<StockNewsDTO>> {
 }
 
 /// Fetch forex news.
-#[allow(dead_code)] // unrouted: press releases / category news land with #300
+#[allow(dead_code)] // unrouted: category news deliberately deferred (#300 optional)
 pub async fn forex_news(limit: u32) -> Result<Vec<StockNewsDTO>> {
     let client = build_client()?;
     let size_str = limit.to_string();
     client
         .get("/api/v4/forex_news", &[("page", "0"), ("size", &size_str)])
         .await
+}
+
+/// Fetch canonical press releases for a symbol.
+pub async fn fetch_press_releases_response(
+    symbol: &str,
+    limit: u32,
+) -> Result<Vec<crate::models::corporate::press_release::PressRelease>> {
+    let dtos = press_releases(symbol, limit).await?;
+    Ok(dtos
+        .into_iter()
+        .map(|d| crate::models::corporate::press_release::PressRelease {
+            symbol: d.symbol.or_else(|| Some(symbol.to_string())),
+            date: d.date,
+            title: d.title,
+            text: d.text,
+        })
+        .collect())
 }
 
 #[cfg(test)]

--- a/src/adapters/fmp/indices/mod.rs
+++ b/src/adapters/fmp/indices/mod.rs
@@ -34,7 +34,6 @@ pub async fn fetch_canonical_index_quote(
 /// A constituent of a major index (S&P 500, Nasdaq, Dow Jones).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
-#[allow(dead_code)] // unrouted: index constituents land with #297
 pub struct IndexConstituentDTO {
     /// Ticker symbol.
     pub symbol: Option<String>,
@@ -60,7 +59,6 @@ pub struct IndexConstituentDTO {
 /// A historical change in index constituency.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
-#[allow(dead_code)] // unrouted: index constituents land with #297
 pub struct HistoricalConstituentDTO {
     /// Date of the change.
     pub date: Option<String>,
@@ -80,35 +78,31 @@ pub struct HistoricalConstituentDTO {
 }
 
 /// Fetch real-time quotes for all major indexes.
-#[allow(dead_code)] // unrouted: index constituents land with #297
+#[allow(dead_code)] // unrouted: batch index quotes deliberately deferred (#297 optional)
 pub async fn major_indexes_quote() -> Result<Vec<FmpQuoteDTO>> {
     let client = build_client()?;
     client.get("/api/v3/quotes/index", &[]).await
 }
 
 /// Fetch current S&P 500 constituents.
-#[allow(dead_code)] // unrouted: index constituents land with #297
 pub async fn sp500_constituents() -> Result<Vec<IndexConstituentDTO>> {
     let client = build_client()?;
     client.get("/api/v3/sp500_constituent", &[]).await
 }
 
 /// Fetch current Nasdaq constituents.
-#[allow(dead_code)] // unrouted: index constituents land with #297
 pub async fn nasdaq_constituents() -> Result<Vec<IndexConstituentDTO>> {
     let client = build_client()?;
     client.get("/api/v3/nasdaq_constituent", &[]).await
 }
 
 /// Fetch current Dow Jones constituents.
-#[allow(dead_code)] // unrouted: index constituents land with #297
 pub async fn dow_constituents() -> Result<Vec<IndexConstituentDTO>> {
     let client = build_client()?;
     client.get("/api/v3/dowjones_constituent", &[]).await
 }
 
 /// Fetch historical S&P 500 constituent changes.
-#[allow(dead_code)] // unrouted: index constituents land with #297
 pub async fn historical_sp500() -> Result<Vec<HistoricalConstituentDTO>> {
     let client = build_client()?;
     client
@@ -116,9 +110,89 @@ pub async fn historical_sp500() -> Result<Vec<HistoricalConstituentDTO>> {
         .await
 }
 
+/// Convert a constituent DTO into the canonical model.
+fn constituent_to_canonical(c: IndexConstituentDTO) -> crate::models::indices::IndexConstituent {
+    crate::models::indices::IndexConstituent {
+        symbol: c.symbol.unwrap_or_default(),
+        name: c.name,
+        sector: c.sector,
+        sub_sector: c.sub_sector,
+        headquarters: c.head_quarter,
+        date_first_added: c.date_first_added,
+        cik: c.cik,
+        founded: c.founded,
+    }
+}
+
+/// Fetch canonical constituents for a major index.
+pub async fn fetch_index_constituents_response(
+    index: crate::models::indices::MajorIndex,
+) -> Result<Vec<crate::models::indices::IndexConstituent>> {
+    use crate::models::indices::MajorIndex;
+    let dtos = match index {
+        MajorIndex::Sp500 => sp500_constituents().await?,
+        MajorIndex::Nasdaq100 => nasdaq_constituents().await?,
+        MajorIndex::DowJones => dow_constituents().await?,
+    };
+    Ok(dtos.into_iter().map(constituent_to_canonical).collect())
+}
+
+/// Fetch canonical historical constituent changes for a major index.
+///
+/// FMP publishes historical changes for the S&P 500 only.
+pub async fn fetch_index_constituent_changes_response(
+    index: crate::models::indices::MajorIndex,
+) -> Result<Vec<crate::models::indices::IndexConstituentChange>> {
+    use crate::models::indices::MajorIndex;
+    let dtos = match index {
+        MajorIndex::Sp500 => historical_sp500().await?,
+        other => {
+            return Err(crate::error::FinanceError::InvalidParameter {
+                param: "index".into(),
+                reason: format!(
+                    "FMP provides historical constituent changes for the S&P 500 only, not {other}"
+                ),
+            });
+        }
+    };
+    Ok(dtos
+        .into_iter()
+        .map(|c| crate::models::indices::IndexConstituentChange {
+            date: c.date,
+            symbol: c.symbol,
+            added_security: c.added_security,
+            removed_ticker: c.removed_ticker,
+            removed_security: c.removed_security,
+            reason: c.reason,
+        })
+        .collect())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn constituent_maps_all_fields() {
+        let dto: IndexConstituentDTO = serde_json::from_value(serde_json::json!({
+            "symbol": "AAPL",
+            "name": "Apple Inc.",
+            "sector": "Information Technology",
+            "subSector": "Technology Hardware",
+            "headQuarter": "Cupertino, CA",
+            "dateFirstAdded": "1982-11-30",
+            "cik": "0000320193",
+            "founded": "1976"
+        }))
+        .unwrap();
+        let c = constituent_to_canonical(dto);
+        assert_eq!(c.symbol, "AAPL");
+        assert_eq!(c.sub_sector.as_deref(), Some("Technology Hardware"));
+        assert_eq!(c.headquarters.as_deref(), Some("Cupertino, CA"));
+        assert_eq!(c.date_first_added.as_deref(), Some("1982-11-30"));
+        assert_eq!(c.cik.as_deref(), Some("0000320193"));
+        assert_eq!(c.founded.as_deref(), Some("1976"));
+    }
 
     #[tokio::test]
     async fn test_sp500_constituents_mock() {

--- a/src/adapters/fmp/market/calendars.rs
+++ b/src/adapters/fmp/market/calendars.rs
@@ -195,6 +195,17 @@ pub async fn fetch_market_calendar_response(
     };
 
     Ok(match kind {
+        // FMP has no market-holiday feed; dispatch falls through to a
+        // provider that serves it (Polygon).
+        CalendarKind::MarketHoliday => {
+            return Err(crate::error::FinanceError::NotSupported {
+                provider: crate::Provider::Fmp,
+                operation: crate::providers::Operation::HolidayCalendar,
+                candidates: crate::providers::Operation::HolidayCalendar
+                    .capability()
+                    .candidate_providers(),
+            });
+        }
         CalendarKind::Earnings => earnings_calendar(from, to)
             .await?
             .into_iter()

--- a/src/adapters/fmp/market/market_performance.rs
+++ b/src/adapters/fmp/market/market_performance.rs
@@ -52,7 +52,6 @@ pub struct SectorPerformanceDTO {
 /// Historical sector performance entry.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
-#[allow(dead_code)] // unrouted: sector-performance history lands with #300
 pub struct HistoricalSectorPerformanceDTO {
     /// Date.
     pub date: Option<String>,
@@ -133,7 +132,6 @@ pub async fn sector_performance() -> Result<Vec<SectorPerformanceDTO>> {
 }
 
 /// Fetch historical sector performance.
-#[allow(dead_code)] // unrouted: sector-performance history lands with #300
 pub async fn historical_sector_performance(
     limit: u32,
 ) -> Result<Vec<HistoricalSectorPerformanceDTO>> {
@@ -241,9 +239,81 @@ pub async fn fetch_industry_pe_response()
         .collect())
 }
 
+/// Convert one historical row into the canonical per-day sector list.
+fn history_to_canonical(
+    d: HistoricalSectorPerformanceDTO,
+) -> crate::models::market::performance::SectorPerformanceHistory {
+    use crate::models::market::performance::SectorPerformance;
+    let sector = |name: &str, v: Option<f64>| SectorPerformance {
+        sector: name.to_string(),
+        change_percent: v,
+    };
+    crate::models::market::performance::SectorPerformanceHistory {
+        date: d.date,
+        sectors: vec![
+            sector("Utilities", d.utilities_changes_percentage),
+            sector("Basic Materials", d.basic_materials_changes_percentage),
+            sector(
+                "Communication Services",
+                d.communication_services_changes_percentage,
+            ),
+            sector("Consumer Cyclical", d.consumer_cyclical_changes_percentage),
+            sector(
+                "Consumer Defensive",
+                d.consumer_defensive_changes_percentage,
+            ),
+            sector("Energy", d.energy_changes_percentage),
+            sector(
+                "Financial Services",
+                d.financial_services_changes_percentage,
+            ),
+            sector("Healthcare", d.healthcare_changes_percentage),
+            sector("Industrials", d.industrials_changes_percentage),
+            sector("Real Estate", d.real_estate_changes_percentage),
+            sector("Technology", d.technology_changes_percentage),
+        ],
+    }
+}
+
+/// Fetch canonical historical sector performance, most recent first.
+pub async fn fetch_sector_performance_history_response(
+    limit: u32,
+) -> Result<Vec<crate::models::market::performance::SectorPerformanceHistory>> {
+    let dtos = historical_sector_performance(limit).await?;
+    Ok(dtos.into_iter().map(history_to_canonical).collect())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn history_maps_all_eleven_sectors() {
+        let row: HistoricalSectorPerformanceDTO = serde_json::from_value(serde_json::json!({
+            "date": "2026-07-31",
+            "utilitiesChangesPercentage": 0.5,
+            "technologyChangesPercentage": -1.25
+        }))
+        .unwrap();
+        let day = history_to_canonical(row);
+        assert_eq!(day.date.as_deref(), Some("2026-07-31"));
+        assert_eq!(day.sectors.len(), 11);
+        let tech = day
+            .sectors
+            .iter()
+            .find(|s| s.sector == "Technology")
+            .unwrap();
+        assert_eq!(tech.change_percent, Some(-1.25));
+        let util = day
+            .sectors
+            .iter()
+            .find(|s| s.sector == "Utilities")
+            .unwrap();
+        assert_eq!(util.change_percent, Some(0.5));
+        // Absent sectors surface as None, not omitted.
+        let energy = day.sectors.iter().find(|s| s.sector == "Energy").unwrap();
+        assert!(energy.change_percent.is_none());
+    }
 
     #[tokio::test]
     async fn test_sector_performance_mock() {

--- a/src/adapters/polygon/discovery/mod.rs
+++ b/src/adapters/polygon/discovery/mod.rs
@@ -152,7 +152,6 @@ pub struct Exchange {
 /// Market holiday.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
-#[allow(dead_code)] // unrouted: market holidays land with #300 (CalendarKind::MarketHoliday)
 pub struct MarketHolidayDTO {
     /// Holiday name.
     pub name: Option<String>,
@@ -302,7 +301,6 @@ pub async fn exchanges(params: &[(&str, &str)]) -> Result<PaginatedResponseDTO<E
 }
 
 /// Fetch upcoming market holidays.
-#[allow(dead_code)] // unrouted: market holidays land with #300 (CalendarKind::MarketHoliday)
 pub async fn market_holidays() -> Result<Vec<MarketHolidayDTO>> {
     let client = build_client()?;
     client
@@ -315,9 +313,68 @@ pub async fn market_holidays() -> Result<Vec<MarketHolidayDTO>> {
         .await
 }
 
+/// Fetch upcoming market holidays as canonical calendar entries.
+pub async fn fetch_market_holidays_response()
+-> Result<Vec<crate::models::calendar::market::MarketCalendarEntry>> {
+    Ok(market_holidays()
+        .await?
+        .into_iter()
+        .map(holiday_to_canonical)
+        .collect())
+}
+
+/// Convert one holiday DTO into a canonical calendar entry.
+fn holiday_to_canonical(
+    h: MarketHolidayDTO,
+) -> crate::models::calendar::market::MarketCalendarEntry {
+    use crate::models::calendar::market::{CalendarDetail, MarketCalendarEntry};
+    MarketCalendarEntry {
+        symbol: None,
+        date: h.date,
+        detail: CalendarDetail::MarketHoliday {
+            name: h.name,
+            exchange: h.exchange,
+            status: h.status,
+            open: h.open,
+            close: h.close,
+        },
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn holiday_maps_to_calendar_entry() {
+        use crate::models::calendar::market::CalendarDetail;
+        let entry = holiday_to_canonical(
+            serde_json::from_value(serde_json::json!({
+                "name": "Thanksgiving",
+                "date": "2026-11-26",
+                "exchange": "NYSE",
+                "status": "closed"
+            }))
+            .unwrap(),
+        );
+        assert_eq!(entry.date.as_deref(), Some("2026-11-26"));
+        assert!(entry.symbol.is_none());
+        match entry.detail {
+            CalendarDetail::MarketHoliday {
+                name,
+                exchange,
+                status,
+                open,
+                close,
+            } => {
+                assert_eq!(name.as_deref(), Some("Thanksgiving"));
+                assert_eq!(exchange.as_deref(), Some("NYSE"));
+                assert_eq!(status.as_deref(), Some("closed"));
+                assert!(open.is_none() && close.is_none());
+            }
+            other => panic!("wrong detail: {other:?}"),
+        }
+    }
 
     #[tokio::test]
     async fn test_ticker_details_mock() {

--- a/src/adapters/polygon/filings/mod.rs
+++ b/src/adapters/polygon/filings/mod.rs
@@ -32,7 +32,6 @@ pub struct FilingEntryDTO {
 /// SEC filing section content.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
-#[allow(dead_code)] // unrouted: filing sections + risk factors land with #299
 pub struct FilingSectionDTO {
     /// Section key/name.
     pub section: Option<String>,
@@ -43,7 +42,6 @@ pub struct FilingSectionDTO {
 /// Risk factor entry.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
-#[allow(dead_code)] // unrouted: filing sections + risk factors land with #299
 pub struct RiskFactorDTO {
     /// Risk factor title.
     pub title: Option<String>,
@@ -58,7 +56,7 @@ pub struct RiskFactorDTO {
 /// Risk category.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
-#[allow(dead_code)] // unrouted: filing sections + risk factors land with #299
+#[allow(dead_code)] // unrouted: risk-category taxonomy; fold into risk factors if a consumer appears
 pub struct RiskCategoryDTO {
     /// Category name.
     pub name: Option<String>,
@@ -69,7 +67,6 @@ pub struct RiskCategoryDTO {
 /// Filing sections response.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
-#[allow(dead_code)] // unrouted: filing sections + risk factors land with #299
 pub struct FilingSectionsResponseDTO {
     /// Request ID.
     pub request_id: Option<String>,
@@ -110,7 +107,6 @@ pub async fn fetch_filings_response(symbol: &str) -> Result<ProviderFilings> {
 }
 
 /// Fetch 10-K filing section content.
-#[allow(dead_code)] // unrouted: filing sections + risk factors land with #299
 pub async fn filing_10k_sections(
     accession_number: &str,
     params: &[(&str, &str)],
@@ -126,7 +122,6 @@ pub async fn filing_10k_sections(
 }
 
 /// Fetch 8-K filing text.
-#[allow(dead_code)] // unrouted: filing sections + risk factors land with #299
 pub async fn filing_8k_text(
     accession_number: &str,
     params: &[(&str, &str)],
@@ -140,15 +135,53 @@ pub async fn filing_8k_text(
 }
 
 /// Fetch risk factors from SEC filings.
-#[allow(dead_code)] // unrouted: filing sections + risk factors land with #299
 pub async fn risk_factors(params: &[(&str, &str)]) -> Result<PaginatedResponseDTO<RiskFactorDTO>> {
     let client = build_client()?;
     client.get("/v1/reference/sec/risk-factors", params).await
 }
 
 /// Fetch risk factor categories.
-#[allow(dead_code)] // unrouted: filing sections + risk factors land with #299
+#[allow(dead_code)] // unrouted: risk-category taxonomy; fold into risk factors if a consumer appears
 pub async fn risk_categories() -> Result<PaginatedResponseDTO<RiskCategoryDTO>> {
     let client = build_client()?;
     client.get("/v1/reference/sec/risk-categories", &[]).await
+}
+
+/// Fetch canonical sectioned text for one filing.
+pub async fn fetch_filing_sections_response(
+    accession_number: &str,
+    form: crate::models::filings::FilingSectionForm,
+) -> Result<Vec<crate::models::filings::FilingSection>> {
+    use crate::models::filings::FilingSectionForm;
+    let resp = match form {
+        FilingSectionForm::TenK => filing_10k_sections(accession_number, &[]).await?,
+        FilingSectionForm::EightK => filing_8k_text(accession_number, &[]).await?,
+    };
+    Ok(resp
+        .results
+        .unwrap_or_default()
+        .into_iter()
+        .map(|d| crate::models::filings::FilingSection {
+            section: d.section,
+            content: d.content,
+        })
+        .collect())
+}
+
+/// Fetch canonical risk factors for a stock ticker.
+pub async fn fetch_risk_factors_response(
+    symbol: &str,
+) -> Result<Vec<crate::models::filings::RiskFactor>> {
+    let paginated = risk_factors(&[("ticker", symbol), ("limit", "100")]).await?;
+    Ok(paginated
+        .results
+        .unwrap_or_default()
+        .into_iter()
+        .map(|d| crate::models::filings::RiskFactor {
+            title: d.title,
+            text: d.text,
+            category: d.category,
+            filing_date: d.filing_date,
+        })
+        .collect())
 }

--- a/src/adapters/polygon/fundamentals/mod.rs
+++ b/src/adapters/polygon/fundamentals/mod.rs
@@ -38,7 +38,6 @@ pub struct FinancialResultDTO {
 /// Short interest data point.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
-#[allow(dead_code)] // unrouted: short interest/volume/float land with #298
 pub struct ShortInterestDTO {
     /// Settlement date.
     pub settlement_date: Option<String>,
@@ -53,7 +52,6 @@ pub struct ShortInterestDTO {
 /// Short volume data point.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
-#[allow(dead_code)] // unrouted: short interest/volume/float land with #298
 pub struct ShortVolumeDTO {
     /// Date.
     pub date: Option<String>,
@@ -68,7 +66,6 @@ pub struct ShortVolumeDTO {
 /// Float data.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
-#[allow(dead_code)] // unrouted: short interest/volume/float land with #298
 pub struct FloatDataDTO {
     /// Ticker symbol.
     pub ticker: Option<String>,
@@ -152,7 +149,6 @@ pub async fn fetch_financials_response(
 }
 
 /// Fetch short interest data for a stock ticker.
-#[allow(dead_code)] // unrouted: short interest/volume/float land with #298
 pub async fn stock_short_interest(
     ticker: &str,
     params: &[(&str, &str)],
@@ -166,7 +162,6 @@ pub async fn stock_short_interest(
 }
 
 /// Fetch short volume data for a stock ticker.
-#[allow(dead_code)] // unrouted: short interest/volume/float land with #298
 pub async fn stock_short_volume(
     ticker: &str,
     params: &[(&str, &str)],
@@ -177,11 +172,68 @@ pub async fn stock_short_volume(
 }
 
 /// Fetch float data for a stock ticker.
-#[allow(dead_code)] // unrouted: short interest/volume/float land with #298
 pub async fn stock_float(ticker: &str) -> Result<PaginatedResponseDTO<FloatDataDTO>> {
     let client = build_client()?;
     let path = format!("/v3/reference/float/{}", encode_path_segment(ticker));
     client.get(&path, &[]).await
+}
+
+/// Fetch canonical short-interest reports for a stock ticker.
+pub async fn fetch_short_interest_response(
+    symbol: &str,
+) -> Result<Vec<crate::models::fundamentals::ShortInterest>> {
+    let paginated = stock_short_interest(symbol, &[("limit", "50")]).await?;
+    Ok(paginated
+        .results
+        .unwrap_or_default()
+        .into_iter()
+        .map(|d| crate::models::fundamentals::ShortInterest {
+            settlement_date: d.settlement_date,
+            short_interest: d.short_interest,
+            avg_daily_volume: d.avg_daily_volume,
+            days_to_cover: d.days_to_cover,
+        })
+        .collect())
+}
+
+/// Fetch canonical daily short-volume data for a stock ticker.
+pub async fn fetch_short_volume_response(
+    symbol: &str,
+) -> Result<Vec<crate::models::fundamentals::ShortVolume>> {
+    let paginated = stock_short_volume(symbol, &[("limit", "50")]).await?;
+    Ok(paginated
+        .results
+        .unwrap_or_default()
+        .into_iter()
+        .map(|d| crate::models::fundamentals::ShortVolume {
+            date: d.date,
+            short_volume: d.short_volume,
+            short_exempt_volume: d.short_exempt_volume,
+            total_volume: d.total_volume,
+        })
+        .collect())
+}
+
+/// Fetch canonical share float / shares outstanding for a stock ticker.
+pub async fn fetch_share_float_response(
+    symbol: &str,
+) -> Result<crate::models::fundamentals::ShareFloat> {
+    let paginated = stock_float(symbol).await?;
+    let d = paginated
+        .results
+        .unwrap_or_default()
+        .into_iter()
+        .next()
+        .ok_or_else(|| crate::error::FinanceError::ResponseStructureError {
+            field: "results".into(),
+            context: format!("no float data returned for {symbol}"),
+        })?;
+    Ok(crate::models::fundamentals::ShareFloat {
+        symbol: d.ticker.or_else(|| Some(symbol.to_string())),
+        float_shares: d.float_shares,
+        outstanding_shares: d.outstanding_shares,
+        date: d.date,
+    })
 }
 
 #[cfg(test)]

--- a/src/domains/filings.rs
+++ b/src/domains/filings.rs
@@ -26,4 +26,46 @@ impl Filings {
             crate::models::filings::ProviderFilings
         )
     }
+
+    /// Fetch the sectioned text of one filing by accession number via the
+    /// FILINGS route (currently Polygon only). Not cached.
+    pub async fn sections(
+        &self,
+        accession_number: &str,
+        form: crate::models::filings::FilingSectionForm,
+    ) -> Result<Vec<crate::models::filings::FilingSection>> {
+        let accession = accession_number.to_string();
+        self.providers
+            .fetch(crate::providers::Capability::FILINGS, move |p| {
+                let accession = accession.clone();
+                let p = p.clone();
+                async move {
+                    p.as_filings()
+                        .ok_or_else(|| {
+                            p.not_supported(crate::providers::Operation::FilingSections)
+                        })?
+                        .fetch_filing_sections(&accession, form)
+                        .await
+                }
+            })
+            .await
+    }
+
+    /// Fetch risk factors extracted from this symbol's SEC filings via the
+    /// FILINGS route (currently Polygon only). Not cached.
+    pub async fn risk_factors(&self) -> Result<Vec<crate::models::filings::RiskFactor>> {
+        let symbol: String = self.symbol().to_string();
+        self.providers
+            .fetch(crate::providers::Capability::FILINGS, move |p| {
+                let symbol = symbol.clone();
+                let p = p.clone();
+                async move {
+                    p.as_filings()
+                        .ok_or_else(|| p.not_supported(crate::providers::Operation::RiskFactors))?
+                        .fetch_risk_factors(&symbol)
+                        .await
+                }
+            })
+            .await
+    }
 }

--- a/src/domains/indices.rs
+++ b/src/domains/indices.rs
@@ -41,6 +41,61 @@ impl Index {
     pub async fn history(&self, range: TimeRange) -> Result<Chart> {
         self.chart(range.default_interval(), range).await
     }
+
+    /// The [`MajorIndex`](crate::models::indices::MajorIndex) this handle's
+    /// symbol denotes, or an error for indices without constituent support.
+    fn major_index(&self) -> Result<crate::models::indices::MajorIndex> {
+        crate::models::indices::MajorIndex::from_symbol(self.symbol()).ok_or_else(|| {
+            crate::error::FinanceError::InvalidParameter {
+                param: "symbol".into(),
+                reason: format!(
+                    "constituents are available for major indices only \
+                     (S&P 500, Nasdaq 100, Dow Jones), not {}",
+                    self.symbol()
+                ),
+            }
+        })
+    }
+
+    /// Fetch the index's current constituents (major indices only). Not
+    /// cached — constituent lists change rarely but the call is uncommon.
+    pub async fn constituents(&self) -> Result<Vec<crate::models::indices::IndexConstituent>> {
+        let index = self.major_index()?;
+        self.providers
+            .fetch(crate::providers::Capability::INDICES, move |p| {
+                let p = p.clone();
+                async move {
+                    p.as_indices()
+                        .ok_or_else(|| {
+                            p.not_supported(crate::providers::Operation::IndexConstituents)
+                        })?
+                        .fetch_index_constituents(index)
+                        .await
+                }
+            })
+            .await
+    }
+
+    /// Fetch historical changes to the index's constituency (currently
+    /// S&P 500 only on FMP).
+    pub async fn constituent_changes(
+        &self,
+    ) -> Result<Vec<crate::models::indices::IndexConstituentChange>> {
+        let index = self.major_index()?;
+        self.providers
+            .fetch(crate::providers::Capability::INDICES, move |p| {
+                let p = p.clone();
+                async move {
+                    p.as_indices()
+                        .ok_or_else(|| {
+                            p.not_supported(crate::providers::Operation::IndexConstituentChanges)
+                        })?
+                        .fetch_index_constituent_changes(index)
+                        .await
+                }
+            })
+            .await
+    }
 }
 
 impl_chartable_analytics!(Index, crate::risk::TradingCalendar::Exchange);

--- a/src/domains/market.rs
+++ b/src/domains/market.rs
@@ -99,6 +99,12 @@ impl MarketCalendar {
     pub async fn economic(&self, from: &str, to: &str) -> Result<Vec<MarketCalendarEntry>> {
         self.fetch(CalendarKind::Economic, from, to).await
     }
+
+    /// Upcoming market holidays and early closes. Providers return their
+    /// upcoming set, so no date range is taken.
+    pub async fn holidays(&self) -> Result<Vec<MarketCalendarEntry>> {
+        self.fetch(CalendarKind::MarketHoliday, "", "").await
+    }
 }
 
 /// Market-wide performance statistics backed by configured data providers.
@@ -128,6 +134,26 @@ impl Market {
                             p.not_supported(crate::providers::Operation::SectorPerformance)
                         })?
                         .fetch_sector_performance()
+                        .await
+                }
+            })
+            .await
+    }
+
+    /// Historical aggregate sector performance, most recent first.
+    pub async fn sector_performance_history(
+        &self,
+        limit: u32,
+    ) -> Result<Vec<crate::models::market::performance::SectorPerformanceHistory>> {
+        self.providers
+            .fetch(Capability::MARKET, move |p| {
+                let p = p.clone();
+                async move {
+                    p.as_market()
+                        .ok_or_else(|| {
+                            p.not_supported(crate::providers::Operation::SectorPerformanceHistory)
+                        })?
+                        .fetch_sector_performance_history(limit)
                         .await
                 }
             })

--- a/src/domains/market.rs
+++ b/src/domains/market.rs
@@ -6,6 +6,7 @@
 use std::sync::Arc;
 
 use crate::error::Result;
+#[cfg(any(feature = "fmp", feature = "polygon", feature = "alphavantage"))]
 use crate::models::calendar::market::{CalendarKind, MarketCalendarEntry};
 use crate::models::market::performance::{
     IndustryPe, MoverDirection, MoverQuote, SectorPe, SectorPerformance,
@@ -19,11 +20,13 @@ use crate::providers::{Capability, ProviderSet};
 /// timeline, these span the whole market over a date range.
 ///
 /// Created via [`Providers::calendar`](crate::Providers::calendar).
+#[cfg(any(feature = "fmp", feature = "polygon", feature = "alphavantage"))]
 pub struct MarketCalendar {
     providers: Arc<ProviderSet>,
     cache: crate::domains::DomainCache<Vec<MarketCalendarEntry>>,
 }
 
+#[cfg(any(feature = "fmp", feature = "polygon", feature = "alphavantage"))]
 impl MarketCalendar {
     pub(crate) fn with_providers(providers: Arc<ProviderSet>) -> Self {
         Self {

--- a/src/domains/mod.rs
+++ b/src/domains/mod.rs
@@ -452,7 +452,6 @@ pub(crate) mod forex;
 pub(crate) mod futures;
 #[cfg(any(feature = "polygon", feature = "fmp"))]
 pub(crate) mod indices;
-#[cfg(any(feature = "fmp", feature = "polygon", feature = "alphavantage"))]
 pub(crate) mod market;
 
 // ── Re-exports ──────────────────────────────────────────────────────
@@ -477,8 +476,9 @@ pub use forex::ForexPair;
 pub use futures::FuturesContract;
 #[cfg(any(feature = "polygon", feature = "fmp"))]
 pub use indices::Index;
+pub use market::Market;
 #[cfg(any(feature = "fmp", feature = "polygon", feature = "alphavantage"))]
-pub use market::{Market, MarketCalendar};
+pub use market::MarketCalendar;
 
 // ── Tests ───────────────────────────────────────────────────────────
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,7 +241,7 @@ pub use models::forex::ForexQuote;
 #[cfg(feature = "polygon")]
 pub use models::futures::FuturesQuote;
 #[cfg(any(feature = "polygon", feature = "fmp"))]
-pub use models::indices::IndexQuote;
+pub use models::indices::{IndexConstituent, IndexConstituentChange, IndexQuote, MajorIndex};
 
 // ============================================================================
 // Nested types - Commonly accessed fields within response types

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,7 +210,7 @@ pub use models::{
     filings::{
         CompanyFacts, EdgarSearchResults, EdgarSubmissions, ProviderFiling, ProviderFilings,
     },
-    fundamentals::FinancialStatement,
+    fundamentals::{FinancialStatement, ShareFloat, ShortInterest, ShortVolume},
     market::currencies::Currency,
     market::exchanges::Exchange,
     market::hours::MarketHours,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,7 +208,8 @@ pub use models::{
     discovery::search::SearchResults,
     discovery::trending::TrendingQuote,
     filings::{
-        CompanyFacts, EdgarSearchResults, EdgarSubmissions, ProviderFiling, ProviderFilings,
+        CompanyFacts, EdgarSearchResults, EdgarSubmissions, FilingSection, FilingSectionForm,
+        ProviderFiling, ProviderFilings, RiskFactor,
     },
     fundamentals::{FinancialStatement, ShareFloat, ShortInterest, ShortVolume},
     market::currencies::Currency,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,7 +175,7 @@ pub use models::discovery::reference::{
 };
 #[cfg(any(feature = "fmp", feature = "polygon", feature = "alphavantage"))]
 pub use models::market::performance::{
-    IndustryPe, MoverDirection, MoverQuote, SectorPe, SectorPerformance,
+    IndustryPe, MoverDirection, MoverQuote, SectorPe, SectorPerformance, SectorPerformanceHistory,
 };
 
 pub use error::{ErrorCategory, FinanceError, Result};
@@ -201,6 +201,7 @@ pub use models::{
     chart::Chart,
     chart::spark::Spark,
     corporate::news::News,
+    corporate::press_release::PressRelease,
     corporate::recommendation::Recommendation,
     corporate::transcript::{Transcript, TranscriptWithMeta},
     discovery::lookup::LookupResults,

--- a/src/models/calendar/market.rs
+++ b/src/models/calendar/market.rs
@@ -21,6 +21,8 @@ pub enum CalendarKind {
     Split,
     /// Macro-economic releases.
     Economic,
+    /// Market holidays and early closes.
+    MarketHoliday,
 }
 
 impl CalendarKind {
@@ -33,6 +35,7 @@ impl CalendarKind {
             Self::Dividend => Operation::DividendCalendar,
             Self::Split => Operation::SplitCalendar,
             Self::Economic => Operation::EconomicCalendar,
+            Self::MarketHoliday => Operation::HolidayCalendar,
         }
     }
 }
@@ -106,6 +109,19 @@ pub enum CalendarDetail {
         numerator: Option<f64>,
         /// Split ratio denominator (old shares).
         denominator: Option<f64>,
+    },
+    /// A market holiday or early close.
+    MarketHoliday {
+        /// Holiday name (e.g. `"Thanksgiving"`).
+        name: Option<String>,
+        /// Exchange the holiday applies to (e.g. `"NYSE"`).
+        exchange: Option<String>,
+        /// Status (e.g. `"closed"`, `"early-close"`).
+        status: Option<String>,
+        /// Open time, when the exchange opens late or closes early.
+        open: Option<String>,
+        /// Close time, when the exchange closes early.
+        close: Option<String>,
     },
     /// A macro-economic release.
     Economic {

--- a/src/models/corporate/mod.rs
+++ b/src/models/corporate/mod.rs
@@ -5,6 +5,8 @@
 // Sub-capability directories
 /// News article models.
 pub mod news;
+
+pub mod press_release;
 /// Recommendation/similar symbol models.
 pub mod recommendation;
 /// Earnings call transcripts.

--- a/src/models/corporate/press_release.rs
+++ b/src/models/corporate/press_release.rs
@@ -1,0 +1,22 @@
+//! Company press-release model.
+//!
+//! Served through the [`Capability::CORPORATE`](crate::Capability::CORPORATE)
+//! route; FMP is currently the only provider. Distinct from
+//! [`News`](super::news::News) — these are the company's own releases, not
+//! press coverage.
+
+use serde::{Deserialize, Serialize};
+
+/// A company press release.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct PressRelease {
+    /// Ticker symbol.
+    pub symbol: Option<String>,
+    /// Publication date/time as reported by the provider.
+    pub date: Option<String>,
+    /// Release title.
+    pub title: Option<String>,
+    /// Full release text.
+    pub text: Option<String>,
+}

--- a/src/models/filings/mod.rs
+++ b/src/models/filings/mod.rs
@@ -8,6 +8,7 @@ mod company_facts;
 pub mod filing_index;
 mod provider;
 mod search;
+mod sections;
 mod submissions;
 
 pub use cik::CikEntry;
@@ -18,6 +19,7 @@ pub use search::{
     EdgarSearchHit, EdgarSearchHitsContainer, EdgarSearchResults, EdgarSearchSource,
     EdgarSearchTotal,
 };
+pub use sections::{FilingSection, FilingSectionForm, RiskFactor};
 pub use submissions::{
     EdgarFiling, EdgarFilingFile, EdgarFilingRecent, EdgarFilings, EdgarSubmissions,
 };

--- a/src/models/filings/sections.rs
+++ b/src/models/filings/sections.rs
@@ -1,0 +1,41 @@
+//! Sectioned filing text and risk-factor models.
+//!
+//! Served through the [`Capability::FILINGS`](crate::Capability::FILINGS)
+//! route; Polygon is currently the only provider (EDGAR serves filing
+//! metadata, not sectioned text).
+
+use serde::{Deserialize, Serialize};
+
+/// Which filing form to fetch sectioned text for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum FilingSectionForm {
+    /// Annual report (10-K) sections.
+    TenK,
+    /// Current report (8-K) text.
+    EightK,
+}
+
+/// One section of an SEC filing's text.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct FilingSection {
+    /// Section key/name (e.g. `"risk_factors"`, `"mdna"`).
+    pub section: Option<String>,
+    /// Section text content.
+    pub content: Option<String>,
+}
+
+/// A risk factor extracted from SEC filings.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct RiskFactor {
+    /// Risk factor title.
+    pub title: Option<String>,
+    /// Risk factor text.
+    pub text: Option<String>,
+    /// Risk category.
+    pub category: Option<String>,
+    /// Date of the filing the factor was extracted from (`YYYY-MM-DD`).
+    pub filing_date: Option<String>,
+}

--- a/src/models/fundamentals/mod.rs
+++ b/src/models/fundamentals/mod.rs
@@ -7,6 +7,10 @@
 mod response;
 pub use response::FinancialStatement;
 
+// Short interest / short volume / share float (provider-routed)
+mod short_activity;
+pub use short_activity::{ShareFloat, ShortInterest, ShortVolume};
+
 // quoteSummary modules (canonical home, re-exported from quote/ for backward compat)
 pub(crate) mod balance_sheet_history;
 pub(crate) mod cashflow_statement_history;

--- a/src/models/fundamentals/short_activity.rs
+++ b/src/models/fundamentals/short_activity.rs
@@ -1,0 +1,48 @@
+//! Short interest, short volume, and share float models.
+//!
+//! Served through the [`Capability::FUNDAMENTALS`](crate::Capability::FUNDAMENTALS)
+//! route; Polygon is currently the only provider.
+
+use serde::{Deserialize, Serialize};
+
+/// A short-interest data point (bi-monthly settlement report).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ShortInterest {
+    /// Settlement date (`YYYY-MM-DD`).
+    pub settlement_date: Option<String>,
+    /// Total shares held short at settlement.
+    pub short_interest: Option<f64>,
+    /// Average daily trading volume over the reporting period.
+    pub avg_daily_volume: Option<f64>,
+    /// Days to cover (short interest / average daily volume).
+    pub days_to_cover: Option<f64>,
+}
+
+/// A daily short-volume data point.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ShortVolume {
+    /// Trade date (`YYYY-MM-DD`).
+    pub date: Option<String>,
+    /// Shares sold short.
+    pub short_volume: Option<f64>,
+    /// Shares sold short exempt from the uptick rule.
+    pub short_exempt_volume: Option<f64>,
+    /// Total volume.
+    pub total_volume: Option<f64>,
+}
+
+/// Share float and shares outstanding.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ShareFloat {
+    /// Ticker symbol.
+    pub symbol: Option<String>,
+    /// Freely tradable shares.
+    pub float_shares: Option<f64>,
+    /// Total shares outstanding.
+    pub outstanding_shares: Option<f64>,
+    /// As-of date (`YYYY-MM-DD`).
+    pub date: Option<String>,
+}

--- a/src/models/indices/mod.rs
+++ b/src/models/indices/mod.rs
@@ -25,10 +25,62 @@ pub struct IndexQuote {
     pub timestamp: Option<i64>,
 }
 
+/// A major stock market index whose constituent lists providers can serve.
+///
+/// Passed to [`Index::constituents`](crate::Index::constituents) (derived from
+/// the handle's symbol) and the INDICES provider route.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum MajorIndex {
+    /// S&P 500 (`^GSPC` / `SPX`).
+    Sp500,
+    /// Nasdaq 100 (`^NDX` / `NDX`).
+    Nasdaq100,
+    /// Dow Jones Industrial Average (`^DJI` / `DJIA`).
+    DowJones,
+}
+
+impl MajorIndex {
+    /// Short lowercase identifier (`"sp500"`, `"nasdaq100"`, `"dowjones"`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Sp500 => "sp500",
+            Self::Nasdaq100 => "nasdaq100",
+            Self::DowJones => "dowjones",
+        }
+    }
+
+    /// Map a common index symbol or name to the major index it denotes.
+    ///
+    /// Accepts the Yahoo caret form, the bare ticker, and common names,
+    /// case-insensitively (e.g. `"^GSPC"`, `"SPX"`, `"sp500"`, `"^DJI"`,
+    /// `"DJIA"`, `"^NDX"`, `"nasdaq 100"`). Returns `None` for anything else.
+    pub fn from_symbol(symbol: &str) -> Option<Self> {
+        let s: String = symbol
+            .trim()
+            .trim_start_matches('^')
+            .chars()
+            .filter(|c| !c.is_whitespace() && *c != '&' && *c != '-')
+            .collect::<String>()
+            .to_ascii_lowercase();
+        match s.as_str() {
+            "gspc" | "spx" | "sp500" => Some(Self::Sp500),
+            "ndx" | "nasdaq100" => Some(Self::Nasdaq100),
+            "dji" | "djia" | "dowjones" | "dow" | "dowjones30" => Some(Self::DowJones),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for MajorIndex {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// A constituent (member) of a major stock market index.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
-#[allow(dead_code)] // unrouted: populated by index constituents (#297)
 pub struct IndexConstituent {
     /// Ticker symbol of the constituent company
     pub symbol: String,
@@ -36,10 +88,60 @@ pub struct IndexConstituent {
     pub name: Option<String>,
     /// Sector classification
     pub sector: Option<String>,
-    /// Industry classification
-    pub industry: Option<String>,
-    /// Market capitalization
-    pub market_cap: Option<f64>,
-    /// Weight in the index
-    pub weight: Option<f64>,
+    /// Sub-sector classification
+    pub sub_sector: Option<String>,
+    /// Headquarters location
+    pub headquarters: Option<String>,
+    /// Date the company was first added to the index (`YYYY-MM-DD`)
+    pub date_first_added: Option<String>,
+    /// SEC CIK number
+    pub cik: Option<String>,
+    /// Year the company was founded
+    pub founded: Option<String>,
+}
+
+/// A historical change in a major index's constituency.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct IndexConstituentChange {
+    /// Date of the change (`YYYY-MM-DD`)
+    pub date: Option<String>,
+    /// Ticker symbol the change concerns
+    pub symbol: Option<String>,
+    /// Security that was added
+    pub added_security: Option<String>,
+    /// Ticker that was removed
+    pub removed_ticker: Option<String>,
+    /// Security that was removed
+    pub removed_security: Option<String>,
+    /// Reason for the change
+    pub reason: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn major_index_maps_common_symbols() {
+        for s in ["^GSPC", "GSPC", "SPX", "sp500", "S&P 500"] {
+            assert_eq!(MajorIndex::from_symbol(s), Some(MajorIndex::Sp500), "{s}");
+        }
+        for s in ["^NDX", "ndx", "NASDAQ 100", "nasdaq100"] {
+            assert_eq!(
+                MajorIndex::from_symbol(s),
+                Some(MajorIndex::Nasdaq100),
+                "{s}"
+            );
+        }
+        for s in ["^DJI", "DJIA", "dow", "Dow Jones"] {
+            assert_eq!(
+                MajorIndex::from_symbol(s),
+                Some(MajorIndex::DowJones),
+                "{s}"
+            );
+        }
+        assert_eq!(MajorIndex::from_symbol("AAPL"), None);
+        assert_eq!(MajorIndex::from_symbol("^IXIC"), None);
+    }
 }

--- a/src/models/market/mod.rs
+++ b/src/models/market/mod.rs
@@ -13,7 +13,6 @@ pub mod industries;
 pub mod market_summary;
 /// Currency pair data.
 /// Market-wide performance statistics routed through `Capability::MARKET`.
-#[cfg(any(feature = "fmp", feature = "polygon", feature = "alphavantage"))]
 pub mod performance;
 /// Sector-level market data.
 pub mod sectors;

--- a/src/models/market/performance.rs
+++ b/src/models/market/performance.rs
@@ -27,6 +27,16 @@ pub struct SectorPerformance {
     pub change_percent: Option<f64>,
 }
 
+/// One day of aggregate performance across every sector.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct SectorPerformanceHistory {
+    /// Date (`YYYY-MM-DD`).
+    pub date: Option<String>,
+    /// Per-sector percentage change on that date.
+    pub sectors: Vec<SectorPerformance>,
+}
+
 /// A sector's aggregate price/earnings ratio.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[non_exhaustive]

--- a/src/models/market/performance.rs
+++ b/src/models/market/performance.rs
@@ -85,11 +85,12 @@ pub struct MoverQuote {
 ///
 /// FMP returns sector performance as a preformatted string, unlike its movers
 /// endpoints which return a bare number.
+#[cfg(feature = "fmp")]
 pub(crate) fn parse_percent(raw: Option<&str>) -> Option<f64> {
     raw?.trim().trim_end_matches('%').trim().parse().ok()
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "fmp"))]
 mod tests {
     use super::*;
 

--- a/src/providers/adapter.rs
+++ b/src/providers/adapter.rs
@@ -145,6 +145,23 @@ pub(crate) trait OptionsProvider: ProviderCore {
 #[async_trait::async_trait]
 pub(crate) trait FilingsProvider: ProviderCore {
     async fn fetch_filings(&self, symbol: &str) -> Result<crate::models::filings::ProviderFilings>;
+
+    /// Fetch the sectioned text of one filing by accession number.
+    async fn fetch_filing_sections(
+        &self,
+        _accession_number: &str,
+        _form: crate::models::filings::FilingSectionForm,
+    ) -> Result<Vec<crate::models::filings::FilingSection>> {
+        Err(self.not_supported(Operation::FilingSections))
+    }
+
+    /// Fetch risk factors extracted from a symbol's SEC filings.
+    async fn fetch_risk_factors(
+        &self,
+        _symbol: &str,
+    ) -> Result<Vec<crate::models::filings::RiskFactor>> {
+        Err(self.not_supported(Operation::RiskFactors))
+    }
 }
 
 // ── Capability traits (feature-gated) ───────────────────────────────

--- a/src/providers/adapter.rs
+++ b/src/providers/adapter.rs
@@ -78,7 +78,7 @@ pub(crate) trait ChartProvider: ProviderCore {
     }
 }
 
-/// [`Capability::FUNDAMENTALS`] — financial statements.
+/// [`Capability::FUNDAMENTALS`] — financial statements and share-supply data.
 #[async_trait::async_trait]
 pub(crate) trait FundamentalsProvider: ProviderCore {
     async fn fetch_financials(
@@ -87,6 +87,30 @@ pub(crate) trait FundamentalsProvider: ProviderCore {
         stmt_type: crate::StatementType,
         frequency: crate::Frequency,
     ) -> Result<crate::models::fundamentals::FinancialStatement>;
+
+    /// Fetch short-interest settlement reports, most recent first.
+    async fn fetch_short_interest(
+        &self,
+        _symbol: &str,
+    ) -> Result<Vec<crate::models::fundamentals::ShortInterest>> {
+        Err(self.not_supported(Operation::ShortInterest))
+    }
+
+    /// Fetch daily short-volume data.
+    async fn fetch_short_volume(
+        &self,
+        _symbol: &str,
+    ) -> Result<Vec<crate::models::fundamentals::ShortVolume>> {
+        Err(self.not_supported(Operation::ShortVolume))
+    }
+
+    /// Fetch share float and shares outstanding.
+    async fn fetch_share_float(
+        &self,
+        _symbol: &str,
+    ) -> Result<crate::models::fundamentals::ShareFloat> {
+        Err(self.not_supported(Operation::ShareFloat))
+    }
 }
 
 /// [`Capability::CORPORATE`] — news, corporate events, similar-symbol

--- a/src/providers/adapter.rs
+++ b/src/providers/adapter.rs
@@ -88,7 +88,7 @@ pub(crate) trait FundamentalsProvider: ProviderCore {
         frequency: crate::Frequency,
     ) -> Result<crate::models::fundamentals::FinancialStatement>;
 
-    /// Fetch short-interest settlement reports, most recent first.
+    /// Fetch bi-monthly short-interest settlement reports.
     async fn fetch_short_interest(
         &self,
         _symbol: &str,
@@ -128,6 +128,15 @@ pub(crate) trait CorporateProvider: ProviderCore {
         _limit: u32,
     ) -> Result<Vec<crate::models::corporate::recommendation::SimilarSymbol>> {
         Err(self.not_supported(Operation::Recommendations))
+    }
+
+    /// Fetch the company's own press releases.
+    async fn fetch_press_releases(
+        &self,
+        _symbol: &str,
+        _limit: u32,
+    ) -> Result<Vec<crate::models::corporate::press_release::PressRelease>> {
+        Err(self.not_supported(Operation::PressReleases))
     }
 }
 
@@ -220,27 +229,45 @@ pub(crate) trait CalendarProvider: ProviderCore {
 }
 
 /// [`Capability::MARKET`] — sector/industry performance and movers.
+///
+/// Movers is the required primary (every current implementor serves it);
+/// the sector/industry statistics default to `NotSupported` since coverage
+/// is ragged (FMP serves all of them, Alpha Vantage only movers).
 #[cfg(any(feature = "fmp", feature = "polygon", feature = "alphavantage"))]
 #[async_trait::async_trait]
 pub(crate) trait MarketProvider: ProviderCore {
-    /// Fetch aggregate performance for every sector.
-    async fn fetch_sector_performance(
-        &self,
-    ) -> Result<Vec<crate::models::market::performance::SectorPerformance>>;
-
-    /// Fetch sector price/earnings ratios.
-    async fn fetch_sector_pe(&self) -> Result<Vec<crate::models::market::performance::SectorPe>>;
-
-    /// Fetch industry price/earnings ratios.
-    async fn fetch_industry_pe(
-        &self,
-    ) -> Result<Vec<crate::models::market::performance::IndustryPe>>;
-
     /// Fetch the market movers list for `direction`.
     async fn fetch_market_movers(
         &self,
         direction: crate::models::market::performance::MoverDirection,
     ) -> Result<Vec<crate::models::market::performance::MoverQuote>>;
+
+    /// Fetch aggregate performance for every sector.
+    async fn fetch_sector_performance(
+        &self,
+    ) -> Result<Vec<crate::models::market::performance::SectorPerformance>> {
+        Err(self.not_supported(Operation::SectorPerformance))
+    }
+
+    /// Fetch historical aggregate sector performance, most recent first.
+    async fn fetch_sector_performance_history(
+        &self,
+        _limit: u32,
+    ) -> Result<Vec<crate::models::market::performance::SectorPerformanceHistory>> {
+        Err(self.not_supported(Operation::SectorPerformanceHistory))
+    }
+
+    /// Fetch sector price/earnings ratios.
+    async fn fetch_sector_pe(&self) -> Result<Vec<crate::models::market::performance::SectorPe>> {
+        Err(self.not_supported(Operation::SectorPerformance))
+    }
+
+    /// Fetch industry price/earnings ratios.
+    async fn fetch_industry_pe(
+        &self,
+    ) -> Result<Vec<crate::models::market::performance::IndustryPe>> {
+        Err(self.not_supported(Operation::SectorPerformance))
+    }
 }
 
 /// [`Capability::CRYPTO`] — cryptocurrency quotes.

--- a/src/providers/adapter.rs
+++ b/src/providers/adapter.rs
@@ -245,6 +245,22 @@ pub(crate) trait ForexProvider: ProviderCore {
 pub(crate) trait IndicesProvider: ProviderCore {
     async fn fetch_indices_quote(&self, symbol: &str)
     -> Result<crate::models::indices::IndexQuote>;
+
+    /// Fetch the current constituents of a major index.
+    async fn fetch_index_constituents(
+        &self,
+        _index: crate::models::indices::MajorIndex,
+    ) -> Result<Vec<crate::models::indices::IndexConstituent>> {
+        Err(self.not_supported(Operation::IndexConstituents))
+    }
+
+    /// Fetch historical constituent changes of a major index.
+    async fn fetch_index_constituent_changes(
+        &self,
+        _index: crate::models::indices::MajorIndex,
+    ) -> Result<Vec<crate::models::indices::IndexConstituentChange>> {
+        Err(self.not_supported(Operation::IndexConstituentChanges))
+    }
 }
 
 /// [`Capability::FUTURES`] — futures contract quotes.

--- a/src/providers/adapter.rs
+++ b/src/providers/adapter.rs
@@ -232,8 +232,7 @@ pub(crate) trait CalendarProvider: ProviderCore {
 ///
 /// Movers is the required primary (every current implementor serves it);
 /// the sector/industry statistics default to `NotSupported` since coverage
-/// is ragged (FMP serves all of them, Alpha Vantage only movers).
-#[cfg(any(feature = "fmp", feature = "polygon", feature = "alphavantage"))]
+/// is ragged (FMP serves all of them; Yahoo and Alpha Vantage only movers).
 #[async_trait::async_trait]
 pub(crate) trait MarketProvider: ProviderCore {
     /// Fetch the market movers list for `direction`.
@@ -389,7 +388,6 @@ pub(crate) trait ProviderAdapter: ProviderCore {
     fn as_calendar(&self) -> Option<&dyn CalendarProvider> {
         None
     }
-    #[cfg(any(feature = "fmp", feature = "polygon", feature = "alphavantage"))]
     fn as_market(&self) -> Option<&dyn MarketProvider> {
         None
     }
@@ -445,6 +443,9 @@ pub(crate) trait ProviderAdapter: ProviderCore {
         if self.as_filings().is_some() {
             caps = caps | Capability::FILINGS;
         }
+        if self.as_market().is_some() {
+            caps = caps | Capability::MARKET;
+        }
         #[cfg(any(feature = "fmp", feature = "polygon", feature = "alphavantage"))]
         {
             if self.as_discovery().is_some() {
@@ -452,9 +453,6 @@ pub(crate) trait ProviderAdapter: ProviderCore {
             }
             if self.as_calendar().is_some() {
                 caps = caps | Capability::CALENDAR;
-            }
-            if self.as_market().is_some() {
-                caps = caps | Capability::MARKET;
             }
         }
         #[cfg(any(

--- a/src/providers/alphavantage.rs
+++ b/src/providers/alphavantage.rs
@@ -5,8 +5,8 @@
 
 use super::{
     ChartProvider, CommoditiesProvider, CorporateProvider, CryptoProvider, EconomicProvider,
-    ForexProvider, FundamentalsProvider, OptionsProvider, ProviderAdapter, ProviderCore,
-    QuoteProvider,
+    ForexProvider, FundamentalsProvider, MarketProvider, OptionsProvider, ProviderAdapter,
+    ProviderCore, QuoteProvider,
 };
 use crate::adapters::alphavantage as av;
 use crate::error::Result;
@@ -136,6 +136,16 @@ impl EconomicProvider for AlphaVantageProvider {
 }
 
 #[async_trait::async_trait]
+impl MarketProvider for AlphaVantageProvider {
+    async fn fetch_market_movers(
+        &self,
+        direction: crate::models::market::performance::MoverDirection,
+    ) -> Result<Vec<crate::models::market::performance::MoverQuote>> {
+        av::fetch_market_movers_response(direction).await
+    }
+}
+
+#[async_trait::async_trait]
 impl ProviderAdapter for AlphaVantageProvider {
     async fn initialize(&self) -> Result<()> {
         let key = std::env::var("ALPHAVANTAGE_API_KEY").map_err(|_| {
@@ -174,6 +184,9 @@ impl ProviderAdapter for AlphaVantageProvider {
         Some(self)
     }
     fn as_commodities(&self) -> Option<&dyn CommoditiesProvider> {
+        Some(self)
+    }
+    fn as_market(&self) -> Option<&dyn MarketProvider> {
         Some(self)
     }
 }

--- a/src/providers/config.rs
+++ b/src/providers/config.rs
@@ -157,8 +157,9 @@ impl Providers {
     /// Create a [`Market`](crate::Market) handle backed by this provider set.
     ///
     /// Routes sector/industry performance and movers through
-    /// [`Capability::MARKET`](crate::Capability::MARKET).
-    #[cfg(any(feature = "fmp", feature = "polygon", feature = "alphavantage"))]
+    /// [`Capability::MARKET`](crate::Capability::MARKET). Movers work on the
+    /// default keyless route (Yahoo screeners); the sector/industry
+    /// statistics need a keyed provider (FMP).
     pub fn market(&self) -> crate::domains::Market {
         crate::domains::Market::with_providers(Arc::clone(&self.set))
     }

--- a/src/providers/fmp.rs
+++ b/src/providers/fmp.rs
@@ -203,6 +203,20 @@ impl IndicesProvider for FmpProvider {
     ) -> Result<crate::models::indices::IndexQuote> {
         crate::adapters::fmp::indices::fetch_canonical_index_quote(symbol).await
     }
+
+    async fn fetch_index_constituents(
+        &self,
+        index: crate::models::indices::MajorIndex,
+    ) -> Result<Vec<crate::models::indices::IndexConstituent>> {
+        crate::adapters::fmp::indices::fetch_index_constituents_response(index).await
+    }
+
+    async fn fetch_index_constituent_changes(
+        &self,
+        index: crate::models::indices::MajorIndex,
+    ) -> Result<Vec<crate::models::indices::IndexConstituentChange>> {
+        crate::adapters::fmp::indices::fetch_index_constituent_changes_response(index).await
+    }
 }
 
 #[async_trait::async_trait]

--- a/src/providers/fmp.rs
+++ b/src/providers/fmp.rs
@@ -124,6 +124,14 @@ impl CorporateProvider for FmpProvider {
     ) -> Result<Vec<crate::models::corporate::recommendation::SimilarSymbol>> {
         crate::adapters::fmp::quote::fetch_canonical_similar_symbols(symbol, limit).await
     }
+
+    async fn fetch_press_releases(
+        &self,
+        symbol: &str,
+        limit: u32,
+    ) -> Result<Vec<crate::models::corporate::press_release::PressRelease>> {
+        crate::adapters::fmp::corporate::fetch_press_releases_response(symbol, limit).await
+    }
 }
 
 #[async_trait::async_trait]
@@ -159,6 +167,24 @@ impl CalendarProvider for FmpProvider {
 
 #[async_trait::async_trait]
 impl MarketProvider for FmpProvider {
+    async fn fetch_market_movers(
+        &self,
+        direction: crate::models::market::performance::MoverDirection,
+    ) -> Result<Vec<crate::models::market::performance::MoverQuote>> {
+        crate::adapters::fmp::market::market_performance::fetch_market_movers_response(direction)
+            .await
+    }
+
+    async fn fetch_sector_performance_history(
+        &self,
+        limit: u32,
+    ) -> Result<Vec<crate::models::market::performance::SectorPerformanceHistory>> {
+        crate::adapters::fmp::market::market_performance::fetch_sector_performance_history_response(
+            limit,
+        )
+        .await
+    }
+
     async fn fetch_sector_performance(
         &self,
     ) -> Result<Vec<crate::models::market::performance::SectorPerformance>> {
@@ -173,14 +199,6 @@ impl MarketProvider for FmpProvider {
         &self,
     ) -> Result<Vec<crate::models::market::performance::IndustryPe>> {
         crate::adapters::fmp::market::market_performance::fetch_industry_pe_response().await
-    }
-
-    async fn fetch_market_movers(
-        &self,
-        direction: crate::models::market::performance::MoverDirection,
-    ) -> Result<Vec<crate::models::market::performance::MoverQuote>> {
-        crate::adapters::fmp::market::market_performance::fetch_market_movers_response(direction)
-            .await
     }
 }
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -371,6 +371,10 @@ pub enum Operation {
     ShortVolume,
     /// Share float and shares outstanding.
     ShareFloat,
+    /// Sectioned text of an SEC filing.
+    FilingSections,
+    /// Risk factors extracted from SEC filings.
+    RiskFactors,
 }
 
 impl Operation {
@@ -410,6 +414,8 @@ impl Operation {
             Self::ShortInterest => "short_interest",
             Self::ShortVolume => "short_volume",
             Self::ShareFloat => "share_float",
+            Self::FilingSections => "filing_sections",
+            Self::RiskFactors => "risk_factors",
         }
     }
 
@@ -431,7 +437,7 @@ impl Operation {
             }
             Self::FuturesQuote => Capability::FUTURES,
             Self::CommoditiesQuote => Capability::COMMODITIES,
-            Self::Filings => Capability::FILINGS,
+            Self::Filings | Self::FilingSections | Self::RiskFactors => Capability::FILINGS,
             Self::SymbolSearch | Self::SymbolDetails | Self::Exchanges | Self::Screener => {
                 Capability::DISCOVERY
             }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -365,6 +365,12 @@ pub enum Operation {
     IndexConstituents,
     /// Historical constituent changes of a major index.
     IndexConstituentChanges,
+    /// Short interest (settlement-date positions).
+    ShortInterest,
+    /// Daily short volume.
+    ShortVolume,
+    /// Share float and shares outstanding.
+    ShareFloat,
 }
 
 impl Operation {
@@ -401,6 +407,9 @@ impl Operation {
             Self::MarketMovers => "market_movers",
             Self::IndexConstituents => "index_constituents",
             Self::IndexConstituentChanges => "index_constituent_changes",
+            Self::ShortInterest => "short_interest",
+            Self::ShortVolume => "short_volume",
+            Self::ShareFloat => "share_float",
         }
     }
 
@@ -409,7 +418,9 @@ impl Operation {
         match self {
             Self::Quote | Self::QuotesBatch => Capability::QUOTE,
             Self::Chart | Self::ChartRange | Self::Spark => Capability::CHART,
-            Self::Financials => Capability::FUNDAMENTALS,
+            Self::Financials | Self::ShortInterest | Self::ShortVolume | Self::ShareFloat => {
+                Capability::FUNDAMENTALS
+            }
             Self::News | Self::Recommendations | Self::Events => Capability::CORPORATE,
             Self::Options => Capability::OPTIONS,
             Self::CryptoQuote => Capability::CRYPTO,

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -939,7 +939,8 @@ mod tests {
             .union(Capability::CHART)
             .union(Capability::FUNDAMENTALS)
             .union(Capability::CORPORATE)
-            .union(Capability::OPTIONS);
+            .union(Capability::OPTIONS)
+            .union(Capability::MARKET);
         assert_eq!(yahoo::CAPS, expected);
     }
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -361,6 +361,10 @@ pub enum Operation {
     SectorPerformance,
     /// Market movers — gainers, losers, most active.
     MarketMovers,
+    /// Current constituents of a major index.
+    IndexConstituents,
+    /// Historical constituent changes of a major index.
+    IndexConstituentChanges,
 }
 
 impl Operation {
@@ -395,6 +399,8 @@ impl Operation {
             Self::EconomicCalendar => "economic_calendar",
             Self::SectorPerformance => "sector_performance",
             Self::MarketMovers => "market_movers",
+            Self::IndexConstituents => "index_constituents",
+            Self::IndexConstituentChanges => "index_constituent_changes",
         }
     }
 
@@ -409,7 +415,9 @@ impl Operation {
             Self::CryptoQuote => Capability::CRYPTO,
             Self::EconomicSeries => Capability::ECONOMIC,
             Self::ForexQuote => Capability::FOREX,
-            Self::IndicesQuote => Capability::INDICES,
+            Self::IndicesQuote | Self::IndexConstituents | Self::IndexConstituentChanges => {
+                Capability::INDICES
+            }
             Self::FuturesQuote => Capability::FUTURES,
             Self::CommoditiesQuote => Capability::COMMODITIES,
             Self::Filings => Capability::FILINGS,

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -361,6 +361,10 @@ pub enum Operation {
     SectorPerformance,
     /// Market movers — gainers, losers, most active.
     MarketMovers,
+    /// Historical sector performance.
+    SectorPerformanceHistory,
+    /// Market-wide holiday calendar.
+    HolidayCalendar,
     /// Current constituents of a major index.
     IndexConstituents,
     /// Historical constituent changes of a major index.
@@ -375,6 +379,8 @@ pub enum Operation {
     FilingSections,
     /// Risk factors extracted from SEC filings.
     RiskFactors,
+    /// Company press releases.
+    PressReleases,
 }
 
 impl Operation {
@@ -409,6 +415,8 @@ impl Operation {
             Self::EconomicCalendar => "economic_calendar",
             Self::SectorPerformance => "sector_performance",
             Self::MarketMovers => "market_movers",
+            Self::SectorPerformanceHistory => "sector_performance_history",
+            Self::HolidayCalendar => "holiday_calendar",
             Self::IndexConstituents => "index_constituents",
             Self::IndexConstituentChanges => "index_constituent_changes",
             Self::ShortInterest => "short_interest",
@@ -416,6 +424,7 @@ impl Operation {
             Self::ShareFloat => "share_float",
             Self::FilingSections => "filing_sections",
             Self::RiskFactors => "risk_factors",
+            Self::PressReleases => "press_releases",
         }
     }
 
@@ -427,7 +436,9 @@ impl Operation {
             Self::Financials | Self::ShortInterest | Self::ShortVolume | Self::ShareFloat => {
                 Capability::FUNDAMENTALS
             }
-            Self::News | Self::Recommendations | Self::Events => Capability::CORPORATE,
+            Self::News | Self::Recommendations | Self::Events | Self::PressReleases => {
+                Capability::CORPORATE
+            }
             Self::Options => Capability::OPTIONS,
             Self::CryptoQuote => Capability::CRYPTO,
             Self::EconomicSeries => Capability::ECONOMIC,
@@ -445,8 +456,11 @@ impl Operation {
             | Self::IpoCalendar
             | Self::DividendCalendar
             | Self::SplitCalendar
-            | Self::EconomicCalendar => Capability::CALENDAR,
-            Self::SectorPerformance | Self::MarketMovers => Capability::MARKET,
+            | Self::EconomicCalendar
+            | Self::HolidayCalendar => Capability::CALENDAR,
+            Self::SectorPerformance | Self::MarketMovers | Self::SectorPerformanceHistory => {
+                Capability::MARKET
+            }
         }
     }
 }
@@ -927,6 +941,28 @@ mod tests {
             .union(Capability::CORPORATE)
             .union(Capability::OPTIONS);
         assert_eq!(yahoo::CAPS, expected);
+    }
+
+    /// Polygon gained CALENDAR (holidays) and AV gained MARKET (movers) via
+    /// accessor overrides; `Provider::capabilities()` must reflect that.
+    #[cfg(feature = "polygon")]
+    #[test]
+    fn polygon_derives_calendar_capability() {
+        assert!(
+            Provider::Polygon
+                .capabilities()
+                .contains(Capability::CALENDAR)
+        );
+    }
+
+    #[cfg(feature = "alphavantage")]
+    #[test]
+    fn alphavantage_derives_market_capability() {
+        assert!(
+            Provider::AlphaVantage
+                .capabilities()
+                .contains(Capability::MARKET)
+        );
     }
 
     #[test]

--- a/src/providers/polygon.rs
+++ b/src/providers/polygon.rs
@@ -64,6 +64,27 @@ impl FundamentalsProvider for PolygonProvider {
     ) -> Result<crate::models::fundamentals::FinancialStatement> {
         polygon::fetch_financials_response(symbol, stmt_type, frequency).await
     }
+
+    async fn fetch_short_interest(
+        &self,
+        symbol: &str,
+    ) -> Result<Vec<crate::models::fundamentals::ShortInterest>> {
+        polygon::fetch_short_interest_response(symbol).await
+    }
+
+    async fn fetch_short_volume(
+        &self,
+        symbol: &str,
+    ) -> Result<Vec<crate::models::fundamentals::ShortVolume>> {
+        polygon::fetch_short_volume_response(symbol).await
+    }
+
+    async fn fetch_share_float(
+        &self,
+        symbol: &str,
+    ) -> Result<crate::models::fundamentals::ShareFloat> {
+        polygon::fetch_share_float_response(symbol).await
+    }
 }
 
 #[async_trait::async_trait]

--- a/src/providers/polygon.rs
+++ b/src/providers/polygon.rs
@@ -180,6 +180,21 @@ impl FilingsProvider for PolygonProvider {
     async fn fetch_filings(&self, symbol: &str) -> Result<crate::models::filings::ProviderFilings> {
         polygon::fetch_filings_response(symbol).await
     }
+
+    async fn fetch_filing_sections(
+        &self,
+        accession_number: &str,
+        form: crate::models::filings::FilingSectionForm,
+    ) -> Result<Vec<crate::models::filings::FilingSection>> {
+        polygon::fetch_filing_sections_response(accession_number, form).await
+    }
+
+    async fn fetch_risk_factors(
+        &self,
+        symbol: &str,
+    ) -> Result<Vec<crate::models::filings::RiskFactor>> {
+        polygon::fetch_risk_factors_response(symbol).await
+    }
 }
 
 #[async_trait::async_trait]

--- a/src/providers/polygon.rs
+++ b/src/providers/polygon.rs
@@ -1,9 +1,9 @@
 //! Polygon.io provider implementation.
 
 use super::{
-    ChartProvider, CorporateProvider, CryptoProvider, DiscoveryProvider, EconomicProvider,
-    FilingsProvider, ForexProvider, FundamentalsProvider, FuturesProvider, IndicesProvider,
-    OptionsProvider, ProviderAdapter, ProviderCore, QuoteProvider,
+    CalendarProvider, ChartProvider, CorporateProvider, CryptoProvider, DiscoveryProvider,
+    EconomicProvider, FilingsProvider, ForexProvider, FundamentalsProvider, FuturesProvider,
+    IndicesProvider, OptionsProvider, ProviderAdapter, ProviderCore, QuoteProvider,
 };
 use crate::adapters::polygon;
 use crate::error::FinanceError;
@@ -198,6 +198,24 @@ impl FilingsProvider for PolygonProvider {
 }
 
 #[async_trait::async_trait]
+impl CalendarProvider for PolygonProvider {
+    /// Polygon serves the holiday calendar only; other kinds fall through to
+    /// the next routed provider. Holidays are date-bounded upstream (Polygon
+    /// returns the upcoming set), so `from`/`to` are ignored.
+    async fn fetch_market_calendar(
+        &self,
+        kind: crate::models::calendar::market::CalendarKind,
+        _from: &str,
+        _to: &str,
+    ) -> Result<Vec<crate::models::calendar::market::MarketCalendarEntry>> {
+        if kind != crate::models::calendar::market::CalendarKind::MarketHoliday {
+            return Err(self.not_supported(kind.operation()));
+        }
+        polygon::fetch_market_holidays_response().await
+    }
+}
+
+#[async_trait::async_trait]
 impl CryptoProvider for PolygonProvider {
     async fn fetch_crypto_quote(
         &self,
@@ -265,6 +283,9 @@ impl ProviderAdapter for PolygonProvider {
         Some(self)
     }
     fn as_filings(&self) -> Option<&dyn FilingsProvider> {
+        Some(self)
+    }
+    fn as_calendar(&self) -> Option<&dyn CalendarProvider> {
         Some(self)
     }
 }

--- a/src/providers/yahoo.rs
+++ b/src/providers/yahoo.rs
@@ -4,8 +4,8 @@
 //! to keep this file focused on routing and lifecycle.
 
 use super::{
-    Capability, ChartProvider, CorporateProvider, FundamentalsProvider, OptionsProvider,
-    ProviderAdapter, ProviderCore, QuoteProvider,
+    Capability, ChartProvider, CorporateProvider, FundamentalsProvider, MarketProvider,
+    OptionsProvider, ProviderAdapter, ProviderCore, QuoteProvider,
 };
 use crate::adapters::yahoo::client::{ClientConfig, YahooClient};
 use crate::constants::{Interval, TimeRange};
@@ -20,7 +20,8 @@ pub(crate) const CAPS: Capability = Capability::QUOTE
     .union(Capability::CHART)
     .union(Capability::FUNDAMENTALS)
     .union(Capability::CORPORATE)
-    .union(Capability::OPTIONS);
+    .union(Capability::OPTIONS)
+    .union(Capability::MARKET);
 
 pub(crate) struct YahooProvider {
     client: Arc<YahooClient>,
@@ -243,6 +244,48 @@ impl CorporateProvider for YahooProvider {
 }
 
 #[async_trait::async_trait]
+impl MarketProvider for YahooProvider {
+    /// Derived from Yahoo's predefined screeners (`day_gainers`,
+    /// `day_losers`, `most_actives`) rather than a dedicated movers endpoint,
+    /// so movers work on the default keyless route.
+    async fn fetch_market_movers(
+        &self,
+        direction: crate::models::market::performance::MoverDirection,
+    ) -> Result<Vec<crate::models::market::performance::MoverQuote>> {
+        use crate::constants::screeners::Screener;
+        use crate::models::market::performance::MoverDirection;
+
+        let screener = match direction {
+            MoverDirection::Gainers => Screener::DayGainers,
+            MoverDirection::Losers => Screener::DayLosers,
+            MoverDirection::MostActive => Screener::MostActives,
+        };
+        let results =
+            crate::adapters::yahoo::discovery::screeners::fetch(&self.client, screener, 25).await?;
+        Ok(screener_quotes_to_movers(results))
+    }
+}
+
+/// Map screener rows to canonical mover quotes.
+fn screener_quotes_to_movers(
+    results: crate::models::discovery::screeners::ScreenerResults,
+) -> Vec<crate::models::market::performance::MoverQuote> {
+    results
+        .quotes
+        .into_iter()
+        .map(|q| crate::models::market::performance::MoverQuote {
+            name: Some(q.short_name.clone())
+                .filter(|s| !s.is_empty())
+                .or(q.long_name),
+            symbol: q.symbol,
+            price: q.regular_market_price.raw,
+            change: q.regular_market_change.raw,
+            change_percent: q.regular_market_change_percent.raw,
+        })
+        .collect()
+}
+
+#[async_trait::async_trait]
 impl OptionsProvider for YahooProvider {
     async fn fetch_options(
         &self,
@@ -269,5 +312,39 @@ impl ProviderAdapter for YahooProvider {
     }
     fn as_options(&self) -> Option<&dyn OptionsProvider> {
         Some(self)
+    }
+    fn as_market(&self) -> Option<&dyn MarketProvider> {
+        Some(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn screener_rows_map_to_mover_quotes() {
+        let results: crate::models::discovery::screeners::ScreenerResults =
+            serde_json::from_value(serde_json::json!({
+                "quotes": [{
+                    "symbol": "NVDA",
+                    "shortName": "NVIDIA Corporation",
+                    "quoteType": "EQUITY",
+                    "exchange": "NMS",
+                    "regularMarketPrice": {"raw": 1234.5, "fmt": "1,234.50"},
+                    "regularMarketChange": {"raw": 56.7, "fmt": "56.70"},
+                    "regularMarketChangePercent": {"raw": 4.81, "fmt": "4.81%"}
+                }],
+                "type": "day_gainers",
+                "description": "Day gainers"
+            }))
+            .unwrap();
+        let movers = screener_quotes_to_movers(results);
+        assert_eq!(movers.len(), 1);
+        assert_eq!(movers[0].symbol, "NVDA");
+        assert_eq!(movers[0].name.as_deref(), Some("NVIDIA Corporation"));
+        assert_eq!(movers[0].price, Some(1234.5));
+        assert_eq!(movers[0].change, Some(56.7));
+        assert_eq!(movers[0].change_percent, Some(4.81));
     }
 }

--- a/src/providers/yahoo.rs
+++ b/src/providers/yahoo.rs
@@ -124,8 +124,88 @@ impl ChartProvider for YahooProvider {
     }
 }
 
+/// Convert a Yahoo epoch timestamp to a `YYYY-MM-DD` date string.
+fn epoch_to_date(ts: i64) -> Option<String> {
+    chrono::DateTime::from_timestamp(ts, 0).map(|dt| dt.format("%Y-%m-%d").to_string())
+}
+
 #[async_trait::async_trait]
 impl FundamentalsProvider for YahooProvider {
+    /// Derived from `defaultKeyStatistics` rather than a dedicated endpoint:
+    /// Yahoo reports the current and prior-month settlement snapshots (with
+    /// `shortRatio` as days-to-cover), so the default keyless route serves
+    /// short interest without an API key. Route to Polygon for deeper history.
+    async fn fetch_short_interest(
+        &self,
+        symbol: &str,
+    ) -> Result<Vec<crate::models::fundamentals::ShortInterest>> {
+        let resp =
+            crate::adapters::yahoo::quote::summary::fetch_summary(&self.client, symbol).await?;
+        let stats = resp.default_key_statistics.ok_or_else(|| {
+            crate::error::FinanceError::ResponseStructureError {
+                field: "defaultKeyStatistics".into(),
+                context: format!("no key statistics returned for {symbol}"),
+            }
+        })?;
+
+        let mut out = Vec::new();
+        if let Some(shares) = stats.shares_short.as_ref().and_then(|v| v.raw) {
+            out.push(crate::models::fundamentals::ShortInterest {
+                settlement_date: stats
+                    .date_short_interest
+                    .as_ref()
+                    .and_then(|v| v.raw)
+                    .and_then(epoch_to_date),
+                short_interest: Some(shares as f64),
+                avg_daily_volume: None,
+                days_to_cover: stats.short_ratio.as_ref().and_then(|v| v.raw),
+            });
+        }
+        if let Some(shares) = stats.shares_short_prior_month.as_ref().and_then(|v| v.raw) {
+            out.push(crate::models::fundamentals::ShortInterest {
+                settlement_date: stats
+                    .shares_short_previous_month_date
+                    .as_ref()
+                    .and_then(|v| v.raw)
+                    .and_then(epoch_to_date),
+                short_interest: Some(shares as f64),
+                avg_daily_volume: None,
+                days_to_cover: None,
+            });
+        }
+        Ok(out)
+    }
+
+    /// Derived from `defaultKeyStatistics` (`floatShares` /
+    /// `sharesOutstanding`) rather than a dedicated endpoint.
+    async fn fetch_share_float(
+        &self,
+        symbol: &str,
+    ) -> Result<crate::models::fundamentals::ShareFloat> {
+        let resp =
+            crate::adapters::yahoo::quote::summary::fetch_summary(&self.client, symbol).await?;
+        let stats = resp.default_key_statistics.ok_or_else(|| {
+            crate::error::FinanceError::ResponseStructureError {
+                field: "defaultKeyStatistics".into(),
+                context: format!("no key statistics returned for {symbol}"),
+            }
+        })?;
+        Ok(crate::models::fundamentals::ShareFloat {
+            symbol: Some(symbol.to_string()),
+            float_shares: stats
+                .float_shares
+                .as_ref()
+                .and_then(|v| v.raw)
+                .map(|r| r as f64),
+            outstanding_shares: stats
+                .shares_outstanding
+                .as_ref()
+                .and_then(|v| v.raw)
+                .map(|r| r as f64),
+            date: None,
+        })
+    }
+
     async fn fetch_financials(
         &self,
         symbol: &str,

--- a/src/ticker/core.rs
+++ b/src/ticker/core.rs
@@ -794,6 +794,28 @@ impl Ticker {
             .await
     }
 
+    /// Fetch the company's own press releases via the configured
+    /// [`Capability::CORPORATE`] provider (currently FMP only). Distinct from
+    /// [`news`](Self::news), which returns press coverage.
+    pub async fn press_releases(
+        &self,
+        limit: u32,
+    ) -> Result<Vec<crate::models::corporate::press_release::PressRelease>> {
+        let symbol = self.symbol.clone();
+        self.providers
+            .fetch(Capability::CORPORATE, move |p| {
+                let symbol = symbol.clone();
+                let p = p.clone();
+                async move {
+                    p.as_corporate()
+                        .ok_or_else(|| p.not_supported(crate::providers::Operation::PressReleases))?
+                        .fetch_press_releases(&symbol, limit)
+                        .await
+                }
+            })
+            .await
+    }
+
     #[cfg(feature = "indicators")]
     /// Calculate a specific technical indicator over a time range.
     pub async fn indicator(

--- a/src/ticker/core.rs
+++ b/src/ticker/core.rs
@@ -736,6 +736,64 @@ impl Ticker {
             .await
     }
 
+    /// Fetch short-interest settlement reports via the configured
+    /// [`Capability::FUNDAMENTALS`] provider. The default Yahoo route derives
+    /// the current and prior-month snapshots from key statistics (keyless);
+    /// route to Polygon for the full bi-monthly history:
+    /// `.route(Capability::FUNDAMENTALS, [Provider::Polygon, Provider::Yahoo])`.
+    pub async fn short_interest(&self) -> Result<Vec<crate::models::fundamentals::ShortInterest>> {
+        let symbol = self.symbol.clone();
+        self.providers
+            .fetch(Capability::FUNDAMENTALS, move |p| {
+                let symbol = symbol.clone();
+                let p = p.clone();
+                async move {
+                    p.as_fundamentals()
+                        .ok_or_else(|| p.not_supported(crate::providers::Operation::ShortInterest))?
+                        .fetch_short_interest(&symbol)
+                        .await
+                }
+            })
+            .await
+    }
+
+    /// Fetch daily short-volume data via the configured
+    /// [`Capability::FUNDAMENTALS`] provider (currently Polygon only).
+    pub async fn short_volume(&self) -> Result<Vec<crate::models::fundamentals::ShortVolume>> {
+        let symbol = self.symbol.clone();
+        self.providers
+            .fetch(Capability::FUNDAMENTALS, move |p| {
+                let symbol = symbol.clone();
+                let p = p.clone();
+                async move {
+                    p.as_fundamentals()
+                        .ok_or_else(|| p.not_supported(crate::providers::Operation::ShortVolume))?
+                        .fetch_short_volume(&symbol)
+                        .await
+                }
+            })
+            .await
+    }
+
+    /// Fetch share float and shares outstanding via the configured
+    /// [`Capability::FUNDAMENTALS`] provider (Yahoo-derived on the default
+    /// route; Polygon serves it too).
+    pub async fn share_float(&self) -> Result<crate::models::fundamentals::ShareFloat> {
+        let symbol = self.symbol.clone();
+        self.providers
+            .fetch(Capability::FUNDAMENTALS, move |p| {
+                let symbol = symbol.clone();
+                let p = p.clone();
+                async move {
+                    p.as_fundamentals()
+                        .ok_or_else(|| p.not_supported(crate::providers::Operation::ShareFloat))?
+                        .fetch_share_float(&symbol)
+                        .await
+                }
+            })
+            .await
+    }
+
     #[cfg(feature = "indicators")]
     /// Calculate a specific technical indicator over a time range.
     pub async fn indicator(


### PR DESCRIPTION
## Description

Adds the library methods for #297–#300

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes

- `Index::constituents()` / `.constituent_changes()` — members and membership history of the S&P 500, Nasdaq 100, and Dow Jones (FMP; history is S&P 500 only). `MajorIndex::from_symbol` accepts common spellings (`^GSPC`, `SPX`, `sp500`, …).
- `Ticker::short_interest()` / `short_volume()` / `share_float()` — Yahoo serves short interest and float on the default keyless route (derived from its key-statistics quote data); Polygon adds the full bi-monthly history and daily short volume.
- `Filings::sections(accession, form)` / `.risk_factors()` — sectioned 10-K/8-K text and extracted risk factors (Polygon).
- `Market::gainers()` / `losers()` / `most_active()` now work on the default keyless route (derived from Yahoo's day-gainers/day-losers/most-actives screeners), with Alpha Vantage and FMP as keyed routes. `providers.market()` no longer requires a provider feature.
- `MarketCalendar::holidays()` — upcoming market holidays and early closes (Polygon).
- `Market::sector_performance_history(limit)` — daily per-sector performance history (FMP).
- `Ticker::press_releases(limit)` — the company's own releases, separate from the press coverage `news()` returns (FMP).

New public models: `MajorIndex`, `IndexConstituent`, `IndexConstituentChange`, `ShortInterest`, `ShortVolume`, `ShareFloat`, `FilingSection`, `FilingSectionForm`, `RiskFactor`, `PressRelease`, `SectorPerformanceHistory`, `CalendarKind::MarketHoliday`.

Library only — REST/GraphQL/MCP/CLI exposure comes separately.

## Breaking Changes

None — all additive.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] All tests pass (`cargo test --features full`)

## Documentation
- [x] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [x] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues
Closes #297
Closes #298
Closes #299
Closes #300