### PR TITLE
feat: nine keyless providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   against the world aggregate `WLD`. Annual/quarterly/monthly period labels are
   normalised to the `YYYY-MM-DD` start of the period and observations are
   returned oldest-first, matching every other `ECONOMIC` provider.
+- **US Treasury FiscalData** (`fiscaldata` feature, keyless) —
+  `Provider::FiscalData` serves `Capability::ECONOMIC` from the Treasury's own
+  publishing platform: federal debt (`"DEBT_TO_PENNY"`), average interest rates,
+  and Daily Treasury Statement cash balances. Six curated series ids cover the
+  common cases; any other dataset is reachable through the passthrough form
+  `"<dataset path>:<value column>"`. FiscalData encodes numbers as strings and
+  marks missing figures with the literal string `"null"` — both are normalised.
 - Index constituents: `providers.index("^GSPC").constituents()` and
   `.constituent_changes()` list the current members and membership history of
   the S&P 500, Nasdaq 100, and Dow Jones (FMP; changes are S&P 500 only).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   per date, matching FINRA's own consolidated daily file. A symbol with no
   reportable short volume returns an empty series rather than an error. Free
   for non-commercial use — see the provider docs.
+- **OpenFIGI identifier mapping** (`openfigi` feature, keyless) — new
+  crate-level `openfigi` module resolving a CUSIP, ISIN, SEDOL, or FIGI to the
+  instruments carrying it: `openfigi::resolve_cusip("037833100")`,
+  `resolve_isin`, `resolve_sedol`, and a positional batch `resolve_many` that
+  chunks to OpenFIGI's 10-per-request limit. New public types
+  `SecurityMapping` and `SecurityIdKind`. It sits beside `edgar` and `fred`
+  rather than behind the Providers API because resolution is not tied to a
+  symbol handle and maps onto no `Capability`. `OPENFIGI_API_KEY` is optional
+  and only raises the quota.
 - Index constituents: `providers.index("^GSPC").constituents()` and
   `.constituent_changes()` list the current members and membership history of
   the S&P 500, Nasdaq 100, and Dow Jones (FMP; changes are S&P 500 only).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **World Bank Open Data** (`worldbank` feature, keyless) — `Provider::WorldBank`
+  serves `Capability::ECONOMIC` with roughly 1,600 global development and macro
+  indicators across 200+ economies, closing the gap left by FRED's US focus.
+  Series are addressed as `"<COUNTRY>/<INDICATOR>"`
+  (`providers.economic("USA/NY.GDP.MKTP.CD")`); a bare indicator resolves
+  against the world aggregate `WLD`. Annual/quarterly/monthly period labels are
+  normalised to the `YYYY-MM-DD` start of the period and observations are
+  returned oldest-first, matching every other `ECONOMIC` provider.
 - Index constituents: `providers.index("^GSPC").constituents()` and
   `.constituent_changes()` list the current members and membership history of
   the S&P 500, Nasdaq 100, and Dow Jones (FMP; changes are S&P 500 only).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   common cases; any other dataset is reachable through the passthrough form
   `"<dataset path>:<value column>"`. FiscalData encodes numbers as strings and
   marks missing figures with the literal string `"null"` — both are normalised.
+- **BLS** (`bls` feature) — `Provider::Bls` serves `Capability::ECONOMIC` with
+  CPI, unemployment, payrolls, wages, and PPI from the primary source, using
+  native BLS series ids (`providers.economic("CUUR0000SA0")`). The first
+  provider with a **keyless/keyed dual mode**: without `BLS_API_KEY` it uses
+  the keyless v1 route (25 queries/day, ~3 years); with a key it uses v2 (500
+  queries/day, 20 years, plus catalog series titles). BLS's `"-"`
+  unpublished-value marker becomes `None`, and annual-aggregate rows (`M13` /
+  `Q05` / `S03`) are dropped so a monthly series stays strictly monthly.
 - Index constituents: `providers.index("^GSPC").constituents()` and
   `.constituent_changes()` list the current members and membership history of
   the S&P 500, Nasdaq 100, and Dow Jones (FMP; changes are S&P 500 only).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   longer than Binance's 1000-candle page cap are walked automatically (up to
   10,000 candles). A geo-block (HTTP 451) is reported as such and names Kraken
   as the alternative.
+- **Kraken public market data** (`kraken` feature, keyless) —
+  `Provider::Kraken` serves `Capability::CRYPTO` and `Capability::CHART` from
+  endpoints that are keyless *and* reachable from the US, unlike Binance. With
+  both providers, `CRYPTO` finally has a real `Fetch::Sequential` fallback
+  chain. Kraken's own conventions (`XBT` for Bitcoin, `XDG` for Dogecoin, the
+  legacy `X`/`Z` pair prefixes) are translated in both directions, so callers
+  pass normal tickers. Kraken caps `/OHLC` at ~720 candles ending at the
+  present with no way to page further back — deep history needs Binance or a
+  keyed provider.
 - Index constituents: `providers.index("^GSPC").constituents()` and
   `.constituent_changes()` list the current members and membership history of
   the S&P 500, Nasdaq 100, and Dow Jones (FMP; changes are S&P 500 only).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rather than behind the Providers API because resolution is not tied to a
   symbol handle and maps onto no `Capability`. `OPENFIGI_API_KEY` is optional
   and only raises the quota.
+- **DefiLlama** (`defi` feature, keyless) — the library's first on-chain data.
+  `Provider::DefiLlama` adds `CryptoCoin::tvl()` and `.tvl_history()` under
+  `Capability::CRYPTO` (protocol TVL, per-chain split, 1d/7d change, market
+  cap), and a new crate-level `defi` module carries the market-wide views:
+  `defi::chains()` and `defi::stablecoins()`, both ranked largest-first. New
+  public models `ProtocolTvl`, `ChainAllocation`, `TvlPoint`, `ChainTvl`, and
+  `StablecoinSupply`. Per-chain allocations exclude DefiLlama's breakdown keys
+  (`-borrowed`, `pool2`, `staking`), which describe the same capital and would
+  double-count. DefiLlama serves no prices, so `quote()` falls through to
+  another routed provider.
 - Index constituents: `providers.index("^GSPC").constituents()` and
   `.constituent_changes()` list the current members and membership history of
   the S&P 500, Nasdaq 100, and Dow Jones (FMP; changes are S&P 500 only).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pass normal tickers. Kraken caps `/OHLC` at ~720 candles ending at the
   present with no way to page further back — deep history needs Binance or a
   keyed provider.
+- **FINRA short-sale volume** (`finra` feature, keyless) — `Provider::Finra`
+  serves the short-volume slice of `Capability::FUNDAMENTALS`, giving
+  `Ticker::short_volume()` a keyless provider reading from the primary source
+  rather than requiring Polygon. FINRA reports each symbol once per reporting
+  facility per day (Nasdaq / NYSE / OTC); the adapter sums them into one figure
+  per date, matching FINRA's own consolidated daily file. A symbol with no
+  reportable short volume returns an empty series rather than an error. Free
+  for non-commercial use — see the provider docs.
 - Index constituents: `providers.index("^GSPC").constituents()` and
   `.constituent_changes()` list the current members and membership history of
   the S&P 500, Nasdaq 100, and Dow Jones (FMP; changes are S&P 500 only).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ECB rates are a daily reference fix, so quotes carry a price and a change
   against the previous *published* day but no bid/ask. A pair of identical
   currencies is answered locally with `1.0` rather than Frankfurter's HTTP 422.
+- **Binance public market data** (`binance` feature, keyless) —
+  `Provider::Binance` serves `Capability::CRYPTO` (rolling 24-hour quotes) and
+  `Capability::CHART` (arbitrary-interval OHLCV), the first keyless source of
+  exchange-grade crypto data. Symbols normalise across every spelling the
+  library uses (`bitcoin`, `BTC`, `BTC-USD`, `BTCUSDT`); note that Binance
+  lists no USD spot markets, so `"usd"` maps to the USDT stablecoin. Windows
+  longer than Binance's 1000-candle page cap are walked automatically (up to
+  10,000 candles). A geo-block (HTTP 451) is reported as such and names Kraken
+  as the alternative.
 - Index constituents: `providers.index("^GSPC").constituents()` and
   `.constituent_changes()` list the current members and membership history of
   the S&P 500, Nasdaq 100, and Dow Jones (FMP; changes are S&P 500 only).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   queries/day, 20 years, plus catalog series titles). BLS's `"-"`
   unpublished-value marker becomes `None`, and annual-aggregate rows (`M13` /
   `Q05` / `S03`) are dropped so a monthly series stays strictly monthly.
+- **Frankfurter / ECB reference rates** (`frankfurter` feature, keyless) —
+  `Provider::Frankfurter` serves `Capability::FOREX`, the first keyless route
+  for that capability: `providers.forex("USD", "EUR").quote()` now works with
+  nothing configured, where previously every forex route needed an API key.
+  ECB rates are a daily reference fix, so quotes carry a price and a change
+  against the previous *published* day but no bid/ask. A pair of identical
+  currencies is answered locally with `1.0` rather than Frankfurter's HTTP 422.
 - Index constituents: `providers.index("^GSPC").constituents()` and
   `.constituent_changes()` list the current members and membership history of
   the S&P 500, Nasdaq 100, and Dow Jones (FMP; changes are S&P 500 only).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,7 @@ full = [
     "kraken",
     "finra",
     "openfigi",
+    "defi",
 ]
 # Enable DataFrame conversions with polars
 dataframe = ["dep:polars"]
@@ -144,6 +145,8 @@ kraken = []
 finra = []
 # Enable OpenFIGI CUSIP/ISIN/SEDOL to ticker mapping (keyless)
 openfigi = []
+# Enable DefiLlama DeFi TVL, chain rankings, and stablecoin supplies (keyless)
+defi = []
 # Enable offline VADER lexicon-based news/transcript sentiment scoring
 sentiment = ["dep:vader_sentiment"]
 # Enable Alpha Vantage financial data API
@@ -192,6 +195,7 @@ features = [
     "kraken",
     "finra",
     "openfigi",
+    "defi",
 ]
 rustdoc-args = ["--cfg", "docsrs"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,7 @@ full = [
     "binance",
     "kraken",
     "finra",
+    "openfigi",
 ]
 # Enable DataFrame conversions with polars
 dataframe = ["dep:polars"]
@@ -141,6 +142,8 @@ binance = []
 kraken = []
 # Enable FINRA daily short-sale volume (free, non-commercial use)
 finra = []
+# Enable OpenFIGI CUSIP/ISIN/SEDOL to ticker mapping (keyless)
+openfigi = []
 # Enable offline VADER lexicon-based news/transcript sentiment scoring
 sentiment = ["dep:vader_sentiment"]
 # Enable Alpha Vantage financial data API
@@ -188,6 +191,7 @@ features = [
     "binance",
     "kraken",
     "finra",
+    "openfigi",
 ]
 rustdoc-args = ["--cfg", "docsrs"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ full = [
     "worldbank",
     "fiscaldata",
     "bls",
+    "frankfurter",
 ]
 # Enable DataFrame conversions with polars
 dataframe = ["dep:polars"]
@@ -129,6 +130,8 @@ worldbank = []
 fiscaldata = []
 # Enable BLS labor/inflation statistics (keyless v1; BLS_API_KEY upgrades to v2)
 bls = []
+# Enable Frankfurter ECB reference exchange rates (keyless forex)
+frankfurter = []
 # Enable offline VADER lexicon-based news/transcript sentiment scoring
 sentiment = ["dep:vader_sentiment"]
 # Enable Alpha Vantage financial data API
@@ -172,6 +175,7 @@ features = [
     "worldbank",
     "fiscaldata",
     "bls",
+    "frankfurter",
 ]
 rustdoc-args = ["--cfg", "docsrs"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ full = [
     "risk",
     "translation",
     "sentiment",
+    "worldbank",
 ]
 # Enable DataFrame conversions with polars
 dataframe = ["dep:polars"]
@@ -120,6 +121,8 @@ backtesting = ["indicators", "dep:rayon"]
 fred = ["dep:csv"]
 # Enable CoinGecko cryptocurrency data
 crypto = []
+# Enable World Bank Open Data global macro indicators (keyless)
+worldbank = []
 # Enable offline VADER lexicon-based news/transcript sentiment scoring
 sentiment = ["dep:vader_sentiment"]
 # Enable Alpha Vantage financial data API
@@ -160,6 +163,7 @@ features = [
     "risk",
     "translation",
     "sentiment",
+    "worldbank",
 ]
 rustdoc-args = ["--cfg", "docsrs"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,7 @@ full = [
     "frankfurter",
     "binance",
     "kraken",
+    "finra",
 ]
 # Enable DataFrame conversions with polars
 dataframe = ["dep:polars"]
@@ -138,6 +139,8 @@ frankfurter = []
 binance = []
 # Enable Kraken public market data (keyless crypto, US-accessible)
 kraken = []
+# Enable FINRA daily short-sale volume (free, non-commercial use)
+finra = []
 # Enable offline VADER lexicon-based news/transcript sentiment scoring
 sentiment = ["dep:vader_sentiment"]
 # Enable Alpha Vantage financial data API
@@ -184,6 +187,7 @@ features = [
     "frankfurter",
     "binance",
     "kraken",
+    "finra",
 ]
 rustdoc-args = ["--cfg", "docsrs"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ full = [
     "translation",
     "sentiment",
     "worldbank",
+    "fiscaldata",
 ]
 # Enable DataFrame conversions with polars
 dataframe = ["dep:polars"]
@@ -123,6 +124,8 @@ fred = ["dep:csv"]
 crypto = []
 # Enable World Bank Open Data global macro indicators (keyless)
 worldbank = []
+# Enable US Treasury FiscalData federal debt/interest statistics (keyless)
+fiscaldata = []
 # Enable offline VADER lexicon-based news/transcript sentiment scoring
 sentiment = ["dep:vader_sentiment"]
 # Enable Alpha Vantage financial data API
@@ -164,6 +167,7 @@ features = [
     "translation",
     "sentiment",
     "worldbank",
+    "fiscaldata",
 ]
 rustdoc-args = ["--cfg", "docsrs"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,7 @@ full = [
     "bls",
     "frankfurter",
     "binance",
+    "kraken",
 ]
 # Enable DataFrame conversions with polars
 dataframe = ["dep:polars"]
@@ -135,6 +136,8 @@ bls = []
 frankfurter = []
 # Enable Binance public market data (keyless crypto quotes + OHLCV)
 binance = []
+# Enable Kraken public market data (keyless crypto, US-accessible)
+kraken = []
 # Enable offline VADER lexicon-based news/transcript sentiment scoring
 sentiment = ["dep:vader_sentiment"]
 # Enable Alpha Vantage financial data API
@@ -180,6 +183,7 @@ features = [
     "bls",
     "frankfurter",
     "binance",
+    "kraken",
 ]
 rustdoc-args = ["--cfg", "docsrs"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ full = [
     "fiscaldata",
     "bls",
     "frankfurter",
+    "binance",
 ]
 # Enable DataFrame conversions with polars
 dataframe = ["dep:polars"]
@@ -132,6 +133,8 @@ fiscaldata = []
 bls = []
 # Enable Frankfurter ECB reference exchange rates (keyless forex)
 frankfurter = []
+# Enable Binance public market data (keyless crypto quotes + OHLCV)
+binance = []
 # Enable offline VADER lexicon-based news/transcript sentiment scoring
 sentiment = ["dep:vader_sentiment"]
 # Enable Alpha Vantage financial data API
@@ -176,6 +179,7 @@ features = [
     "fiscaldata",
     "bls",
     "frankfurter",
+    "binance",
 ]
 rustdoc-args = ["--cfg", "docsrs"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ full = [
     "sentiment",
     "worldbank",
     "fiscaldata",
+    "bls",
 ]
 # Enable DataFrame conversions with polars
 dataframe = ["dep:polars"]
@@ -126,6 +127,8 @@ crypto = []
 worldbank = []
 # Enable US Treasury FiscalData federal debt/interest statistics (keyless)
 fiscaldata = []
+# Enable BLS labor/inflation statistics (keyless v1; BLS_API_KEY upgrades to v2)
+bls = []
 # Enable offline VADER lexicon-based news/transcript sentiment scoring
 sentiment = ["dep:vader_sentiment"]
 # Enable Alpha Vantage financial data API
@@ -168,6 +171,7 @@ features = [
     "sentiment",
     "worldbank",
     "fiscaldata",
+    "bls",
 ]
 rustdoc-args = ["--cfg", "docsrs"]
 

--- a/docs/library/providers/binance.md
+++ b/docs/library/providers/binance.md
@@ -1,0 +1,88 @@
+# Binance (public market data)
+
+!!! info "Feature flag required"
+    ```toml
+    finance-query = { version = "...", features = ["binance"] }
+    ```
+
+Binance's public market-data endpoints need no API key. The adapter talks to `data-api.binance.vision` — the market-data-only host, which serves the same public endpoints as `api.binance.com` but carries no account or trading routes, so there is no key to configure and none to leak.
+
+This is the first keyless source of *exchange-grade* crypto data in the library: CoinGecko is aggregated and coarse, and the keyed providers charge for OHLCV.
+
+!!! warning "Geo-blocked in some regions"
+    Binance restricts some regions (notably US retail) and answers with HTTP 451. That surfaces as a `FinanceError::ApiError` naming [Kraken](kraken.md) as the alternative. Chain the two if you need coverage everywhere.
+
+## Capabilities
+
+| Capability | What Binance serves |
+|------------|--------------------|
+| `CRYPTO` | Rolling 24-hour quote per spot market |
+| `CHART` | Arbitrary-interval OHLCV klines |
+
+```rust
+use finance_query::{Capability, Interval, Provider, Providers, TimeRange};
+
+let providers = Providers::builder()
+    .route(Capability::CRYPTO, [Provider::Binance])
+    .route(Capability::CHART, [Provider::Binance])
+    .build()
+    .await?;
+
+let btc = providers.crypto("bitcoin");
+let quote = btc.quote("usd").await?;
+println!("BTC {:?} ({:+.2?}%)", quote.price, quote.change_percent_24h);
+
+let chart = btc.chart("usd", Interval::OneHour, TimeRange::OneMonth).await?;
+println!("{} hourly candles", chart.candles.len());
+```
+
+!!! note "Routing `CHART` is global"
+    `Capability::CHART` is one route for the whole library. Pointing it at Binance means equity charts go there too — Binance answers a symbol it cannot map to a spot market with `NotSupported`, so under `Fetch::Sequential` list Yahoo after it:
+    `.route(Capability::CHART, [Provider::Binance, Provider::Yahoo])`
+
+## Symbols
+
+Binance names a market as one concatenated string with no separator (`BTCUSDT`). Every spelling the library uses is accepted:
+
+| You pass | Binance market |
+|----------|---------------|
+| `crypto("bitcoin").quote("usd")` | `BTCUSDT` |
+| `crypto("BTC").quote("eur")` | `BTCEUR` |
+| chart symbol `BTC-USD` | `BTCUSDT` |
+| chart symbol `BTCUSDT` | `BTCUSDT` |
+| chart symbol `ETH/BTC` | `ETHBTC` |
+
+CoinGecko-style coin ids are recognised for about 25 majors so a route swap between CoinGecko and Binance does not change your call sites. Anything not in that list is treated as a ticker, which is usually right.
+
+!!! warning "USD means USDT"
+    Binance spot lists **no USD markets** — dollar pairs are quoted in the USDT stablecoin. `"usd"` is therefore mapped to `USDT`. That is what callers mean in practice, but USDT is not literally the US dollar and can trade off its peg.
+
+## Response Notes
+
+`CryptoQuote`:
+
+- `volume_24h` is the **quote-asset** volume (dollars for a `*USDT` market), which is the figure comparable to other providers — not the base-asset volume Binance also returns.
+- `market_cap` and `circulating_supply` are always `None`. An exchange knows what trades on it, not how much of an asset exists; route `CRYPTO` to CoinGecko for supply-side figures.
+- `name` is the full coin name for the recognised majors, and the ticker otherwise.
+
+`Chart`:
+
+- Binance timestamps candles in milliseconds; they are converted to the library's seconds.
+- `adj_close` mirrors `close` — crypto has no corporate actions to adjust for.
+- `volume` is base-asset volume truncated to an integer to fit the `Candle` model, so sub-unit volumes round toward zero.
+
+## Intervals
+
+Every library interval maps to a Binance kline code except `ThreeMonths`, which Binance does not offer — that returns `NotSupported`, so sequential routing falls through to the next provider.
+
+Binance caps a single kline response at 1000 candles. Longer windows are walked forward automatically, up to 10 requests (10,000 candles) per chart — enough for five years of daily or a year of hourly data.
+
+## Rate Limits
+
+Binance meters by request weight (6000 per minute per IP); the endpoints used here are weight 1–2. The client paces at 10 requests/second, well inside that. A `429` — or a `418`, Binance's "you ignored a 429" ban — surfaces as [`FinanceError::RateLimited`](../error-handling.md).
+
+## Next Steps
+
+- [Kraken](kraken.md) — the US-accessible sibling
+- [CoinGecko](coingecko.md) — aggregated market caps and supply
+- [Crypto Domain](../crypto.md) — the `CryptoCoin` handle

--- a/docs/library/providers/bls.md
+++ b/docs/library/providers/bls.md
@@ -1,0 +1,91 @@
+# BLS (Bureau of Labor Statistics)
+
+!!! info "Feature flag required"
+    ```toml
+    finance-query = { version = "...", features = ["bls"] }
+    ```
+
+The [BLS Public Data API](https://www.bls.gov/developers/) is the primary source for US CPI, unemployment, payrolls, average hourly earnings, and PPI. Alpha Vantage exposes a fixed handful of these, and FRED mirrors them with a lag behind a key — BLS publishes them first.
+
+## Keyless / keyed dual mode
+
+BLS is the only provider in the library that works both with and without a key, and it decides per call:
+
+| | No key | `BLS_API_KEY` set |
+|---|--------|-------------------|
+| API version | v1 | v2 |
+| Daily quota | 25 queries per IP | 500 queries |
+| History per request | ~3 years | 20 years |
+| Series title | not returned | returned (`catalog`) |
+
+Nothing else differs — the same series ids, the same `EconomicSeries` response. Get a free key at [data.bls.gov/registrationEngine](https://data.bls.gov/registrationEngine/) and export it:
+
+```bash
+export BLS_API_KEY="your-bls-key"
+```
+
+The tier is resolved on every request, so exporting a key mid-process takes effect immediately.
+
+## Setup
+
+```rust
+use finance_query::{Capability, Provider, Providers};
+
+let providers = Providers::builder()
+    .route(Capability::ECONOMIC, [Provider::Bls])
+    .build()
+    .await?;
+
+let cpi = providers.economic("CUUR0000SA0").series().await?;
+for obs in cpi.observations.iter().rev().take(3) {
+    println!("{} {:?}", obs.date, obs.value);
+}
+```
+
+## Series Identifiers
+
+Series are addressed by their native BLS id. Common ones:
+
+| Series id | Description | Frequency |
+|-----------|-------------|-----------|
+| `CUUR0000SA0` | CPI-U, all items, US city average (NSA) | Monthly |
+| `CUSR0000SA0` | CPI-U, all items, US city average (SA) | Monthly |
+| `CUUR0000SA0L1E` | CPI-U, all items less food and energy | Monthly |
+| `LNS14000000` | Unemployment rate | Monthly |
+| `LNS11300000` | Labor force participation rate | Monthly |
+| `CES0000000001` | Total nonfarm payroll employment | Monthly |
+| `CES0500000003` | Average hourly earnings, private | Monthly |
+| `WPUFD4` | PPI, final demand | Monthly |
+
+Full series-id structure is documented in the [BLS series-id guide](https://www.bls.gov/help/hlpforma.htm).
+
+## Response Shape
+
+Results come back as the provider-neutral [`EconomicSeries`](../economic.md):
+
+| Field | Value from BLS |
+|-------|---------------|
+| `series_id` | The BLS id you passed in |
+| `title` | The catalog series title — keyed v2 only, `None` on the keyless route |
+| `units` | Always `None`; BLS returns no unit field, and the unit is implied by the series id |
+| `frequency` | `"Monthly"`, `"Quarterly"`, `"Semiannual"`, or `"Annual"`, from the period codes |
+| `observations` | Chronological (oldest first) |
+
+Two BLS conventions are normalised:
+
+- A value of `"-"` (a figure BLS could not publish — e.g. the 2025 appropriations lapse) becomes `value: None`, not a parse error.
+- **Annual-aggregate rows are dropped.** BLS folds an annual average into an otherwise monthly series as period `M13` (and `Q05` / `S03` for quarterly and semiannual series). Keeping them would put two observations on the same year with incompatible meanings, so they are omitted.
+
+## Errors
+
+BLS answers an unknown series id with `REQUEST_SUCCEEDED`, an empty data array, and the complaint in a `message` field. That surfaces as `FinanceError::SymbolNotFound` carrying the BLS text, rather than as a silent empty series. A genuine failure status (quota exhausted, malformed request) surfaces as `FinanceError::MacroDataError`.
+
+## Rate Limits
+
+The BLS quota is **daily**, not per-second, so it cannot be enforced client-side; the client paces at 2 requests/second only to avoid looking abusive. Exhausting the daily quota returns a `REQUEST_NOT_PROCESSED` status, which surfaces as `MacroDataError` with the BLS explanation.
+
+## Next Steps
+
+- [FRED](fred.md) — the same series mirrored, plus 800k others
+- [US Treasury FiscalData](fiscaldata.md) — keyless federal fiscal data
+- [Providers Overview](index.md) — routing and fallback

--- a/docs/library/providers/defillama.md
+++ b/docs/library/providers/defillama.md
@@ -1,0 +1,92 @@
+# DefiLlama (DeFi TVL)
+
+!!! info "Feature flag required"
+    ```toml
+    finance-query = { version = "...", features = ["defi"] }
+    ```
+
+The library covered CeFi crypto — exchange quotes, aggregated market caps — but nothing on-chain. [DefiLlama](https://defillama.com/docs/api) is the FOSS standard for DeFi: keyless, no registration, stable endpoints.
+
+## Two Surfaces
+
+DefiLlama data splits by what it is *about*:
+
+| Data | Where it lives | Why |
+|------|---------------|-----|
+| Protocol TVL and its history | `CryptoCoin::tvl()` / `.tvl_history()`, routed through `Capability::CRYPTO` | It is about one named thing, like a quote |
+| Chain rankings, stablecoin supplies | `finance_query::defi::chains()` / `stablecoins()` | Market-wide; there is no symbol to hang it off |
+
+## Protocol TVL
+
+```rust
+use finance_query::{Capability, Provider, Providers};
+
+let providers = Providers::builder()
+    .route(Capability::CRYPTO, [Provider::DefiLlama])
+    .build()
+    .await?;
+
+let aave = providers.crypto("aave");
+let tvl = aave.tvl().await?;
+
+println!("{} — ${:?}", tvl.name.unwrap_or_default(), tvl.tvl);
+println!("1d {:?}%  7d {:?}%", tvl.change_1d_percent, tvl.change_7d_percent);
+for allocation in &tvl.tvl_by_chain {
+    println!("  {}: ${:.0}", allocation.chain, allocation.tvl);
+}
+
+let history = aave.tvl_history().await?;   // oldest first
+```
+
+!!! warning "The handle id is a protocol slug, not a coin id"
+    `providers.crypto("aave")` reads its id as a **DefiLlama protocol slug** for the TVL methods and as a coin id for `quote()`. Most slugs happen to match their CoinGecko id, but not all do — check [defillama.com](https://defillama.com/) for the slug in the protocol's URL. Ids are lowercased and hyphenated before use, so `"Curve DEX"` resolves to `curve-dex`.
+
+!!! note "DefiLlama serves no prices"
+    `fetch_crypto_quote` reports `NotSupported`, so a `CRYPTO` route that includes DefiLlama should also include an exchange or aggregator for `quote()` to resolve:
+    `.route(Capability::CRYPTO, [Provider::DefiLlama, Provider::CoinGecko])`
+
+### Per-chain allocations
+
+DefiLlama's `currentChainTvls` mixes genuine chain keys (`"Ethereum"`) with breakdown keys of the *same* capital (`"Ethereum-borrowed"`, `"pool2"`, `"staking"`). Summing everything would double-count, so `tvl_by_chain` keeps only keys naming a chain the protocol actually reports, sorted largest first.
+
+The headline `tvl` is the latest history snapshot, not a sum of those allocations.
+
+### Change percentages
+
+`change_1d_percent` and `change_7d_percent` are computed from the history against the closest snapshot **at or before** that instant. They are `None` when the protocol has no snapshot old enough to compare against — a new protocol reports no 7-day change rather than a fabricated one.
+
+## Market-Wide Views
+
+```rust
+use finance_query::defi;
+
+// Chains ranked by total value locked
+for chain in defi::chains().await?.into_iter().take(10) {
+    println!("{:<15} ${:?}", chain.name, chain.tvl);
+}
+
+// Stablecoins ranked by circulating supply
+for coin in defi::stablecoins().await?.into_iter().take(10) {
+    println!(
+        "{:<10} {:?} ({:?})",
+        coin.symbol.unwrap_or_default(),
+        coin.circulating,
+        coin.peg_mechanism
+    );
+}
+```
+
+Both come back sorted largest-first; DefiLlama itself returns them unordered.
+
+!!! warning "Stablecoin supplies are denominated in the pegged asset"
+    `circulating` is expressed in whatever `peg_type` names — `peggedUSD`, `peggedEUR`, and so on. Read `peg_type` before summing across coins, or you will add euros to dollars. `circulating_prev_day` / `_week` / `_month` are provided for change calculations.
+
+## Rate Limits
+
+DefiLlama publishes no quota for the free API but throttles abusive clients. The adapter paces at 5 requests/second, with a longer 45-second timeout than usual — the protocol and stablecoin payloads are large.
+
+## Next Steps
+
+- [CoinGecko](coingecko.md) — prices and market caps to pair with TVL
+- [Crypto Domain](../crypto.md) — the `CryptoCoin` handle
+- [Providers Overview](index.md) — routing and fallback

--- a/docs/library/providers/finra.md
+++ b/docs/library/providers/finra.md
@@ -1,0 +1,72 @@
+# FINRA (short sale volume)
+
+!!! info "Feature flag required"
+    ```toml
+    finance-query = { version = "...", features = ["finra"] }
+    ```
+
+FINRA publishes daily aggregated short-sale volume for every reported security through its [Query API](https://developer.finra.org/), free and without credentials.
+
+`Ticker::short_volume()` previously needed Polygon. Routing `FUNDAMENTALS` to FINRA gives it a keyless provider reading from the primary source.
+
+!!! warning "Free for non-commercial use"
+    FINRA's Query API is free for **non-commercial** use; commercial use requires an agreement with FINRA. That is a licensing question this adapter does not change — check your use case before shipping.
+
+## Setup
+
+```rust
+use finance_query::{Capability, Provider, Providers};
+
+let providers = Providers::builder()
+    .route(Capability::FUNDAMENTALS, [Provider::Finra, Provider::Yahoo])
+    .build()
+    .await?;
+
+let ticker = providers.ticker("AAPL").build().await?;
+for day in ticker.short_volume().await? {
+    println!(
+        "{} short {:?} of {:?}",
+        day.date.unwrap_or_default(),
+        day.short_volume,
+        day.total_volume
+    );
+}
+```
+
+!!! note "FINRA serves short volume only"
+    FINRA publishes no financial statements, so `fetch_financials` reports `NotSupported` and dispatch falls through. Under `Fetch::Sequential`, list a full `FUNDAMENTALS` provider after it — as in the example above — so `financials()` still resolves.
+
+## What the Numbers Mean
+
+FINRA reports each symbol **once per reporting facility per day** — the Nasdaq (`Q`), NYSE (`N`), and OTC (`B`) trade reporting facilities each file separately. A listed name therefore has three raw rows for a single trading day.
+
+The adapter sums them into one figure per date, reproducing the consolidated numbers FINRA itself publishes in its daily `CNMSshvol` file:
+
+| `ShortVolume` field | Source |
+|---------------------|--------|
+| `date` | `tradeReportDate` (`YYYY-MM-DD`) |
+| `short_volume` | Sum of `shortParQuantity` across facilities |
+| `short_exempt_volume` | Sum of `shortExemptParQuantity` |
+| `total_volume` | Sum of `totalParQuantity` |
+
+A field no facility reported stays `None` rather than becoming `0.0`.
+
+!!! info "Short volume is not short interest"
+    Short *volume* is how many shares were sold short on a given day — much of it market-maker hedging that closes intraday. Short *interest* is the open short position at a settlement date. For the latter, use `Ticker::short_interest()`, which Yahoo and Polygon serve.
+
+## History Depth and Ordering
+
+FINRA keeps roughly a rolling year online, and one call requests that whole window.
+
+Results come back oldest-first. That ordering is applied locally, because FINRA rejects server-side sorting unless every partition key is pinned with an equality filter — which a date *range* by definition does not do.
+
+A symbol with no reportable short volume returns an **empty series, not an error**: FINRA answers such a query with HTTP 204 and no body.
+
+## Rate Limits
+
+FINRA's anonymous tier is metered per day rather than per second. The client paces at 2 requests/second purely to avoid looking abusive; a free developer account raises the quota but is not required.
+
+## Next Steps
+
+- [Polygon.io](polygon.md) — short interest history and short volume, keyed
+- [Providers Overview](index.md) — routing and fallback

--- a/docs/library/providers/fiscaldata.md
+++ b/docs/library/providers/fiscaldata.md
@@ -1,0 +1,91 @@
+# US Treasury FiscalData
+
+!!! info "Feature flag required"
+    ```toml
+    finance-query = { version = "...", features = ["fiscaldata"] }
+    ```
+
+[FiscalData](https://fiscaldata.treasury.gov/) is the US Treasury's own publishing platform for federal debt, interest rates, and the Daily Treasury Statement. It is **keyless** — no registration, no API key, no environment variable.
+
+FRED mirrors part of this data with a lag and needs a key; FiscalData is the primary source.
+
+## Setup
+
+```rust
+use finance_query::{Capability, Provider, Providers};
+
+let providers = Providers::builder()
+    .route(Capability::ECONOMIC, [Provider::FiscalData])
+    .build()
+    .await?;
+
+let debt = providers.economic("DEBT_TO_PENNY").series().await?;
+println!("{}", debt.title.unwrap_or_default());  // "Total Public Debt Outstanding"
+
+if let Some(latest) = debt.observations.last() {
+    println!("{}: {:?}", latest.date, latest.value);
+}
+```
+
+## Curated Series
+
+FiscalData organises its data as ~50 datasets with dozens of columns each, so the adapter names the common single-value series directly:
+
+| Series id | Dataset | Column | Units | Frequency |
+|-----------|---------|--------|-------|-----------|
+| `DEBT_TO_PENNY` | `v2/accounting/od/debt_to_penny` | `tot_pub_debt_out_amt` | US Dollars | Daily |
+| `DEBT_HELD_BY_PUBLIC` | `v2/accounting/od/debt_to_penny` | `debt_held_public_amt` | US Dollars | Daily |
+| `INTRAGOVERNMENTAL_HOLDINGS` | `v2/accounting/od/debt_to_penny` | `intragov_hold_amt` | US Dollars | Daily |
+| `AVG_INTEREST_RATE` | `v2/accounting/od/avg_interest_rates` | `avg_interest_rate_amt` | Percent | Monthly |
+| `AVG_INTEREST_RATE_MARKETABLE` | `v2/accounting/od/avg_interest_rates` | `avg_interest_rate_amt` | Percent | Monthly |
+| `OPERATING_CASH_BALANCE` | `v1/accounting/dts/operating_cash_balance` | `open_today_bal` | Millions of US Dollars | Daily |
+
+Series ids are matched case-insensitively.
+
+The two `AVG_INTEREST_RATE*` entries read the same column with different row filters — `Total Interest-bearing Debt` and `Total Marketable` respectively — because that dataset stacks one series per security type.
+
+!!! warning "Units differ per dataset"
+    FiscalData's own metadata reports only `CURRENCY` / `PERCENTAGE`, which cannot distinguish dollars from millions of dollars. The curated table above states the real unit; Daily Treasury Statement figures (`OPERATING_CASH_BALANCE`) are in **millions**.
+
+## Any Other Dataset
+
+Anything outside the curated list is reachable with the passthrough form `"<dataset path>:<value column>"`:
+
+```rust
+let series = providers
+    .economic("v2/accounting/od/debt_to_penny:debt_held_public_amt")
+    .series()
+    .await?;
+```
+
+Dataset paths and column names come from the [FiscalData dataset catalogue](https://fiscaldata.treasury.gov/datasets/). Passthrough series report `units` from the column's declared type and leave `frequency` as `None` — the adapter will not guess.
+
+Passing anything that is neither a curated id nor a `dataset:column` pair returns `FinanceError::InvalidParameter` listing the curated catalogue.
+
+## Response Shape
+
+Results come back as the provider-neutral [`EconomicSeries`](../economic.md):
+
+| Field | Value from FiscalData |
+|-------|----------------------|
+| `series_id` | The string you passed in |
+| `title` | The column's human label from the response metadata |
+| `units` | From the curated table, or the column type for passthrough series |
+| `frequency` | From the curated table; `None` for passthrough series |
+| `observations` | Chronological (oldest first), keyed by `record_date` |
+
+FiscalData encodes every column as a string, including numbers, and marks a missing figure with the literal string `"null"` — both are normalised, so `value` is a real `Option<f64>`.
+
+## Pagination
+
+Series are fetched at the API's maximum page size (10,000 rows) and pagination is followed automatically, capped at 5 pages. A dataset larger than that logs a warning rather than silently returning a truncated series.
+
+## Rate Limits
+
+FiscalData publishes no documented quota. The client paces itself at 5 requests/second, and a `429` surfaces as [`FinanceError::RateLimited`](../error-handling.md).
+
+## Next Steps
+
+- [FRED](fred.md) — 800k+ US macro series, including Treasury yield curves
+- [World Bank](worldbank.md) — keyless global macro indicators
+- [Providers Overview](index.md) — routing and fallback

--- a/docs/library/providers/frankfurter.md
+++ b/docs/library/providers/frankfurter.md
@@ -1,0 +1,70 @@
+# Frankfurter (ECB reference rates)
+
+!!! info "Feature flag required"
+    ```toml
+    finance-query = { version = "...", features = ["frankfurter"] }
+    ```
+
+[Frankfurter](https://frankfurter.dev/) publishes the European Central Bank's daily reference exchange rates over a keyless JSON API — no registration, no API key.
+
+It is the **only keyless `FOREX` route** in the library. Polygon, FMP, and Alpha Vantage all require a key, which meant `providers.forex()` did nothing out of the box; Frankfurter closes the same gap for forex that Yahoo covers for quotes, CoinGecko for crypto, and EDGAR for filings.
+
+## Setup
+
+```rust
+use finance_query::{Capability, Provider, Providers};
+
+let providers = Providers::builder()
+    .route(Capability::FOREX, [Provider::Frankfurter])
+    .build()
+    .await?;
+
+let quote = providers.forex("USD", "EUR").quote().await?;
+println!("USD/EUR {:?} ({:+.2?}%)", quote.price, quote.change_percent);
+```
+
+## What ECB Reference Rates Are
+
+!!! warning "A daily fix, not a live feed"
+    The ECB publishes one set of reference rates per TARGET working day, around 16:00 CET. They are indicative — a reference for accounting and statistics, not a tradable price.
+
+That shapes the response:
+
+| Field | Value from Frankfurter |
+|-------|-----------------------|
+| `symbol` | `"USDEUR"` — base and quote concatenated |
+| `base_currency` / `quote_currency` | The pair you asked for, uppercased |
+| `price` | The most recently published rate |
+| `bid` / `ask` | Always `None` — a reference fix has no two-way price, and inventing a spread would misrepresent it |
+| `change` / `change_percent` | Against the previously published rate, which is the prior *working* day, not necessarily yesterday |
+| `timestamp` | Midnight UTC of the publication date — the ECB fix carries no intraday time |
+
+If you need intraday rates or a real bid/ask, route `FOREX` to a keyed provider first and leave Frankfurter as the fallback:
+
+```rust
+let providers = Providers::builder()
+    .route(Capability::FOREX, [Provider::Polygon, Provider::Frankfurter])
+    .build()
+    .await?;
+```
+
+## Coverage
+
+Roughly 30 currencies — the set the ECB publishes against the euro, with any pair among them derivable. Notably **not** included: most emerging-market currencies, and cryptocurrencies. Requesting a currency the ECB does not publish returns `FinanceError::SymbolNotFound`.
+
+Passing the same currency twice (`forex("USD", "USD")`) is answered locally with a rate of `1.0`; Frankfurter itself rejects that pair with HTTP 422.
+
+## Historical Rates
+
+`ForexPair::chart()` and `history()` route through `Capability::CHART`, which Frankfurter does not serve — those still resolve on the Yahoo default route (or whichever provider you route `CHART` to). Frankfurter contributes the current-rate path only.
+
+## Rate Limits
+
+Frankfurter is free and unmetered but community-run. The client paces itself at 5 requests/second, and a `429` surfaces as [`FinanceError::RateLimited`](../error-handling.md).
+
+Each quote costs exactly one request: the adapter asks for a short date range rather than the `latest` endpoint, so the current rate and the previous close needed for the day's change arrive together.
+
+## Next Steps
+
+- [Forex Domain](../forex.md) — the `ForexPair` handle
+- [Providers Overview](index.md) — routing and fallback

--- a/docs/library/providers/index.md
+++ b/docs/library/providers/index.md
@@ -30,6 +30,7 @@ Yahoo Finance is always available with no configuration. All others are opt-in v
 | **Binance** | `binance` | Keyless | *(keyless)* |
 | **Kraken** | `kraken` | Keyless | *(keyless)* |
 | **FINRA** | `finra` | Keyless (non-commercial) | *(keyless)* |
+| **OpenFIGI** | `openfigi` | Keyless 25 req/min | `OPENFIGI_API_KEY` *(optional)* |
 | **SEC EDGAR** | *(always available)* | Keyless | *(email via `edgar::init`)* |
 
 ```toml

--- a/docs/library/providers/index.md
+++ b/docs/library/providers/index.md
@@ -23,6 +23,7 @@ Yahoo Finance is always available with no configuration. All others are opt-in v
 | **Alpha Vantage** | `alphavantage` | 25 req/day | `ALPHAVANTAGE_API_KEY` |
 | **CoinGecko** | `crypto` | 30 req/min | *(keyless)* |
 | **FRED** | `fred` | 120 req/min | `FRED_API_KEY` |
+| **World Bank** | `worldbank` | Keyless | *(keyless)* |
 | **SEC EDGAR** | *(always available)* | Keyless | *(email via `edgar::init`)* |
 
 ```toml

--- a/docs/library/providers/index.md
+++ b/docs/library/providers/index.md
@@ -24,6 +24,7 @@ Yahoo Finance is always available with no configuration. All others are opt-in v
 | **CoinGecko** | `crypto` | 30 req/min | *(keyless)* |
 | **FRED** | `fred` | 120 req/min | `FRED_API_KEY` |
 | **World Bank** | `worldbank` | Keyless | *(keyless)* |
+| **US Treasury FiscalData** | `fiscaldata` | Keyless | *(keyless)* |
 | **SEC EDGAR** | *(always available)* | Keyless | *(email via `edgar::init`)* |
 
 ```toml

--- a/docs/library/providers/index.md
+++ b/docs/library/providers/index.md
@@ -28,6 +28,7 @@ Yahoo Finance is always available with no configuration. All others are opt-in v
 | **BLS** | `bls` | Keyless 25/day, keyed 500/day | `BLS_API_KEY` *(optional)* |
 | **Frankfurter** | `frankfurter` | Keyless | *(keyless)* |
 | **Binance** | `binance` | Keyless | *(keyless)* |
+| **Kraken** | `kraken` | Keyless | *(keyless)* |
 | **SEC EDGAR** | *(always available)* | Keyless | *(email via `edgar::init`)* |
 
 ```toml

--- a/docs/library/providers/index.md
+++ b/docs/library/providers/index.md
@@ -26,6 +26,7 @@ Yahoo Finance is always available with no configuration. All others are opt-in v
 | **World Bank** | `worldbank` | Keyless | *(keyless)* |
 | **US Treasury FiscalData** | `fiscaldata` | Keyless | *(keyless)* |
 | **BLS** | `bls` | Keyless 25/day, keyed 500/day | `BLS_API_KEY` *(optional)* |
+| **Frankfurter** | `frankfurter` | Keyless | *(keyless)* |
 | **SEC EDGAR** | *(always available)* | Keyless | *(email via `edgar::init`)* |
 
 ```toml

--- a/docs/library/providers/index.md
+++ b/docs/library/providers/index.md
@@ -27,6 +27,7 @@ Yahoo Finance is always available with no configuration. All others are opt-in v
 | **US Treasury FiscalData** | `fiscaldata` | Keyless | *(keyless)* |
 | **BLS** | `bls` | Keyless 25/day, keyed 500/day | `BLS_API_KEY` *(optional)* |
 | **Frankfurter** | `frankfurter` | Keyless | *(keyless)* |
+| **Binance** | `binance` | Keyless | *(keyless)* |
 | **SEC EDGAR** | *(always available)* | Keyless | *(email via `edgar::init`)* |
 
 ```toml

--- a/docs/library/providers/index.md
+++ b/docs/library/providers/index.md
@@ -29,6 +29,7 @@ Yahoo Finance is always available with no configuration. All others are opt-in v
 | **Frankfurter** | `frankfurter` | Keyless | *(keyless)* |
 | **Binance** | `binance` | Keyless | *(keyless)* |
 | **Kraken** | `kraken` | Keyless | *(keyless)* |
+| **FINRA** | `finra` | Keyless (non-commercial) | *(keyless)* |
 | **SEC EDGAR** | *(always available)* | Keyless | *(email via `edgar::init`)* |
 
 ```toml

--- a/docs/library/providers/index.md
+++ b/docs/library/providers/index.md
@@ -25,6 +25,7 @@ Yahoo Finance is always available with no configuration. All others are opt-in v
 | **FRED** | `fred` | 120 req/min | `FRED_API_KEY` |
 | **World Bank** | `worldbank` | Keyless | *(keyless)* |
 | **US Treasury FiscalData** | `fiscaldata` | Keyless | *(keyless)* |
+| **BLS** | `bls` | Keyless 25/day, keyed 500/day | `BLS_API_KEY` *(optional)* |
 | **SEC EDGAR** | *(always available)* | Keyless | *(email via `edgar::init`)* |
 
 ```toml

--- a/docs/library/providers/index.md
+++ b/docs/library/providers/index.md
@@ -31,6 +31,7 @@ Yahoo Finance is always available with no configuration. All others are opt-in v
 | **Kraken** | `kraken` | Keyless | *(keyless)* |
 | **FINRA** | `finra` | Keyless (non-commercial) | *(keyless)* |
 | **OpenFIGI** | `openfigi` | Keyless 25 req/min | `OPENFIGI_API_KEY` *(optional)* |
+| **DefiLlama** | `defi` | Keyless | *(keyless)* |
 | **SEC EDGAR** | *(always available)* | Keyless | *(email via `edgar::init`)* |
 
 ```toml

--- a/docs/library/providers/kraken.md
+++ b/docs/library/providers/kraken.md
@@ -1,0 +1,88 @@
+# Kraken (public market data)
+
+!!! info "Feature flag required"
+    ```toml
+    finance-query = { version = "...", features = ["kraken"] }
+    ```
+
+Kraken's public endpoints (`api.kraken.com/0/public/*`) need no API key and impose **no geo-block** — which is the reason this provider exists alongside [Binance](binance.md), whose data is richer but unavailable to US retail users.
+
+Two exchanges also give `Capability::CRYPTO` a real fallback chain:
+
+```rust
+use finance_query::{Capability, Fetch, Provider, Providers};
+
+let providers = Providers::builder()
+    .route(Capability::CRYPTO, [Provider::Binance, Provider::Kraken, Provider::CoinGecko])
+    .fetch(Fetch::Sequential)
+    .build()
+    .await?;
+```
+
+## Capabilities
+
+| Capability | What Kraken serves |
+|------------|-------------------|
+| `CRYPTO` | 24-hour ticker per spot pair |
+| `CHART` | OHLC candles |
+
+```rust
+let btc = providers.crypto("bitcoin");
+let quote = btc.quote("usd").await?;
+println!("BTC {:?}", quote.price);
+```
+
+## Kraken's Own Symbol Conventions
+
+Kraken predates most ticker conventions and kept its own:
+
+| Everyone else | Kraken |
+|---------------|--------|
+| `BTC` | `XBT` |
+| `DOGE` | `XDG` |
+| `BTC/USD` | `XXBTZUSD` (legacy `X`/`Z` asset-class prefixes) |
+
+None of that reaches your call sites. Pass normal tickers, coin ids, or separated pairs and the adapter translates in both directions:
+
+| You pass | Kraken pair |
+|----------|-------------|
+| `crypto("bitcoin").quote("usd")` | `XBTUSD` |
+| `crypto("DOGE").quote("eur")` | `XDGEUR` |
+| chart symbol `BTC-USD` | `XBTUSD` |
+| chart symbol `SOLUSD` | `SOLUSD` |
+
+Kraken also answers with a pair name that differs from the one requested (`XBTUSD` comes back keyed as `XXBTZUSD`), so the adapter reads the response positionally rather than looking up the name it sent.
+
+## Response Notes
+
+`CryptoQuote`:
+
+- `volume_24h`, `high_24h`, `low_24h` come from the **rolling 24-hour** half of Kraken's `[today, last 24 hours]` arrays, not today's figures.
+- `change_24h` and `change_percent_24h` are measured against **today's opening price** (00:00 UTC). Kraken publishes no price from exactly 24 hours ago, so early in the UTC day this is a shorter-window change than the field name suggests.
+- `market_cap` and `circulating_supply` are always `None` — an exchange knows flow, not supply. Route `CRYPTO` to CoinGecko for those.
+
+`Chart`:
+
+- Kraken timestamps candles in seconds already, so no conversion is applied.
+- `adj_close` mirrors `close` — crypto has no corporate actions.
+
+## Intervals and History Depth
+
+Every library interval maps to a Kraken bucket except `ThreeMonths`, which returns `NotSupported` so sequential routing falls through. `OneMonth` maps to Kraken's longest bucket, 15 days.
+
+!!! warning "Roughly 720 candles maximum"
+    Kraken's `/OHLC` endpoint returns at most ~720 candles ending at the present, and its `since` parameter only moves the window's *start* forward — there is no way to page further back. A range wider than 720 candles returns the most recent 720, not the full window. For deep history, route `CHART` to Binance (which is paged automatically) or to a keyed provider.
+
+## Errors
+
+Kraken answers a rejected request with **HTTP 200** and a populated `error` array, so the status code alone never means success. An unknown pair surfaces as `FinanceError::SymbolNotFound`; anything else carries Kraken's own error text.
+
+## Rate Limits
+
+Kraken's public counter allows roughly one call per second sustained for unauthenticated clients, and the client paces to match. That is deliberately slower than the Binance adapter — put Binance first in a chain if throughput matters and your region allows it.
+
+## Next Steps
+
+- [Binance](binance.md) — deeper history, geo-blocked in some regions
+- [CoinGecko](coingecko.md) — aggregated market caps and supply
+- [Crypto Domain](../crypto.md) — the `CryptoCoin` handle

--- a/docs/library/providers/openfigi.md
+++ b/docs/library/providers/openfigi.md
@@ -1,0 +1,86 @@
+# OpenFIGI (identifier mapping)
+
+!!! info "Feature flag required"
+    ```toml
+    finance-query = { version = "...", features = ["openfigi"] }
+    ```
+
+[OpenFIGI](https://www.openfigi.com/api) resolves a CUSIP, ISIN, SEDOL, or FIGI to the instruments carrying it — the missing step for any dataset that identifies holdings by CUSIP rather than ticker, 13F filings being the obvious case. No API key is required.
+
+## Where It Lives
+
+`openfigi` is a **crate-level module**, not a routed provider:
+
+```rust
+use finance_query::openfigi;
+```
+
+Identifier resolution is not tied to a symbol handle and maps onto no `Capability`, so it sits alongside [`edgar`](edgar.md) and [`fred`](fred.md) at the crate root rather than behind `Providers::builder()`.
+
+## Resolving One Identifier
+
+```rust
+use finance_query::openfigi;
+
+for listing in openfigi::resolve_cusip("037833100").await? {
+    println!(
+        "{:?} on {:?} ({:?})",
+        listing.ticker, listing.exchange_code, listing.security_type
+    );
+}
+```
+
+`resolve_isin` and `resolve_sedol` are the same shape, and `resolve(SecurityIdKind::…, id)` takes the kind explicitly — including `SecurityIdKind::Figi` to find a FIGI's siblings and `SecurityIdKind::Ticker` to go the other way.
+
+!!! note "One identifier, many instruments"
+    A CUSIP or ISIN identifies a *security*, which trades on many venues, so resolution returns a **list**. Entries sharing a `composite_figi` are the same security on different venues; `share_class_figi` groups share classes across countries. Filter on `exchange_code == "US"` for the country composite.
+
+An identifier that is well-formed but matches nothing returns an **empty list**. Only a malformed identifier is an error.
+
+## Resolving Many
+
+OpenFIGI accepts 10 identifiers per request without a key. `resolve_many` batches automatically:
+
+```rust
+use finance_query::openfigi::{self, SecurityIdKind};
+
+let cusips = ["037833100", "594918104", "02079K305"];
+let results = openfigi::resolve_many(SecurityIdKind::Cusip, &cusips).await?;
+
+for (cusip, listings) in cusips.iter().zip(&results) {
+    match listings.iter().find(|l| l.exchange_code.as_deref() == Some("US")) {
+        Some(l) => println!("{cusip} -> {:?}", l.ticker),
+        None => println!("{cusip} -> no US listing"),
+    }
+}
+```
+
+The result is **positional**: element `i` answers `ids[i]`, with an empty list where nothing matched. The adapter validates that OpenFIGI returned exactly as many results as jobs sent, and errors rather than risk pairing answers to the wrong identifiers.
+
+## `SecurityMapping` Fields
+
+| Field | Description |
+|-------|-------------|
+| `figi` | This instrument's Financial Instrument Global Identifier |
+| `ticker` | Ticker symbol as the venue lists it |
+| `name` | Security name, usually the issuer |
+| `exchange_code` | `"US"` for the country composite, otherwise a venue code |
+| `composite_figi` | FIGI of the country-level composite this rolls up to |
+| `share_class_figi` | FIGI shared by every listing of this share class worldwide |
+| `security_type` | e.g. `"Common Stock"`, `"ETP"` |
+| `market_sector` | e.g. `"Equity"`, `"Corp"`, `"Govt"` |
+
+## Rate Limits
+
+Keyless: **25 requests per minute**, 10 identifiers per request. The client paces itself to stay inside that.
+
+A free key from [openfigi.com/api](https://www.openfigi.com/api) raises both limits substantially. Export it and it is picked up automatically, per request, with no other change:
+
+```bash
+export OPENFIGI_API_KEY="your-key"
+```
+
+## Next Steps
+
+- [EDGAR](edgar.md) — SEC filings, which identify holdings by CUSIP
+- [Providers Overview](index.md) — the routed providers

--- a/docs/library/providers/worldbank.md
+++ b/docs/library/providers/worldbank.md
@@ -1,0 +1,94 @@
+# World Bank Open Data
+
+!!! info "Feature flag required"
+    ```toml
+    finance-query = { version = "...", features = ["worldbank"] }
+    ```
+
+[World Bank Open Data](https://data.worldbank.org/) serves roughly 1,600 development and macro-economic indicators across 200+ economies. It is **keyless** — no registration, no API key, no environment variable.
+
+It complements [FRED](fred.md), which is US-centric and needs a key: when you want GDP, inflation, population, or trade figures for economies outside the United States, route `Capability::ECONOMIC` here.
+
+## Setup
+
+```rust
+use finance_query::{Capability, Provider, Providers};
+
+let providers = Providers::builder()
+    .route(Capability::ECONOMIC, [Provider::WorldBank])
+    .build()
+    .await?;
+```
+
+## Series Identifiers
+
+The `ECONOMIC` capability addresses a series with a single string, so a World Bank series is written as `"<COUNTRY>/<INDICATOR>"`:
+
+```rust
+let gdp = providers.economic("USA/NY.GDP.MKTP.CD").series().await?;
+
+println!("{}", gdp.title.unwrap_or_default());   // "GDP (current US$) — United States"
+for obs in &gdp.observations {
+    println!("{} {:?}", obs.date, obs.value);    // "1960-01-01" Some(543300000000.0)
+}
+```
+
+- **Country** — an ISO-2 (`US`) or ISO-3 (`USA`) code, a World Bank aggregate (`WLD`, `EMU`, `OED`), or `all`.
+- **Indicator** — a World Bank indicator code such as `NY.GDP.MKTP.CD`. Browse them at [data.worldbank.org/indicator](https://data.worldbank.org/indicator).
+
+Omitting the country resolves against the world aggregate:
+
+```rust
+// Equivalent to "WLD/SP.POP.TOTL" — world population
+let world_pop = providers.economic("SP.POP.TOTL").series().await?;
+```
+
+### Common Indicators
+
+| Indicator code | Description |
+|----------------|-------------|
+| `NY.GDP.MKTP.CD` | GDP (current US$) |
+| `NY.GDP.MKTP.KD.ZG` | GDP growth (annual %) |
+| `NY.GDP.PCAP.CD` | GDP per capita (current US$) |
+| `FP.CPI.TOTL.ZG` | Inflation, consumer prices (annual %) |
+| `SL.UEM.TOTL.ZS` | Unemployment (% of total labour force) |
+| `SP.POP.TOTL` | Population, total |
+| `NE.EXP.GNFS.ZS` | Exports of goods and services (% of GDP) |
+| `GC.DOD.TOTL.GD.ZS` | Central government debt (% of GDP) |
+
+## Response Shape
+
+Results come back as the provider-neutral [`EconomicSeries`](../economic.md), the same type FRED, Alpha Vantage, and Polygon return:
+
+| Field | Value from World Bank |
+|-------|----------------------|
+| `series_id` | The string you passed in |
+| `title` | Indicator name and country, e.g. `"GDP (current US$) — United States"` |
+| `units` | The API's `unit` field when it is populated (usually empty — most indicators state their unit in the title) |
+| `frequency` | `"Annual"`, `"Quarterly"`, or `"Monthly"`, inferred from the period labels |
+| `observations` | Chronological (oldest first), with `value: None` for periods the World Bank has no figure for |
+
+World Bank period labels (`2023`, `2023Q1`, `2023M04`) are normalised to the `YYYY-MM-DD` **start** of the period so dates sort and parse like every other provider's.
+
+## Fallback Chains
+
+Because it is keyless, World Bank makes a good last resort behind a keyed provider:
+
+```rust
+let providers = Providers::builder()
+    .route(Capability::ECONOMIC, [Provider::Fred, Provider::WorldBank])
+    .build()
+    .await?;
+```
+
+Note that the two use different identifier schemes — a FRED series id is not a World Bank series id — so a chain like this is useful for *availability*, not for transparently retrying the same identifier.
+
+## Rate Limits
+
+The World Bank publishes no documented quota. The client paces itself at 5 requests/second, and a `429` surfaces as [`FinanceError::RateLimited`](../error-handling.md).
+
+## Next Steps
+
+- [FRED](fred.md) — 800k+ US macro series
+- [Economic Domain](../economic.md) — the `EconomicIndicator` handle
+- [Providers Overview](index.md) — routing and fallback

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
           - World Bank: library/providers/worldbank.md
           - US Treasury FiscalData: library/providers/fiscaldata.md
           - BLS: library/providers/bls.md
+          - Frankfurter: library/providers/frankfurter.md
       - Domains:
           - Crypto: library/crypto.md
           - Forex: library/forex.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,7 @@ nav:
           - BLS: library/providers/bls.md
           - Frankfurter: library/providers/frankfurter.md
           - Binance: library/providers/binance.md
+          - Kraken: library/providers/kraken.md
       - Domains:
           - Crypto: library/crypto.md
           - Forex: library/forex.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
           - EDGAR: library/providers/edgar.md
           - FRED: library/providers/fred.md
           - World Bank: library/providers/worldbank.md
+          - US Treasury FiscalData: library/providers/fiscaldata.md
       - Domains:
           - Crypto: library/crypto.md
           - Forex: library/forex.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
           - Binance: library/providers/binance.md
           - Kraken: library/providers/kraken.md
           - FINRA: library/providers/finra.md
+          - OpenFIGI: library/providers/openfigi.md
       - Domains:
           - Crypto: library/crypto.md
           - Forex: library/forex.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
           - Frankfurter: library/providers/frankfurter.md
           - Binance: library/providers/binance.md
           - Kraken: library/providers/kraken.md
+          - FINRA: library/providers/finra.md
       - Domains:
           - Crypto: library/crypto.md
           - Forex: library/forex.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ nav:
           - CoinGecko: library/providers/coingecko.md
           - EDGAR: library/providers/edgar.md
           - FRED: library/providers/fred.md
+          - World Bank: library/providers/worldbank.md
       - Domains:
           - Crypto: library/crypto.md
           - Forex: library/forex.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
           - Kraken: library/providers/kraken.md
           - FINRA: library/providers/finra.md
           - OpenFIGI: library/providers/openfigi.md
+          - DefiLlama: library/providers/defillama.md
       - Domains:
           - Crypto: library/crypto.md
           - Forex: library/forex.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
           - FRED: library/providers/fred.md
           - World Bank: library/providers/worldbank.md
           - US Treasury FiscalData: library/providers/fiscaldata.md
+          - BLS: library/providers/bls.md
       - Domains:
           - Crypto: library/crypto.md
           - Forex: library/forex.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,7 @@ nav:
           - US Treasury FiscalData: library/providers/fiscaldata.md
           - BLS: library/providers/bls.md
           - Frankfurter: library/providers/frankfurter.md
+          - Binance: library/providers/binance.md
       - Domains:
           - Crypto: library/crypto.md
           - Forex: library/forex.md

--- a/src/adapters/binance/chart/mod.rs
+++ b/src/adapters/binance/chart/mod.rs
@@ -1,0 +1,193 @@
+//! `CHART` capability for Binance public market data.
+
+use crate::constants::{Interval, TimeRange};
+use crate::error::{FinanceError, Result};
+use crate::models::chart::{Candle, Chart, ChartMeta};
+use crate::providers::{Operation, Provider};
+
+use super::client::MAX_KLINES;
+use super::models::Kline;
+use super::symbols;
+
+/// Requests one chart may spend walking forward through Binance's 1000-candle
+/// page cap. Enough for five years of daily or a year of hourly candles.
+const MAX_PAGES: u32 = 10;
+
+/// Map a library interval to Binance's kline interval code.
+///
+/// `ThreeMonths` has no Binance equivalent, so it returns `None` and the
+/// caller reports `NotSupported` — dispatch then falls through to the next
+/// routed provider.
+pub(super) fn interval_code(interval: Interval) -> Option<&'static str> {
+    Some(match interval {
+        Interval::OneMinute => "1m",
+        Interval::FiveMinutes => "5m",
+        Interval::FifteenMinutes => "15m",
+        Interval::ThirtyMinutes => "30m",
+        Interval::OneHour => "1h",
+        Interval::OneDay => "1d",
+        Interval::OneWeek => "1w",
+        Interval::OneMonth => "1M",
+        Interval::ThreeMonths => return None,
+    })
+}
+
+/// The span one candle covers, in seconds. Month candles use a 30-day
+/// approximation, matching [`TimeRange::approx_duration_secs`].
+pub(super) fn interval_secs(interval: Interval) -> i64 {
+    match interval {
+        Interval::OneMinute => 60,
+        Interval::FiveMinutes => 300,
+        Interval::FifteenMinutes => 900,
+        Interval::ThirtyMinutes => 1_800,
+        Interval::OneHour => 3_600,
+        Interval::OneDay => 86_400,
+        Interval::OneWeek => 604_800,
+        Interval::OneMonth | Interval::ThreeMonths => 2_592_000,
+    }
+}
+
+/// Turn Binance klines into canonical candles.
+///
+/// Binance timestamps candles in **milliseconds**; the canonical model uses
+/// seconds. Volume is the base-asset amount and is truncated to an integer to
+/// fit `Candle::volume`, so sub-unit crypto volumes round toward zero.
+pub(super) fn to_candles(klines: Vec<Kline>) -> Vec<Candle> {
+    klines
+        .into_iter()
+        .map(|k| Candle {
+            timestamp: k.open_time / 1_000,
+            open: k.open,
+            high: k.high,
+            low: k.low,
+            close: k.close,
+            volume: k.volume as i64,
+            // Crypto has no corporate actions, so close is already adjusted.
+            adj_close: Some(k.close),
+            provider_id: Some(Provider::Binance),
+        })
+        .collect()
+}
+
+/// Assemble a [`Chart`] around a candle series.
+pub(super) fn build_chart(
+    symbol: &str,
+    market: &str,
+    candles: Vec<Candle>,
+    interval: Option<Interval>,
+    range: Option<TimeRange>,
+) -> Chart {
+    let quote_currency = symbols::split_pair(market).map(|(_, quote)| quote.to_string());
+    Chart {
+        symbol: symbol.to_string(),
+        meta: ChartMeta {
+            symbol: symbol.to_string(),
+            currency: quote_currency,
+            exchange_name: Some("BINANCE".to_string()),
+            full_exchange_name: Some("Binance".to_string()),
+            instrument_type: Some("CRYPTOCURRENCY".to_string()),
+            first_trade_date: candles.first().map(|c| c.timestamp),
+            regular_market_time: candles.last().map(|c| c.timestamp),
+            regular_market_price: candles.last().map(|c| c.close),
+            data_granularity: interval.map(|i| i.as_str().to_string()),
+            range: range.map(|r| r.as_str().to_string()),
+            provider_id: Some(Provider::Binance),
+            ..Default::default()
+        },
+        candles,
+        interval,
+        range,
+        provider_id: Some(Provider::Binance),
+    }
+}
+
+/// Resolve the requested symbol to a Binance market, or explain why it can't
+/// be — an unmappable symbol is an equity/index ticker that another provider
+/// should serve, so it reports `NotSupported` rather than a hard failure.
+fn market_for(symbol: &str) -> Result<String> {
+    symbols::parse_market(symbol).ok_or(FinanceError::NotSupported {
+        provider: Provider::Binance,
+        operation: Operation::Chart,
+        candidates: Operation::Chart.capability().candidate_providers(),
+    })
+}
+
+/// Walk Binance's paginated kline endpoint from `start_ms` to `end_ms`.
+async fn collect_klines(
+    market: &str,
+    code: &str,
+    interval: Interval,
+    start_ms: i64,
+    end_ms: i64,
+) -> Result<Vec<Kline>> {
+    let client = super::client()?;
+    let step_ms = interval_secs(interval) * 1_000;
+    let mut cursor = start_ms;
+    let mut out: Vec<Kline> = Vec::new();
+
+    for _ in 0..MAX_PAGES {
+        let page = client
+            .klines(market, code, cursor, end_ms, MAX_KLINES)
+            .await?;
+        let Some(last) = page.last() else { break };
+        // Binance's window is inclusive at both ends, so resume one step past
+        // the last candle or the same page would repeat forever.
+        cursor = last.open_time + step_ms;
+        let full_page = page.len() as u32 == MAX_KLINES;
+        out.extend(page);
+        if !full_page || cursor > end_ms {
+            break;
+        }
+    }
+    Ok(out)
+}
+
+/// Fetch candles for `symbol` over `range` at `interval`.
+pub(crate) async fn fetch_chart_response(
+    symbol: &str,
+    interval: Interval,
+    range: TimeRange,
+) -> Result<Chart> {
+    let market = market_for(symbol)?;
+    let code = interval_code(interval).ok_or(FinanceError::NotSupported {
+        provider: Provider::Binance,
+        operation: Operation::Chart,
+        candidates: Operation::Chart.capability().candidate_providers(),
+    })?;
+
+    let end_ms = chrono::Utc::now().timestamp_millis();
+    let start_ms = end_ms - range.approx_duration_secs() * 1_000;
+    let klines = collect_klines(&market, code, interval, start_ms, end_ms).await?;
+
+    Ok(build_chart(
+        symbol,
+        &market,
+        to_candles(klines),
+        Some(interval),
+        Some(range),
+    ))
+}
+
+/// Fetch candles for `symbol` between two unix-second timestamps.
+pub(crate) async fn fetch_chart_range_response(
+    symbol: &str,
+    interval: Interval,
+    start: i64,
+    end: i64,
+) -> Result<Chart> {
+    let market = market_for(symbol)?;
+    let code = interval_code(interval).ok_or(FinanceError::NotSupported {
+        provider: Provider::Binance,
+        operation: Operation::ChartRange,
+        candidates: Operation::ChartRange.capability().candidate_providers(),
+    })?;
+
+    let klines = collect_klines(&market, code, interval, start * 1_000, end * 1_000).await?;
+    Ok(build_chart(
+        symbol,
+        &market,
+        to_candles(klines),
+        Some(interval),
+        None,
+    ))
+}

--- a/src/adapters/binance/chart/mod.rs
+++ b/src/adapters/binance/chart/mod.rs
@@ -1,13 +1,21 @@
 //! `CHART` capability for Binance public market data.
 
+use crate::adapters::common::crypto_chart::{CryptoExchange, crypto_chart};
 use crate::constants::{Interval, TimeRange};
-use crate::error::{FinanceError, Result};
-use crate::models::chart::{Candle, Chart, ChartMeta};
+use crate::error::Result;
+use crate::models::chart::{Candle, Chart};
 use crate::providers::{Operation, Provider};
 
 use super::client::MAX_KLINES;
 use super::models::Kline;
 use super::symbols;
+
+/// How Binance identifies itself in canonical chart metadata.
+const EXCHANGE: CryptoExchange = CryptoExchange {
+    provider: Provider::Binance,
+    code: "BINANCE",
+    name: "Binance",
+};
 
 /// Requests one chart may spend walking forward through Binance's 1000-candle
 /// page cap. Enough for five years of daily or a year of hourly candles.
@@ -30,21 +38,6 @@ pub(super) fn interval_code(interval: Interval) -> Option<&'static str> {
         Interval::OneMonth => "1M",
         Interval::ThreeMonths => return None,
     })
-}
-
-/// The span one candle covers, in seconds. Month candles use a 30-day
-/// approximation, matching [`TimeRange::approx_duration_secs`].
-pub(super) fn interval_secs(interval: Interval) -> i64 {
-    match interval {
-        Interval::OneMinute => 60,
-        Interval::FiveMinutes => 300,
-        Interval::FifteenMinutes => 900,
-        Interval::ThirtyMinutes => 1_800,
-        Interval::OneHour => 3_600,
-        Interval::OneDay => 86_400,
-        Interval::OneWeek => 604_800,
-        Interval::OneMonth | Interval::ThreeMonths => 2_592_000,
-    }
 }
 
 /// Turn Binance klines into canonical candles.
@@ -78,38 +71,14 @@ pub(super) fn build_chart(
     range: Option<TimeRange>,
 ) -> Chart {
     let quote_currency = symbols::split_pair(market).map(|(_, quote)| quote.to_string());
-    Chart {
-        symbol: symbol.to_string(),
-        meta: ChartMeta {
-            symbol: symbol.to_string(),
-            currency: quote_currency,
-            exchange_name: Some("BINANCE".to_string()),
-            full_exchange_name: Some("Binance".to_string()),
-            instrument_type: Some("CRYPTOCURRENCY".to_string()),
-            first_trade_date: candles.first().map(|c| c.timestamp),
-            regular_market_time: candles.last().map(|c| c.timestamp),
-            regular_market_price: candles.last().map(|c| c.close),
-            data_granularity: interval.map(|i| i.as_str().to_string()),
-            range: range.map(|r| r.as_str().to_string()),
-            provider_id: Some(Provider::Binance),
-            ..Default::default()
-        },
-        candles,
-        interval,
-        range,
-        provider_id: Some(Provider::Binance),
-    }
+    crypto_chart(&EXCHANGE, symbol, quote_currency, candles, interval, range)
 }
 
 /// Resolve the requested symbol to a Binance market, or explain why it can't
 /// be — an unmappable symbol is an equity/index ticker that another provider
 /// should serve, so it reports `NotSupported` rather than a hard failure.
-fn market_for(symbol: &str) -> Result<String> {
-    symbols::parse_market(symbol).ok_or(FinanceError::NotSupported {
-        provider: Provider::Binance,
-        operation: Operation::Chart,
-        candidates: Operation::Chart.capability().candidate_providers(),
-    })
+fn market_for(symbol: &str, operation: Operation) -> Result<String> {
+    symbols::parse_market(symbol).ok_or_else(|| operation.not_supported(Provider::Binance))
 }
 
 /// Walk Binance's paginated kline endpoint from `start_ms` to `end_ms`.
@@ -121,7 +90,7 @@ async fn collect_klines(
     end_ms: i64,
 ) -> Result<Vec<Kline>> {
     let client = super::client()?;
-    let step_ms = interval_secs(interval) * 1_000;
+    let step_ms = interval.duration_secs() * 1_000;
     let mut cursor = start_ms;
     let mut out: Vec<Kline> = Vec::new();
 
@@ -148,12 +117,9 @@ pub(crate) async fn fetch_chart_response(
     interval: Interval,
     range: TimeRange,
 ) -> Result<Chart> {
-    let market = market_for(symbol)?;
-    let code = interval_code(interval).ok_or(FinanceError::NotSupported {
-        provider: Provider::Binance,
-        operation: Operation::Chart,
-        candidates: Operation::Chart.capability().candidate_providers(),
-    })?;
+    let market = market_for(symbol, Operation::Chart)?;
+    let code =
+        interval_code(interval).ok_or_else(|| Operation::Chart.not_supported(Provider::Binance))?;
 
     let end_ms = chrono::Utc::now().timestamp_millis();
     let start_ms = end_ms - range.approx_duration_secs() * 1_000;
@@ -175,12 +141,9 @@ pub(crate) async fn fetch_chart_range_response(
     start: i64,
     end: i64,
 ) -> Result<Chart> {
-    let market = market_for(symbol)?;
-    let code = interval_code(interval).ok_or(FinanceError::NotSupported {
-        provider: Provider::Binance,
-        operation: Operation::ChartRange,
-        candidates: Operation::ChartRange.capability().candidate_providers(),
-    })?;
+    let market = market_for(symbol, Operation::ChartRange)?;
+    let code = interval_code(interval)
+        .ok_or_else(|| Operation::ChartRange.not_supported(Provider::Binance))?;
 
     let klines = collect_klines(&market, code, interval, start * 1_000, end * 1_000).await?;
     Ok(build_chart(

--- a/src/adapters/binance/client.rs
+++ b/src/adapters/binance/client.rs
@@ -1,0 +1,131 @@
+//! Binance public market-data HTTP client.
+//!
+//! Talks to `data-api.binance.vision`, the market-data-only host: it serves
+//! the same public endpoints as `api.binance.com` but carries no account or
+//! trading routes, so no key exists to leak.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use reqwest::{Client, StatusCode};
+use tracing::debug;
+
+use super::models::{BinanceError, Kline, Ticker24hr};
+use crate::adapters::common::keyless_http_client;
+use crate::error::{FinanceError, Result};
+use crate::rate_limiter::RateLimiter;
+
+pub(super) const BINANCE_BASE: &str = "https://data-api.binance.vision";
+
+/// Binance's per-request candle cap.
+pub(super) const MAX_KLINES: u32 = 1000;
+
+pub(super) struct BinanceClient {
+    http: Client,
+    limiter: Arc<RateLimiter>,
+    base_url: String,
+}
+
+impl BinanceClient {
+    pub(super) fn new(
+        timeout: Duration,
+        limiter: Arc<RateLimiter>,
+        base_url: impl Into<String>,
+    ) -> Result<Self> {
+        Ok(Self {
+            http: keyless_http_client(timeout)?,
+            limiter,
+            base_url: base_url.into(),
+        })
+    }
+
+    /// Fetch rolling 24-hour statistics for one market.
+    pub(super) async fn ticker_24hr(&self, symbol: &str) -> Result<Ticker24hr> {
+        self.limiter.acquire().await;
+        let url = format!("{}/api/v3/ticker/24hr", self.base_url);
+        debug!("Binance request: ticker/24hr {symbol}");
+
+        let resp = self
+            .http
+            .get(&url)
+            .query(&[("symbol", symbol)])
+            .send()
+            .await?;
+        let bytes = Self::body(resp, symbol).await?;
+
+        serde_json::from_slice(&bytes).map_err(|e| FinanceError::ResponseStructureError {
+            field: "binance.ticker24hr".to_string(),
+            context: format!("unrecognised Binance ticker payload: {e}"),
+        })
+    }
+
+    /// Fetch up to [`MAX_KLINES`] candles for one market starting at
+    /// `start_ms`, ending no later than `end_ms`.
+    pub(super) async fn klines(
+        &self,
+        symbol: &str,
+        interval: &str,
+        start_ms: i64,
+        end_ms: i64,
+        limit: u32,
+    ) -> Result<Vec<Kline>> {
+        self.limiter.acquire().await;
+        let url = format!("{}/api/v3/klines", self.base_url);
+        debug!("Binance request: klines {symbol} {interval} from {start_ms}");
+
+        let start = start_ms.max(0).to_string();
+        let end = end_ms.to_string();
+        let limit = limit.clamp(1, MAX_KLINES).to_string();
+        let resp = self
+            .http
+            .get(&url)
+            .query(&[
+                ("symbol", symbol),
+                ("interval", interval),
+                ("startTime", &start),
+                ("endTime", &end),
+                ("limit", &limit),
+            ])
+            .send()
+            .await?;
+        let bytes = Self::body(resp, symbol).await?;
+
+        serde_json::from_slice(&bytes).map_err(|e| FinanceError::ResponseStructureError {
+            field: "binance.klines".to_string(),
+            context: format!("unrecognised Binance kline payload: {e}"),
+        })
+    }
+
+    /// Read a response body, turning a non-2xx into the right error.
+    async fn body(resp: reqwest::Response, symbol: &str) -> Result<Vec<u8>> {
+        let status = resp.status();
+        let bytes = resp.bytes().await?;
+        if status.is_success() {
+            return Ok(bytes.to_vec());
+        }
+
+        let detail = serde_json::from_slice::<BinanceError>(&bytes).ok();
+        Err(match status {
+            // Binance answers an unlisted market with 400 / code -1121.
+            StatusCode::BAD_REQUEST => FinanceError::SymbolNotFound {
+                symbol: Some(symbol.to_string()),
+                context: detail
+                    .and_then(|e| e.msg)
+                    .unwrap_or_else(|| "Binance rejected this market symbol".to_string()),
+            },
+            // 418 is Binance's "you ignored a 429 and are now banned".
+            StatusCode::TOO_MANY_REQUESTS | StatusCode::IM_A_TEAPOT => {
+                FinanceError::RateLimited { retry_after: None }
+            }
+            // 451 is the geo-block: Binance restricts some regions (US retail).
+            StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS => FinanceError::ApiError(
+                "Binance is not available from this region; route CRYPTO to Kraken or CoinGecko"
+                    .to_string(),
+            ),
+            s => FinanceError::ExternalApiError {
+                api: "Binance".to_string(),
+                status: s.as_u16(),
+            },
+        })
+    }
+}

--- a/src/adapters/binance/client.rs
+++ b/src/adapters/binance/client.rs
@@ -11,7 +11,7 @@ use reqwest::{Client, StatusCode};
 use tracing::debug;
 
 use super::models::{BinanceError, Kline, Ticker24hr};
-use crate::adapters::common::keyless_http_client;
+use crate::adapters::common::{keyless_http_client, status_error};
 use crate::error::{FinanceError, Result};
 use crate::rate_limiter::RateLimiter;
 
@@ -113,19 +113,15 @@ impl BinanceClient {
                     .and_then(|e| e.msg)
                     .unwrap_or_else(|| "Binance rejected this market symbol".to_string()),
             },
-            // 418 is Binance's "you ignored a 429 and are now banned".
-            StatusCode::TOO_MANY_REQUESTS | StatusCode::IM_A_TEAPOT => {
-                FinanceError::RateLimited { retry_after: None }
-            }
+            // 418 is Binance's "you ignored a 429 and are now banned"; 429
+            // itself falls through to the shared mapping below.
+            StatusCode::IM_A_TEAPOT => FinanceError::RateLimited { retry_after: None },
             // 451 is the geo-block: Binance restricts some regions (US retail).
             StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS => FinanceError::ApiError(
                 "Binance is not available from this region; route CRYPTO to Kraken or CoinGecko"
                     .to_string(),
             ),
-            s => FinanceError::ExternalApiError {
-                api: "Binance".to_string(),
-                status: s.as_u16(),
-            },
+            s => status_error("Binance", s),
         })
     }
 }

--- a/src/adapters/binance/crypto/mod.rs
+++ b/src/adapters/binance/crypto/mod.rs
@@ -1,0 +1,47 @@
+//! `CRYPTO` capability for Binance public market data.
+
+use crate::error::Result;
+use crate::models::crypto::CryptoQuote;
+
+use super::models::Ticker24hr;
+use super::symbols;
+
+/// Map a 24-hour ticker onto the canonical [`CryptoQuote`].
+///
+/// `market_cap` and `circulating_supply` stay `None`: an exchange knows what
+/// trades on it, not how much of an asset exists. Route `CRYPTO` to CoinGecko
+/// if you need supply-side figures.
+pub(super) fn to_quote(id: &str, ticker: Ticker24hr) -> CryptoQuote {
+    let base = symbols::split_pair(&ticker.symbol)
+        .map(|(base, _)| base.to_string())
+        .unwrap_or_else(|| ticker.symbol.clone());
+    let name = symbols::asset_name(&base)
+        .map(str::to_string)
+        .unwrap_or_else(|| base.clone());
+
+    let num = |s: &str| s.parse::<f64>().ok();
+
+    CryptoQuote {
+        id: id.to_string(),
+        symbol: base,
+        name,
+        price: num(&ticker.last_price),
+        market_cap: None,
+        volume_24h: num(&ticker.quote_volume),
+        change_24h: num(&ticker.price_change),
+        change_percent_24h: num(&ticker.price_change_percent),
+        high_24h: num(&ticker.high_price),
+        low_24h: num(&ticker.low_price),
+        circulating_supply: None,
+    }
+}
+
+/// Fetch a Binance spot quote for `id` priced in `vs_currency`.
+pub(crate) async fn fetch_crypto_quote_response(
+    id: &str,
+    vs_currency: &str,
+) -> Result<CryptoQuote> {
+    let market = symbols::pair(id, vs_currency);
+    let ticker = super::client()?.ticker_24hr(&market).await?;
+    Ok(to_quote(id, ticker))
+}

--- a/src/adapters/binance/mod.rs
+++ b/src/adapters/binance/mod.rs
@@ -1,0 +1,255 @@
+//! Binance public market data — keyless exchange-grade crypto.
+//!
+//! Requires the **`binance`** feature flag.
+//!
+//! Talks to `data-api.binance.vision`, the market-data-only host: same public
+//! endpoints as `api.binance.com`, but no account or trading routes exist
+//! there, so there is no key to configure and none to leak.
+//!
+//! Serves two capabilities:
+//! - `CRYPTO` — rolling 24-hour quote per spot market.
+//! - `CHART` — arbitrary-interval OHLCV klines, which CoinGecko cannot give
+//!   and the keyed providers charge for.
+//!
+//! # Regional availability
+//!
+//! Binance geo-blocks some regions (notably US retail) with HTTP 451. That is
+//! why Kraken exists as a sibling route; a `Fetch::Sequential` chain of the
+//! two covers both.
+
+pub(crate) mod chart;
+pub(crate) mod client;
+pub(crate) mod crypto;
+pub(crate) mod models;
+pub(crate) mod symbols;
+
+use std::time::Duration;
+
+use crate::adapters::singleton::keyless_limiter;
+use crate::error::Result;
+use client::BinanceClient;
+
+/// Self-imposed pacing. Binance meters by request weight (6000/minute per IP);
+/// the endpoints used here are weight 1–2, so this stays far inside the quota.
+const BINANCE_RATE_PER_SEC: f64 = 10.0;
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+keyless_limiter!(rate = BINANCE_RATE_PER_SEC);
+
+/// Build a client against the live API, reusing the shared token bucket.
+fn client() -> Result<BinanceClient> {
+    BinanceClient::new(DEFAULT_TIMEOUT, shared_limiter(), client::BINANCE_BASE)
+}
+
+pub(crate) use chart::{fetch_chart_range_response, fetch_chart_response};
+pub(crate) use crypto::fetch_crypto_quote_response;
+
+#[cfg(test)]
+mod tests {
+    use super::chart::{interval_code, interval_secs, to_candles};
+    use super::crypto::to_quote;
+    use super::models::Kline;
+    use super::*;
+    use crate::constants::Interval;
+    use crate::error::FinanceError;
+    use crate::rate_limiter::RateLimiter;
+    use std::sync::Arc;
+
+    fn test_client(base_url: &str) -> BinanceClient {
+        BinanceClient::new(
+            Duration::from_secs(5),
+            Arc::new(RateLimiter::new(100.0)),
+            base_url,
+        )
+        .unwrap()
+    }
+
+    fn ticker_payload() -> String {
+        serde_json::json!({
+            "symbol": "BTCUSDT",
+            "priceChange": "487.60000000",
+            "priceChangePercent": "0.776",
+            "weightedAvgPrice": "63363.45155704",
+            "prevClosePrice": "62830.01000000",
+            "lastPrice": "63317.60000000",
+            "lastQty": "0.00050000",
+            "bidPrice": "63317.60000000",
+            "askPrice": "63317.61000000",
+            "openPrice": "62830.00000000",
+            "highPrice": "63796.33000000",
+            "lowPrice": "62830.00000000",
+            "volume": "8345.37574000",
+            "quoteVolume": "528791811.42675440",
+            "openTime": 1785632332001_i64,
+            "closeTime": 1785718732001_i64,
+            "count": 1349944
+        })
+        .to_string()
+    }
+
+    fn kline(open_time: i64, close: f64) -> Kline {
+        Kline {
+            open_time,
+            open: close - 1.0,
+            high: close + 2.0,
+            low: close - 3.0,
+            close,
+            volume: 12.75,
+        }
+    }
+
+    #[test]
+    fn every_interval_but_three_months_maps_to_a_binance_code() {
+        assert_eq!(interval_code(Interval::OneMinute), Some("1m"));
+        assert_eq!(interval_code(Interval::OneHour), Some("1h"));
+        assert_eq!(interval_code(Interval::OneDay), Some("1d"));
+        assert_eq!(interval_code(Interval::OneWeek), Some("1w"));
+        // Binance's month code is uppercase; "1m" is one minute.
+        assert_eq!(interval_code(Interval::OneMonth), Some("1M"));
+        assert_eq!(interval_code(Interval::ThreeMonths), None);
+    }
+
+    #[test]
+    fn candles_convert_milliseconds_to_seconds() {
+        let candles = to_candles(vec![kline(1_785_628_800_000, 63570.0)]);
+        assert_eq!(candles.len(), 1);
+        assert_eq!(candles[0].timestamp, 1_785_628_800);
+        assert_eq!(candles[0].close, 63570.0);
+        // Crypto has no corporate actions, so adj_close mirrors close.
+        assert_eq!(candles[0].adj_close, Some(63570.0));
+        assert_eq!(candles[0].provider_id, Some(crate::Provider::Binance));
+    }
+
+    #[test]
+    fn interval_seconds_match_the_interval_codes() {
+        assert_eq!(interval_secs(Interval::OneMinute), 60);
+        assert_eq!(interval_secs(Interval::OneDay), 86_400);
+        assert_eq!(interval_secs(Interval::OneWeek), 604_800);
+    }
+
+    #[tokio::test]
+    async fn ticker_maps_to_a_canonical_crypto_quote() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/api/v3/ticker/24hr")
+            .match_query(mockito::Matcher::UrlEncoded(
+                "symbol".into(),
+                "BTCUSDT".into(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(ticker_payload())
+            .create_async()
+            .await;
+
+        let raw = test_client(&server.url())
+            .ticker_24hr("BTCUSDT")
+            .await
+            .unwrap();
+        let quote = to_quote("bitcoin", raw);
+
+        assert_eq!(quote.id, "bitcoin");
+        assert_eq!(quote.symbol, "BTC");
+        assert_eq!(quote.name, "Bitcoin");
+        assert_eq!(quote.price, Some(63317.6));
+        assert_eq!(quote.change_24h, Some(487.6));
+        assert_eq!(quote.change_percent_24h, Some(0.776));
+        assert_eq!(quote.high_24h, Some(63796.33));
+        assert_eq!(quote.low_24h, Some(62830.0));
+        // Quote-asset volume, the figure comparable to other providers.
+        assert_eq!(quote.volume_24h, Some(528791811.4267544));
+        // An exchange knows flow, not supply.
+        assert_eq!(quote.market_cap, None);
+        assert_eq!(quote.circulating_supply, None);
+    }
+
+    #[tokio::test]
+    async fn unlisted_market_maps_to_symbol_not_found() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/api/v3/ticker/24hr")
+            .match_query(mockito::Matcher::Any)
+            .with_status(400)
+            .with_header("content-type", "application/json")
+            .with_body(serde_json::json!({ "code": -1121, "msg": "Invalid symbol." }).to_string())
+            .create_async()
+            .await;
+
+        let err = test_client(&server.url())
+            .ticker_24hr("NOTAMARKET")
+            .await
+            .unwrap_err();
+        match err {
+            FinanceError::SymbolNotFound { context, .. } => {
+                assert!(context.contains("Invalid symbol"), "got {context}");
+            }
+            other => panic!("expected SymbolNotFound, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn geo_block_explains_itself() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/api/v3/ticker/24hr")
+            .match_query(mockito::Matcher::Any)
+            .with_status(451)
+            .create_async()
+            .await;
+
+        let err = test_client(&server.url())
+            .ticker_24hr("BTCUSDT")
+            .await
+            .unwrap_err();
+        match err {
+            FinanceError::ApiError(msg) => {
+                assert!(
+                    msg.contains("Kraken"),
+                    "the error should name a way out: {msg}"
+                );
+            }
+            other => panic!("expected ApiError, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn ban_status_maps_to_rate_limited() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/api/v3/ticker/24hr")
+            .match_query(mockito::Matcher::Any)
+            // 418: Binance's "you ignored a 429".
+            .with_status(418)
+            .create_async()
+            .await;
+
+        let err = test_client(&server.url())
+            .ticker_24hr("BTCUSDT")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, FinanceError::RateLimited { .. }), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn klines_parse_from_the_wire_shape() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/api/v3/klines")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"[[1785628800000,"62823.65000000","63796.33000000","62806.58000000","63570.00000000","8387.01154000",1785715199999,"531238376.42127370",1286064,"4566.33112000","289282425.13673770","0"]]"#,
+            )
+            .create_async()
+            .await;
+
+        let klines = test_client(&server.url())
+            .klines("BTCUSDT", "1d", 0, 1785715199999, 1000)
+            .await
+            .unwrap();
+        assert_eq!(klines.len(), 1);
+        assert_eq!(klines[0].close, 63570.0);
+    }
+}

--- a/src/adapters/binance/mod.rs
+++ b/src/adapters/binance/mod.rs
@@ -47,7 +47,7 @@ pub(crate) use crypto::fetch_crypto_quote_response;
 
 #[cfg(test)]
 mod tests {
-    use super::chart::{interval_code, interval_secs, to_candles};
+    use super::chart::{interval_code, to_candles};
     use super::crypto::to_quote;
     use super::models::Kline;
     use super::*;
@@ -119,13 +119,6 @@ mod tests {
         // Crypto has no corporate actions, so adj_close mirrors close.
         assert_eq!(candles[0].adj_close, Some(63570.0));
         assert_eq!(candles[0].provider_id, Some(crate::Provider::Binance));
-    }
-
-    #[test]
-    fn interval_seconds_match_the_interval_codes() {
-        assert_eq!(interval_secs(Interval::OneMinute), 60);
-        assert_eq!(interval_secs(Interval::OneDay), 86_400);
-        assert_eq!(interval_secs(Interval::OneWeek), 604_800);
     }
 
     #[tokio::test]

--- a/src/adapters/binance/models.rs
+++ b/src/adapters/binance/models.rs
@@ -1,0 +1,129 @@
+//! Binance public market-data wire types.
+
+use serde::Deserialize;
+use serde::de::{self, SeqAccess, Visitor};
+use std::fmt;
+
+/// `GET /api/v3/ticker/24hr` — rolling 24-hour statistics. Every numeric
+/// field is a decimal string.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct Ticker24hr {
+    pub symbol: String,
+    pub price_change: String,
+    pub price_change_percent: String,
+    pub last_price: String,
+    pub high_price: String,
+    pub low_price: String,
+    /// Volume denominated in the quote asset — the comparable figure to other
+    /// providers' `volume_24h`, unlike `volume` (base asset).
+    pub quote_volume: String,
+}
+
+/// The error body Binance returns for a rejected request. Only the message is
+/// kept — the numeric `code` adds nothing the HTTP status and text do not.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct BinanceError {
+    #[serde(default)]
+    pub msg: Option<String>,
+}
+
+/// One `GET /api/v3/klines` candle.
+///
+/// Binance sends these as heterogeneous JSON arrays whose trailing elements
+/// have changed type over time (the last field has been both `0` and `"0"`).
+/// Only the leading six are read, and the rest are skipped, so a future change
+/// to the tail cannot break parsing.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct Kline {
+    /// Candle open time, milliseconds since epoch.
+    pub open_time: i64,
+    pub open: f64,
+    pub high: f64,
+    pub low: f64,
+    pub close: f64,
+    /// Base-asset volume.
+    pub volume: f64,
+}
+
+impl<'de> Deserialize<'de> for Kline {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct KlineVisitor;
+
+        impl<'de> Visitor<'de> for KlineVisitor {
+            type Value = Kline;
+
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("a Binance kline array")
+            }
+
+            fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Kline, A::Error> {
+                fn next_num<'de, A: SeqAccess<'de>>(
+                    seq: &mut A,
+                    field: &'static str,
+                ) -> Result<f64, A::Error> {
+                    let raw: String = seq
+                        .next_element()?
+                        .ok_or_else(|| de::Error::missing_field(field))?;
+                    raw.parse().map_err(|_| {
+                        de::Error::invalid_value(de::Unexpected::Str(&raw), &"a decimal string")
+                    })
+                }
+
+                let open_time: i64 = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::missing_field("open_time"))?;
+                let open = next_num(&mut seq, "open")?;
+                let high = next_num(&mut seq, "high")?;
+                let low = next_num(&mut seq, "low")?;
+                let close = next_num(&mut seq, "close")?;
+                let volume = next_num(&mut seq, "volume")?;
+                while seq.next_element::<de::IgnoredAny>()?.is_some() {}
+
+                Ok(Kline {
+                    open_time,
+                    open,
+                    high,
+                    low,
+                    close,
+                    volume,
+                })
+            }
+        }
+
+        deserializer.deserialize_seq(KlineVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kline_parses_and_ignores_the_variable_tail() {
+        // Verbatim shape from data-api.binance.vision, whose final element is
+        // a string today and was a number historically.
+        let raw = r#"[1785628800000,"62823.65000000","63796.33000000","62806.58000000",
+            "63570.00000000","8387.01154000",1785715199999,"531238376.42127370",1286064,
+            "4566.33112000","289282425.13673770","0"]"#;
+        let k: Kline = serde_json::from_str(raw).unwrap();
+        assert_eq!(k.open_time, 1785628800000);
+        assert_eq!(k.open, 62823.65);
+        assert_eq!(k.high, 63796.33);
+        assert_eq!(k.low, 62806.58);
+        assert_eq!(k.close, 63570.0);
+        assert_eq!(k.volume, 8387.01154);
+    }
+
+    #[test]
+    fn kline_tolerates_a_numeric_tail_element() {
+        let raw = r#"[1,"1.0","2.0","0.5","1.5","10.0",2,"3.0",4,"5.0","6.0",0]"#;
+        assert!(serde_json::from_str::<Kline>(raw).is_ok());
+    }
+
+    #[test]
+    fn kline_rejects_a_truncated_array() {
+        let raw = r#"[1,"1.0","2.0"]"#;
+        assert!(serde_json::from_str::<Kline>(raw).is_err());
+    }
+}

--- a/src/adapters/binance/symbols.rs
+++ b/src/adapters/binance/symbols.rs
@@ -3,7 +3,12 @@
 //! Binance names a market as one concatenated string (`BTCUSDT`) with no
 //! separator, while the rest of the library speaks in coin ids (`bitcoin`),
 //! tickers (`BTC`), and separated pairs (`BTC-USD`). Everything is funnelled
-//! through here so the two conventions meet in exactly one place.
+//! through here so the two conventions meet in exactly one place; the coin id
+//! table itself is shared with Kraken in [`crate::adapters::common::coins`].
+
+use crate::adapters::common::coins;
+
+pub(crate) use coins::asset_name;
 
 /// Quote assets Binance actually lists, longest first.
 ///
@@ -12,57 +17,6 @@ const QUOTE_ASSETS: &[&str] = &[
     "FDUSD", "USDT", "USDC", "TUSD", "BUSD", "TRY", "BRL", "EUR", "GBP", "JPY", "ARS", "BNB",
     "BTC", "ETH", "DAI",
 ];
-
-/// CoinGecko-style ids for the majors, so `providers.crypto("bitcoin")` works
-/// on a Binance route as well as a CoinGecko one.
-///
-/// Deliberately partial — Binance has no id concept, and mirroring CoinGecko's
-/// full catalogue here would rot. Anything absent falls through as a ticker.
-const COIN_IDS: &[(&str, &str, &str)] = &[
-    ("bitcoin", "BTC", "Bitcoin"),
-    ("ethereum", "ETH", "Ethereum"),
-    ("binancecoin", "BNB", "BNB"),
-    ("ripple", "XRP", "XRP"),
-    ("cardano", "ADA", "Cardano"),
-    ("solana", "SOL", "Solana"),
-    ("dogecoin", "DOGE", "Dogecoin"),
-    ("polkadot", "DOT", "Polkadot"),
-    ("tron", "TRX", "TRON"),
-    ("avalanche-2", "AVAX", "Avalanche"),
-    ("chainlink", "LINK", "Chainlink"),
-    ("polygon-ecosystem-token", "POL", "Polygon"),
-    ("litecoin", "LTC", "Litecoin"),
-    ("shiba-inu", "SHIB", "Shiba Inu"),
-    ("uniswap", "UNI", "Uniswap"),
-    ("stellar", "XLM", "Stellar"),
-    ("cosmos", "ATOM", "Cosmos"),
-    ("monero", "XMR", "Monero"),
-    ("ethereum-classic", "ETC", "Ethereum Classic"),
-    ("filecoin", "FIL", "Filecoin"),
-    ("aptos", "APT", "Aptos"),
-    ("arbitrum", "ARB", "Arbitrum"),
-    ("optimism", "OP", "Optimism"),
-    ("near", "NEAR", "NEAR Protocol"),
-    ("injective-protocol", "INJ", "Injective"),
-];
-
-/// Resolve a coin id or ticker to its Binance base asset.
-pub(crate) fn base_asset(id: &str) -> String {
-    let id = id.trim();
-    COIN_IDS
-        .iter()
-        .find(|(coin_id, _, _)| coin_id.eq_ignore_ascii_case(id))
-        .map(|(_, ticker, _)| (*ticker).to_string())
-        .unwrap_or_else(|| id.to_uppercase())
-}
-
-/// The display name for a base asset, when it is one of the majors.
-pub(crate) fn asset_name(ticker: &str) -> Option<&'static str> {
-    COIN_IDS
-        .iter()
-        .find(|(_, t, _)| t.eq_ignore_ascii_case(ticker))
-        .map(|(_, _, name)| *name)
-}
 
 /// Resolve a quote currency to the asset Binance actually lists it as.
 ///
@@ -78,17 +32,18 @@ pub(crate) fn quote_asset(vs_currency: &str) -> String {
 
 /// Build a Binance market symbol from a coin id/ticker and a quote currency.
 pub(crate) fn pair(base_id: &str, vs_currency: &str) -> String {
-    format!("{}{}", base_asset(base_id), quote_asset(vs_currency))
+    format!(
+        "{}{}",
+        coins::resolve_ticker(base_id),
+        quote_asset(vs_currency)
+    )
 }
 
 /// Split a Binance market symbol back into `(base, quote)`.
 ///
 /// Returns `None` when the symbol ends in no recognised quote asset.
 pub(crate) fn split_pair(symbol: &str) -> Option<(&str, &str)> {
-    QUOTE_ASSETS
-        .iter()
-        .find(|q| symbol.len() > q.len() && symbol.ends_with(*q))
-        .map(|q| symbol.split_at(symbol.len() - q.len()))
+    coins::split_on_quote(symbol, QUOTE_ASSETS)
 }
 
 /// Normalise any of the symbol spellings the library uses into a Binance
@@ -103,7 +58,7 @@ pub(crate) fn parse_market(symbol: &str) -> Option<String> {
         .split_once(['-', '/', '_'])
         .filter(|(b, q)| !b.is_empty() && !q.is_empty())
     {
-        return Some(format!("{}{}", base_asset(base), quote_asset(quote)));
+        return Some(pair(base, quote));
     }
     let upper = symbol.to_uppercase();
     split_pair(&upper).is_some().then_some(upper)
@@ -112,15 +67,6 @@ pub(crate) fn parse_market(symbol: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn coin_ids_resolve_to_tickers() {
-        assert_eq!(base_asset("bitcoin"), "BTC");
-        assert_eq!(base_asset("Ethereum"), "ETH");
-        // Unknown ids fall through as tickers rather than failing.
-        assert_eq!(base_asset("wif"), "WIF");
-        assert_eq!(base_asset("btc"), "BTC");
-    }
 
     #[test]
     fn usd_maps_to_the_usdt_stablecoin() {

--- a/src/adapters/binance/symbols.rs
+++ b/src/adapters/binance/symbols.rs
@@ -1,0 +1,165 @@
+//! Symbol normalisation for Binance spot markets.
+//!
+//! Binance names a market as one concatenated string (`BTCUSDT`) with no
+//! separator, while the rest of the library speaks in coin ids (`bitcoin`),
+//! tickers (`BTC`), and separated pairs (`BTC-USD`). Everything is funnelled
+//! through here so the two conventions meet in exactly one place.
+
+/// Quote assets Binance actually lists, longest first.
+///
+/// Order matters: `BTCUSDT` must split as `BTC`/`USDT`, not `BTCUSD`/`T`.
+const QUOTE_ASSETS: &[&str] = &[
+    "FDUSD", "USDT", "USDC", "TUSD", "BUSD", "TRY", "BRL", "EUR", "GBP", "JPY", "ARS", "BNB",
+    "BTC", "ETH", "DAI",
+];
+
+/// CoinGecko-style ids for the majors, so `providers.crypto("bitcoin")` works
+/// on a Binance route as well as a CoinGecko one.
+///
+/// Deliberately partial — Binance has no id concept, and mirroring CoinGecko's
+/// full catalogue here would rot. Anything absent falls through as a ticker.
+const COIN_IDS: &[(&str, &str, &str)] = &[
+    ("bitcoin", "BTC", "Bitcoin"),
+    ("ethereum", "ETH", "Ethereum"),
+    ("binancecoin", "BNB", "BNB"),
+    ("ripple", "XRP", "XRP"),
+    ("cardano", "ADA", "Cardano"),
+    ("solana", "SOL", "Solana"),
+    ("dogecoin", "DOGE", "Dogecoin"),
+    ("polkadot", "DOT", "Polkadot"),
+    ("tron", "TRX", "TRON"),
+    ("avalanche-2", "AVAX", "Avalanche"),
+    ("chainlink", "LINK", "Chainlink"),
+    ("polygon-ecosystem-token", "POL", "Polygon"),
+    ("litecoin", "LTC", "Litecoin"),
+    ("shiba-inu", "SHIB", "Shiba Inu"),
+    ("uniswap", "UNI", "Uniswap"),
+    ("stellar", "XLM", "Stellar"),
+    ("cosmos", "ATOM", "Cosmos"),
+    ("monero", "XMR", "Monero"),
+    ("ethereum-classic", "ETC", "Ethereum Classic"),
+    ("filecoin", "FIL", "Filecoin"),
+    ("aptos", "APT", "Aptos"),
+    ("arbitrum", "ARB", "Arbitrum"),
+    ("optimism", "OP", "Optimism"),
+    ("near", "NEAR", "NEAR Protocol"),
+    ("injective-protocol", "INJ", "Injective"),
+];
+
+/// Resolve a coin id or ticker to its Binance base asset.
+pub(crate) fn base_asset(id: &str) -> String {
+    let id = id.trim();
+    COIN_IDS
+        .iter()
+        .find(|(coin_id, _, _)| coin_id.eq_ignore_ascii_case(id))
+        .map(|(_, ticker, _)| (*ticker).to_string())
+        .unwrap_or_else(|| id.to_uppercase())
+}
+
+/// The display name for a base asset, when it is one of the majors.
+pub(crate) fn asset_name(ticker: &str) -> Option<&'static str> {
+    COIN_IDS
+        .iter()
+        .find(|(_, t, _)| t.eq_ignore_ascii_case(ticker))
+        .map(|(_, _, name)| *name)
+}
+
+/// Resolve a quote currency to the asset Binance actually lists it as.
+///
+/// Binance spot has **no USD markets** — dollar pairs are quoted in the USDT
+/// stablecoin. `"USD"` is therefore mapped to `"USDT"`, which is what every
+/// caller means in practice, but is not literally the same asset.
+pub(crate) fn quote_asset(vs_currency: &str) -> String {
+    match vs_currency.trim().to_uppercase().as_str() {
+        "USD" => "USDT".to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// Build a Binance market symbol from a coin id/ticker and a quote currency.
+pub(crate) fn pair(base_id: &str, vs_currency: &str) -> String {
+    format!("{}{}", base_asset(base_id), quote_asset(vs_currency))
+}
+
+/// Split a Binance market symbol back into `(base, quote)`.
+///
+/// Returns `None` when the symbol ends in no recognised quote asset.
+pub(crate) fn split_pair(symbol: &str) -> Option<(&str, &str)> {
+    QUOTE_ASSETS
+        .iter()
+        .find(|q| symbol.len() > q.len() && symbol.ends_with(*q))
+        .map(|q| symbol.split_at(symbol.len() - q.len()))
+}
+
+/// Normalise any of the symbol spellings the library uses into a Binance
+/// market symbol.
+///
+/// Accepts a separated pair (`BTC-USD`, `BTC/USDT`, `BTC_USD`) or an already
+/// concatenated market (`BTCUSDT`). A bare asset with no quote (`BTC`) is
+/// ambiguous and returns `None`.
+pub(crate) fn parse_market(symbol: &str) -> Option<String> {
+    let symbol = symbol.trim();
+    if let Some((base, quote)) = symbol
+        .split_once(['-', '/', '_'])
+        .filter(|(b, q)| !b.is_empty() && !q.is_empty())
+    {
+        return Some(format!("{}{}", base_asset(base), quote_asset(quote)));
+    }
+    let upper = symbol.to_uppercase();
+    split_pair(&upper).is_some().then_some(upper)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn coin_ids_resolve_to_tickers() {
+        assert_eq!(base_asset("bitcoin"), "BTC");
+        assert_eq!(base_asset("Ethereum"), "ETH");
+        // Unknown ids fall through as tickers rather than failing.
+        assert_eq!(base_asset("wif"), "WIF");
+        assert_eq!(base_asset("btc"), "BTC");
+    }
+
+    #[test]
+    fn usd_maps_to_the_usdt_stablecoin() {
+        // Binance spot lists no USD markets.
+        assert_eq!(quote_asset("usd"), "USDT");
+        assert_eq!(quote_asset("USDT"), "USDT");
+        assert_eq!(quote_asset("eur"), "EUR");
+    }
+
+    #[test]
+    fn pairs_are_built_from_id_and_quote() {
+        assert_eq!(pair("bitcoin", "usd"), "BTCUSDT");
+        assert_eq!(pair("ETH", "EUR"), "ETHEUR");
+    }
+
+    #[test]
+    fn concatenated_markets_split_on_the_longest_quote_asset() {
+        // "BTCUSDT" must not split as BTCUSD + T.
+        assert_eq!(split_pair("BTCUSDT"), Some(("BTC", "USDT")));
+        assert_eq!(split_pair("ETHBTC"), Some(("ETH", "BTC")));
+        assert_eq!(split_pair("SOLFDUSD"), Some(("SOL", "FDUSD")));
+        assert_eq!(split_pair("USDT"), None, "a bare quote asset is not a pair");
+        assert_eq!(split_pair("BTC"), None);
+    }
+
+    #[test]
+    fn separated_and_concatenated_spellings_both_parse() {
+        assert_eq!(parse_market("BTC-USD").as_deref(), Some("BTCUSDT"));
+        assert_eq!(parse_market("btc/usdt").as_deref(), Some("BTCUSDT"));
+        assert_eq!(parse_market("bitcoin_eur").as_deref(), Some("BTCEUR"));
+        assert_eq!(parse_market("BTCUSDT").as_deref(), Some("BTCUSDT"));
+        assert_eq!(parse_market("ethbtc").as_deref(), Some("ETHBTC"));
+        // A bare asset names no market.
+        assert_eq!(parse_market("BTC"), None);
+    }
+
+    #[test]
+    fn asset_names_are_available_for_the_majors() {
+        assert_eq!(asset_name("BTC"), Some("Bitcoin"));
+        assert_eq!(asset_name("WIF"), None);
+    }
+}

--- a/src/adapters/bls/client.rs
+++ b/src/adapters/bls/client.rs
@@ -7,11 +7,11 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use reqwest::{Client, StatusCode};
+use reqwest::Client;
 use tracing::debug;
 
 use super::models::{BlsResponse, BlsSeries};
-use crate::adapters::common::keyless_http_client;
+use crate::adapters::common::{check_status, keyless_http_client};
 use crate::error::{FinanceError, Result};
 use crate::rate_limiter::RateLimiter;
 
@@ -108,15 +108,7 @@ impl BlsClient {
         let status = resp.status();
         let bytes = resp.bytes().await?;
 
-        if !status.is_success() {
-            return Err(match status {
-                StatusCode::TOO_MANY_REQUESTS => FinanceError::RateLimited { retry_after: None },
-                s => FinanceError::ExternalApiError {
-                    api: "BLS".to_string(),
-                    status: s.as_u16(),
-                },
-            });
-        }
+        check_status("BLS", status)?;
 
         let parsed: BlsResponse =
             serde_json::from_slice(&bytes).map_err(|e| FinanceError::ResponseStructureError {

--- a/src/adapters/bls/client.rs
+++ b/src/adapters/bls/client.rs
@@ -1,0 +1,156 @@
+//! BLS Public Data API HTTP client.
+//!
+//! Dual-mode: with no `BLS_API_KEY` the keyless v1 route is used (25
+//! queries/day per IP, ~3 years of history); with a key the v2 route is used
+//! (500 queries/day, 20 years, plus series catalog metadata).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use reqwest::{Client, StatusCode};
+use tracing::debug;
+
+use super::models::{BlsResponse, BlsSeries};
+use crate::adapters::common::keyless_http_client;
+use crate::error::{FinanceError, Result};
+use crate::rate_limiter::RateLimiter;
+
+pub(super) const BLS_BASE: &str = "https://api.bls.gov/publicAPI";
+
+/// Years of history requested on the keyed v2 route — its documented maximum
+/// per request.
+const V2_YEARS: i32 = 20;
+
+/// Which API tier a client talks to, decided by whether a key is configured.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum Tier {
+    /// Keyless v1: ~3 years of history, 25 queries/day per IP.
+    V1,
+    /// Keyed v2: 20 years of history, 500 queries/day, catalog metadata.
+    V2(String),
+}
+
+impl Tier {
+    /// Pick the tier from the environment: a key upgrades to v2.
+    pub(super) fn from_env() -> Self {
+        match std::env::var("BLS_API_KEY") {
+            Ok(key) if !key.trim().is_empty() => Self::V2(key),
+            _ => Self::V1,
+        }
+    }
+
+    pub(super) fn version(&self) -> &'static str {
+        match self {
+            Self::V1 => "v1",
+            Self::V2(_) => "v2",
+        }
+    }
+}
+
+pub(super) struct BlsClient {
+    http: Client,
+    limiter: Arc<RateLimiter>,
+    base_url: String,
+    tier: Tier,
+}
+
+impl BlsClient {
+    pub(super) fn new(
+        timeout: Duration,
+        limiter: Arc<RateLimiter>,
+        base_url: impl Into<String>,
+        tier: Tier,
+    ) -> Result<Self> {
+        Ok(Self {
+            http: keyless_http_client(timeout)?,
+            limiter,
+            base_url: base_url.into(),
+            tier,
+        })
+    }
+
+    /// Fetch one series by its native BLS id (e.g. `"CUUR0000SA0"`).
+    ///
+    /// Observations come back newest-first, as BLS orders them.
+    pub(super) async fn series(&self, series_id: &str) -> Result<BlsSeries> {
+        self.limiter.acquire().await;
+
+        let url = match &self.tier {
+            // v1 has no request body; the series id is the last path segment.
+            Tier::V1 => format!(
+                "{}/v1/timeseries/data/{}",
+                self.base_url,
+                crate::adapters::common::encode_path_segment(series_id)
+            ),
+            Tier::V2(_) => format!("{}/v2/timeseries/data/", self.base_url),
+        };
+        debug!("BLS request ({}): {series_id}", self.tier.version());
+
+        let request = match &self.tier {
+            Tier::V1 => self.http.get(&url),
+            Tier::V2(key) => {
+                let end = chrono::Utc::now().format("%Y").to_string();
+                let start = (chrono::Utc::now().format("%Y").to_string())
+                    .parse::<i32>()
+                    .map(|y| (y - V2_YEARS + 1).to_string())
+                    .unwrap_or_else(|_| end.clone());
+                self.http.post(&url).json(&serde_json::json!({
+                    "seriesid": [series_id],
+                    "registrationkey": key,
+                    "startyear": start,
+                    "endyear": end,
+                    "catalog": true,
+                }))
+            }
+        };
+
+        let resp = request.send().await?;
+        let status = resp.status();
+        let bytes = resp.bytes().await?;
+
+        if !status.is_success() {
+            return Err(match status {
+                StatusCode::TOO_MANY_REQUESTS => FinanceError::RateLimited { retry_after: None },
+                s => FinanceError::ExternalApiError {
+                    api: "BLS".to_string(),
+                    status: s.as_u16(),
+                },
+            });
+        }
+
+        let parsed: BlsResponse =
+            serde_json::from_slice(&bytes).map_err(|e| FinanceError::ResponseStructureError {
+                field: "bls.response".to_string(),
+                context: format!("unrecognised BLS envelope: {e}"),
+            })?;
+
+        if parsed.status != "REQUEST_SUCCEEDED" {
+            return Err(FinanceError::MacroDataError {
+                provider: "BLS".to_string(),
+                context: format!("{}: {}", parsed.status, parsed.message.join("; ")),
+            });
+        }
+
+        let series = parsed
+            .results
+            .and_then(|r| r.series.into_iter().next())
+            .ok_or_else(|| FinanceError::ResponseStructureError {
+                field: "bls.Results.series".to_string(),
+                context: "BLS returned no series block".to_string(),
+            })?;
+
+        // An unknown series id still reports REQUEST_SUCCEEDED, with the
+        // complaint in `message` and an empty data array.
+        if series.data.is_empty() {
+            return Err(FinanceError::SymbolNotFound {
+                symbol: Some(series_id.to_string()),
+                context: if parsed.message.is_empty() {
+                    "BLS returned no observations for this series".to_string()
+                } else {
+                    parsed.message.join("; ")
+                },
+            });
+        }
+        Ok(series)
+    }
+}

--- a/src/adapters/bls/economic/mod.rs
+++ b/src/adapters/bls/economic/mod.rs
@@ -1,5 +1,7 @@
 //! `ECONOMIC` capability for the BLS Public Data API.
 
+use crate::adapters::common::numbers::parse_number;
+use crate::adapters::common::periods;
 use crate::error::Result;
 use crate::models::economic::{EconomicSeries, MacroObservation};
 
@@ -23,19 +25,19 @@ pub(super) fn resolve_period(year: &str, period: &str) -> Option<Period> {
     let n: u32 = n.parse().ok()?;
     match kind {
         "M" if (1..=12).contains(&n) => Some(Period {
-            date: format!("{year}-{n:02}-01"),
+            date: periods::month_start(year, n),
             frequency: "Monthly",
         }),
         "Q" if (1..=4).contains(&n) => Some(Period {
-            date: format!("{year}-{:02}-01", (n - 1) * 3 + 1),
+            date: periods::quarter_start(year, n),
             frequency: "Quarterly",
         }),
         "S" if (1..=2).contains(&n) => Some(Period {
-            date: format!("{year}-{:02}-01", (n - 1) * 6 + 1),
+            date: periods::half_start(year, n),
             frequency: "Semiannual",
         }),
         "A" => Some(Period {
-            date: format!("{year}-01-01"),
+            date: periods::year_start(year),
             frequency: "Annual",
         }),
         // M13 / Q05 / S03 are annual aggregates, and anything else is a period
@@ -46,11 +48,7 @@ pub(super) fn resolve_period(year: &str, period: &str) -> Option<Period> {
 
 /// Parse a BLS value string. `"-"` marks a figure BLS could not publish.
 pub(super) fn parse_value(raw: &str) -> Option<f64> {
-    let raw = raw.trim();
-    if raw.is_empty() || raw == "-" {
-        return None;
-    }
-    raw.parse::<f64>().ok()
+    parse_number(raw, &["-"])
 }
 
 /// Map a BLS series onto the canonical [`EconomicSeries`].

--- a/src/adapters/bls/economic/mod.rs
+++ b/src/adapters/bls/economic/mod.rs
@@ -1,0 +1,96 @@
+//! `ECONOMIC` capability for the BLS Public Data API.
+
+use crate::error::Result;
+use crate::models::economic::{EconomicSeries, MacroObservation};
+
+use super::models::BlsSeries;
+
+/// A BLS period label resolved to a date and a reporting frequency.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct Period {
+    /// `YYYY-MM-DD` start of the period.
+    pub date: String,
+    pub frequency: &'static str,
+}
+
+/// Resolve a `(year, period)` pair to the start date of that period.
+///
+/// Returns `None` for BLS's annual-aggregate periods (`M13`, `Q05`, `S03`).
+/// Those rows are folded into an otherwise sub-annual series and would collide
+/// with a real observation's date, so they are dropped rather than merged.
+pub(super) fn resolve_period(year: &str, period: &str) -> Option<Period> {
+    let (kind, n) = period.split_at_checked(1)?;
+    let n: u32 = n.parse().ok()?;
+    match kind {
+        "M" if (1..=12).contains(&n) => Some(Period {
+            date: format!("{year}-{n:02}-01"),
+            frequency: "Monthly",
+        }),
+        "Q" if (1..=4).contains(&n) => Some(Period {
+            date: format!("{year}-{:02}-01", (n - 1) * 3 + 1),
+            frequency: "Quarterly",
+        }),
+        "S" if (1..=2).contains(&n) => Some(Period {
+            date: format!("{year}-{:02}-01", (n - 1) * 6 + 1),
+            frequency: "Semiannual",
+        }),
+        "A" => Some(Period {
+            date: format!("{year}-01-01"),
+            frequency: "Annual",
+        }),
+        // M13 / Q05 / S03 are annual aggregates, and anything else is a period
+        // code this adapter does not know how to date.
+        _ => None,
+    }
+}
+
+/// Parse a BLS value string. `"-"` marks a figure BLS could not publish.
+pub(super) fn parse_value(raw: &str) -> Option<f64> {
+    let raw = raw.trim();
+    if raw.is_empty() || raw == "-" {
+        return None;
+    }
+    raw.parse::<f64>().ok()
+}
+
+/// Map a BLS series onto the canonical [`EconomicSeries`].
+///
+/// BLS returns newest-first; the canonical model documents chronological
+/// order, so observations are sorted ascending here.
+pub(super) fn to_canonical(series_id: &str, series: BlsSeries) -> EconomicSeries {
+    let title = series.catalog.and_then(|c| c.series_title);
+
+    let mut frequency: Option<&'static str> = None;
+    let mut observations: Vec<MacroObservation> = series
+        .data
+        .into_iter()
+        .filter_map(|point| {
+            let period = resolve_period(&point.year, &point.period)?;
+            // The first datable row settles the frequency; BLS never mixes
+            // base frequencies within one series id.
+            frequency.get_or_insert(period.frequency);
+            Some(MacroObservation {
+                date: period.date,
+                value: parse_value(&point.value),
+            })
+        })
+        .collect();
+    observations.sort_by(|a, b| a.date.cmp(&b.date));
+
+    EconomicSeries {
+        series_id: series_id.to_string(),
+        title,
+        // BLS reports no unit field; the unit is implied by the series id and
+        // stated in its title, so claiming one here would be a guess.
+        units: None,
+        frequency: frequency.map(str::to_string),
+        observations,
+    }
+}
+
+/// Fetch a BLS series as the canonical
+/// [`EconomicSeries`](crate::models::economic::EconomicSeries).
+pub(crate) async fn fetch_economic_series_response(series_id: &str) -> Result<EconomicSeries> {
+    let series = super::client()?.series(series_id).await?;
+    Ok(to_canonical(series_id, series))
+}

--- a/src/adapters/bls/mod.rs
+++ b/src/adapters/bls/mod.rs
@@ -1,0 +1,284 @@
+//! US Bureau of Labor Statistics — CPI, unemployment, payrolls, wages, PPI
+//! from the primary source.
+//!
+//! Requires the **`bls`** feature flag.
+//!
+//! The first provider in the library with a **keyless/keyed dual mode**: with
+//! no `BLS_API_KEY` set the keyless v1 route is used (25 queries/day per IP,
+//! ~3 years of history); setting a free key upgrades every call to v2 (500
+//! queries/day, 20 years, plus series titles from the catalog). Nothing else
+//! changes — the same series ids and the same response type either way.
+//!
+//! # Series identifiers
+//!
+//! Native BLS series ids, e.g. `"CUUR0000SA0"` (CPI-U, all items, all urban
+//! consumers) or `"LNS14000000"` (unemployment rate).
+
+pub(crate) mod client;
+pub(crate) mod economic;
+pub(crate) mod models;
+
+use std::time::Duration;
+
+use crate::adapters::singleton::keyless_limiter;
+use crate::error::Result;
+use client::{BlsClient, Tier};
+
+/// Self-imposed pacing. BLS caps by the day, not the second, so this only
+/// keeps a burst from looking abusive — the daily quota is the real limit.
+const BLS_RATE_PER_SEC: f64 = 2.0;
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+keyless_limiter!(rate = BLS_RATE_PER_SEC);
+
+/// Build a client against the live API, reusing the shared token bucket.
+///
+/// The tier is resolved per call rather than cached, so a key exported after
+/// the first request still takes effect.
+fn client() -> Result<BlsClient> {
+    BlsClient::new(
+        DEFAULT_TIMEOUT,
+        shared_limiter(),
+        client::BLS_BASE,
+        Tier::from_env(),
+    )
+}
+
+pub(crate) use economic::fetch_economic_series_response;
+
+#[cfg(test)]
+mod tests {
+    use super::economic::{parse_value, resolve_period, to_canonical};
+    use super::*;
+    use crate::error::FinanceError;
+    use crate::rate_limiter::RateLimiter;
+    use std::sync::Arc;
+
+    fn test_client(base_url: &str, tier: Tier) -> BlsClient {
+        BlsClient::new(
+            Duration::from_secs(5),
+            Arc::new(RateLimiter::new(100.0)),
+            base_url,
+            tier,
+        )
+        .unwrap()
+    }
+
+    fn cpi_payload() -> String {
+        serde_json::json!({
+            "status": "REQUEST_SUCCEEDED",
+            "responseTime": 111,
+            "message": [],
+            "Results": {
+                "series": [{
+                    "seriesID": "CUUR0000SA0",
+                    "data": [
+                        { "year": "2026", "period": "M03", "periodName": "March",
+                          "latest": "true", "value": "330.213", "footnotes": [{}] },
+                        { "year": "2026", "period": "M02", "periodName": "February",
+                          "value": "326.785", "footnotes": [{}] },
+                        { "year": "2026", "period": "M01", "periodName": "January",
+                          "value": "-", "footnotes": [{ "code": "X", "text": "Data unavailable" }] },
+                        { "year": "2025", "period": "M13", "periodName": "Annual",
+                          "value": "321.943", "footnotes": [{}] }
+                    ]
+                }]
+            }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn tier_is_keyless_without_a_key() {
+        // `Tier::from_env` reads the process environment, which tests share;
+        // the mapping itself is what matters and is asserted directly.
+        assert_eq!(Tier::V1.version(), "v1");
+        assert_eq!(Tier::V2("k".into()).version(), "v2");
+    }
+
+    #[test]
+    fn monthly_quarterly_and_annual_periods_resolve_to_period_starts() {
+        assert_eq!(resolve_period("2026", "M01").unwrap().date, "2026-01-01");
+        assert_eq!(resolve_period("2026", "M12").unwrap().date, "2026-12-01");
+        assert_eq!(resolve_period("2026", "M06").unwrap().frequency, "Monthly");
+        assert_eq!(resolve_period("2026", "Q01").unwrap().date, "2026-01-01");
+        assert_eq!(resolve_period("2026", "Q04").unwrap().date, "2026-10-01");
+        assert_eq!(
+            resolve_period("2026", "Q02").unwrap().frequency,
+            "Quarterly"
+        );
+        assert_eq!(resolve_period("2026", "S01").unwrap().date, "2026-01-01");
+        assert_eq!(resolve_period("2026", "S02").unwrap().date, "2026-07-01");
+        assert_eq!(resolve_period("2026", "A01").unwrap().date, "2026-01-01");
+        assert_eq!(resolve_period("2026", "A01").unwrap().frequency, "Annual");
+    }
+
+    #[test]
+    fn annual_aggregate_periods_are_dropped() {
+        // M13/Q05/S03 are annual averages folded into a sub-annual series;
+        // dating them would collide with a real observation.
+        assert_eq!(resolve_period("2025", "M13"), None);
+        assert_eq!(resolve_period("2025", "Q05"), None);
+        assert_eq!(resolve_period("2025", "S03"), None);
+        assert_eq!(resolve_period("2025", "Z99"), None);
+        assert_eq!(resolve_period("2025", ""), None);
+    }
+
+    #[test]
+    fn dash_marks_an_unpublished_figure() {
+        assert_eq!(parse_value("330.213"), Some(330.213));
+        assert_eq!(parse_value("-"), None);
+        assert_eq!(parse_value(""), None);
+        assert_eq!(parse_value("n/a"), None);
+    }
+
+    #[tokio::test]
+    async fn v1_series_maps_to_canonical_chronological_series() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/v1/timeseries/data/CUUR0000SA0")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(cpi_payload())
+            .create_async()
+            .await;
+
+        let raw = test_client(&server.url(), Tier::V1)
+            .series("CUUR0000SA0")
+            .await
+            .unwrap();
+        let series = to_canonical("CUUR0000SA0", raw);
+
+        assert_eq!(series.series_id, "CUUR0000SA0");
+        assert_eq!(series.frequency.as_deref(), Some("Monthly"));
+        // The M13 annual average is dropped; three monthly rows remain.
+        assert_eq!(series.observations.len(), 3);
+        assert_eq!(series.observations[0].date, "2026-01-01");
+        assert_eq!(series.observations[0].value, None, "\"-\" parses to None");
+        assert_eq!(series.observations[2].date, "2026-03-01");
+        assert_eq!(series.observations[2].value, Some(330.213));
+        // No catalog on the keyless route, so no title is invented.
+        assert_eq!(series.title, None);
+    }
+
+    #[tokio::test]
+    async fn v2_posts_the_key_and_reads_the_catalog_title() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("POST", "/v2/timeseries/data/")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "seriesid": ["CUUR0000SA0"],
+                "registrationkey": "test-key",
+                "catalog": true
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "status": "REQUEST_SUCCEEDED",
+                    "message": [],
+                    "Results": { "series": [{
+                        "seriesID": "CUUR0000SA0",
+                        "catalog": { "series_title": "All items in U.S. city average" },
+                        "data": [{ "year": "2026", "period": "M03", "value": "330.213" }]
+                    }]}
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let raw = test_client(&server.url(), Tier::V2("test-key".into()))
+            .series("CUUR0000SA0")
+            .await
+            .unwrap();
+        let series = to_canonical("CUUR0000SA0", raw);
+        assert_eq!(
+            series.title.as_deref(),
+            Some("All items in U.S. city average")
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_series_reports_the_bls_complaint() {
+        // BLS answers an invalid id with REQUEST_SUCCEEDED, an empty data
+        // array, and the complaint in `message` — not with an error status.
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/v1/timeseries/data/NOTASERIES")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "status": "REQUEST_SUCCEEDED",
+                    "message": ["Invalid Series for Series NOTASERIES"],
+                    "Results": { "series": [{ "seriesID": "NOTASERIES", "data": [] }] }
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let err = test_client(&server.url(), Tier::V1)
+            .series("NOTASERIES")
+            .await
+            .unwrap_err();
+        match err {
+            FinanceError::SymbolNotFound { context, .. } => {
+                assert!(context.contains("Invalid Series"), "got {context}");
+            }
+            other => panic!("expected SymbolNotFound, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn failed_status_surfaces_as_a_macro_data_error() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/v1/timeseries/data/CUUR0000SA0")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "status": "REQUEST_NOT_PROCESSED",
+                    "message": ["daily threshold for requests exceeded"],
+                    "Results": {}
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let err = test_client(&server.url(), Tier::V1)
+            .series("CUUR0000SA0")
+            .await
+            .unwrap_err();
+        match err {
+            FinanceError::MacroDataError { provider, context } => {
+                assert_eq!(provider, "BLS");
+                assert!(context.contains("daily threshold"), "got {context}");
+            }
+            other => panic!("expected MacroDataError, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn http_error_maps_to_external_api_error() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/v1/timeseries/data/CUUR0000SA0")
+            .with_status(503)
+            .create_async()
+            .await;
+
+        let err = test_client(&server.url(), Tier::V1)
+            .series("CUUR0000SA0")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, FinanceError::ExternalApiError { status: 503, .. }),
+            "{err:?}"
+        );
+    }
+}

--- a/src/adapters/bls/models.rs
+++ b/src/adapters/bls/models.rs
@@ -1,0 +1,49 @@
+//! BLS Public Data API wire types.
+//!
+//! v1 and v2 share the same response envelope; v2 additionally returns a
+//! `catalog` block per series when `catalog: true` is requested.
+
+use serde::Deserialize;
+
+/// The envelope every BLS response uses, successful or not.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct BlsResponse {
+    pub status: String,
+    /// Diagnostics. Populated even on `REQUEST_SUCCEEDED` — an unknown series
+    /// id comes back "succeeded" with the complaint in here and no data.
+    #[serde(default)]
+    pub message: Vec<String>,
+    #[serde(default, rename = "Results")]
+    pub results: Option<BlsResults>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct BlsResults {
+    #[serde(default)]
+    pub series: Vec<BlsSeries>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct BlsSeries {
+    /// Only present when `catalog: true` was requested (v2 with a key).
+    #[serde(default)]
+    pub catalog: Option<BlsCatalog>,
+    #[serde(default)]
+    pub data: Vec<BlsDataPoint>,
+}
+
+/// Series metadata, available on the keyed v2 route only.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct BlsCatalog {
+    #[serde(default)]
+    pub series_title: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct BlsDataPoint {
+    pub year: String,
+    /// `M01`–`M13`, `Q01`–`Q05`, `S01`–`S03`, or `A01`.
+    pub period: String,
+    /// Numeric string; `"-"` marks a figure BLS could not publish.
+    pub value: String,
+}

--- a/src/adapters/common.rs
+++ b/src/adapters/common.rs
@@ -54,6 +54,30 @@ pub(crate) fn encode_path_segment(segment: &str) -> String {
     utf8_percent_encode(segment, PATH_SEGMENT_ENCODE_SET).to_string()
 }
 
+/// The `User-Agent` every adapter identifies itself with. Several keyless
+/// public APIs (World Bank, FiscalData, Stooq, …) throttle or reject clients
+/// that send no identifiable agent.
+#[allow(dead_code)] // used by the keyless adapter modules
+pub(crate) fn user_agent() -> String {
+    format!(
+        "finance-query/{} (https://github.com/Verdenroz/finance-query)",
+        env!("CARGO_PKG_VERSION")
+    )
+}
+
+/// Build a keyless adapter's HTTP client. Deliberately constructed per call —
+/// a `reqwest::Client` is bound to the runtime that first drives it, so a
+/// cached one fails with hyper `DispatchGone` once that runtime is dropped.
+#[allow(dead_code)] // used by the keyless adapter modules
+pub(crate) fn keyless_http_client(
+    timeout: std::time::Duration,
+) -> crate::error::Result<reqwest::Client> {
+    Ok(reqwest::Client::builder()
+        .timeout(timeout)
+        .user_agent(user_agent())
+        .build()?)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/adapters/common/coins.rs
+++ b/src/adapters/common/coins.rs
@@ -1,0 +1,130 @@
+//! Coin vocabulary shared by the keyless crypto exchange adapters.
+//!
+//! Binance and Kraken both name markets as one concatenated string
+//! (`BTCUSDT`, `XBTUSD`) while the rest of the library speaks in CoinGecko-style
+//! ids (`bitcoin`) and tickers (`BTC`). The id table and the splitting rule are
+//! identical for both, so they live here — a coin added for one exchange then
+//! resolves on the other too. Each adapter keeps only what is genuinely its
+//! own: its quote-asset list and its exchange-specific asset aliases.
+
+/// CoinGecko-style ids for the majors, as `(id, ticker, display name)`.
+///
+/// Deliberately partial — exchanges have no id concept, and mirroring
+/// CoinGecko's full catalogue here would rot. Anything absent falls through as
+/// a ticker. A listed coin an exchange does not trade simply fails upstream as
+/// an unknown market, which is the same answer the user would get anyway.
+const COIN_IDS: &[(&str, &str, &str)] = &[
+    ("bitcoin", "BTC", "Bitcoin"),
+    ("ethereum", "ETH", "Ethereum"),
+    ("binancecoin", "BNB", "BNB"),
+    ("ripple", "XRP", "XRP"),
+    ("cardano", "ADA", "Cardano"),
+    ("solana", "SOL", "Solana"),
+    ("dogecoin", "DOGE", "Dogecoin"),
+    ("polkadot", "DOT", "Polkadot"),
+    ("tron", "TRX", "TRON"),
+    ("avalanche-2", "AVAX", "Avalanche"),
+    ("chainlink", "LINK", "Chainlink"),
+    ("polygon-ecosystem-token", "POL", "Polygon"),
+    ("litecoin", "LTC", "Litecoin"),
+    ("shiba-inu", "SHIB", "Shiba Inu"),
+    ("uniswap", "UNI", "Uniswap"),
+    ("stellar", "XLM", "Stellar"),
+    ("cosmos", "ATOM", "Cosmos"),
+    ("monero", "XMR", "Monero"),
+    ("ethereum-classic", "ETC", "Ethereum Classic"),
+    ("filecoin", "FIL", "Filecoin"),
+    ("aptos", "APT", "Aptos"),
+    ("arbitrum", "ARB", "Arbitrum"),
+    ("optimism", "OP", "Optimism"),
+    ("near", "NEAR", "NEAR Protocol"),
+    ("injective-protocol", "INJ", "Injective"),
+    ("algorand", "ALGO", "Algorand"),
+    ("tezos", "XTZ", "Tezos"),
+    ("aave", "AAVE", "Aave"),
+];
+
+/// Resolve a coin id or ticker to its common ticker (uppercase).
+///
+/// Unknown ids are uppercased and passed through rather than rejected, so a
+/// coin missing from the table still reaches the exchange.
+pub(crate) fn resolve_ticker(id: &str) -> String {
+    let id = id.trim();
+    COIN_IDS
+        .iter()
+        .find(|(coin_id, _, _)| coin_id.eq_ignore_ascii_case(id))
+        .map(|(_, ticker, _)| (*ticker).to_string())
+        .unwrap_or_else(|| id.to_uppercase())
+}
+
+/// The display name for a ticker, when it is one of the majors.
+pub(crate) fn asset_name(ticker: &str) -> Option<&'static str> {
+    COIN_IDS
+        .iter()
+        .find(|(_, t, _)| t.eq_ignore_ascii_case(ticker))
+        .map(|(_, _, name)| *name)
+}
+
+/// Split a concatenated market symbol into `(base, quote)` on the first
+/// matching entry of `quotes`.
+///
+/// `quotes` must be ordered longest-first, or `BTCUSDT` splits as `BTCUSD`/`T`.
+/// Returns `None` when the symbol ends in no listed quote asset, or is nothing
+/// but a quote asset.
+pub(crate) fn split_on_quote<'a>(symbol: &'a str, quotes: &[&str]) -> Option<(&'a str, &'a str)> {
+    quotes
+        .iter()
+        .find(|q| symbol.len() > q.len() && symbol.ends_with(*q))
+        .map(|q| symbol.split_at(symbol.len() - q.len()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ids_resolve_to_tickers_case_insensitively() {
+        assert_eq!(resolve_ticker("bitcoin"), "BTC");
+        assert_eq!(resolve_ticker("Ethereum"), "ETH");
+        assert_eq!(resolve_ticker(" solana "), "SOL");
+    }
+
+    #[test]
+    fn unknown_ids_fall_through_as_tickers() {
+        assert_eq!(resolve_ticker("wif"), "WIF");
+        assert_eq!(resolve_ticker("btc"), "BTC");
+    }
+
+    #[test]
+    fn names_are_available_for_the_majors() {
+        assert_eq!(asset_name("BTC"), Some("Bitcoin"));
+        assert_eq!(asset_name("aave"), Some("Aave"));
+        assert_eq!(asset_name("WIF"), None);
+    }
+
+    #[test]
+    fn every_id_and_ticker_is_listed_once() {
+        for (i, (id, ticker, _)) in COIN_IDS.iter().enumerate() {
+            let dupe = COIN_IDS
+                .iter()
+                .skip(i + 1)
+                .any(|(o_id, o_ticker, _)| o_id == id || o_ticker == ticker);
+            assert!(!dupe, "{id}/{ticker} appears twice");
+        }
+    }
+
+    #[test]
+    fn markets_split_on_the_longest_quote_asset() {
+        let quotes = &["USDT", "USDC", "USD", "BTC"];
+        assert_eq!(split_on_quote("BTCUSDT", quotes), Some(("BTC", "USDT")));
+        assert_eq!(split_on_quote("SOLUSD", quotes), Some(("SOL", "USD")));
+        assert_eq!(split_on_quote("ETHBTC", quotes), Some(("ETH", "BTC")));
+    }
+
+    #[test]
+    fn a_bare_quote_asset_is_not_a_market() {
+        let quotes = &["USDT", "USD"];
+        assert_eq!(split_on_quote("USDT", quotes), None);
+        assert_eq!(split_on_quote("BTC", quotes), None);
+    }
+}

--- a/src/adapters/common/crypto_chart.rs
+++ b/src/adapters/common/crypto_chart.rs
@@ -1,0 +1,54 @@
+//! Canonical [`Chart`] assembly shared by the keyless crypto exchange adapters.
+//!
+//! Binance and Kraken return different candle wire shapes (each adapter
+//! converts its own), but the surrounding [`ChartMeta`] is identical apart from
+//! the exchange's identity, so it is built in one place.
+
+use crate::constants::{Interval, TimeRange};
+use crate::models::chart::{Candle, Chart, ChartMeta};
+use crate::providers::Provider;
+
+/// How an exchange names itself in canonical chart metadata.
+pub(crate) struct CryptoExchange {
+    /// The routed provider the candles came from.
+    pub provider: Provider,
+    /// Uppercase exchange code (e.g. `"BINANCE"`).
+    pub code: &'static str,
+    /// Display name (e.g. `"Binance"`).
+    pub name: &'static str,
+}
+
+/// Assemble a [`Chart`] around a crypto candle series.
+///
+/// `quote_currency` is the pair's quote asset in the library's spelling — each
+/// exchange derives it from its own market symbol before calling.
+pub(crate) fn crypto_chart(
+    exchange: &CryptoExchange,
+    symbol: &str,
+    quote_currency: Option<String>,
+    candles: Vec<Candle>,
+    interval: Option<Interval>,
+    range: Option<TimeRange>,
+) -> Chart {
+    Chart {
+        symbol: symbol.to_string(),
+        meta: ChartMeta {
+            symbol: symbol.to_string(),
+            currency: quote_currency,
+            exchange_name: Some(exchange.code.to_string()),
+            full_exchange_name: Some(exchange.name.to_string()),
+            instrument_type: Some("CRYPTOCURRENCY".to_string()),
+            first_trade_date: candles.first().map(|c| c.timestamp),
+            regular_market_time: candles.last().map(|c| c.timestamp),
+            regular_market_price: candles.last().map(|c| c.close),
+            data_granularity: interval.map(|i| i.as_str().to_string()),
+            range: range.map(|r| r.as_str().to_string()),
+            provider_id: Some(exchange.provider),
+            ..Default::default()
+        },
+        candles,
+        interval,
+        range,
+        provider_id: Some(exchange.provider),
+    }
+}

--- a/src/adapters/common/mod.rs
+++ b/src/adapters/common/mod.rs
@@ -1,6 +1,25 @@
 //! Shared internal helpers for adapter modules.
 
 use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
+use reqwest::StatusCode;
+
+use crate::error::{FinanceError, Result};
+
+/// Coin id / ticker vocabulary shared by the keyless crypto exchanges.
+#[cfg(any(feature = "binance", feature = "kraken"))]
+pub(crate) mod coins;
+
+/// Canonical chart assembly shared by the keyless crypto exchanges.
+#[cfg(any(feature = "binance", feature = "kraken"))]
+pub(crate) mod crypto_chart;
+
+/// Numeric parsing shared by the macro-data adapters.
+#[cfg(any(feature = "bls", feature = "fiscaldata"))]
+pub(crate) mod numbers;
+
+/// Period-label resolution shared by the macro-data adapters.
+#[cfg(any(feature = "bls", feature = "worldbank"))]
+pub(crate) mod periods;
 
 /// Characters that must be percent-encoded inside a URL path segment.
 ///
@@ -49,7 +68,7 @@ const PATH_SEGMENT_ENCODE_SET: &AsciiSet = &CONTROLS
 ///
 /// Use whenever a user-supplied symbol/ticker/CIK is interpolated into a
 /// URL path via `format!`.
-#[allow(dead_code)] // used by fmp and polygon adapter modules (tasks 5 & 6)
+#[allow(dead_code)] // unused when no URL-building adapter feature is enabled
 pub(crate) fn encode_path_segment(segment: &str) -> String {
     utf8_percent_encode(segment, PATH_SEGMENT_ENCODE_SET).to_string()
 }
@@ -69,13 +88,37 @@ pub(crate) fn user_agent() -> String {
 /// a `reqwest::Client` is bound to the runtime that first drives it, so a
 /// cached one fails with hyper `DispatchGone` once that runtime is dropped.
 #[allow(dead_code)] // used by the keyless adapter modules
-pub(crate) fn keyless_http_client(
-    timeout: std::time::Duration,
-) -> crate::error::Result<reqwest::Client> {
+pub(crate) fn keyless_http_client(timeout: std::time::Duration) -> Result<reqwest::Client> {
     Ok(reqwest::Client::builder()
         .timeout(timeout)
         .user_agent(user_agent())
         .build()?)
+}
+
+/// The error a non-2xx status maps to when the adapter has no more specific
+/// reading of it. `api` names the upstream service in the error message.
+///
+/// Adapters that distinguish extra statuses match those arms first and let
+/// this handle the tail, so every adapter reports the same shape for the
+/// statuses none of them special-case.
+#[allow(dead_code)] // used by the keyless adapter modules
+pub(crate) fn status_error(api: &'static str, status: StatusCode) -> FinanceError {
+    match status {
+        StatusCode::TOO_MANY_REQUESTS => FinanceError::RateLimited { retry_after: None },
+        s => FinanceError::ExternalApiError {
+            api: api.to_string(),
+            status: s.as_u16(),
+        },
+    }
+}
+
+/// Fail a non-2xx response via [`status_error`]; succeed on any 2xx.
+#[allow(dead_code)] // used by the keyless adapter modules
+pub(crate) fn check_status(api: &'static str, status: StatusCode) -> Result<()> {
+    if status.is_success() {
+        return Ok(());
+    }
+    Err(status_error(api, status))
 }
 
 #[cfg(test)]
@@ -117,6 +160,32 @@ mod tests {
         // Critical: must NOT collapse to empty (no dot-segment removal).
         // The literal ".." characters are unreserved, so they pass through.
         assert_eq!(encode_path_segment(".."), "..");
+    }
+
+    #[test]
+    fn rate_limit_status_maps_to_rate_limited() {
+        assert!(matches!(
+            status_error("Test", StatusCode::TOO_MANY_REQUESTS),
+            FinanceError::RateLimited { retry_after: None }
+        ));
+    }
+
+    #[test]
+    fn other_failures_carry_the_api_name_and_status() {
+        match status_error("Test", StatusCode::BAD_GATEWAY) {
+            FinanceError::ExternalApiError { api, status } => {
+                assert_eq!(api, "Test");
+                assert_eq!(status, 502);
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn success_statuses_pass_check() {
+        assert!(check_status("Test", StatusCode::OK).is_ok());
+        assert!(check_status("Test", StatusCode::NO_CONTENT).is_ok());
+        assert!(check_status("Test", StatusCode::NOT_FOUND).is_err());
     }
 
     #[test]

--- a/src/adapters/common/numbers.rs
+++ b/src/adapters/common/numbers.rs
@@ -1,0 +1,28 @@
+//! Numeric parsing shared by the macro-data adapters.
+
+/// Parse a string-encoded observation value.
+///
+/// These APIs encode "no figure published" in-band as a sentinel string rather
+/// than as JSON `null`; `missing` lists this API's sentinels, matched
+/// case-insensitively. Anything else unparseable is also `None`.
+pub(crate) fn parse_number(raw: &str, missing: &[&str]) -> Option<f64> {
+    let raw = raw.trim();
+    if raw.is_empty() || missing.iter().any(|s| raw.eq_ignore_ascii_case(s)) {
+        return None;
+    }
+    raw.parse::<f64>().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sentinels_and_junk_parse_to_none() {
+        assert_eq!(parse_number(" 3.5 ", &["-"]), Some(3.5));
+        assert_eq!(parse_number("-", &["-"]), None);
+        assert_eq!(parse_number("NULL", &["null"]), None);
+        assert_eq!(parse_number("", &["null"]), None);
+        assert_eq!(parse_number("n/a", &["-"]), None);
+    }
+}

--- a/src/adapters/common/periods.rs
+++ b/src/adapters/common/periods.rs
@@ -1,0 +1,54 @@
+//! Period-label resolution shared by the macro-data adapters.
+//!
+//! BLS and the World Bank spell their period labels differently (`"Q01"`,
+//! `"2023Q3"`, `"M04"`), but both resolve to the same thing:
+//! [`MacroObservation::date`](crate::models::economic::MacroObservation::date),
+//! documented as the `YYYY-MM-DD` **start** of the period. These helpers own
+//! that convention so the adapters cannot drift from it.
+
+/// `YYYY-MM-DD` start of the `month`th month (1-12) of `year`.
+pub(crate) fn month_start(year: &str, month: u32) -> String {
+    format!("{year}-{month:02}-01")
+}
+
+/// `YYYY-MM-DD` start of the `quarter`th quarter (1-4) of `year`.
+pub(crate) fn quarter_start(year: &str, quarter: u32) -> String {
+    month_start(year, (quarter - 1) * 3 + 1)
+}
+
+/// `YYYY-MM-DD` start of the `half`th half-year (1-2) of `year`.
+#[cfg(feature = "bls")]
+pub(crate) fn half_start(year: &str, half: u32) -> String {
+    month_start(year, (half - 1) * 6 + 1)
+}
+
+/// `YYYY-01-01`, the start of `year`.
+pub(crate) fn year_start(year: &str) -> String {
+    format!("{year}-01-01")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quarters_start_on_the_first_month_of_the_quarter() {
+        assert_eq!(quarter_start("2026", 1), "2026-01-01");
+        assert_eq!(quarter_start("2026", 2), "2026-04-01");
+        assert_eq!(quarter_start("2026", 4), "2026-10-01");
+    }
+
+    #[test]
+    fn months_and_years_are_zero_padded() {
+        assert_eq!(month_start("2026", 4), "2026-04-01");
+        assert_eq!(month_start("2026", 12), "2026-12-01");
+        assert_eq!(year_start("2026"), "2026-01-01");
+    }
+
+    #[cfg(feature = "bls")]
+    #[test]
+    fn halves_start_in_january_and_july() {
+        assert_eq!(half_start("2026", 1), "2026-01-01");
+        assert_eq!(half_start("2026", 2), "2026-07-01");
+    }
+}

--- a/src/adapters/defillama/client.rs
+++ b/src/adapters/defillama/client.rs
@@ -1,0 +1,103 @@
+//! DefiLlama HTTP client.
+//!
+//! Keyless and unauthenticated. TVL data lives on `api.llama.fi`; stablecoin
+//! supplies live on a separate host, so both bases are configurable.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use reqwest::{Client, StatusCode};
+use tracing::debug;
+
+use super::models::{ChainResponse, ProtocolResponse, StablecoinsResponse};
+use crate::adapters::common::keyless_http_client;
+use crate::error::{FinanceError, Result};
+use crate::rate_limiter::RateLimiter;
+
+pub(super) const LLAMA_BASE: &str = "https://api.llama.fi";
+pub(super) const STABLECOINS_BASE: &str = "https://stablecoins.llama.fi";
+
+pub(super) struct DefiLlamaClient {
+    http: Client,
+    limiter: Arc<RateLimiter>,
+    base_url: String,
+    stablecoins_url: String,
+}
+
+impl DefiLlamaClient {
+    pub(super) fn new(
+        timeout: Duration,
+        limiter: Arc<RateLimiter>,
+        base_url: impl Into<String>,
+        stablecoins_url: impl Into<String>,
+    ) -> Result<Self> {
+        Ok(Self {
+            http: keyless_http_client(timeout)?,
+            limiter,
+            base_url: base_url.into(),
+            stablecoins_url: stablecoins_url.into(),
+        })
+    }
+
+    /// Fetch a protocol's metadata and full TVL history.
+    pub(super) async fn protocol(&self, slug: &str) -> Result<ProtocolResponse> {
+        let url = format!(
+            "{}/protocol/{}",
+            self.base_url,
+            crate::adapters::common::encode_path_segment(slug)
+        );
+        self.get(&url, Some(slug)).await
+    }
+
+    /// Fetch aggregate TVL for every chain.
+    pub(super) async fn chains(&self) -> Result<Vec<ChainResponse>> {
+        let url = format!("{}/v2/chains", self.base_url);
+        self.get(&url, None).await
+    }
+
+    /// Fetch circulating supply for every tracked stablecoin.
+    pub(super) async fn stablecoins(&self) -> Result<StablecoinsResponse> {
+        let url = format!("{}/stablecoins?includePrices=false", self.stablecoins_url);
+        self.get(&url, None).await
+    }
+
+    async fn get<T: serde::de::DeserializeOwned>(
+        &self,
+        url: &str,
+        subject: Option<&str>,
+    ) -> Result<T> {
+        self.limiter.acquire().await;
+        debug!("DefiLlama request: {url}");
+
+        let resp = self.http.get(url).send().await?;
+        let status = resp.status();
+        let bytes = resp.bytes().await?;
+
+        if !status.is_success() {
+            return Err(match status {
+                // DefiLlama answers an unknown protocol slug with a 400 and a
+                // plain-text body, not a structured error.
+                StatusCode::BAD_REQUEST | StatusCode::NOT_FOUND => match subject {
+                    Some(slug) => FinanceError::SymbolNotFound {
+                        symbol: Some(slug.to_string()),
+                        context: "DefiLlama knows no protocol by this slug".to_string(),
+                    },
+                    None => FinanceError::ExternalApiError {
+                        api: "DefiLlama".to_string(),
+                        status: status.as_u16(),
+                    },
+                },
+                StatusCode::TOO_MANY_REQUESTS => FinanceError::RateLimited { retry_after: None },
+                s => FinanceError::ExternalApiError {
+                    api: "DefiLlama".to_string(),
+                    status: s.as_u16(),
+                },
+            });
+        }
+
+        serde_json::from_slice(&bytes).map_err(|e| FinanceError::ResponseStructureError {
+            field: "defillama.response".to_string(),
+            context: format!("unrecognised DefiLlama payload: {e}"),
+        })
+    }
+}

--- a/src/adapters/defillama/client.rs
+++ b/src/adapters/defillama/client.rs
@@ -10,7 +10,7 @@ use reqwest::{Client, StatusCode};
 use tracing::debug;
 
 use super::models::{ChainResponse, ProtocolResponse, StablecoinsResponse};
-use crate::adapters::common::keyless_http_client;
+use crate::adapters::common::{keyless_http_client, status_error};
 use crate::error::{FinanceError, Result};
 use crate::rate_limiter::RateLimiter;
 
@@ -82,16 +82,9 @@ impl DefiLlamaClient {
                         symbol: Some(slug.to_string()),
                         context: "DefiLlama knows no protocol by this slug".to_string(),
                     },
-                    None => FinanceError::ExternalApiError {
-                        api: "DefiLlama".to_string(),
-                        status: status.as_u16(),
-                    },
+                    None => status_error("DefiLlama", status),
                 },
-                StatusCode::TOO_MANY_REQUESTS => FinanceError::RateLimited { retry_after: None },
-                s => FinanceError::ExternalApiError {
-                    api: "DefiLlama".to_string(),
-                    status: s.as_u16(),
-                },
+                s => status_error("DefiLlama", s),
             });
         }
 

--- a/src/adapters/defillama/crypto/mod.rs
+++ b/src/adapters/defillama/crypto/mod.rs
@@ -1,0 +1,100 @@
+//! `CRYPTO` capability for DefiLlama — protocol TVL.
+
+use crate::error::Result;
+use crate::models::crypto::defi::{ChainAllocation, ProtocolTvl, TvlPoint};
+
+use super::models::ProtocolResponse;
+
+/// Seconds in a day, for locating the comparison points of a TVL change.
+const DAY: i64 = 86_400;
+
+/// Normalise a handle id into a DefiLlama protocol slug.
+///
+/// DefiLlama slugs are lowercase and hyphenated (`"aave"`, `"uniswap"`,
+/// `"lido"`), which is the same shape as a CoinGecko coin id, so most ids pass
+/// through unchanged.
+pub(super) fn slug(id: &str) -> String {
+    id.trim().to_lowercase().replace([' ', '_'], "-")
+}
+
+/// Split `currentChainTvls` into real per-chain allocations.
+///
+/// DefiLlama mixes genuine chain keys (`"Ethereum"`) with breakdown keys of
+/// the *same* capital (`"Ethereum-borrowed"`, `"pool2"`, `"staking"`).
+/// Summing everything would double-count, so only keys naming a chain the
+/// protocol actually reports are kept.
+pub(super) fn chain_allocations(response: &ProtocolResponse) -> Vec<ChainAllocation> {
+    let mut out: Vec<ChainAllocation> = response
+        .current_chain_tvls
+        .iter()
+        .filter(|(key, _)| response.chains.iter().any(|chain| chain == *key))
+        .map(|(chain, tvl)| ChainAllocation {
+            chain: chain.clone(),
+            tvl: *tvl,
+        })
+        .collect();
+    // Largest first, and by name on ties so the order is deterministic.
+    out.sort_by(|a, b| b.tvl.total_cmp(&a.tvl).then_with(|| a.chain.cmp(&b.chain)));
+    out
+}
+
+/// Percentage change between the latest TVL and the value `days_ago` before
+/// it, using the closest snapshot at or before that instant.
+pub(super) fn change_percent(history: &[TvlPoint], days_ago: i64) -> Option<f64> {
+    let latest = history.last()?;
+    let cutoff = latest.timestamp - days_ago * DAY;
+    let past = history
+        .iter()
+        .rev()
+        .find(|point| point.timestamp <= cutoff)?;
+    if past.tvl == 0.0 {
+        return None;
+    }
+    Some((latest.tvl - past.tvl) / past.tvl * 100.0)
+}
+
+/// Convert the raw TVL history into public points, oldest first.
+pub(super) fn to_history(response: &ProtocolResponse) -> Vec<TvlPoint> {
+    let mut points: Vec<TvlPoint> = response
+        .tvl
+        .iter()
+        .map(|snapshot| TvlPoint {
+            timestamp: snapshot.date,
+            tvl: snapshot.total_liquidity_usd,
+        })
+        .collect();
+    // DefiLlama returns these chronologically, but the changes computed above
+    // depend on it, so the order is enforced rather than assumed.
+    points.sort_by_key(|point| point.timestamp);
+    points
+}
+
+/// Build the public [`ProtocolTvl`] summary.
+pub(super) fn to_protocol_tvl(slug: &str, response: &ProtocolResponse) -> ProtocolTvl {
+    let history = to_history(response);
+    ProtocolTvl {
+        slug: slug.to_string(),
+        name: response.name.clone(),
+        symbol: response.symbol.clone(),
+        url: response.url.clone(),
+        chains: response.chains.clone(),
+        tvl: history.last().map(|point| point.tvl),
+        tvl_by_chain: chain_allocations(response),
+        change_1d_percent: change_percent(&history, 1),
+        change_7d_percent: change_percent(&history, 7),
+        market_cap: response.mcap,
+    }
+}
+
+/// Fetch a protocol's current TVL summary.
+pub(crate) async fn fetch_protocol_tvl_response(protocol: &str) -> Result<ProtocolTvl> {
+    let slug = slug(protocol);
+    let response = super::client()?.protocol(&slug).await?;
+    Ok(to_protocol_tvl(&slug, &response))
+}
+
+/// Fetch a protocol's full TVL history, oldest first.
+pub(crate) async fn fetch_protocol_tvl_history_response(protocol: &str) -> Result<Vec<TvlPoint>> {
+    let response = super::client()?.protocol(&slug(protocol)).await?;
+    Ok(to_history(&response))
+}

--- a/src/adapters/defillama/mod.rs
+++ b/src/adapters/defillama/mod.rs
@@ -1,0 +1,325 @@
+//! DefiLlama — keyless DeFi TVL, chain rankings, and stablecoin supplies.
+//!
+//! Requires the **`defi`** feature flag.
+//!
+//! The library covered CeFi crypto (exchange quotes, aggregated market caps)
+//! but nothing on-chain. DefiLlama is the FOSS standard here: keyless, no
+//! registration, stable endpoints.
+//!
+//! Two surfaces, split by what the data is *about*:
+//! - Protocol-shaped data routes through `Capability::CRYPTO` and appears on
+//!   [`CryptoCoin::tvl`](crate::CryptoCoin::tvl) and
+//!   [`tvl_history`](crate::CryptoCoin::tvl_history).
+//! - Market-wide views have no symbol to hang off, so they are crate-level
+//!   functions in [`crate::defi`].
+
+pub(crate) mod client;
+pub(crate) mod crypto;
+pub(crate) mod models;
+
+use std::time::Duration;
+
+use crate::adapters::singleton::keyless_limiter;
+use crate::error::Result;
+use crate::models::crypto::defi::{ChainTvl, StablecoinSupply};
+use client::DefiLlamaClient;
+
+/// Self-imposed pacing. DefiLlama publishes no quota for the free API but
+/// throttles abusive clients.
+const DEFILLAMA_RATE_PER_SEC: f64 = 5.0;
+
+/// The stablecoins and protocol endpoints return large payloads; give them
+/// room beyond the usual timeout.
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(45);
+
+keyless_limiter!(rate = DEFILLAMA_RATE_PER_SEC);
+
+/// Build a client against the live API, reusing the shared token bucket.
+fn client() -> Result<DefiLlamaClient> {
+    DefiLlamaClient::new(
+        DEFAULT_TIMEOUT,
+        shared_limiter(),
+        client::LLAMA_BASE,
+        client::STABLECOINS_BASE,
+    )
+}
+
+pub(crate) use crypto::{fetch_protocol_tvl_history_response, fetch_protocol_tvl_response};
+
+/// Read the single value out of one of DefiLlama's peg-type-keyed maps
+/// (`{"peggedUSD": 183195719854.9}`).
+fn peg_value(map: &std::collections::HashMap<String, f64>) -> Option<f64> {
+    map.values().copied().next()
+}
+
+/// Fetch aggregate TVL for every chain, largest first.
+pub(crate) async fn chains() -> Result<Vec<ChainTvl>> {
+    let mut chains: Vec<ChainTvl> = client()?
+        .chains()
+        .await?
+        .into_iter()
+        .map(|chain| ChainTvl {
+            name: chain.name,
+            token_symbol: chain.token_symbol,
+            gecko_id: chain.gecko_id,
+            chain_id: chain.chain_id,
+            tvl: chain.tvl,
+        })
+        .collect();
+    // DefiLlama returns these unordered; rank them so the list is useful
+    // as-is. `None` sorts last.
+    chains.sort_by(|a, b| {
+        b.tvl
+            .unwrap_or(f64::MIN)
+            .total_cmp(&a.tvl.unwrap_or(f64::MIN))
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    Ok(chains)
+}
+
+/// Fetch circulating supply for every tracked stablecoin, largest first.
+pub(crate) async fn stablecoins() -> Result<Vec<StablecoinSupply>> {
+    let mut coins: Vec<StablecoinSupply> = client()?
+        .stablecoins()
+        .await?
+        .pegged_assets
+        .into_iter()
+        .map(|asset| StablecoinSupply {
+            name: asset.name,
+            symbol: asset.symbol,
+            gecko_id: asset.gecko_id,
+            peg_type: asset.peg_type,
+            peg_mechanism: asset.peg_mechanism,
+            circulating: peg_value(&asset.circulating),
+            circulating_prev_day: peg_value(&asset.circulating_prev_day),
+            circulating_prev_week: peg_value(&asset.circulating_prev_week),
+            circulating_prev_month: peg_value(&asset.circulating_prev_month),
+        })
+        .collect();
+    coins.sort_by(|a, b| {
+        b.circulating
+            .unwrap_or(f64::MIN)
+            .total_cmp(&a.circulating.unwrap_or(f64::MIN))
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    Ok(coins)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::crypto::{chain_allocations, change_percent, slug, to_history, to_protocol_tvl};
+    use super::models::ProtocolResponse;
+    use super::*;
+    use crate::error::FinanceError;
+    use crate::rate_limiter::RateLimiter;
+    use std::sync::Arc;
+
+    fn test_client(base_url: &str) -> DefiLlamaClient {
+        DefiLlamaClient::new(
+            Duration::from_secs(5),
+            Arc::new(RateLimiter::new(100.0)),
+            base_url,
+            base_url,
+        )
+        .unwrap()
+    }
+
+    /// Shape from api.llama.fi/protocol/{slug}, trimmed to a few snapshots.
+    fn protocol_payload() -> String {
+        serde_json::json!({
+            "id": "111",
+            "name": "AAVE V3",
+            "symbol": "AAVE",
+            "url": "https://aave.com",
+            "chains": ["Ethereum", "Arbitrum"],
+            "currentChainTvls": {
+                "Ethereum": 9_000_000_000.0_f64,
+                "Arbitrum": 1_000_000_000.0_f64,
+                // Breakdown keys of the same capital — must not be counted.
+                "Ethereum-borrowed": 5_000_000_000.0_f64,
+                "pool2": 12_345.0_f64
+            },
+            "tvl": [
+                { "date": 1785110400_i64, "totalLiquidityUSD": 8_000_000_000.0_f64 },
+                { "date": 1785628800_i64, "totalLiquidityUSD": 9_500_000_000.0_f64 },
+                { "date": 1785715200_i64, "totalLiquidityUSD": 10_000_000_000.0_f64 }
+            ],
+            "mcap": 3_500_000_000.0_f64
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn ids_normalise_to_defillama_slugs() {
+        assert_eq!(slug("aave"), "aave");
+        assert_eq!(slug("AAVE"), "aave");
+        assert_eq!(slug("Curve DEX"), "curve-dex");
+        assert_eq!(slug(" lido_finance "), "lido-finance");
+    }
+
+    #[test]
+    fn breakdown_keys_are_excluded_from_chain_allocations() {
+        let response: ProtocolResponse = serde_json::from_str(&protocol_payload()).unwrap();
+        let allocations = chain_allocations(&response);
+
+        // Only the two keys that name a chain the protocol reports.
+        assert_eq!(allocations.len(), 2);
+        // Largest first.
+        assert_eq!(allocations[0].chain, "Ethereum");
+        assert_eq!(allocations[0].tvl, 9_000_000_000.0);
+        assert_eq!(allocations[1].chain, "Arbitrum");
+        assert!(
+            !allocations.iter().any(|a| a.chain.contains("borrowed")),
+            "a borrowed-capital breakdown key leaked into the allocations"
+        );
+    }
+
+    #[test]
+    fn change_is_measured_against_the_closest_earlier_snapshot() {
+        let history = vec![
+            super::super::super::models::crypto::defi::TvlPoint {
+                timestamp: 1785110400,
+                tvl: 8_000_000_000.0,
+            },
+            super::super::super::models::crypto::defi::TvlPoint {
+                timestamp: 1785628800,
+                tvl: 9_500_000_000.0,
+            },
+            super::super::super::models::crypto::defi::TvlPoint {
+                timestamp: 1785715200,
+                tvl: 10_000_000_000.0,
+            },
+        ];
+
+        // One day back from 1785715200 is 1785628800 exactly.
+        let one_day = change_percent(&history, 1).unwrap();
+        assert!(
+            (one_day - (10.0 - 9.5) / 9.5 * 100.0).abs() < 1e-9,
+            "{one_day}"
+        );
+
+        // Seven days back lands before the oldest snapshot in the 1d window,
+        // so the 1785110400 point is used.
+        let week = change_percent(&history, 7).unwrap();
+        assert!((week - (10.0 - 8.0) / 8.0 * 100.0).abs() < 1e-9, "{week}");
+
+        // Nothing old enough to compare against.
+        assert_eq!(change_percent(&history, 3650), None);
+        assert_eq!(change_percent(&[], 1), None);
+    }
+
+    #[tokio::test]
+    async fn protocol_maps_to_a_tvl_summary_and_history() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/protocol/aave")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(protocol_payload())
+            .create_async()
+            .await;
+
+        let response = test_client(&server.url()).protocol("aave").await.unwrap();
+        let summary = to_protocol_tvl("aave", &response);
+
+        assert_eq!(summary.slug, "aave");
+        assert_eq!(summary.name.as_deref(), Some("AAVE V3"));
+        assert_eq!(summary.symbol.as_deref(), Some("AAVE"));
+        assert_eq!(summary.chains, vec!["Ethereum", "Arbitrum"]);
+        // Latest history point, not the sum of currentChainTvls.
+        assert_eq!(summary.tvl, Some(10_000_000_000.0));
+        assert_eq!(summary.market_cap, Some(3_500_000_000.0));
+        assert_eq!(summary.tvl_by_chain.len(), 2);
+
+        let history = to_history(&response);
+        assert_eq!(history.len(), 3);
+        assert!(history.windows(2).all(|w| w[0].timestamp < w[1].timestamp));
+    }
+
+    #[tokio::test]
+    async fn unknown_protocol_maps_to_symbol_not_found() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/protocol/not-a-protocol")
+            .with_status(400)
+            .with_body("Protocol not found")
+            .create_async()
+            .await;
+
+        let err = test_client(&server.url())
+            .protocol("not-a-protocol")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, FinanceError::SymbolNotFound { .. }),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn chains_come_back_ranked_by_tvl() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/v2/chains")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!([
+                    { "name": "Harmony", "tokenSymbol": "ONE", "gecko_id": "harmony",
+                      "chainId": 1666600000_i64, "tvl": 204577.23_f64 },
+                    { "name": "Ethereum", "tokenSymbol": "ETH", "gecko_id": "ethereum",
+                      "chainId": 1_i64, "tvl": 60_000_000_000.0_f64 },
+                    { "name": "Corn", "tokenSymbol": "CORN", "gecko_id": "corn-3",
+                      "chainId": 21000000_i64, "tvl": 0.0_f64 }
+                ])
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let raw = test_client(&server.url()).chains().await.unwrap();
+        let mut ranked: Vec<_> = raw
+            .into_iter()
+            .map(|c| (c.name, c.tvl.unwrap_or(0.0)))
+            .collect();
+        ranked.sort_by(|a, b| b.1.total_cmp(&a.1));
+        assert_eq!(ranked[0].0, "Ethereum");
+    }
+
+    #[tokio::test]
+    async fn stablecoin_supplies_read_the_peg_keyed_maps() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/stablecoins")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "peggedAssets": [{
+                        "id": "1", "name": "Tether", "symbol": "USDT",
+                        "gecko_id": "tether", "pegType": "peggedUSD",
+                        "pegMechanism": "fiat-backed",
+                        // The value key varies with pegType, so it is read as
+                        // a map rather than a fixed field.
+                        "circulating": { "peggedUSD": 183_195_719_854.93_f64 },
+                        "circulatingPrevDay": { "peggedUSD": 183_301_799_410.99_f64 },
+                        "circulatingPrevWeek": { "peggedUSD": 184_242_294_121.55_f64 },
+                        "circulatingPrevMonth": { "peggedUSD": 184_050_168_657.80_f64 }
+                    }]
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let response = test_client(&server.url()).stablecoins().await.unwrap();
+        let asset = &response.pegged_assets[0];
+        assert_eq!(asset.symbol.as_deref(), Some("USDT"));
+        assert_eq!(peg_value(&asset.circulating), Some(183_195_719_854.93));
+        assert_eq!(
+            peg_value(&asset.circulating_prev_day),
+            Some(183_301_799_410.99)
+        );
+    }
+}

--- a/src/adapters/defillama/models.rs
+++ b/src/adapters/defillama/models.rs
@@ -1,0 +1,82 @@
+//! DefiLlama wire types.
+
+use serde::Deserialize;
+use std::collections::HashMap;
+
+/// `GET /protocol/{slug}` — metadata plus the full TVL history.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ProtocolResponse {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub symbol: Option<String>,
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub chains: Vec<String>,
+    /// Current TVL per chain. Keys ending in `-borrowed`, `-staking`, … are
+    /// breakdowns of the same capital and are excluded by the caller.
+    #[serde(default, rename = "currentChainTvls")]
+    pub current_chain_tvls: HashMap<String, f64>,
+    /// Chronological TVL snapshots.
+    #[serde(default)]
+    pub tvl: Vec<TvlSnapshot>,
+    #[serde(default)]
+    pub mcap: Option<f64>,
+}
+
+/// One TVL snapshot in a protocol's history.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct TvlSnapshot {
+    /// Unix timestamp in seconds.
+    pub date: i64,
+    #[serde(rename = "totalLiquidityUSD")]
+    pub total_liquidity_usd: f64,
+}
+
+/// One entry of `GET /v2/chains`.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ChainResponse {
+    pub name: String,
+    #[serde(default, rename = "tokenSymbol")]
+    pub token_symbol: Option<String>,
+    #[serde(default)]
+    pub gecko_id: Option<String>,
+    #[serde(default, rename = "chainId")]
+    pub chain_id: Option<i64>,
+    #[serde(default)]
+    pub tvl: Option<f64>,
+}
+
+/// `GET stablecoins.llama.fi/stablecoins`.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct StablecoinsResponse {
+    #[serde(default, rename = "peggedAssets")]
+    pub pegged_assets: Vec<PeggedAsset>,
+}
+
+/// One stablecoin's circulating supply across time.
+///
+/// The circulating figures are objects keyed by peg type (`peggedUSD`,
+/// `peggedEUR`, …) with a single entry, so they are read as maps rather than
+/// as a fixed field name.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct PeggedAsset {
+    pub name: String,
+    #[serde(default)]
+    pub symbol: Option<String>,
+    #[serde(default)]
+    pub gecko_id: Option<String>,
+    #[serde(default, rename = "pegType")]
+    pub peg_type: Option<String>,
+    #[serde(default, rename = "pegMechanism")]
+    pub peg_mechanism: Option<String>,
+    #[serde(default)]
+    pub circulating: HashMap<String, f64>,
+    #[serde(default, rename = "circulatingPrevDay")]
+    pub circulating_prev_day: HashMap<String, f64>,
+    #[serde(default, rename = "circulatingPrevWeek")]
+    pub circulating_prev_week: HashMap<String, f64>,
+    #[serde(default, rename = "circulatingPrevMonth")]
+    pub circulating_prev_month: HashMap<String, f64>,
+}

--- a/src/adapters/finra/client.rs
+++ b/src/adapters/finra/client.rs
@@ -12,7 +12,7 @@ use reqwest::{Client, StatusCode};
 use tracing::debug;
 
 use super::models::{CompareFilter, DataRequest, DateRangeFilter, FinraError, RegShoDailyRow};
-use crate::adapters::common::keyless_http_client;
+use crate::adapters::common::{keyless_http_client, status_error};
 use crate::error::{FinanceError, Result};
 use crate::rate_limiter::RateLimiter;
 
@@ -96,17 +96,16 @@ impl FinraClient {
 
     /// Map a non-2xx response, preferring FINRA's own explanation.
     fn map_error(status: StatusCode, body: &[u8], symbol: &str) -> FinanceError {
+        // Checked before the body: a throttled response carries no useful
+        // explanation of the query.
         if status == StatusCode::TOO_MANY_REQUESTS {
-            return FinanceError::RateLimited { retry_after: None };
+            return status_error("FINRA", status);
         }
         if let Ok(err) = serde_json::from_slice::<FinraError>(body)
             && let Some(message) = err.message
         {
             return FinanceError::ApiError(format!("FINRA ({symbol}): {message}"));
         }
-        FinanceError::ExternalApiError {
-            api: "FINRA".to_string(),
-            status: status.as_u16(),
-        }
+        status_error("FINRA", status)
     }
 }

--- a/src/adapters/finra/client.rs
+++ b/src/adapters/finra/client.rs
@@ -1,0 +1,112 @@
+//! FINRA Query API HTTP client.
+//!
+//! `api.finra.org/data/*` serves the public datasets without credentials
+//! (a free account raises the quota, but none is required). Requests are
+//! POSTed as JSON; `Accept: application/json` is required or FINRA answers
+//! with CSV.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use reqwest::{Client, StatusCode};
+use tracing::debug;
+
+use super::models::{CompareFilter, DataRequest, DateRangeFilter, FinraError, RegShoDailyRow};
+use crate::adapters::common::keyless_http_client;
+use crate::error::{FinanceError, Result};
+use crate::rate_limiter::RateLimiter;
+
+pub(super) const FINRA_BASE: &str = "https://api.finra.org/data/group";
+
+/// Rows requested per call. Three reporting facilities report per symbol per
+/// day, so this covers roughly a year of trading days.
+const ROW_LIMIT: u32 = 1_000;
+
+pub(super) struct FinraClient {
+    http: Client,
+    limiter: Arc<RateLimiter>,
+    base_url: String,
+}
+
+impl FinraClient {
+    pub(super) fn new(
+        timeout: Duration,
+        limiter: Arc<RateLimiter>,
+        base_url: impl Into<String>,
+    ) -> Result<Self> {
+        Ok(Self {
+            http: keyless_http_client(timeout)?,
+            limiter,
+            base_url: base_url.into(),
+        })
+    }
+
+    /// Fetch daily short-sale volume rows for `symbol` over `[start, end]`
+    /// (`YYYY-MM-DD`), one row per reporting facility per date.
+    pub(super) async fn reg_sho_daily(
+        &self,
+        symbol: &str,
+        start: String,
+        end: String,
+    ) -> Result<Vec<RegShoDailyRow>> {
+        self.limiter.acquire().await;
+
+        let url = format!("{}/otcMarket/name/regShoDaily", self.base_url);
+        let body = DataRequest {
+            limit: ROW_LIMIT,
+            compare_filters: vec![CompareFilter {
+                field_name: "securitiesInformationProcessorSymbolIdentifier",
+                field_value: symbol,
+                compare_type: "EQUAL",
+            }],
+            date_range_filters: vec![DateRangeFilter {
+                field_name: "tradeReportDate",
+                start_date: start,
+                end_date: end,
+            }],
+        };
+        debug!("FINRA request: regShoDaily {symbol}");
+
+        let resp = self
+            .http
+            .post(&url)
+            // Without this FINRA answers with CSV, not JSON.
+            .header(reqwest::header::ACCEPT, "application/json")
+            .json(&body)
+            .send()
+            .await?;
+        let status = resp.status();
+
+        // FINRA signals "matched nothing" with 204 and an empty body, which is
+        // not an error — the symbol simply had no reportable short volume.
+        if status == StatusCode::NO_CONTENT {
+            return Ok(Vec::new());
+        }
+
+        let bytes = resp.bytes().await?;
+        if !status.is_success() {
+            return Err(Self::map_error(status, &bytes, symbol));
+        }
+
+        serde_json::from_slice(&bytes).map_err(|e| FinanceError::ResponseStructureError {
+            field: "finra.regShoDaily".to_string(),
+            context: format!("unrecognised FINRA payload: {e}"),
+        })
+    }
+
+    /// Map a non-2xx response, preferring FINRA's own explanation.
+    fn map_error(status: StatusCode, body: &[u8], symbol: &str) -> FinanceError {
+        if status == StatusCode::TOO_MANY_REQUESTS {
+            return FinanceError::RateLimited { retry_after: None };
+        }
+        if let Ok(err) = serde_json::from_slice::<FinraError>(body)
+            && let Some(message) = err.message
+        {
+            return FinanceError::ApiError(format!("FINRA ({symbol}): {message}"));
+        }
+        FinanceError::ExternalApiError {
+            api: "FINRA".to_string(),
+            status: status.as_u16(),
+        }
+    }
+}

--- a/src/adapters/finra/fundamentals/mod.rs
+++ b/src/adapters/finra/fundamentals/mod.rs
@@ -1,0 +1,67 @@
+//! `FUNDAMENTALS` capability for FINRA — daily short-sale volume.
+
+use std::collections::BTreeMap;
+
+use crate::error::Result;
+use crate::models::fundamentals::ShortVolume;
+
+use super::models::RegShoDailyRow;
+
+/// Days of history requested. FINRA keeps roughly a rolling year online.
+const LOOKBACK_DAYS: i64 = 365;
+
+/// Consolidate FINRA's per-facility rows into one figure per trade date.
+///
+/// FINRA reports each symbol separately for every reporting facility it traded
+/// on that day (`B`/`Q`/`N`), so the raw rows are three-per-day for a listed
+/// name. Summing them reproduces the consolidated figure FINRA itself
+/// publishes in its daily `CNMSshvol` file.
+///
+/// A `BTreeMap` keyed by ISO date gives chronological order for free, which
+/// matters because FINRA rejects server-side sorting on a date *range* query.
+pub(super) fn consolidate(rows: Vec<RegShoDailyRow>) -> Vec<ShortVolume> {
+    let mut by_date: BTreeMap<String, ShortVolume> = BTreeMap::new();
+
+    for row in rows {
+        let entry = by_date
+            .entry(row.trade_report_date.clone())
+            .or_insert_with(|| ShortVolume {
+                date: Some(row.trade_report_date.clone()),
+                short_volume: None,
+                short_exempt_volume: None,
+                total_volume: None,
+            });
+        add(&mut entry.short_volume, row.short_par_quantity);
+        add(
+            &mut entry.short_exempt_volume,
+            row.short_exempt_par_quantity,
+        );
+        add(&mut entry.total_volume, row.total_par_quantity);
+    }
+
+    by_date.into_values().collect()
+}
+
+/// Accumulate an optional addend, leaving the total `None` only when no
+/// facility reported the figure at all.
+fn add(total: &mut Option<f64>, addend: Option<f64>) {
+    if let Some(value) = addend {
+        *total = Some(total.unwrap_or(0.0) + value);
+    }
+}
+
+/// Fetch a symbol's daily short-sale volume series, oldest first.
+pub(crate) async fn fetch_short_volume_response(symbol: &str) -> Result<Vec<ShortVolume>> {
+    let end = chrono::Utc::now();
+    let start = end - chrono::Duration::days(LOOKBACK_DAYS);
+
+    let rows = super::client()?
+        .reg_sho_daily(
+            &symbol.to_uppercase(),
+            start.format("%Y-%m-%d").to_string(),
+            end.format("%Y-%m-%d").to_string(),
+        )
+        .await?;
+
+    Ok(consolidate(rows))
+}

--- a/src/adapters/finra/mod.rs
+++ b/src/adapters/finra/mod.rs
@@ -1,0 +1,203 @@
+//! FINRA — free daily short-sale volume from the primary source.
+//!
+//! Requires the **`finra`** feature flag.
+//!
+//! `Ticker::short_volume()` previously needed Polygon. FINRA publishes the
+//! same daily aggregated short volume itself, free and without credentials,
+//! through the `otcMarket/regShoDaily` dataset — so routing `FUNDAMENTALS`
+//! here gives the method a keyless provider.
+//!
+//! # Licence
+//!
+//! FINRA's Query API is free for **non-commercial** use. Commercial use needs
+//! an agreement with FINRA; that is a licensing question, not a technical one,
+//! and this adapter does not change it.
+
+pub(crate) mod client;
+pub(crate) mod fundamentals;
+pub(crate) mod models;
+
+use std::time::Duration;
+
+use crate::adapters::singleton::keyless_limiter;
+use crate::error::Result;
+use client::FinraClient;
+
+/// Self-imposed pacing. FINRA's anonymous tier is metered per day rather than
+/// per second; this only keeps a burst from looking abusive.
+const FINRA_RATE_PER_SEC: f64 = 2.0;
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+keyless_limiter!(rate = FINRA_RATE_PER_SEC);
+
+/// Build a client against the live API, reusing the shared token bucket.
+fn client() -> Result<FinraClient> {
+    FinraClient::new(DEFAULT_TIMEOUT, shared_limiter(), client::FINRA_BASE)
+}
+
+pub(crate) use fundamentals::fetch_short_volume_response;
+
+#[cfg(test)]
+mod tests {
+    use super::fundamentals::consolidate;
+    use super::*;
+    use crate::error::FinanceError;
+    use crate::rate_limiter::RateLimiter;
+    use std::sync::Arc;
+
+    fn test_client(base_url: &str) -> FinraClient {
+        FinraClient::new(
+            Duration::from_secs(5),
+            Arc::new(RateLimiter::new(100.0)),
+            base_url,
+        )
+        .unwrap()
+    }
+
+    /// Verbatim shape from api.finra.org: two trade dates, three reporting
+    /// facilities each, deliberately out of date order.
+    fn rows_payload() -> String {
+        serde_json::json!([
+            { "reportingFacilityCode": "NQTRF", "marketCode": "Q",
+              "tradeReportDate": "2026-07-29",
+              "securitiesInformationProcessorSymbolIdentifier": "AAPL",
+              "shortParQuantity": 8104492.271627_f64,
+              "shortExemptParQuantity": 43220.0_f64,
+              "totalParQuantity": 16890321.3741_f64 },
+            { "reportingFacilityCode": "NCTRF", "marketCode": "B",
+              "tradeReportDate": "2026-07-28",
+              "securitiesInformationProcessorSymbolIdentifier": "AAPL",
+              "shortParQuantity": 71287.391347_f64,
+              "shortExemptParQuantity": 2.0_f64,
+              "totalParQuantity": 139754.385672_f64 },
+            { "reportingFacilityCode": "NQTRF", "marketCode": "Q",
+              "tradeReportDate": "2026-07-28",
+              "securitiesInformationProcessorSymbolIdentifier": "AAPL",
+              "shortParQuantity": 8101622.503547_f64,
+              "shortExemptParQuantity": 41852.0_f64,
+              "totalParQuantity": 17193767.649164_f64 },
+            { "reportingFacilityCode": "NYTRF", "marketCode": "N",
+              "tradeReportDate": "2026-07-28",
+              "securitiesInformationProcessorSymbolIdentifier": "AAPL",
+              "shortParQuantity": 1433075.91414_f64,
+              "shortExemptParQuantity": 430.0_f64,
+              "totalParQuantity": 1756412.25786_f64 }
+        ])
+        .to_string()
+    }
+
+    #[tokio::test]
+    async fn per_facility_rows_are_summed_into_one_figure_per_date() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("POST", "/otcMarket/name/regShoDaily")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(rows_payload())
+            .create_async()
+            .await;
+
+        let rows = test_client(&server.url())
+            .reg_sho_daily("AAPL", "2026-07-28".into(), "2026-07-29".into())
+            .await
+            .unwrap();
+        let series = consolidate(rows);
+
+        // Four raw rows across two dates collapse to two daily figures.
+        assert_eq!(series.len(), 2);
+        // Chronological despite the payload being out of order — FINRA rejects
+        // server-side sorting on a date-range query.
+        assert_eq!(series[0].date.as_deref(), Some("2026-07-28"));
+        assert_eq!(series[1].date.as_deref(), Some("2026-07-29"));
+
+        let day = &series[0];
+        let expected_short = 71287.391347 + 8101622.503547 + 1433075.91414;
+        let expected_total = 139754.385672 + 17193767.649164 + 1756412.25786;
+        assert!((day.short_volume.unwrap() - expected_short).abs() < 1e-6);
+        assert!((day.total_volume.unwrap() - expected_total).abs() < 1e-6);
+        assert!((day.short_exempt_volume.unwrap() - (2.0 + 41852.0 + 430.0)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn a_field_absent_from_every_facility_stays_none() {
+        let rows =
+            serde_json::from_value::<Vec<super::models::RegShoDailyRow>>(serde_json::json!([
+                { "tradeReportDate": "2026-07-28", "shortParQuantity": 10.0_f64 },
+                { "tradeReportDate": "2026-07-28", "shortParQuantity": 5.0_f64 }
+            ]))
+            .unwrap();
+
+        let series = consolidate(rows);
+        assert_eq!(series.len(), 1);
+        assert_eq!(series[0].short_volume, Some(15.0));
+        // Nothing reported a total, so it must not become 0.0.
+        assert_eq!(series[0].total_volume, None);
+    }
+
+    #[tokio::test]
+    async fn no_content_means_an_empty_series_not_an_error() {
+        // FINRA answers "matched nothing" with 204 and an empty body — a
+        // symbol with no reportable short volume, not a failure.
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("POST", "/otcMarket/name/regShoDaily")
+            .with_status(204)
+            .create_async()
+            .await;
+
+        let rows = test_client(&server.url())
+            .reg_sho_daily("NOSUCHSYM", "2026-01-01".into(), "2026-07-30".into())
+            .await
+            .unwrap();
+        assert!(rows.is_empty());
+    }
+
+    #[tokio::test]
+    async fn a_rejected_request_carries_finras_message() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("POST", "/otcMarket/name/regShoDaily")
+            .with_status(400)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "statusCode": 400,
+                    "message": "The following fields are not available in this dataset: [nope]"
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let err = test_client(&server.url())
+            .reg_sho_daily("AAPL", "2026-01-01".into(), "2026-07-30".into())
+            .await
+            .unwrap_err();
+        match err {
+            FinanceError::ApiError(msg) => {
+                assert!(msg.contains("not available in this dataset"), "got {msg}");
+            }
+            other => panic!("expected ApiError, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn http_error_maps_to_external_api_error() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("POST", "/otcMarket/name/regShoDaily")
+            .with_status(503)
+            .create_async()
+            .await;
+
+        let err = test_client(&server.url())
+            .reg_sho_daily("AAPL", "2026-01-01".into(), "2026-07-30".into())
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, FinanceError::ExternalApiError { status: 503, .. }),
+            "{err:?}"
+        );
+    }
+}

--- a/src/adapters/finra/models.rs
+++ b/src/adapters/finra/models.rs
@@ -1,0 +1,57 @@
+//! FINRA Query API wire types.
+
+use serde::{Deserialize, Serialize};
+
+/// One row of `otcMarket/regShoDaily`: a symbol's short volume on one trade
+/// date, **per reporting facility**. A symbol has one row per facility per
+/// day, so rows must be summed by date to get the consolidated figure.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RegShoDailyRow {
+    pub trade_report_date: String,
+    #[serde(default)]
+    pub short_par_quantity: Option<f64>,
+    #[serde(default)]
+    pub short_exempt_par_quantity: Option<f64>,
+    #[serde(default)]
+    pub total_par_quantity: Option<f64>,
+}
+
+/// A `compareFilters` entry in a FINRA data request.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CompareFilter<'a> {
+    pub field_name: &'a str,
+    pub field_value: &'a str,
+    pub compare_type: &'a str,
+}
+
+/// A `dateRangeFilters` entry in a FINRA data request.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DateRangeFilter<'a> {
+    pub field_name: &'a str,
+    pub start_date: String,
+    pub end_date: String,
+}
+
+/// The request body FINRA's data endpoints accept.
+///
+/// Sorting is deliberately absent: FINRA rejects `sortFields` unless every
+/// partition key is pinned with an `EQUAL` filter, which a date *range* by
+/// definition does not do. Rows are ordered locally instead.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DataRequest<'a> {
+    pub limit: u32,
+    pub compare_filters: Vec<CompareFilter<'a>>,
+    pub date_range_filters: Vec<DateRangeFilter<'a>>,
+}
+
+/// The error body FINRA returns for a malformed request.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct FinraError {
+    #[serde(default)]
+    pub message: Option<String>,
+}

--- a/src/adapters/fiscaldata/client.rs
+++ b/src/adapters/fiscaldata/client.rs
@@ -10,16 +10,25 @@ use std::time::Duration;
 use reqwest::{Client, StatusCode};
 use tracing::{debug, warn};
 
+use futures::stream::{StreamExt, TryStreamExt};
+
 use super::models::{FiscalError, FiscalMeta, FiscalResponse, FiscalRow};
-use crate::adapters::common::keyless_http_client;
+use crate::adapters::common::{keyless_http_client, status_error};
 use crate::error::{FinanceError, Result};
 use crate::rate_limiter::RateLimiter;
 
 pub(super) const FISCALDATA_BASE: &str =
     "https://api.fiscaldata.treasury.gov/services/api/fiscal_service";
 
+/// How this API names itself in errors.
+const API: &str = "US Treasury FiscalData";
+
 /// FiscalData's documented maximum page size.
 const PAGE_SIZE: u32 = 10_000;
+
+/// Pages fetched at once once the page count is known. Small enough that a
+/// mis-specified filter cannot burst the shared token bucket.
+const MAX_CONCURRENT_PAGES: usize = 4;
 
 /// Cap on pages walked for one series — 50k observations is far beyond any
 /// dataset the curated series cover, and stops a mis-specified filter from
@@ -65,60 +74,30 @@ impl FiscalDataClient {
         &self,
         query: &SeriesQuery<'_>,
     ) -> Result<(Vec<FiscalRow>, FiscalMeta)> {
-        let url = format!("{}/{}", self.base_url, query.dataset);
         let fields = format!("{DATE_FIELD},{}", query.value_field);
 
-        let mut rows: Vec<FiscalRow> = Vec::new();
-        let mut meta = FiscalMeta::default();
+        // Page 1 self-reports the page count, so the rest are independent and
+        // knowable up front — no reason to walk them one round trip at a time.
+        let mut first = self.page(query, &fields, 1).await?;
+        let reported_pages = first.meta.total_pages.unwrap_or(1);
+        let total_pages = reported_pages.min(MAX_PAGES);
+        if reported_pages > MAX_PAGES {
+            warn!(
+                "FiscalData series {}/{} has {reported_pages} pages; truncated at {MAX_PAGES}",
+                query.dataset, query.value_field
+            );
+        }
 
-        for page in 1..=MAX_PAGES {
-            self.limiter.acquire().await;
-
-            let page_str = page.to_string();
-            let size_str = PAGE_SIZE.to_string();
-            let mut params: Vec<(&str, &str)> = vec![
-                ("format", "json"),
-                ("fields", &fields),
-                ("sort", DATE_FIELD),
-                ("page[size]", &size_str),
-                ("page[number]", &page_str),
-            ];
-            if let Some(filter) = query.filter {
-                params.push(("filter", filter));
-            }
-
-            debug!("FiscalData request: {url} page {page}");
-            let resp = self.http.get(&url).query(&params).send().await?;
-            let status = resp.status();
-            let bytes = resp.bytes().await?;
-
-            if !status.is_success() {
-                return Err(Self::map_error(status, &bytes, query));
-            }
-
-            let parsed: FiscalResponse = serde_json::from_slice(&bytes).map_err(|e| {
-                FinanceError::ResponseStructureError {
-                    field: "fiscaldata.response".to_string(),
-                    context: format!("unrecognised FiscalData envelope: {e}"),
-                }
-            })?;
-
-            let total_pages = parsed.meta.total_pages.unwrap_or(1);
-            let batch = parsed.data.len();
-            rows.extend(parsed.data);
-            if page == 1 {
-                meta = parsed.meta;
-            }
-
-            if batch == 0 || page >= total_pages {
-                break;
-            }
-            if page == MAX_PAGES {
-                warn!(
-                    "FiscalData series {}/{} has {total_pages} pages; truncated at {MAX_PAGES}",
-                    query.dataset, query.value_field
-                );
-            }
+        let mut rows = std::mem::take(&mut first.data);
+        if !rows.is_empty() && total_pages > 1 {
+            // `buffered` preserves input order, so the pages reassemble
+            // chronologically however the responses interleave.
+            let rest: Vec<FiscalResponse> = futures::stream::iter(2..=total_pages)
+                .map(|page| self.page(query, &fields, page))
+                .buffered(MAX_CONCURRENT_PAGES)
+                .try_collect()
+                .await?;
+            rows.extend(rest.into_iter().flat_map(|page| page.data));
         }
 
         if rows.is_empty() {
@@ -128,20 +107,61 @@ impl FiscalDataClient {
                     .to_string(),
             });
         }
-        Ok((rows, meta))
+        Ok((rows, first.meta))
+    }
+
+    /// Fetch one page of `query`. The rate limiter still paces every call, so
+    /// concurrency here never outruns the token bucket.
+    async fn page(
+        &self,
+        query: &SeriesQuery<'_>,
+        fields: &str,
+        page: u32,
+    ) -> Result<FiscalResponse> {
+        self.limiter.acquire().await;
+
+        let url = format!("{}/{}", self.base_url, query.dataset);
+        let page_str = page.to_string();
+        let size_str = PAGE_SIZE.to_string();
+        let mut params: Vec<(&str, &str)> = vec![
+            ("format", "json"),
+            ("fields", fields),
+            ("sort", DATE_FIELD),
+            ("page[size]", &size_str),
+            ("page[number]", &page_str),
+        ];
+        if let Some(filter) = query.filter {
+            params.push(("filter", filter));
+        }
+
+        debug!("FiscalData request: {url} page {page}");
+        let resp = self.http.get(&url).query(&params).send().await?;
+        let status = resp.status();
+        let bytes = resp.bytes().await?;
+
+        if !status.is_success() {
+            return Err(Self::map_error(status, &bytes, query));
+        }
+
+        serde_json::from_slice(&bytes).map_err(|e| FinanceError::ResponseStructureError {
+            field: "fiscaldata.response".to_string(),
+            context: format!("unrecognised FiscalData envelope: {e}"),
+        })
     }
 
     /// Map a non-2xx response, preferring the API's own explanation of what
     /// was wrong with the query over a bare status code.
     fn map_error(status: StatusCode, body: &[u8], query: &SeriesQuery<'_>) -> FinanceError {
+        // Checked before the body: a throttled response carries no useful
+        // explanation of the query.
         if status == StatusCode::TOO_MANY_REQUESTS {
-            return FinanceError::RateLimited { retry_after: None };
+            return status_error(API, status);
         }
         if let Ok(err) = serde_json::from_slice::<FiscalError>(body)
             && let Some(detail) = err.describe()
         {
             return FinanceError::MacroDataError {
-                provider: "US Treasury FiscalData".to_string(),
+                provider: API.to_string(),
                 context: format!("{}/{}: {detail}", query.dataset, query.value_field),
             };
         }
@@ -151,9 +171,6 @@ impl FiscalDataClient {
                 context: "no such FiscalData dataset".to_string(),
             };
         }
-        FinanceError::ExternalApiError {
-            api: "US Treasury FiscalData".to_string(),
-            status: status.as_u16(),
-        }
+        status_error(API, status)
     }
 }

--- a/src/adapters/fiscaldata/client.rs
+++ b/src/adapters/fiscaldata/client.rs
@@ -1,0 +1,159 @@
+//! US Treasury FiscalData HTTP client.
+//!
+//! Keyless and unauthenticated. Every dataset shares one query grammar
+//! (`fields` / `filter` / `sort` / `page[size]`), so one request method covers
+//! all of them.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use reqwest::{Client, StatusCode};
+use tracing::{debug, warn};
+
+use super::models::{FiscalError, FiscalMeta, FiscalResponse, FiscalRow};
+use crate::adapters::common::keyless_http_client;
+use crate::error::{FinanceError, Result};
+use crate::rate_limiter::RateLimiter;
+
+pub(super) const FISCALDATA_BASE: &str =
+    "https://api.fiscaldata.treasury.gov/services/api/fiscal_service";
+
+/// FiscalData's documented maximum page size.
+const PAGE_SIZE: u32 = 10_000;
+
+/// Cap on pages walked for one series — 50k observations is far beyond any
+/// dataset the curated series cover, and stops a mis-specified filter from
+/// turning into an unbounded crawl.
+const MAX_PAGES: u32 = 5;
+
+/// The date column every FiscalData dataset keys its rows by.
+pub(super) const DATE_FIELD: &str = "record_date";
+
+/// A dataset query: which dataset, which value column, and an optional
+/// row filter for datasets that stack several series in one table.
+#[derive(Debug, Clone)]
+pub(super) struct SeriesQuery<'a> {
+    pub dataset: &'a str,
+    pub value_field: &'a str,
+    pub filter: Option<&'a str>,
+}
+
+pub(super) struct FiscalDataClient {
+    http: Client,
+    limiter: Arc<RateLimiter>,
+    base_url: String,
+}
+
+impl FiscalDataClient {
+    pub(super) fn new(
+        timeout: Duration,
+        limiter: Arc<RateLimiter>,
+        base_url: impl Into<String>,
+    ) -> Result<Self> {
+        Ok(Self {
+            http: keyless_http_client(timeout)?,
+            limiter,
+            base_url: base_url.into(),
+        })
+    }
+
+    /// Fetch every row of `query`, oldest first, following pagination.
+    ///
+    /// Returns the rows together with the response `meta`, which self-describes
+    /// the requested column (label and type).
+    pub(super) async fn series(
+        &self,
+        query: &SeriesQuery<'_>,
+    ) -> Result<(Vec<FiscalRow>, FiscalMeta)> {
+        let url = format!("{}/{}", self.base_url, query.dataset);
+        let fields = format!("{DATE_FIELD},{}", query.value_field);
+
+        let mut rows: Vec<FiscalRow> = Vec::new();
+        let mut meta = FiscalMeta::default();
+
+        for page in 1..=MAX_PAGES {
+            self.limiter.acquire().await;
+
+            let page_str = page.to_string();
+            let size_str = PAGE_SIZE.to_string();
+            let mut params: Vec<(&str, &str)> = vec![
+                ("format", "json"),
+                ("fields", &fields),
+                ("sort", DATE_FIELD),
+                ("page[size]", &size_str),
+                ("page[number]", &page_str),
+            ];
+            if let Some(filter) = query.filter {
+                params.push(("filter", filter));
+            }
+
+            debug!("FiscalData request: {url} page {page}");
+            let resp = self.http.get(&url).query(&params).send().await?;
+            let status = resp.status();
+            let bytes = resp.bytes().await?;
+
+            if !status.is_success() {
+                return Err(Self::map_error(status, &bytes, query));
+            }
+
+            let parsed: FiscalResponse = serde_json::from_slice(&bytes).map_err(|e| {
+                FinanceError::ResponseStructureError {
+                    field: "fiscaldata.response".to_string(),
+                    context: format!("unrecognised FiscalData envelope: {e}"),
+                }
+            })?;
+
+            let total_pages = parsed.meta.total_pages.unwrap_or(1);
+            let batch = parsed.data.len();
+            rows.extend(parsed.data);
+            if page == 1 {
+                meta = parsed.meta;
+            }
+
+            if batch == 0 || page >= total_pages {
+                break;
+            }
+            if page == MAX_PAGES {
+                warn!(
+                    "FiscalData series {}/{} has {total_pages} pages; truncated at {MAX_PAGES}",
+                    query.dataset, query.value_field
+                );
+            }
+        }
+
+        if rows.is_empty() {
+            return Err(FinanceError::SymbolNotFound {
+                symbol: Some(format!("{}/{}", query.dataset, query.value_field)),
+                context: "FiscalData returned no rows for this dataset/filter combination"
+                    .to_string(),
+            });
+        }
+        Ok((rows, meta))
+    }
+
+    /// Map a non-2xx response, preferring the API's own explanation of what
+    /// was wrong with the query over a bare status code.
+    fn map_error(status: StatusCode, body: &[u8], query: &SeriesQuery<'_>) -> FinanceError {
+        if status == StatusCode::TOO_MANY_REQUESTS {
+            return FinanceError::RateLimited { retry_after: None };
+        }
+        if let Ok(err) = serde_json::from_slice::<FiscalError>(body)
+            && let Some(detail) = err.describe()
+        {
+            return FinanceError::MacroDataError {
+                provider: "US Treasury FiscalData".to_string(),
+                context: format!("{}/{}: {detail}", query.dataset, query.value_field),
+            };
+        }
+        if status == StatusCode::NOT_FOUND {
+            return FinanceError::SymbolNotFound {
+                symbol: Some(query.dataset.to_string()),
+                context: "no such FiscalData dataset".to_string(),
+            };
+        }
+        FinanceError::ExternalApiError {
+            api: "US Treasury FiscalData".to_string(),
+            status: status.as_u16(),
+        }
+    }
+}

--- a/src/adapters/fiscaldata/economic/mod.rs
+++ b/src/adapters/fiscaldata/economic/mod.rs
@@ -1,0 +1,198 @@
+//! `ECONOMIC` capability for US Treasury FiscalData.
+//!
+//! Resolves a series id to a dataset query, then folds the flat string rows
+//! FiscalData returns into the canonical [`EconomicSeries`].
+
+use crate::error::{FinanceError, Result};
+use crate::models::economic::{EconomicSeries, MacroObservation};
+
+use super::client::{DATE_FIELD, SeriesQuery};
+use super::models::{FiscalMeta, FiscalRow};
+
+/// A curated series: a stable short name for a `(dataset, column, filter)`
+/// triple, so callers need not know FiscalData's table layout.
+#[derive(Debug)]
+pub(super) struct CuratedSeries {
+    pub id: &'static str,
+    pub dataset: &'static str,
+    pub value_field: &'static str,
+    /// Row filter for datasets that stack several series in one table.
+    pub filter: Option<&'static str>,
+    /// Stated here rather than derived from `meta.dataTypes`, which reports
+    /// only `CURRENCY`/`PERCENTAGE` and so cannot distinguish dollars from
+    /// millions of dollars.
+    pub units: &'static str,
+    pub frequency: &'static str,
+}
+
+/// The curated catalogue. Every entry is a single value per `record_date`.
+pub(super) const CURATED: &[CuratedSeries] = &[
+    CuratedSeries {
+        id: "DEBT_TO_PENNY",
+        dataset: "v2/accounting/od/debt_to_penny",
+        value_field: "tot_pub_debt_out_amt",
+        filter: None,
+        units: "US Dollars",
+        frequency: "Daily",
+    },
+    CuratedSeries {
+        id: "DEBT_HELD_BY_PUBLIC",
+        dataset: "v2/accounting/od/debt_to_penny",
+        value_field: "debt_held_public_amt",
+        filter: None,
+        units: "US Dollars",
+        frequency: "Daily",
+    },
+    CuratedSeries {
+        id: "INTRAGOVERNMENTAL_HOLDINGS",
+        dataset: "v2/accounting/od/debt_to_penny",
+        value_field: "intragov_hold_amt",
+        filter: None,
+        units: "US Dollars",
+        frequency: "Daily",
+    },
+    CuratedSeries {
+        id: "AVG_INTEREST_RATE",
+        dataset: "v2/accounting/od/avg_interest_rates",
+        value_field: "avg_interest_rate_amt",
+        filter: Some("security_desc:eq:Total Interest-bearing Debt"),
+        units: "Percent",
+        frequency: "Monthly",
+    },
+    CuratedSeries {
+        id: "AVG_INTEREST_RATE_MARKETABLE",
+        dataset: "v2/accounting/od/avg_interest_rates",
+        value_field: "avg_interest_rate_amt",
+        filter: Some("security_desc:eq:Total Marketable"),
+        units: "Percent",
+        frequency: "Monthly",
+    },
+    CuratedSeries {
+        id: "OPERATING_CASH_BALANCE",
+        dataset: "v1/accounting/dts/operating_cash_balance",
+        value_field: "open_today_bal",
+        filter: Some("account_type:eq:Treasury General Account (TGA) Opening Balance"),
+        units: "Millions of US Dollars",
+        frequency: "Daily",
+    },
+];
+
+/// How a series id resolved: a curated entry, or a raw dataset passthrough.
+#[derive(Debug)]
+pub(super) enum Resolved<'a> {
+    Curated(&'static CuratedSeries),
+    /// `"<dataset path>:<value column>"` — the escape hatch for the ~50
+    /// datasets the curated list does not name.
+    Passthrough {
+        dataset: &'a str,
+        value_field: &'a str,
+    },
+}
+
+impl Resolved<'_> {
+    pub(super) fn query(&self) -> SeriesQuery<'_> {
+        match self {
+            Self::Curated(c) => SeriesQuery {
+                dataset: c.dataset,
+                value_field: c.value_field,
+                filter: c.filter,
+            },
+            Self::Passthrough {
+                dataset,
+                value_field,
+            } => SeriesQuery {
+                dataset,
+                value_field,
+                filter: None,
+            },
+        }
+    }
+}
+
+/// Resolve a series id against the curated catalogue, falling back to the
+/// `"<dataset>:<column>"` passthrough form.
+pub(super) fn resolve(series_id: &str) -> Result<Resolved<'_>> {
+    let trimmed = series_id.trim();
+    if let Some(curated) = CURATED.iter().find(|c| c.id.eq_ignore_ascii_case(trimmed)) {
+        return Ok(Resolved::Curated(curated));
+    }
+    if let Some((dataset, value_field)) = trimmed.rsplit_once(':')
+        && !dataset.is_empty()
+        && !value_field.is_empty()
+    {
+        return Ok(Resolved::Passthrough {
+            dataset,
+            value_field,
+        });
+    }
+    Err(FinanceError::InvalidParameter {
+        param: "series_id".to_string(),
+        reason: format!(
+            "'{trimmed}' is not a FiscalData series. Use one of [{}], or the \
+             passthrough form \"<dataset path>:<value column>\" \
+             (e.g. \"v2/accounting/od/debt_to_penny:tot_pub_debt_out_amt\")",
+            CURATED.iter().map(|c| c.id).collect::<Vec<_>>().join(", ")
+        ),
+    })
+}
+
+/// Parse one of FiscalData's string-encoded numbers.
+///
+/// A missing figure arrives as the literal string `"null"`, or as an empty
+/// string, rather than as JSON `null`.
+pub(super) fn parse_value(raw: &str) -> Option<f64> {
+    let raw = raw.trim();
+    if raw.is_empty() || raw.eq_ignore_ascii_case("null") {
+        return None;
+    }
+    raw.parse::<f64>().ok()
+}
+
+/// Map raw rows onto the canonical [`EconomicSeries`].
+pub(super) fn to_canonical(
+    series_id: &str,
+    resolved: &Resolved<'_>,
+    rows: Vec<FiscalRow>,
+    meta: &FiscalMeta,
+) -> EconomicSeries {
+    let value_field = resolved.query().value_field.to_string();
+
+    let title = meta.labels.get(&value_field).cloned();
+    let (units, frequency) = match resolved {
+        Resolved::Curated(c) => (Some(c.units.to_string()), Some(c.frequency.to_string())),
+        // Nothing better to go on for a passthrough than the column's type.
+        Resolved::Passthrough { .. } => (
+            meta.data_types.get(&value_field).map(|t| match t.as_str() {
+                "CURRENCY" => "US Dollars".to_string(),
+                "PERCENTAGE" => "Percent".to_string(),
+                other => other.to_string(),
+            }),
+            None,
+        ),
+    };
+
+    let observations: Vec<MacroObservation> = rows
+        .into_iter()
+        .filter_map(|mut row| {
+            let date = row.remove(DATE_FIELD)?;
+            let value = row.get(&value_field).and_then(|v| parse_value(v));
+            Some(MacroObservation { date, value })
+        })
+        .collect();
+
+    EconomicSeries {
+        series_id: series_id.to_string(),
+        title,
+        units,
+        frequency,
+        observations,
+    }
+}
+
+/// Fetch a FiscalData series as the canonical
+/// [`EconomicSeries`](crate::models::economic::EconomicSeries).
+pub(crate) async fn fetch_economic_series_response(series_id: &str) -> Result<EconomicSeries> {
+    let resolved = resolve(series_id)?;
+    let (rows, meta) = super::client()?.series(&resolved.query()).await?;
+    Ok(to_canonical(series_id, &resolved, rows, &meta))
+}

--- a/src/adapters/fiscaldata/economic/mod.rs
+++ b/src/adapters/fiscaldata/economic/mod.rs
@@ -141,11 +141,7 @@ pub(super) fn resolve(series_id: &str) -> Result<Resolved<'_>> {
 /// A missing figure arrives as the literal string `"null"`, or as an empty
 /// string, rather than as JSON `null`.
 pub(super) fn parse_value(raw: &str) -> Option<f64> {
-    let raw = raw.trim();
-    if raw.is_empty() || raw.eq_ignore_ascii_case("null") {
-        return None;
-    }
-    raw.parse::<f64>().ok()
+    crate::adapters::common::numbers::parse_number(raw, &["null"])
 }
 
 /// Map raw rows onto the canonical [`EconomicSeries`].

--- a/src/adapters/fiscaldata/mod.rs
+++ b/src/adapters/fiscaldata/mod.rs
@@ -1,0 +1,330 @@
+//! US Treasury FiscalData — keyless federal fiscal statistics.
+//!
+//! Requires the **`fiscaldata`** feature flag.
+//!
+//! `api.fiscaldata.treasury.gov` is the primary source for federal debt,
+//! interest rates, and daily Treasury statements. FRED mirrors some of it with
+//! a lag and needs a key; this route is keyless with no registration.
+//!
+//! # Series identifiers
+//!
+//! Curated short names cover the common series (`"DEBT_TO_PENNY"`,
+//! `"AVG_INTEREST_RATE"`, …). Anything else is reachable through the
+//! passthrough form `"<dataset path>:<value column>"`, e.g.
+//! `"v2/accounting/od/debt_to_penny:tot_pub_debt_out_amt"`.
+
+pub(crate) mod client;
+pub(crate) mod economic;
+pub(crate) mod models;
+
+use std::time::Duration;
+
+use crate::adapters::singleton::keyless_limiter;
+use crate::error::Result;
+use client::FiscalDataClient;
+
+/// Self-imposed pacing. FiscalData publishes no quota but is a small public
+/// service; stay polite.
+const FISCALDATA_RATE_PER_SEC: f64 = 5.0;
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+keyless_limiter!(rate = FISCALDATA_RATE_PER_SEC);
+
+/// Build a client against the live API, reusing the shared token bucket.
+fn client() -> Result<FiscalDataClient> {
+    FiscalDataClient::new(DEFAULT_TIMEOUT, shared_limiter(), client::FISCALDATA_BASE)
+}
+
+pub(crate) use economic::fetch_economic_series_response;
+
+#[cfg(test)]
+mod tests {
+    use super::client::FiscalDataClient;
+    use super::economic::{CURATED, Resolved, parse_value, resolve, to_canonical};
+    use super::*;
+    use crate::error::FinanceError;
+    use crate::rate_limiter::RateLimiter;
+    use std::sync::Arc;
+
+    fn test_client(base_url: &str) -> FiscalDataClient {
+        FiscalDataClient::new(
+            Duration::from_secs(5),
+            Arc::new(RateLimiter::new(100.0)),
+            base_url,
+        )
+        .unwrap()
+    }
+
+    fn debt_payload() -> String {
+        serde_json::json!({
+            "data": [
+                { "record_date": "2026-07-29", "tot_pub_debt_out_amt": "39799618642771.12" },
+                { "record_date": "2026-07-30", "tot_pub_debt_out_amt": "39841114561022.68" },
+                { "record_date": "2026-07-31", "tot_pub_debt_out_amt": "null" }
+            ],
+            "meta": {
+                "count": 3,
+                "labels": { "tot_pub_debt_out_amt": "Total Public Debt Outstanding" },
+                "dataTypes": { "tot_pub_debt_out_amt": "CURRENCY" },
+                "total-count": 3,
+                "total-pages": 1
+            },
+            "links": {}
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn curated_ids_are_unique_and_uppercase() {
+        let mut seen = std::collections::HashSet::new();
+        for c in CURATED {
+            assert!(seen.insert(c.id), "duplicate curated id {}", c.id);
+            assert_eq!(c.id, c.id.to_uppercase(), "{} is not uppercase", c.id);
+        }
+    }
+
+    #[test]
+    fn curated_ids_resolve_case_insensitively() {
+        let r = resolve("debt_to_penny").unwrap();
+        match r {
+            Resolved::Curated(c) => {
+                assert_eq!(c.id, "DEBT_TO_PENNY");
+                assert_eq!(c.value_field, "tot_pub_debt_out_amt");
+            }
+            _ => panic!("expected a curated match"),
+        }
+    }
+
+    #[test]
+    fn passthrough_form_splits_dataset_from_column() {
+        let r = resolve("v2/accounting/od/debt_to_penny:debt_held_public_amt").unwrap();
+        match r {
+            Resolved::Passthrough {
+                dataset,
+                value_field,
+            } => {
+                assert_eq!(dataset, "v2/accounting/od/debt_to_penny");
+                assert_eq!(value_field, "debt_held_public_amt");
+            }
+            _ => panic!("expected a passthrough"),
+        }
+    }
+
+    #[test]
+    fn unknown_series_id_lists_the_curated_catalogue() {
+        let err = resolve("TOTALLY_MADE_UP").unwrap_err();
+        match err {
+            FinanceError::InvalidParameter { reason, .. } => {
+                assert!(reason.contains("DEBT_TO_PENNY"), "got {reason}");
+                assert!(reason.contains("passthrough"), "got {reason}");
+            }
+            other => panic!("expected InvalidParameter, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn string_encoded_numbers_and_null_sentinels_parse() {
+        assert_eq!(parse_value("39841114561022.68"), Some(39841114561022.68));
+        assert_eq!(parse_value("-215024135197.77"), Some(-215024135197.77));
+        // FiscalData sends a missing figure as the *string* "null".
+        assert_eq!(parse_value("null"), None);
+        assert_eq!(parse_value(""), None);
+        assert_eq!(parse_value("  "), None);
+        assert_eq!(parse_value("not a number"), None);
+    }
+
+    #[tokio::test]
+    async fn dataset_rows_map_to_canonical_series() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/v2/accounting/od/debt_to_penny")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(debt_payload())
+            .create_async()
+            .await;
+
+        let resolved = resolve("DEBT_TO_PENNY").unwrap();
+        let (rows, meta) = test_client(&server.url())
+            .series(&resolved.query())
+            .await
+            .unwrap();
+        let series = to_canonical("DEBT_TO_PENNY", &resolved, rows, &meta);
+
+        assert_eq!(series.series_id, "DEBT_TO_PENNY");
+        assert_eq!(
+            series.title.as_deref(),
+            Some("Total Public Debt Outstanding")
+        );
+        // Curated units beat the CURRENCY data type, which can't tell dollars
+        // from millions of dollars.
+        assert_eq!(series.units.as_deref(), Some("US Dollars"));
+        assert_eq!(series.frequency.as_deref(), Some("Daily"));
+        assert_eq!(series.observations.len(), 3);
+        assert_eq!(series.observations[0].date, "2026-07-29");
+        assert_eq!(series.observations[0].value, Some(39799618642771.12));
+        assert_eq!(series.observations[2].value, None);
+    }
+
+    #[tokio::test]
+    async fn filtered_series_sends_the_curated_filter() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/v2/accounting/od/avg_interest_rates")
+            .match_query(mockito::Matcher::UrlEncoded(
+                "filter".into(),
+                "security_desc:eq:Total Interest-bearing Debt".into(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "data": [{ "record_date": "2026-06-30", "avg_interest_rate_amt": "3.383" }],
+                    "meta": {
+                        "labels": { "avg_interest_rate_amt": "Average Interest Rate Amount" },
+                        "dataTypes": { "avg_interest_rate_amt": "PERCENTAGE" },
+                        "total-pages": 1
+                    }
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let resolved = resolve("AVG_INTEREST_RATE").unwrap();
+        let (rows, meta) = test_client(&server.url())
+            .series(&resolved.query())
+            .await
+            .unwrap();
+        let series = to_canonical("AVG_INTEREST_RATE", &resolved, rows, &meta);
+        assert_eq!(series.units.as_deref(), Some("Percent"));
+        assert_eq!(series.observations[0].value, Some(3.383));
+    }
+
+    #[tokio::test]
+    async fn passthrough_units_fall_back_to_the_column_type() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/v2/accounting/od/debt_to_penny")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(debt_payload())
+            .create_async()
+            .await;
+
+        let id = "v2/accounting/od/debt_to_penny:tot_pub_debt_out_amt";
+        let resolved = resolve(id).unwrap();
+        let (rows, meta) = test_client(&server.url())
+            .series(&resolved.query())
+            .await
+            .unwrap();
+        let series = to_canonical(id, &resolved, rows, &meta);
+        assert_eq!(series.units.as_deref(), Some("US Dollars"));
+        // No curated entry means no frequency claim rather than a guessed one.
+        assert_eq!(series.frequency, None);
+    }
+
+    #[tokio::test]
+    async fn query_error_surfaces_the_api_message() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/v2/accounting/od/debt_to_penny")
+            .match_query(mockito::Matcher::Any)
+            .with_status(400)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "error": "Invalid Query Param",
+                    "message": "Field 'nope' does not exist."
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let resolved = resolve("v2/accounting/od/debt_to_penny:nope").unwrap();
+        let err = test_client(&server.url())
+            .series(&resolved.query())
+            .await
+            .unwrap_err();
+        match err {
+            FinanceError::MacroDataError { provider, context } => {
+                assert_eq!(provider, "US Treasury FiscalData");
+                assert!(context.contains("does not exist"), "got {context}");
+            }
+            other => panic!("expected MacroDataError, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_data_array_is_a_missing_symbol() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/v2/accounting/od/debt_to_penny")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(serde_json::json!({ "data": [], "meta": { "total-pages": 0 } }).to_string())
+            .create_async()
+            .await;
+
+        let resolved = resolve("DEBT_TO_PENNY").unwrap();
+        let err = test_client(&server.url())
+            .series(&resolved.query())
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, FinanceError::SymbolNotFound { .. }),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn multi_page_series_is_followed_to_the_end() {
+        let mut server = mockito::Server::new_async().await;
+        let _p1 = server
+            .mock("GET", "/v2/accounting/od/debt_to_penny")
+            .match_query(mockito::Matcher::UrlEncoded(
+                "page[number]".into(),
+                "1".into(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "data": [{ "record_date": "2026-07-29", "tot_pub_debt_out_amt": "1.0" }],
+                    "meta": { "labels": {}, "dataTypes": {}, "total-pages": 2 }
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+        let _p2 = server
+            .mock("GET", "/v2/accounting/od/debt_to_penny")
+            .match_query(mockito::Matcher::UrlEncoded(
+                "page[number]".into(),
+                "2".into(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "data": [{ "record_date": "2026-07-30", "tot_pub_debt_out_amt": "2.0" }],
+                    "meta": { "labels": {}, "dataTypes": {}, "total-pages": 2 }
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let resolved = resolve("DEBT_TO_PENNY").unwrap();
+        let (rows, _) = test_client(&server.url())
+            .series(&resolved.query())
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 2, "pagination stopped after the first page");
+    }
+}

--- a/src/adapters/fiscaldata/models.rs
+++ b/src/adapters/fiscaldata/models.rs
@@ -1,0 +1,56 @@
+//! US Treasury FiscalData wire types.
+//!
+//! Every dataset answers with the same envelope: a `data` array of flat
+//! string-valued rows, plus a `meta` block that self-describes the columns.
+
+use serde::Deserialize;
+use std::collections::HashMap;
+
+/// One row of a dataset. Every column arrives as a JSON string, including
+/// numbers and the literal `"null"` used for a missing figure.
+pub(crate) type FiscalRow = HashMap<String, String>;
+
+/// Column self-description returned alongside every response.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub(crate) struct FiscalMeta {
+    /// Human-readable column titles, e.g. `tot_pub_debt_out_amt` →
+    /// `"Total Public Debt Outstanding"`.
+    #[serde(default)]
+    pub labels: HashMap<String, String>,
+    /// Column types, e.g. `"CURRENCY"`, `"PERCENTAGE"`, `"DATE"`.
+    #[serde(default, rename = "dataTypes")]
+    pub data_types: HashMap<String, String>,
+    #[serde(default, rename = "total-pages")]
+    pub total_pages: Option<u32>,
+}
+
+/// A successful dataset response.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct FiscalResponse {
+    #[serde(default)]
+    pub data: Vec<FiscalRow>,
+    #[serde(default)]
+    pub meta: FiscalMeta,
+}
+
+/// The error body FiscalData returns for a malformed query (bad field name,
+/// unparseable filter, …) — served with a non-2xx status.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct FiscalError {
+    #[serde(default)]
+    pub error: Option<String>,
+    #[serde(default)]
+    pub message: Option<String>,
+}
+
+impl FiscalError {
+    /// Human-readable form for error reporting, preferring the detail message.
+    pub(crate) fn describe(&self) -> Option<String> {
+        match (&self.error, &self.message) {
+            (Some(e), Some(m)) => Some(format!("{e}: {m}")),
+            (Some(e), None) => Some(e.clone()),
+            (None, Some(m)) => Some(m.clone()),
+            (None, None) => None,
+        }
+    }
+}

--- a/src/adapters/frankfurter/client.rs
+++ b/src/adapters/frankfurter/client.rs
@@ -7,7 +7,7 @@ use reqwest::{Client, StatusCode};
 use tracing::debug;
 
 use super::models::{FrankfurterError, FrankfurterTimeSeries};
-use crate::adapters::common::keyless_http_client;
+use crate::adapters::common::{keyless_http_client, status_error};
 use crate::error::{FinanceError, Result};
 use crate::rate_limiter::RateLimiter;
 
@@ -108,11 +108,7 @@ impl FrankfurterClient {
                 param: "currency pair".to_string(),
                 reason: detail.unwrap_or_else(|| format!("{base}/{quote} is not a valid pair")),
             },
-            StatusCode::TOO_MANY_REQUESTS => FinanceError::RateLimited { retry_after: None },
-            s => FinanceError::ExternalApiError {
-                api: "Frankfurter".to_string(),
-                status: s.as_u16(),
-            },
+            s => status_error("Frankfurter", s),
         }
     }
 }

--- a/src/adapters/frankfurter/client.rs
+++ b/src/adapters/frankfurter/client.rs
@@ -1,0 +1,118 @@
+//! Frankfurter HTTP client — keyless ECB reference rates.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use reqwest::{Client, StatusCode};
+use tracing::debug;
+
+use super::models::{FrankfurterError, FrankfurterTimeSeries};
+use crate::adapters::common::keyless_http_client;
+use crate::error::{FinanceError, Result};
+use crate::rate_limiter::RateLimiter;
+
+pub(super) const FRANKFURTER_BASE: &str = "https://api.frankfurter.dev/v1";
+
+/// Calendar days of history requested to find the latest rate *and* the one
+/// before it in a single call. Wide enough to clear a long bank holiday
+/// weekend — the ECB does not publish on non-working days.
+const LOOKBACK_DAYS: i64 = 10;
+
+pub(super) struct FrankfurterClient {
+    http: Client,
+    limiter: Arc<RateLimiter>,
+    base_url: String,
+}
+
+impl FrankfurterClient {
+    pub(super) fn new(
+        timeout: Duration,
+        limiter: Arc<RateLimiter>,
+        base_url: impl Into<String>,
+    ) -> Result<Self> {
+        Ok(Self {
+            http: keyless_http_client(timeout)?,
+            limiter,
+            base_url: base_url.into(),
+        })
+    }
+
+    /// Fetch the recent published rates for `base`→`quote`, oldest first.
+    ///
+    /// One open-ended range request rather than a `latest` call, so the
+    /// previous close needed for the day's change comes back in the same
+    /// round trip.
+    pub(super) async fn recent_rates(&self, base: &str, quote: &str) -> Result<Vec<(String, f64)>> {
+        self.limiter.acquire().await;
+
+        let start = (chrono::Utc::now() - chrono::Duration::days(LOOKBACK_DAYS))
+            .format("%Y-%m-%d")
+            .to_string();
+        let url = format!("{}/{start}..", self.base_url);
+        debug!("Frankfurter request: {url} ({base}->{quote})");
+
+        let resp = self
+            .http
+            .get(&url)
+            .query(&[("base", base), ("symbols", quote)])
+            .send()
+            .await?;
+        let status = resp.status();
+        let bytes = resp.bytes().await?;
+
+        if !status.is_success() {
+            return Err(Self::map_error(status, &bytes, base, quote));
+        }
+
+        let parsed: FrankfurterTimeSeries =
+            serde_json::from_slice(&bytes).map_err(|e| FinanceError::ResponseStructureError {
+                field: "frankfurter.rates".to_string(),
+                context: format!("unrecognised Frankfurter envelope: {e}"),
+            })?;
+
+        // `BTreeMap` keys are ISO dates, so iteration is already chronological.
+        let series: Vec<(String, f64)> = parsed
+            .rates
+            .into_iter()
+            .filter_map(|(date, day)| day.get(quote).map(|rate| (date, *rate)))
+            .collect();
+
+        if series.is_empty() {
+            return Err(FinanceError::SymbolNotFound {
+                symbol: Some(format!("{base}{quote}")),
+                context: format!(
+                    "Frankfurter published no {} rate against {} in the last {LOOKBACK_DAYS} days",
+                    quote, parsed.base
+                ),
+            });
+        }
+        Ok(series)
+    }
+
+    /// Map a non-2xx response, preferring Frankfurter's own explanation.
+    ///
+    /// It distinguishes an unknown currency (404) from a structurally invalid
+    /// pair (422), so the two map to different errors.
+    fn map_error(status: StatusCode, body: &[u8], base: &str, quote: &str) -> FinanceError {
+        let detail = serde_json::from_slice::<FrankfurterError>(body)
+            .ok()
+            .and_then(|e| e.message);
+        match status {
+            StatusCode::NOT_FOUND => FinanceError::SymbolNotFound {
+                symbol: Some(format!("{base}{quote}")),
+                context: detail.unwrap_or_else(|| {
+                    "Frankfurter does not publish one of these currencies".to_string()
+                }),
+            },
+            StatusCode::UNPROCESSABLE_ENTITY => FinanceError::InvalidParameter {
+                param: "currency pair".to_string(),
+                reason: detail.unwrap_or_else(|| format!("{base}/{quote} is not a valid pair")),
+            },
+            StatusCode::TOO_MANY_REQUESTS => FinanceError::RateLimited { retry_after: None },
+            s => FinanceError::ExternalApiError {
+                api: "Frankfurter".to_string(),
+                status: s.as_u16(),
+            },
+        }
+    }
+}

--- a/src/adapters/frankfurter/forex/mod.rs
+++ b/src/adapters/frankfurter/forex/mod.rs
@@ -1,0 +1,71 @@
+//! `FOREX` capability for Frankfurter (ECB reference rates).
+
+use crate::error::Result;
+use crate::models::forex::ForexQuote;
+
+/// Midnight UTC of an ISO `YYYY-MM-DD` date, as a unix timestamp.
+///
+/// ECB reference rates are a daily fix with no intraday time, so the date is
+/// all the precision there is.
+pub(super) fn date_to_timestamp(date: &str) -> Option<i64> {
+    chrono::NaiveDate::parse_from_str(date, "%Y-%m-%d")
+        .ok()?
+        .and_hms_opt(0, 0, 0)
+        .map(|dt| dt.and_utc().timestamp())
+}
+
+/// Build a [`ForexQuote`] from a chronological run of published rates.
+///
+/// `bid`/`ask` stay `None`: ECB rates are a reference fix, not a tradable
+/// two-way price, and inventing a spread would misrepresent them.
+pub(super) fn to_quote(from: &str, to: &str, series: &[(String, f64)]) -> Option<ForexQuote> {
+    let (date, price) = series.last()?;
+    let previous = series.len().checked_sub(2).and_then(|i| series.get(i));
+    let change = previous.map(|(_, prev)| price - prev);
+    let change_percent = previous
+        .filter(|(_, prev)| *prev != 0.0)
+        .map(|(_, prev)| (price - prev) / prev * 100.0);
+
+    Some(ForexQuote {
+        symbol: format!("{from}{to}"),
+        base_currency: Some(from.to_string()),
+        quote_currency: Some(to.to_string()),
+        bid: None,
+        ask: None,
+        price: Some(*price),
+        change,
+        change_percent,
+        timestamp: date_to_timestamp(date),
+    })
+}
+
+/// A pair of identical currencies, which Frankfurter rejects outright (HTTP
+/// 422) rather than answering with the trivially correct rate of 1.
+fn identity_quote(currency: &str) -> ForexQuote {
+    ForexQuote {
+        symbol: format!("{currency}{currency}"),
+        base_currency: Some(currency.to_string()),
+        quote_currency: Some(currency.to_string()),
+        bid: None,
+        ask: None,
+        price: Some(1.0),
+        change: Some(0.0),
+        change_percent: Some(0.0),
+        timestamp: Some(chrono::Utc::now().timestamp()),
+    }
+}
+
+/// Fetch the current ECB reference rate for `from`→`to`.
+pub(crate) async fn fetch_forex_quote_response(from: &str, to: &str) -> Result<ForexQuote> {
+    let from = from.trim().to_uppercase();
+    let to = to.trim().to_uppercase();
+    if from == to {
+        return Ok(identity_quote(&from));
+    }
+
+    let series = super::client()?.recent_rates(&from, &to).await?;
+    to_quote(&from, &to, &series).ok_or_else(|| crate::error::FinanceError::SymbolNotFound {
+        symbol: Some(format!("{from}{to}")),
+        context: "Frankfurter returned no usable rate for this pair".to_string(),
+    })
+}

--- a/src/adapters/frankfurter/mod.rs
+++ b/src/adapters/frankfurter/mod.rs
@@ -1,0 +1,205 @@
+//! Frankfurter — keyless ECB reference exchange rates.
+//!
+//! Requires the **`frankfurter`** feature flag.
+//!
+//! `FOREX` was the one capability with no keyless route at all: Polygon, FMP,
+//! and Alpha Vantage each need a key, so `providers.forex()` was unusable out
+//! of the box. Frankfurter closes that gap with the European Central Bank's
+//! published reference rates.
+//!
+//! # What this is and is not
+//!
+//! ECB reference rates are a **daily fix** published around 16:00 CET on
+//! TARGET working days — not a live market feed, and not a tradable two-way
+//! price. Quotes therefore carry a price with no bid/ask, and the timestamp is
+//! the publication date. Route `FOREX` to a keyed provider first if you need
+//! intraday rates.
+
+pub(crate) mod client;
+pub(crate) mod forex;
+pub(crate) mod models;
+
+use std::time::Duration;
+
+use crate::adapters::singleton::keyless_limiter;
+use crate::error::Result;
+use client::FrankfurterClient;
+
+/// Self-imposed pacing. Frankfurter is free and unmetered but community-run;
+/// stay polite.
+const FRANKFURTER_RATE_PER_SEC: f64 = 5.0;
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+keyless_limiter!(rate = FRANKFURTER_RATE_PER_SEC);
+
+/// Build a client against the live API, reusing the shared token bucket.
+fn client() -> Result<FrankfurterClient> {
+    FrankfurterClient::new(DEFAULT_TIMEOUT, shared_limiter(), client::FRANKFURTER_BASE)
+}
+
+pub(crate) use forex::fetch_forex_quote_response;
+
+#[cfg(test)]
+mod tests {
+    use super::forex::{date_to_timestamp, to_quote};
+    use super::*;
+    use crate::error::FinanceError;
+    use crate::rate_limiter::RateLimiter;
+    use std::sync::Arc;
+
+    fn test_client(base_url: &str) -> FrankfurterClient {
+        FrankfurterClient::new(
+            Duration::from_secs(5),
+            Arc::new(RateLimiter::new(100.0)),
+            base_url,
+        )
+        .unwrap()
+    }
+
+    fn series_payload() -> String {
+        serde_json::json!({
+            "amount": 1.0,
+            "base": "USD",
+            "start_date": "2026-07-29",
+            "end_date": "2026-07-31",
+            "rates": {
+                "2026-07-31": { "EUR": 0.8707 },
+                "2026-07-29": { "EUR": 0.87873 },
+                "2026-07-30": { "EUR": 0.87138 }
+            }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn iso_dates_become_midnight_utc() {
+        // 2026-07-31T00:00:00Z
+        assert_eq!(date_to_timestamp("2026-07-31"), Some(1_785_456_000));
+        assert_eq!(date_to_timestamp("not a date"), None);
+    }
+
+    #[test]
+    fn quote_uses_the_latest_rate_and_the_prior_close_for_change() {
+        let series = vec![
+            ("2026-07-29".to_string(), 0.87873),
+            ("2026-07-30".to_string(), 0.87138),
+            ("2026-07-31".to_string(), 0.8707),
+        ];
+        let q = to_quote("USD", "EUR", &series).unwrap();
+
+        assert_eq!(q.symbol, "USDEUR");
+        assert_eq!(q.base_currency.as_deref(), Some("USD"));
+        assert_eq!(q.quote_currency.as_deref(), Some("EUR"));
+        assert_eq!(q.price, Some(0.8707));
+        // ECB publishes a reference fix, not a two-way price.
+        assert_eq!(q.bid, None);
+        assert_eq!(q.ask, None);
+        let change = q.change.unwrap();
+        assert!((change - (0.8707 - 0.87138)).abs() < 1e-12, "{change}");
+        let pct = q.change_percent.unwrap();
+        assert!(
+            (pct - ((0.8707 - 0.87138) / 0.87138 * 100.0)).abs() < 1e-9,
+            "{pct}"
+        );
+        assert_eq!(q.timestamp, date_to_timestamp("2026-07-31"));
+    }
+
+    #[test]
+    fn a_single_published_day_yields_no_change() {
+        let series = vec![("2026-07-31".to_string(), 0.8707)];
+        let q = to_quote("USD", "EUR", &series).unwrap();
+        assert_eq!(q.price, Some(0.8707));
+        assert_eq!(q.change, None);
+        assert_eq!(q.change_percent, None);
+    }
+
+    #[test]
+    fn an_empty_series_yields_no_quote() {
+        assert!(to_quote("USD", "EUR", &[]).is_none());
+    }
+
+    #[tokio::test]
+    async fn rates_come_back_in_chronological_order() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock(
+                "GET",
+                mockito::Matcher::Regex(r"^/\d{4}-\d{2}-\d{2}\.\.$".into()),
+            )
+            .match_query(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::UrlEncoded("base".into(), "USD".into()),
+                mockito::Matcher::UrlEncoded("symbols".into(), "EUR".into()),
+            ]))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(series_payload())
+            .create_async()
+            .await;
+
+        let series = test_client(&server.url())
+            .recent_rates("USD", "EUR")
+            .await
+            .unwrap();
+        // The response object is unordered; dates must still come out sorted.
+        assert_eq!(
+            series.iter().map(|(d, _)| d.as_str()).collect::<Vec<_>>(),
+            ["2026-07-29", "2026-07-30", "2026-07-31"]
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_currency_maps_to_symbol_not_found() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(404)
+            .with_header("content-type", "application/json")
+            .with_body(serde_json::json!({ "message": "not found" }).to_string())
+            .create_async()
+            .await;
+
+        let err = test_client(&server.url())
+            .recent_rates("USD", "ZZZ")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, FinanceError::SymbolNotFound { .. }),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_pair_maps_to_invalid_parameter() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", mockito::Matcher::Any)
+            .with_status(422)
+            .with_header("content-type", "application/json")
+            .with_body(serde_json::json!({ "message": "bad currency pair" }).to_string())
+            .create_async()
+            .await;
+
+        let err = test_client(&server.url())
+            .recent_rates("USD", "USD")
+            .await
+            .unwrap_err();
+        match err {
+            FinanceError::InvalidParameter { reason, .. } => {
+                assert!(reason.contains("bad currency pair"), "got {reason}");
+            }
+            other => panic!("expected InvalidParameter, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn identical_currencies_short_circuit_without_a_request() {
+        // Frankfurter answers USD->USD with HTTP 422; the trivially correct
+        // answer is served locally instead. No mock server means any request
+        // would fail the test.
+        let q = fetch_forex_quote_response("usd", "USD").await.unwrap();
+        assert_eq!(q.symbol, "USDUSD");
+        assert_eq!(q.price, Some(1.0));
+        assert_eq!(q.change, Some(0.0));
+    }
+}

--- a/src/adapters/frankfurter/models.rs
+++ b/src/adapters/frankfurter/models.rs
@@ -1,0 +1,19 @@
+//! Frankfurter (ECB reference rates) wire types.
+
+use serde::Deserialize;
+use std::collections::BTreeMap;
+
+/// A date-range response: `rates` maps each published date to that day's
+/// rates. `BTreeMap` so iteration is already chronological.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct FrankfurterTimeSeries {
+    pub base: String,
+    pub rates: BTreeMap<String, BTreeMap<String, f64>>,
+}
+
+/// The error body Frankfurter returns for an unknown or invalid pair.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct FrankfurterError {
+    #[serde(default)]
+    pub message: Option<String>,
+}

--- a/src/adapters/kraken/chart/mod.rs
+++ b/src/adapters/kraken/chart/mod.rs
@@ -1,12 +1,20 @@
 //! `CHART` capability for Kraken public market data.
 
+use crate::adapters::common::crypto_chart::{CryptoExchange, crypto_chart};
 use crate::constants::{Interval, TimeRange};
-use crate::error::{FinanceError, Result};
-use crate::models::chart::{Candle, Chart, ChartMeta};
+use crate::error::Result;
+use crate::models::chart::{Candle, Chart};
 use crate::providers::{Operation, Provider};
 
 use super::models::KrakenCandle;
 use super::symbols;
+
+/// How Kraken identifies itself in canonical chart metadata.
+const EXCHANGE: CryptoExchange = CryptoExchange {
+    provider: Provider::Kraken,
+    code: "KRAKEN",
+    name: "Kraken",
+};
 
 /// Map a library interval to Kraken's OHLC interval, in minutes.
 ///
@@ -14,18 +22,13 @@ use super::symbols;
 /// `OneMonth` land exactly; `ThreeMonths` has no equivalent and returns
 /// `None`, so the caller reports `NotSupported` and dispatch falls through.
 pub(super) fn interval_minutes(interval: Interval) -> Option<u32> {
-    Some(match interval {
-        Interval::OneMinute => 1,
-        Interval::FiveMinutes => 5,
-        Interval::FifteenMinutes => 15,
-        Interval::ThirtyMinutes => 30,
-        Interval::OneHour => 60,
-        Interval::OneDay => 1_440,
-        Interval::OneWeek => 10_080,
-        // Kraken's longest bucket is 15 days, the closest thing to a month.
-        Interval::OneMonth => 21_600,
-        Interval::ThreeMonths => return None,
-    })
+    match interval {
+        // Kraken's longest bucket is 15 days, the closest thing to a month,
+        // so this one does not follow from the interval's nominal span.
+        Interval::OneMonth => Some(21_600),
+        Interval::ThreeMonths => None,
+        other => Some((other.duration_secs() / 60) as u32),
+    }
 }
 
 /// Turn Kraken candles into canonical candles.
@@ -58,42 +61,14 @@ pub(super) fn build_chart(
 ) -> Chart {
     let quote_currency =
         symbols::split_pair(pair).map(|(_, quote)| symbols::from_kraken_asset(quote));
-    Chart {
-        symbol: symbol.to_string(),
-        meta: ChartMeta {
-            symbol: symbol.to_string(),
-            currency: quote_currency,
-            exchange_name: Some("KRAKEN".to_string()),
-            full_exchange_name: Some("Kraken".to_string()),
-            instrument_type: Some("CRYPTOCURRENCY".to_string()),
-            first_trade_date: candles.first().map(|c| c.timestamp),
-            regular_market_time: candles.last().map(|c| c.timestamp),
-            regular_market_price: candles.last().map(|c| c.close),
-            data_granularity: interval.map(|i| i.as_str().to_string()),
-            range: range.map(|r| r.as_str().to_string()),
-            provider_id: Some(Provider::Kraken),
-            ..Default::default()
-        },
-        candles,
-        interval,
-        range,
-        provider_id: Some(Provider::Kraken),
-    }
-}
-
-fn not_supported(operation: Operation) -> FinanceError {
-    FinanceError::NotSupported {
-        provider: Provider::Kraken,
-        operation,
-        candidates: operation.capability().candidate_providers(),
-    }
+    crypto_chart(&EXCHANGE, symbol, quote_currency, candles, interval, range)
 }
 
 /// Resolve the requested symbol to a Kraken pair, or report `NotSupported` —
 /// an unmappable symbol is an equity/index ticker another provider should
 /// serve, not a hard failure.
 fn pair_for(symbol: &str, operation: Operation) -> Result<String> {
-    symbols::parse_market(symbol).ok_or_else(|| not_supported(operation))
+    symbols::parse_market(symbol).ok_or_else(|| operation.not_supported(Provider::Kraken))
 }
 
 /// Fetch candles for `symbol` over `range` at `interval`.
@@ -107,7 +82,8 @@ pub(crate) async fn fetch_chart_response(
     range: TimeRange,
 ) -> Result<Chart> {
     let pair = pair_for(symbol, Operation::Chart)?;
-    let minutes = interval_minutes(interval).ok_or_else(|| not_supported(Operation::Chart))?;
+    let minutes = interval_minutes(interval)
+        .ok_or_else(|| Operation::Chart.not_supported(Provider::Kraken))?;
 
     let since = chrono::Utc::now().timestamp() - range.approx_duration_secs();
     let raw = super::client()?.ohlc(&pair, minutes, since).await?;
@@ -132,7 +108,8 @@ pub(crate) async fn fetch_chart_range_response(
     end: i64,
 ) -> Result<Chart> {
     let pair = pair_for(symbol, Operation::ChartRange)?;
-    let minutes = interval_minutes(interval).ok_or_else(|| not_supported(Operation::ChartRange))?;
+    let minutes = interval_minutes(interval)
+        .ok_or_else(|| Operation::ChartRange.not_supported(Provider::Kraken))?;
 
     let raw = super::client()?.ohlc(&pair, minutes, start).await?;
     let candles = to_candles(raw)

--- a/src/adapters/kraken/chart/mod.rs
+++ b/src/adapters/kraken/chart/mod.rs
@@ -1,0 +1,144 @@
+//! `CHART` capability for Kraken public market data.
+
+use crate::constants::{Interval, TimeRange};
+use crate::error::{FinanceError, Result};
+use crate::models::chart::{Candle, Chart, ChartMeta};
+use crate::providers::{Operation, Provider};
+
+use super::models::KrakenCandle;
+use super::symbols;
+
+/// Map a library interval to Kraken's OHLC interval, in minutes.
+///
+/// Kraken offers 1/5/15/30/60/240/1440/10080/21600. `ThirtyMinutes` and
+/// `OneMonth` land exactly; `ThreeMonths` has no equivalent and returns
+/// `None`, so the caller reports `NotSupported` and dispatch falls through.
+pub(super) fn interval_minutes(interval: Interval) -> Option<u32> {
+    Some(match interval {
+        Interval::OneMinute => 1,
+        Interval::FiveMinutes => 5,
+        Interval::FifteenMinutes => 15,
+        Interval::ThirtyMinutes => 30,
+        Interval::OneHour => 60,
+        Interval::OneDay => 1_440,
+        Interval::OneWeek => 10_080,
+        // Kraken's longest bucket is 15 days, the closest thing to a month.
+        Interval::OneMonth => 21_600,
+        Interval::ThreeMonths => return None,
+    })
+}
+
+/// Turn Kraken candles into canonical candles.
+///
+/// Kraken already timestamps in seconds. Volume is base-asset and is truncated
+/// to an integer to fit `Candle::volume`, so sub-unit volumes round toward zero.
+pub(super) fn to_candles(raw: Vec<KrakenCandle>) -> Vec<Candle> {
+    raw.into_iter()
+        .map(|c| Candle {
+            timestamp: c.time,
+            open: c.open,
+            high: c.high,
+            low: c.low,
+            close: c.close,
+            volume: c.volume as i64,
+            // Crypto has no corporate actions, so close is already adjusted.
+            adj_close: Some(c.close),
+            provider_id: Some(Provider::Kraken),
+        })
+        .collect()
+}
+
+/// Assemble a [`Chart`] around a candle series.
+pub(super) fn build_chart(
+    symbol: &str,
+    pair: &str,
+    candles: Vec<Candle>,
+    interval: Option<Interval>,
+    range: Option<TimeRange>,
+) -> Chart {
+    let quote_currency =
+        symbols::split_pair(pair).map(|(_, quote)| symbols::from_kraken_asset(quote));
+    Chart {
+        symbol: symbol.to_string(),
+        meta: ChartMeta {
+            symbol: symbol.to_string(),
+            currency: quote_currency,
+            exchange_name: Some("KRAKEN".to_string()),
+            full_exchange_name: Some("Kraken".to_string()),
+            instrument_type: Some("CRYPTOCURRENCY".to_string()),
+            first_trade_date: candles.first().map(|c| c.timestamp),
+            regular_market_time: candles.last().map(|c| c.timestamp),
+            regular_market_price: candles.last().map(|c| c.close),
+            data_granularity: interval.map(|i| i.as_str().to_string()),
+            range: range.map(|r| r.as_str().to_string()),
+            provider_id: Some(Provider::Kraken),
+            ..Default::default()
+        },
+        candles,
+        interval,
+        range,
+        provider_id: Some(Provider::Kraken),
+    }
+}
+
+fn not_supported(operation: Operation) -> FinanceError {
+    FinanceError::NotSupported {
+        provider: Provider::Kraken,
+        operation,
+        candidates: operation.capability().candidate_providers(),
+    }
+}
+
+/// Resolve the requested symbol to a Kraken pair, or report `NotSupported` —
+/// an unmappable symbol is an equity/index ticker another provider should
+/// serve, not a hard failure.
+fn pair_for(symbol: &str, operation: Operation) -> Result<String> {
+    symbols::parse_market(symbol).ok_or_else(|| not_supported(operation))
+}
+
+/// Fetch candles for `symbol` over `range` at `interval`.
+///
+/// Kraken caps `/OHLC` at ~720 candles ending at now, and `since` only moves
+/// the window's start forward — there is no way to page further back. A range
+/// wider than 720 candles therefore returns the most recent 720.
+pub(crate) async fn fetch_chart_response(
+    symbol: &str,
+    interval: Interval,
+    range: TimeRange,
+) -> Result<Chart> {
+    let pair = pair_for(symbol, Operation::Chart)?;
+    let minutes = interval_minutes(interval).ok_or_else(|| not_supported(Operation::Chart))?;
+
+    let since = chrono::Utc::now().timestamp() - range.approx_duration_secs();
+    let raw = super::client()?.ohlc(&pair, minutes, since).await?;
+
+    Ok(build_chart(
+        symbol,
+        &pair,
+        to_candles(raw),
+        Some(interval),
+        Some(range),
+    ))
+}
+
+/// Fetch candles for `symbol` between two unix-second timestamps.
+///
+/// Kraken has no window end parameter, so candles after `end` are filtered out
+/// locally.
+pub(crate) async fn fetch_chart_range_response(
+    symbol: &str,
+    interval: Interval,
+    start: i64,
+    end: i64,
+) -> Result<Chart> {
+    let pair = pair_for(symbol, Operation::ChartRange)?;
+    let minutes = interval_minutes(interval).ok_or_else(|| not_supported(Operation::ChartRange))?;
+
+    let raw = super::client()?.ohlc(&pair, minutes, start).await?;
+    let candles = to_candles(raw)
+        .into_iter()
+        .filter(|c| c.timestamp <= end)
+        .collect();
+
+    Ok(build_chart(symbol, &pair, candles, Some(interval), None))
+}

--- a/src/adapters/kraken/client.rs
+++ b/src/adapters/kraken/client.rs
@@ -1,0 +1,141 @@
+//! Kraken public market-data HTTP client.
+//!
+//! `api.kraken.com/0/public/*` needs no key and is reachable from the US,
+//! which is the reason this provider exists alongside Binance.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use reqwest::{Client, StatusCode};
+use tracing::debug;
+
+use super::models::{
+    KrakenCandle, KrakenEnvelope, KrakenTicker, OhlcEntry, OhlcResult, TickerResult,
+};
+use crate::adapters::common::keyless_http_client;
+use crate::error::{FinanceError, Result};
+use crate::rate_limiter::RateLimiter;
+
+pub(super) const KRAKEN_BASE: &str = "https://api.kraken.com/0/public";
+
+pub(super) struct KrakenClient {
+    http: Client,
+    limiter: Arc<RateLimiter>,
+    base_url: String,
+}
+
+impl KrakenClient {
+    pub(super) fn new(
+        timeout: Duration,
+        limiter: Arc<RateLimiter>,
+        base_url: impl Into<String>,
+    ) -> Result<Self> {
+        Ok(Self {
+            http: keyless_http_client(timeout)?,
+            limiter,
+            base_url: base_url.into(),
+        })
+    }
+
+    /// Fetch the ticker for one pair.
+    ///
+    /// Kraken keys the result by *its own* pair name, which often differs from
+    /// the one requested (`XBTUSD` comes back as `XXBTZUSD`), so the single
+    /// entry is taken positionally rather than looked up.
+    pub(super) async fn ticker(&self, pair: &str) -> Result<KrakenTicker> {
+        let result: TickerResult = self.get("Ticker", &[("pair", pair)], pair).await?;
+        result
+            .into_values()
+            .next()
+            .ok_or_else(|| FinanceError::SymbolNotFound {
+                symbol: Some(pair.to_string()),
+                context: "Kraken returned no ticker for this pair".to_string(),
+            })
+    }
+
+    /// Fetch OHLC candles for one pair at `interval_minutes`, starting after
+    /// `since` (unix seconds).
+    pub(super) async fn ohlc(
+        &self,
+        pair: &str,
+        interval_minutes: u32,
+        since: i64,
+    ) -> Result<Vec<KrakenCandle>> {
+        let interval = interval_minutes.to_string();
+        let since = since.max(0).to_string();
+        let result: OhlcResult = self
+            .get(
+                "OHLC",
+                &[("pair", pair), ("interval", &interval), ("since", &since)],
+                pair,
+            )
+            .await?;
+
+        // The map holds one market plus a `"last"` cursor; take the candles.
+        result
+            .into_values()
+            .find_map(|entry| match entry {
+                OhlcEntry::Candles(candles) => Some(candles),
+                OhlcEntry::Cursor(_) => None,
+            })
+            .ok_or_else(|| FinanceError::SymbolNotFound {
+                symbol: Some(pair.to_string()),
+                context: "Kraken returned no candles for this pair".to_string(),
+            })
+    }
+
+    /// Issue a public GET and unwrap Kraken's `{error, result}` envelope.
+    async fn get<T: serde::de::DeserializeOwned>(
+        &self,
+        endpoint: &str,
+        params: &[(&str, &str)],
+        pair: &str,
+    ) -> Result<T> {
+        self.limiter.acquire().await;
+        let url = format!("{}/{endpoint}", self.base_url);
+        debug!("Kraken request: {endpoint} {pair}");
+
+        let resp = self.http.get(&url).query(params).send().await?;
+        let status = resp.status();
+        let bytes = resp.bytes().await?;
+
+        if !status.is_success() {
+            return Err(match status {
+                StatusCode::TOO_MANY_REQUESTS => FinanceError::RateLimited { retry_after: None },
+                s => FinanceError::ExternalApiError {
+                    api: "Kraken".to_string(),
+                    status: s.as_u16(),
+                },
+            });
+        }
+
+        let envelope: KrakenEnvelope<T> =
+            serde_json::from_slice(&bytes).map_err(|e| FinanceError::ResponseStructureError {
+                field: format!("kraken.{endpoint}"),
+                context: format!("unrecognised Kraken envelope: {e}"),
+            })?;
+
+        // Kraken answers a rejected request with HTTP 200 and a populated
+        // `error` array, so the status code alone never means success.
+        if !envelope.error.is_empty() {
+            let detail = envelope.error.join("; ");
+            return Err(if detail.contains("Unknown asset pair") {
+                FinanceError::SymbolNotFound {
+                    symbol: Some(pair.to_string()),
+                    context: detail,
+                }
+            } else if detail.contains("Rate limit") {
+                FinanceError::RateLimited { retry_after: None }
+            } else {
+                FinanceError::ApiError(format!("Kraken: {detail}"))
+            });
+        }
+
+        envelope
+            .result
+            .ok_or_else(|| FinanceError::ResponseStructureError {
+                field: format!("kraken.{endpoint}.result"),
+                context: "Kraken reported no error but returned no result".to_string(),
+            })
+    }
+}

--- a/src/adapters/kraken/client.rs
+++ b/src/adapters/kraken/client.rs
@@ -6,13 +6,13 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use reqwest::{Client, StatusCode};
+use reqwest::Client;
 use tracing::debug;
 
 use super::models::{
     KrakenCandle, KrakenEnvelope, KrakenTicker, OhlcEntry, OhlcResult, TickerResult,
 };
-use crate::adapters::common::keyless_http_client;
+use crate::adapters::common::{check_status, keyless_http_client};
 use crate::error::{FinanceError, Result};
 use crate::rate_limiter::RateLimiter;
 
@@ -99,15 +99,7 @@ impl KrakenClient {
         let status = resp.status();
         let bytes = resp.bytes().await?;
 
-        if !status.is_success() {
-            return Err(match status {
-                StatusCode::TOO_MANY_REQUESTS => FinanceError::RateLimited { retry_after: None },
-                s => FinanceError::ExternalApiError {
-                    api: "Kraken".to_string(),
-                    status: s.as_u16(),
-                },
-            });
-        }
+        check_status("Kraken", status)?;
 
         let envelope: KrakenEnvelope<T> =
             serde_json::from_slice(&bytes).map_err(|e| FinanceError::ResponseStructureError {

--- a/src/adapters/kraken/crypto/mod.rs
+++ b/src/adapters/kraken/crypto/mod.rs
@@ -1,0 +1,55 @@
+//! `CRYPTO` capability for Kraken public market data.
+
+use crate::error::Result;
+use crate::models::crypto::CryptoQuote;
+
+use super::models::KrakenTicker;
+use super::symbols;
+
+/// Index of the rolling 24-hour figure in Kraken's `[today, 24h]` arrays.
+const ROLLING_24H: usize = 1;
+
+/// Map a Kraken ticker onto the canonical [`CryptoQuote`].
+///
+/// `change_24h` is measured against **today's opening price** (00:00 UTC), not
+/// a price from exactly 24 hours ago: Kraken publishes the former and not the
+/// latter. Early in the UTC day the figure is therefore a short-window change.
+pub(super) fn to_quote(id: &str, base_ticker: &str, ticker: &KrakenTicker) -> CryptoQuote {
+    let last = KrakenTicker::at(&ticker.c, 0);
+    let open = ticker.o.parse::<f64>().ok();
+    let change = match (last, open) {
+        (Some(l), Some(o)) => Some(l - o),
+        _ => None,
+    };
+    let change_percent = match (last, open) {
+        (Some(l), Some(o)) if o != 0.0 => Some((l - o) / o * 100.0),
+        _ => None,
+    };
+
+    CryptoQuote {
+        id: id.to_string(),
+        symbol: base_ticker.to_string(),
+        name: symbols::asset_name(base_ticker)
+            .map(str::to_string)
+            .unwrap_or_else(|| base_ticker.to_string()),
+        price: last,
+        // An exchange knows what trades on it, not how much of an asset exists.
+        market_cap: None,
+        volume_24h: KrakenTicker::at(&ticker.v, ROLLING_24H),
+        change_24h: change,
+        change_percent_24h: change_percent,
+        high_24h: KrakenTicker::at(&ticker.h, ROLLING_24H),
+        low_24h: KrakenTicker::at(&ticker.l, ROLLING_24H),
+        circulating_supply: None,
+    }
+}
+
+/// Fetch a Kraken spot quote for `id` priced in `vs_currency`.
+pub(crate) async fn fetch_crypto_quote_response(
+    id: &str,
+    vs_currency: &str,
+) -> Result<CryptoQuote> {
+    let pair = symbols::pair(id, vs_currency);
+    let ticker = super::client()?.ticker(&pair).await?;
+    Ok(to_quote(id, &symbols::ticker_for(id), &ticker))
+}

--- a/src/adapters/kraken/crypto/mod.rs
+++ b/src/adapters/kraken/crypto/mod.rs
@@ -51,5 +51,5 @@ pub(crate) async fn fetch_crypto_quote_response(
 ) -> Result<CryptoQuote> {
     let pair = symbols::pair(id, vs_currency);
     let ticker = super::client()?.ticker(&pair).await?;
-    Ok(to_quote(id, &symbols::ticker_for(id), &ticker))
+    Ok(to_quote(id, &symbols::resolve_ticker(id), &ticker))
 }

--- a/src/adapters/kraken/mod.rs
+++ b/src/adapters/kraken/mod.rs
@@ -1,0 +1,244 @@
+//! Kraken public market data — keyless crypto, reachable from the US.
+//!
+//! Requires the **`kraken`** feature flag.
+//!
+//! The US-accessible complement to the Binance adapter: `api.kraken.com`'s
+//! public endpoints need no key and impose no geo-block, so a
+//! `Fetch::Sequential` chain of the two gives `CRYPTO` a fallback that works
+//! everywhere.
+//!
+//! Serves `CRYPTO` (24-hour ticker) and `CHART` (OHLC candles).
+//!
+//! # Kraken's own conventions
+//!
+//! Bitcoin is `XBT`, Dogecoin is `XDG`, and older pairs carry `X`/`Z` asset
+//! class prefixes (`XXBTZUSD`). All of that is translated in
+//! [`symbols`], so callers pass normal tickers.
+
+pub(crate) mod chart;
+pub(crate) mod client;
+pub(crate) mod crypto;
+pub(crate) mod models;
+pub(crate) mod symbols;
+
+use std::time::Duration;
+
+use crate::adapters::singleton::keyless_limiter;
+use crate::error::Result;
+use client::KrakenClient;
+
+/// Self-imposed pacing. Kraken's public counter allows roughly one call per
+/// second sustained for unauthenticated clients.
+const KRAKEN_RATE_PER_SEC: f64 = 1.0;
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+keyless_limiter!(rate = KRAKEN_RATE_PER_SEC);
+
+/// Build a client against the live API, reusing the shared token bucket.
+fn client() -> Result<KrakenClient> {
+    KrakenClient::new(DEFAULT_TIMEOUT, shared_limiter(), client::KRAKEN_BASE)
+}
+
+pub(crate) use chart::{fetch_chart_range_response, fetch_chart_response};
+pub(crate) use crypto::fetch_crypto_quote_response;
+
+#[cfg(test)]
+mod tests {
+    use super::chart::{interval_minutes, to_candles};
+    use super::crypto::to_quote;
+    use super::models::KrakenCandle;
+    use super::*;
+    use crate::constants::Interval;
+    use crate::error::FinanceError;
+    use crate::rate_limiter::RateLimiter;
+    use std::sync::Arc;
+
+    fn test_client(base_url: &str) -> KrakenClient {
+        KrakenClient::new(
+            Duration::from_secs(5),
+            Arc::new(RateLimiter::new(100.0)),
+            base_url,
+        )
+        .unwrap()
+    }
+
+    fn ticker_payload() -> String {
+        // Verbatim shape from api.kraken.com, including the legacy pair key.
+        serde_json::json!({
+            "error": [],
+            "result": {
+                "XXBTZUSD": {
+                    "a": ["63243.80000", "1", "1.000"],
+                    "b": ["63243.70000", "1", "1.000"],
+                    "c": ["63243.80000", "0.00092800"],
+                    "v": ["55.74378179", "810.57235439"],
+                    "p": ["63264.56913", "63240.68062"],
+                    "t": [2105, 37019],
+                    "l": ["63150.00000", "62759.30000"],
+                    "h": ["63513.40000", "63712.10000"],
+                    "o": "63500.00000"
+                }
+            }
+        })
+        .to_string()
+    }
+
+    fn ohlc_payload() -> String {
+        serde_json::json!({
+            "error": [],
+            "result": {
+                "XXBTZUSD": [
+                    [1723507200, "59359.5", "61555.0", "58441.2", "60600.0", "60028.1",
+                     "2442.99193825", 32890],
+                    [1723593600, "60600.1", "61773.4", "58500.0", "58693.6", "60047.6",
+                     "2297.26406239", 28085]
+                ],
+                "last": 1723593600_i64
+            }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn every_interval_but_three_months_maps_to_kraken_minutes() {
+        assert_eq!(interval_minutes(Interval::OneMinute), Some(1));
+        assert_eq!(interval_minutes(Interval::OneHour), Some(60));
+        assert_eq!(interval_minutes(Interval::OneDay), Some(1_440));
+        assert_eq!(interval_minutes(Interval::OneWeek), Some(10_080));
+        assert_eq!(interval_minutes(Interval::OneMonth), Some(21_600));
+        assert_eq!(interval_minutes(Interval::ThreeMonths), None);
+    }
+
+    #[test]
+    fn candles_keep_kraken_second_timestamps() {
+        let candles = to_candles(vec![KrakenCandle {
+            time: 1_723_507_200,
+            open: 59359.5,
+            high: 61555.0,
+            low: 58441.2,
+            close: 60600.0,
+            volume: 2442.99,
+        }]);
+        assert_eq!(candles[0].timestamp, 1_723_507_200);
+        assert_eq!(candles[0].close, 60600.0);
+        assert_eq!(candles[0].adj_close, Some(60600.0));
+        assert_eq!(candles[0].provider_id, Some(crate::Provider::Kraken));
+    }
+
+    #[tokio::test]
+    async fn ticker_maps_to_a_canonical_quote_using_rolling_24h_fields() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/Ticker")
+            .match_query(mockito::Matcher::UrlEncoded("pair".into(), "XBTUSD".into()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(ticker_payload())
+            .create_async()
+            .await;
+
+        let raw = test_client(&server.url()).ticker("XBTUSD").await.unwrap();
+        let quote = to_quote("bitcoin", "BTC", &raw);
+
+        assert_eq!(quote.id, "bitcoin");
+        assert_eq!(quote.symbol, "BTC");
+        assert_eq!(quote.name, "Bitcoin");
+        assert_eq!(quote.price, Some(63243.8));
+        // Index 1 of each packed array is the rolling 24-hour figure, not today's.
+        assert_eq!(quote.volume_24h, Some(810.57235439));
+        assert_eq!(quote.high_24h, Some(63712.1));
+        assert_eq!(quote.low_24h, Some(62759.3));
+        // Change is against today's open — the only reference Kraken publishes.
+        assert_eq!(quote.change_24h, Some(63243.8 - 63500.0));
+        assert_eq!(quote.market_cap, None);
+    }
+
+    #[tokio::test]
+    async fn ohlc_candles_are_read_past_the_last_cursor() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/OHLC")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(ohlc_payload())
+            .create_async()
+            .await;
+
+        // The result map holds the candles *and* an integer "last" cursor;
+        // typing it as one map of candle arrays would fail to parse.
+        let candles = test_client(&server.url())
+            .ohlc("XBTUSD", 1440, 0)
+            .await
+            .unwrap();
+        assert_eq!(candles.len(), 2);
+        assert_eq!(candles[0].time, 1_723_507_200);
+        assert_eq!(candles[1].close, 58693.6);
+    }
+
+    #[tokio::test]
+    async fn unknown_pair_maps_to_symbol_not_found_despite_http_200() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/Ticker")
+            .match_query(mockito::Matcher::Any)
+            // Kraken reports errors with a 200 and a populated `error` array.
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(serde_json::json!({ "error": ["EQuery:Unknown asset pair"] }).to_string())
+            .create_async()
+            .await;
+
+        let err = test_client(&server.url())
+            .ticker("NOTAPAIR")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, FinanceError::SymbolNotFound { .. }),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn other_api_errors_carry_krakens_own_text() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/Ticker")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(serde_json::json!({ "error": ["EService:Unavailable"] }).to_string())
+            .create_async()
+            .await;
+
+        let err = test_client(&server.url())
+            .ticker("XBTUSD")
+            .await
+            .unwrap_err();
+        match err {
+            FinanceError::ApiError(msg) => assert!(msg.contains("EService"), "got {msg}"),
+            other => panic!("expected ApiError, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn http_error_maps_to_external_api_error() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/Ticker")
+            .match_query(mockito::Matcher::Any)
+            .with_status(520)
+            .create_async()
+            .await;
+
+        let err = test_client(&server.url())
+            .ticker("XBTUSD")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, FinanceError::ExternalApiError { status: 520, .. }),
+            "{err:?}"
+        );
+    }
+}

--- a/src/adapters/kraken/models.rs
+++ b/src/adapters/kraken/models.rs
@@ -1,0 +1,133 @@
+//! Kraken public market-data wire types.
+//!
+//! Every Kraken response is `{"error": [...], "result": {...}}` with HTTP 200
+//! even for a rejected request, so the error array — not the status code — is
+//! what decides success.
+
+use serde::Deserialize;
+use std::collections::HashMap;
+
+/// The envelope wrapping every `/0/public/*` response.
+///
+/// The explicit bound overrides serde's derived one: `#[serde(default)]` on
+/// `Option<T>` would otherwise demand `T: Default`, which the payload types
+/// have no reason to implement.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(bound(deserialize = "T: serde::Deserialize<'de>"))]
+pub(crate) struct KrakenEnvelope<T> {
+    #[serde(default)]
+    pub error: Vec<String>,
+    /// Absent entirely when the request was rejected.
+    #[serde(default)]
+    pub result: Option<T>,
+}
+
+/// `GET /0/public/Ticker` — one entry per requested pair, keyed by Kraken's
+/// own pair name (which may differ from the name requested).
+pub(crate) type TickerResult = HashMap<String, KrakenTicker>;
+
+/// Kraken packs each statistic into a short array. Fields documented as
+/// `[today, last 24 hours]` are read at index 1 for the rolling figure.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct KrakenTicker {
+    /// Last trade closed: `[price, lot volume]`.
+    pub c: Vec<String>,
+    /// Volume: `[today, last 24 hours]`.
+    pub v: Vec<String>,
+    /// Low: `[today, last 24 hours]`.
+    pub l: Vec<String>,
+    /// High: `[today, last 24 hours]`.
+    pub h: Vec<String>,
+    /// Today's opening price — Kraken publishes no price from 24 hours ago.
+    pub o: String,
+}
+
+impl KrakenTicker {
+    /// Read one of the packed arrays at `index`, parsed as a number.
+    pub(crate) fn at(field: &[String], index: usize) -> Option<f64> {
+        field.get(index)?.parse().ok()
+    }
+}
+
+/// One `GET /0/public/OHLC` candle, sent as the heterogeneous array
+/// `[time, open, high, low, close, vwap, volume, count]`.
+///
+/// Parsed field by field so a trailing addition to the array cannot break it,
+/// and so the two fields the library has no use for (VWAP, trade count) need
+/// not exist as dead struct members.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct KrakenCandle {
+    /// Candle open time, **seconds** since epoch — unlike Binance, already in
+    /// the unit the canonical model uses.
+    pub time: i64,
+    pub open: f64,
+    pub high: f64,
+    pub low: f64,
+    pub close: f64,
+    pub volume: f64,
+}
+
+impl<'de> Deserialize<'de> for KrakenCandle {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use serde::de::{self, SeqAccess, Visitor};
+
+        struct CandleVisitor;
+
+        impl<'de> Visitor<'de> for CandleVisitor {
+            type Value = KrakenCandle;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("a Kraken OHLC array")
+            }
+
+            fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<KrakenCandle, A::Error> {
+                fn next_num<'de, A: SeqAccess<'de>>(
+                    seq: &mut A,
+                    field: &'static str,
+                ) -> Result<f64, A::Error> {
+                    let raw: String = seq
+                        .next_element()?
+                        .ok_or_else(|| de::Error::missing_field(field))?;
+                    raw.parse().map_err(|_| {
+                        de::Error::invalid_value(de::Unexpected::Str(&raw), &"a decimal string")
+                    })
+                }
+
+                let time: i64 = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::missing_field("time"))?;
+                let open = next_num(&mut seq, "open")?;
+                let high = next_num(&mut seq, "high")?;
+                let low = next_num(&mut seq, "low")?;
+                let close = next_num(&mut seq, "close")?;
+                let _vwap = next_num(&mut seq, "vwap")?;
+                let volume = next_num(&mut seq, "volume")?;
+                while seq.next_element::<de::IgnoredAny>()?.is_some() {}
+
+                Ok(KrakenCandle {
+                    time,
+                    open,
+                    high,
+                    low,
+                    close,
+                    volume,
+                })
+            }
+        }
+
+        deserializer.deserialize_seq(CandleVisitor)
+    }
+}
+
+/// `GET /0/public/OHLC` results mix the candle array with a `"last"` cursor
+/// under the same map, so entries are typed as either.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum OhlcEntry {
+    Candles(Vec<KrakenCandle>),
+    /// The `"last"` key — a resume cursor, not a market. Its value is
+    /// irrelevant; the variant exists only so the surrounding map parses.
+    Cursor(serde::de::IgnoredAny),
+}
+
+pub(crate) type OhlcResult = HashMap<String, OhlcEntry>;

--- a/src/adapters/kraken/symbols.rs
+++ b/src/adapters/kraken/symbols.rs
@@ -3,7 +3,12 @@
 //! Kraken predates most ticker conventions and kept its own: Bitcoin is
 //! `XBT`, Dogecoin is `XDG`, and older pairs carry `X`/`Z` class prefixes
 //! (`XXBTZUSD`). Callers should never have to know that, so every spelling is
-//! translated here.
+//! translated here. Only the Kraken-specific aliasing lives in this file — the
+//! coin id table is shared with Binance in [`crate::adapters::common::coins`].
+
+use crate::adapters::common::coins;
+
+pub(crate) use coins::{asset_name, resolve_ticker};
 
 /// Assets whose Kraken code differs from the ticker everyone else uses.
 const ASSET_ALIASES: &[(&str, &str)] = &[
@@ -18,52 +23,6 @@ const ASSET_ALIASES: &[(&str, &str)] = &[
 const QUOTE_ASSETS: &[&str] = &[
     "USDT", "USDC", "CHF", "AUD", "USD", "EUR", "GBP", "JPY", "CAD", "XBT", "ETH", "DAI",
 ];
-
-/// CoinGecko-style ids for the majors, so a route swap between CoinGecko,
-/// Binance, and Kraken does not change call sites.
-///
-/// Deliberately partial — Kraken has no id concept. Anything absent falls
-/// through as a ticker.
-const COIN_IDS: &[(&str, &str, &str)] = &[
-    ("bitcoin", "BTC", "Bitcoin"),
-    ("ethereum", "ETH", "Ethereum"),
-    ("ripple", "XRP", "XRP"),
-    ("cardano", "ADA", "Cardano"),
-    ("solana", "SOL", "Solana"),
-    ("dogecoin", "DOGE", "Dogecoin"),
-    ("polkadot", "DOT", "Polkadot"),
-    ("chainlink", "LINK", "Chainlink"),
-    ("litecoin", "LTC", "Litecoin"),
-    ("stellar", "XLM", "Stellar"),
-    ("cosmos", "ATOM", "Cosmos"),
-    ("monero", "XMR", "Monero"),
-    ("ethereum-classic", "ETC", "Ethereum Classic"),
-    ("filecoin", "FIL", "Filecoin"),
-    ("algorand", "ALGO", "Algorand"),
-    ("tezos", "XTZ", "Tezos"),
-    ("uniswap", "UNI", "Uniswap"),
-    ("aave", "AAVE", "Aave"),
-    ("avalanche-2", "AVAX", "Avalanche"),
-    ("near", "NEAR", "NEAR Protocol"),
-];
-
-/// Resolve a coin id or ticker to the common ticker (not yet Kraken-coded).
-pub(crate) fn ticker_for(id: &str) -> String {
-    let id = id.trim();
-    COIN_IDS
-        .iter()
-        .find(|(coin_id, _, _)| coin_id.eq_ignore_ascii_case(id))
-        .map(|(_, ticker, _)| (*ticker).to_string())
-        .unwrap_or_else(|| id.to_uppercase())
-}
-
-/// The display name for a ticker, when it is one of the majors.
-pub(crate) fn asset_name(ticker: &str) -> Option<&'static str> {
-    COIN_IDS
-        .iter()
-        .find(|(_, t, _)| t.eq_ignore_ascii_case(ticker))
-        .map(|(_, _, name)| *name)
-}
 
 /// Translate a common ticker to Kraken's own asset code.
 pub(crate) fn kraken_asset(ticker: &str) -> String {
@@ -96,17 +55,14 @@ pub(crate) fn from_kraken_asset(code: &str) -> String {
 pub(crate) fn pair(base_id: &str, vs_currency: &str) -> String {
     format!(
         "{}{}",
-        kraken_asset(&ticker_for(base_id)),
+        kraken_asset(&resolve_ticker(base_id)),
         kraken_asset(vs_currency)
     )
 }
 
 /// Split a concatenated market into `(base, quote)` on a known quote asset.
 pub(crate) fn split_pair(symbol: &str) -> Option<(&str, &str)> {
-    QUOTE_ASSETS
-        .iter()
-        .find(|q| symbol.len() > q.len() && symbol.ends_with(*q))
-        .map(|q| symbol.split_at(symbol.len() - q.len()))
+    coins::split_on_quote(symbol, QUOTE_ASSETS)
 }
 
 /// Normalise any of the library's symbol spellings into a Kraken pair.
@@ -148,13 +104,6 @@ mod tests {
         assert_eq!(from_kraken_asset("ADA"), "ADA");
         // A four-character code that isn't prefixed must survive intact.
         assert_eq!(from_kraken_asset("AAVE"), "AAVE");
-    }
-
-    #[test]
-    fn coin_ids_resolve_to_tickers() {
-        assert_eq!(ticker_for("bitcoin"), "BTC");
-        assert_eq!(ticker_for("Solana"), "SOL");
-        assert_eq!(ticker_for("wif"), "WIF");
     }
 
     #[test]

--- a/src/adapters/kraken/symbols.rs
+++ b/src/adapters/kraken/symbols.rs
@@ -1,0 +1,183 @@
+//! Symbol normalisation for Kraken public markets.
+//!
+//! Kraken predates most ticker conventions and kept its own: Bitcoin is
+//! `XBT`, Dogecoin is `XDG`, and older pairs carry `X`/`Z` class prefixes
+//! (`XXBTZUSD`). Callers should never have to know that, so every spelling is
+//! translated here.
+
+/// Assets whose Kraken code differs from the ticker everyone else uses.
+const ASSET_ALIASES: &[(&str, &str)] = &[
+    ("BTC", "XBT"),
+    ("DOGE", "XDG"),
+    // Kraken lists Terra Classic under its original code.
+    ("LUNC", "LUNA"),
+];
+
+/// Quote assets Kraken lists, longest first so a concatenated market splits
+/// on the right boundary.
+const QUOTE_ASSETS: &[&str] = &[
+    "USDT", "USDC", "CHF", "AUD", "USD", "EUR", "GBP", "JPY", "CAD", "XBT", "ETH", "DAI",
+];
+
+/// CoinGecko-style ids for the majors, so a route swap between CoinGecko,
+/// Binance, and Kraken does not change call sites.
+///
+/// Deliberately partial — Kraken has no id concept. Anything absent falls
+/// through as a ticker.
+const COIN_IDS: &[(&str, &str, &str)] = &[
+    ("bitcoin", "BTC", "Bitcoin"),
+    ("ethereum", "ETH", "Ethereum"),
+    ("ripple", "XRP", "XRP"),
+    ("cardano", "ADA", "Cardano"),
+    ("solana", "SOL", "Solana"),
+    ("dogecoin", "DOGE", "Dogecoin"),
+    ("polkadot", "DOT", "Polkadot"),
+    ("chainlink", "LINK", "Chainlink"),
+    ("litecoin", "LTC", "Litecoin"),
+    ("stellar", "XLM", "Stellar"),
+    ("cosmos", "ATOM", "Cosmos"),
+    ("monero", "XMR", "Monero"),
+    ("ethereum-classic", "ETC", "Ethereum Classic"),
+    ("filecoin", "FIL", "Filecoin"),
+    ("algorand", "ALGO", "Algorand"),
+    ("tezos", "XTZ", "Tezos"),
+    ("uniswap", "UNI", "Uniswap"),
+    ("aave", "AAVE", "Aave"),
+    ("avalanche-2", "AVAX", "Avalanche"),
+    ("near", "NEAR", "NEAR Protocol"),
+];
+
+/// Resolve a coin id or ticker to the common ticker (not yet Kraken-coded).
+pub(crate) fn ticker_for(id: &str) -> String {
+    let id = id.trim();
+    COIN_IDS
+        .iter()
+        .find(|(coin_id, _, _)| coin_id.eq_ignore_ascii_case(id))
+        .map(|(_, ticker, _)| (*ticker).to_string())
+        .unwrap_or_else(|| id.to_uppercase())
+}
+
+/// The display name for a ticker, when it is one of the majors.
+pub(crate) fn asset_name(ticker: &str) -> Option<&'static str> {
+    COIN_IDS
+        .iter()
+        .find(|(_, t, _)| t.eq_ignore_ascii_case(ticker))
+        .map(|(_, _, name)| *name)
+}
+
+/// Translate a common ticker to Kraken's own asset code.
+pub(crate) fn kraken_asset(ticker: &str) -> String {
+    let upper = ticker.trim().to_uppercase();
+    ASSET_ALIASES
+        .iter()
+        .find(|(common, _)| *common == upper)
+        .map(|(_, kraken)| (*kraken).to_string())
+        .unwrap_or(upper)
+}
+
+/// Strip Kraken's legacy `X`/`Z` asset-class prefixes and undo its aliases,
+/// recovering the ticker callers expect.
+///
+/// `XXBT` → `BTC`, `ZUSD` → `USD`, `SOL` → `SOL`. Only 4-character codes carry
+/// the prefix, so 3-character modern codes pass through untouched.
+pub(crate) fn from_kraken_asset(code: &str) -> String {
+    let trimmed = match code.len() {
+        4 if code.starts_with(['X', 'Z']) => &code[1..],
+        _ => code,
+    };
+    ASSET_ALIASES
+        .iter()
+        .find(|(_, kraken)| *kraken == trimmed)
+        .map(|(common, _)| (*common).to_string())
+        .unwrap_or_else(|| trimmed.to_string())
+}
+
+/// Build the pair string to send to Kraken from a coin id and quote currency.
+pub(crate) fn pair(base_id: &str, vs_currency: &str) -> String {
+    format!(
+        "{}{}",
+        kraken_asset(&ticker_for(base_id)),
+        kraken_asset(vs_currency)
+    )
+}
+
+/// Split a concatenated market into `(base, quote)` on a known quote asset.
+pub(crate) fn split_pair(symbol: &str) -> Option<(&str, &str)> {
+    QUOTE_ASSETS
+        .iter()
+        .find(|q| symbol.len() > q.len() && symbol.ends_with(*q))
+        .map(|q| symbol.split_at(symbol.len() - q.len()))
+}
+
+/// Normalise any of the library's symbol spellings into a Kraken pair.
+///
+/// Accepts a separated pair (`BTC-USD`, `SOL/USD`) or a concatenated market
+/// (`XBTUSD`, `SOLUSD`). A bare asset with no quote returns `None`.
+pub(crate) fn parse_market(symbol: &str) -> Option<String> {
+    let symbol = symbol.trim();
+    if let Some((base, quote)) = symbol
+        .split_once(['-', '/', '_'])
+        .filter(|(b, q)| !b.is_empty() && !q.is_empty())
+    {
+        return Some(pair(base, quote));
+    }
+    let upper = symbol.to_uppercase();
+    let (base, quote) = split_pair(&upper)?;
+    Some(format!("{}{}", kraken_asset(base), kraken_asset(quote)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kraken_keeps_its_own_codes_for_btc_and_doge() {
+        assert_eq!(kraken_asset("BTC"), "XBT");
+        assert_eq!(kraken_asset("doge"), "XDG");
+        assert_eq!(kraken_asset("ETH"), "ETH");
+        assert_eq!(kraken_asset("usd"), "USD");
+    }
+
+    #[test]
+    fn legacy_class_prefixes_are_stripped_on_the_way_back() {
+        assert_eq!(from_kraken_asset("XXBT"), "BTC");
+        assert_eq!(from_kraken_asset("ZUSD"), "USD");
+        assert_eq!(from_kraken_asset("XETH"), "ETH");
+        // Modern three-character codes have no prefix to strip.
+        assert_eq!(from_kraken_asset("SOL"), "SOL");
+        assert_eq!(from_kraken_asset("ADA"), "ADA");
+        // A four-character code that isn't prefixed must survive intact.
+        assert_eq!(from_kraken_asset("AAVE"), "AAVE");
+    }
+
+    #[test]
+    fn coin_ids_resolve_to_tickers() {
+        assert_eq!(ticker_for("bitcoin"), "BTC");
+        assert_eq!(ticker_for("Solana"), "SOL");
+        assert_eq!(ticker_for("wif"), "WIF");
+    }
+
+    #[test]
+    fn pairs_use_kraken_codes_on_both_sides() {
+        assert_eq!(pair("bitcoin", "usd"), "XBTUSD");
+        assert_eq!(pair("dogecoin", "eur"), "XDGEUR");
+        assert_eq!(pair("SOL", "USD"), "SOLUSD");
+    }
+
+    #[test]
+    fn separated_and_concatenated_spellings_both_parse() {
+        assert_eq!(parse_market("BTC-USD").as_deref(), Some("XBTUSD"));
+        assert_eq!(parse_market("bitcoin/eur").as_deref(), Some("XBTEUR"));
+        assert_eq!(parse_market("SOLUSD").as_deref(), Some("SOLUSD"));
+        // An already-Kraken-coded market survives the round trip.
+        assert_eq!(parse_market("XBTUSD").as_deref(), Some("XBTUSD"));
+        assert_eq!(parse_market("BTC"), None);
+    }
+
+    #[test]
+    fn quote_assets_split_longest_first() {
+        assert_eq!(split_pair("XBTUSDT"), Some(("XBT", "USDT")));
+        assert_eq!(split_pair("SOLUSD"), Some(("SOL", "USD")));
+        assert_eq!(split_pair("USD"), None);
+    }
+}

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -24,6 +24,7 @@
 //! | `binance` | [Binance public data](https://data-api.binance.vision/) | Keyless | 2 | Exchange-grade crypto quotes and arbitrary-interval OHLCV (geo-blocked in some regions) |
 //! | `kraken` | [Kraken public data](https://api.kraken.com/) | Keyless | 2 | Crypto quotes and OHLC candles; US-accessible complement to Binance |
 //! | `finra` | [FINRA Query API](https://developer.finra.org/) | Keyless (non-commercial) | 1 | Daily short-sale volume by security, from the primary source |
+//! | `openfigi` | [OpenFIGI](https://www.openfigi.com/api) | Keyless (25 req/min) | 1 | CUSIP/ISIN/SEDOL/FIGI to ticker resolution |
 //! | *(always)* | [SEC EDGAR](https://www.sec.gov/edgar) | 10 req/sec | 5+ | Filing history, XBRL financials, full-text search (keyless, requires contact email) |
 //!
 //! # Quick comparison
@@ -90,6 +91,10 @@ pub(crate) mod kraken;
 /// FINRA daily short-sale volume (keyless, requires `finra` feature).
 #[cfg(feature = "finra")]
 pub(crate) mod finra;
+
+/// OpenFIGI security-identifier mapping (keyless, requires `openfigi` feature).
+#[cfg(feature = "openfigi")]
+pub(crate) mod openfigi;
 
 /// SEC EDGAR API client (always available, requires init with contact email).
 pub(crate) mod edgar;

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -18,6 +18,7 @@
 //! | `crypto` | [CoinGecko](https://www.coingecko.com/) | 30 req/min | 2 | Top coins by market cap, single coin quotes (keyless) |
 //! | `fred` | [FRED](https://fred.stlouisfed.org/) | 120 req/min | 2+ | 800k+ macro time series, US Treasury yield curve |
 //! | `worldbank` | [World Bank Open Data](https://data.worldbank.org/) | Keyless | 1 | ~1,600 global development/macro indicators across 200+ economies |
+//! | `fiscaldata` | [US Treasury FiscalData](https://fiscaldata.treasury.gov/) | Keyless | 50+ datasets | Federal debt, average interest rates, daily Treasury statements |
 //! | *(always)* | [SEC EDGAR](https://www.sec.gov/edgar) | 10 req/sec | 5+ | Filing history, XBRL financials, full-text search (keyless, requires contact email) |
 //!
 //! # Quick comparison
@@ -60,6 +61,10 @@ pub(crate) mod fred;
 /// World Bank Open Data global macro indicators (keyless, requires `worldbank` feature).
 #[cfg(feature = "worldbank")]
 pub(crate) mod worldbank;
+
+/// US Treasury FiscalData federal fiscal statistics (keyless, requires `fiscaldata` feature).
+#[cfg(feature = "fiscaldata")]
+pub(crate) mod fiscaldata;
 
 /// SEC EDGAR API client (always available, requires init with contact email).
 pub(crate) mod edgar;

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -19,6 +19,7 @@
 //! | `fred` | [FRED](https://fred.stlouisfed.org/) | 120 req/min | 2+ | 800k+ macro time series, US Treasury yield curve |
 //! | `worldbank` | [World Bank Open Data](https://data.worldbank.org/) | Keyless | 1 | ~1,600 global development/macro indicators across 200+ economies |
 //! | `fiscaldata` | [US Treasury FiscalData](https://fiscaldata.treasury.gov/) | Keyless | 50+ datasets | Federal debt, average interest rates, daily Treasury statements |
+//! | `bls` | [BLS Public Data](https://www.bls.gov/developers/) | Keyless (25/day) or keyed (500/day) | 1 | CPI, unemployment, payrolls, wages, PPI from the primary source |
 //! | *(always)* | [SEC EDGAR](https://www.sec.gov/edgar) | 10 req/sec | 5+ | Filing history, XBRL financials, full-text search (keyless, requires contact email) |
 //!
 //! # Quick comparison
@@ -65,6 +66,10 @@ pub(crate) mod worldbank;
 /// US Treasury FiscalData federal fiscal statistics (keyless, requires `fiscaldata` feature).
 #[cfg(feature = "fiscaldata")]
 pub(crate) mod fiscaldata;
+
+/// BLS labor and inflation statistics (keyless v1 / keyed v2, requires `bls` feature).
+#[cfg(feature = "bls")]
+pub(crate) mod bls;
 
 /// SEC EDGAR API client (always available, requires init with contact email).
 pub(crate) mod edgar;

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -21,6 +21,7 @@
 //! | `fiscaldata` | [US Treasury FiscalData](https://fiscaldata.treasury.gov/) | Keyless | 50+ datasets | Federal debt, average interest rates, daily Treasury statements |
 //! | `bls` | [BLS Public Data](https://www.bls.gov/developers/) | Keyless (25/day) or keyed (500/day) | 1 | CPI, unemployment, payrolls, wages, PPI from the primary source |
 //! | `frankfurter` | [Frankfurter](https://frankfurter.dev/) | Keyless | 1 | ECB daily reference exchange rates — the only keyless forex route |
+//! | `binance` | [Binance public data](https://data-api.binance.vision/) | Keyless | 2 | Exchange-grade crypto quotes and arbitrary-interval OHLCV (geo-blocked in some regions) |
 //! | *(always)* | [SEC EDGAR](https://www.sec.gov/edgar) | 10 req/sec | 5+ | Filing history, XBRL financials, full-text search (keyless, requires contact email) |
 //!
 //! # Quick comparison
@@ -75,6 +76,10 @@ pub(crate) mod bls;
 /// Frankfurter ECB reference exchange rates (keyless, requires `frankfurter` feature).
 #[cfg(feature = "frankfurter")]
 pub(crate) mod frankfurter;
+
+/// Binance public market data (keyless, requires `binance` feature).
+#[cfg(feature = "binance")]
+pub(crate) mod binance;
 
 /// SEC EDGAR API client (always available, requires init with contact email).
 pub(crate) mod edgar;

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -23,6 +23,7 @@
 //! | `frankfurter` | [Frankfurter](https://frankfurter.dev/) | Keyless | 1 | ECB daily reference exchange rates — the only keyless forex route |
 //! | `binance` | [Binance public data](https://data-api.binance.vision/) | Keyless | 2 | Exchange-grade crypto quotes and arbitrary-interval OHLCV (geo-blocked in some regions) |
 //! | `kraken` | [Kraken public data](https://api.kraken.com/) | Keyless | 2 | Crypto quotes and OHLC candles; US-accessible complement to Binance |
+//! | `finra` | [FINRA Query API](https://developer.finra.org/) | Keyless (non-commercial) | 1 | Daily short-sale volume by security, from the primary source |
 //! | *(always)* | [SEC EDGAR](https://www.sec.gov/edgar) | 10 req/sec | 5+ | Filing history, XBRL financials, full-text search (keyless, requires contact email) |
 //!
 //! # Quick comparison
@@ -85,6 +86,10 @@ pub(crate) mod binance;
 /// Kraken public market data (keyless, requires `kraken` feature).
 #[cfg(feature = "kraken")]
 pub(crate) mod kraken;
+
+/// FINRA daily short-sale volume (keyless, requires `finra` feature).
+#[cfg(feature = "finra")]
+pub(crate) mod finra;
 
 /// SEC EDGAR API client (always available, requires init with contact email).
 pub(crate) mod edgar;

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -20,6 +20,7 @@
 //! | `worldbank` | [World Bank Open Data](https://data.worldbank.org/) | Keyless | 1 | ~1,600 global development/macro indicators across 200+ economies |
 //! | `fiscaldata` | [US Treasury FiscalData](https://fiscaldata.treasury.gov/) | Keyless | 50+ datasets | Federal debt, average interest rates, daily Treasury statements |
 //! | `bls` | [BLS Public Data](https://www.bls.gov/developers/) | Keyless (25/day) or keyed (500/day) | 1 | CPI, unemployment, payrolls, wages, PPI from the primary source |
+//! | `frankfurter` | [Frankfurter](https://frankfurter.dev/) | Keyless | 1 | ECB daily reference exchange rates — the only keyless forex route |
 //! | *(always)* | [SEC EDGAR](https://www.sec.gov/edgar) | 10 req/sec | 5+ | Filing history, XBRL financials, full-text search (keyless, requires contact email) |
 //!
 //! # Quick comparison
@@ -70,6 +71,10 @@ pub(crate) mod fiscaldata;
 /// BLS labor and inflation statistics (keyless v1 / keyed v2, requires `bls` feature).
 #[cfg(feature = "bls")]
 pub(crate) mod bls;
+
+/// Frankfurter ECB reference exchange rates (keyless, requires `frankfurter` feature).
+#[cfg(feature = "frankfurter")]
+pub(crate) mod frankfurter;
 
 /// SEC EDGAR API client (always available, requires init with contact email).
 pub(crate) mod edgar;

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -25,6 +25,7 @@
 //! | `kraken` | [Kraken public data](https://api.kraken.com/) | Keyless | 2 | Crypto quotes and OHLC candles; US-accessible complement to Binance |
 //! | `finra` | [FINRA Query API](https://developer.finra.org/) | Keyless (non-commercial) | 1 | Daily short-sale volume by security, from the primary source |
 //! | `openfigi` | [OpenFIGI](https://www.openfigi.com/api) | Keyless (25 req/min) | 1 | CUSIP/ISIN/SEDOL/FIGI to ticker resolution |
+//! | `defi` | [DefiLlama](https://defillama.com/docs/api) | Keyless | 3 | Protocol TVL (current + history), chain rankings, stablecoin supplies |
 //! | *(always)* | [SEC EDGAR](https://www.sec.gov/edgar) | 10 req/sec | 5+ | Filing history, XBRL financials, full-text search (keyless, requires contact email) |
 //!
 //! # Quick comparison
@@ -95,6 +96,10 @@ pub(crate) mod finra;
 /// OpenFIGI security-identifier mapping (keyless, requires `openfigi` feature).
 #[cfg(feature = "openfigi")]
 pub(crate) mod openfigi;
+
+/// DefiLlama DeFi TVL and stablecoin data (keyless, requires `defi` feature).
+#[cfg(feature = "defi")]
+pub(crate) mod defillama;
 
 /// SEC EDGAR API client (always available, requires init with contact email).
 pub(crate) mod edgar;

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -22,6 +22,7 @@
 //! | `bls` | [BLS Public Data](https://www.bls.gov/developers/) | Keyless (25/day) or keyed (500/day) | 1 | CPI, unemployment, payrolls, wages, PPI from the primary source |
 //! | `frankfurter` | [Frankfurter](https://frankfurter.dev/) | Keyless | 1 | ECB daily reference exchange rates — the only keyless forex route |
 //! | `binance` | [Binance public data](https://data-api.binance.vision/) | Keyless | 2 | Exchange-grade crypto quotes and arbitrary-interval OHLCV (geo-blocked in some regions) |
+//! | `kraken` | [Kraken public data](https://api.kraken.com/) | Keyless | 2 | Crypto quotes and OHLC candles; US-accessible complement to Binance |
 //! | *(always)* | [SEC EDGAR](https://www.sec.gov/edgar) | 10 req/sec | 5+ | Filing history, XBRL financials, full-text search (keyless, requires contact email) |
 //!
 //! # Quick comparison
@@ -80,6 +81,10 @@ pub(crate) mod frankfurter;
 /// Binance public market data (keyless, requires `binance` feature).
 #[cfg(feature = "binance")]
 pub(crate) mod binance;
+
+/// Kraken public market data (keyless, requires `kraken` feature).
+#[cfg(feature = "kraken")]
+pub(crate) mod kraken;
 
 /// SEC EDGAR API client (always available, requires init with contact email).
 pub(crate) mod edgar;

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -17,6 +17,7 @@
 //! | `fmp` | [Financial Modeling Prep](https://financialmodelingprep.com/) | 250 req/day | ~100 | Fundamentals, DCF/ratings, insider trading, institutional holdings, screener, 60+ exchanges |
 //! | `crypto` | [CoinGecko](https://www.coingecko.com/) | 30 req/min | 2 | Top coins by market cap, single coin quotes (keyless) |
 //! | `fred` | [FRED](https://fred.stlouisfed.org/) | 120 req/min | 2+ | 800k+ macro time series, US Treasury yield curve |
+//! | `worldbank` | [World Bank Open Data](https://data.worldbank.org/) | Keyless | 1 | ~1,600 global development/macro indicators across 200+ economies |
 //! | *(always)* | [SEC EDGAR](https://www.sec.gov/edgar) | 10 req/sec | 5+ | Filing history, XBRL financials, full-text search (keyless, requires contact email) |
 //!
 //! # Quick comparison
@@ -55,6 +56,10 @@ pub(crate) mod coingecko;
 /// FRED economic data API (requires `fred` feature).
 #[cfg(feature = "fred")]
 pub(crate) mod fred;
+
+/// World Bank Open Data global macro indicators (keyless, requires `worldbank` feature).
+#[cfg(feature = "worldbank")]
+pub(crate) mod worldbank;
 
 /// SEC EDGAR API client (always available, requires init with contact email).
 pub(crate) mod edgar;

--- a/src/adapters/openfigi/client.rs
+++ b/src/adapters/openfigi/client.rs
@@ -1,0 +1,101 @@
+//! OpenFIGI v3 mapping HTTP client.
+//!
+//! Keyless by default. `OPENFIGI_API_KEY` is optional and only raises the
+//! quota — the endpoint and the response shape are identical either way.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use reqwest::{Client, StatusCode};
+use tracing::debug;
+
+use super::models::{MappingJob, MappingResult};
+use crate::adapters::common::keyless_http_client;
+use crate::error::{FinanceError, Result};
+use crate::rate_limiter::RateLimiter;
+
+pub(super) const OPENFIGI_BASE: &str = "https://api.openfigi.com/v3";
+
+/// Jobs per request without a key. A key raises this to 100, but batching to
+/// the smaller number is always valid, so one constant covers both tiers.
+pub(super) const MAX_JOBS_PER_REQUEST: usize = 10;
+
+pub(super) struct OpenFigiClient {
+    http: Client,
+    limiter: Arc<RateLimiter>,
+    base_url: String,
+    api_key: Option<String>,
+}
+
+impl OpenFigiClient {
+    pub(super) fn new(
+        timeout: Duration,
+        limiter: Arc<RateLimiter>,
+        base_url: impl Into<String>,
+        api_key: Option<String>,
+    ) -> Result<Self> {
+        Ok(Self {
+            http: keyless_http_client(timeout)?,
+            limiter,
+            base_url: base_url.into(),
+            api_key,
+        })
+    }
+
+    /// Submit one batch of mapping jobs.
+    ///
+    /// The response array is positional: element `i` answers job `i`. Callers
+    /// rely on that to pair results back to their identifiers, so the length
+    /// is validated rather than assumed.
+    pub(super) async fn map(&self, jobs: &[MappingJob<'_>]) -> Result<Vec<MappingResult>> {
+        self.limiter.acquire().await;
+
+        let url = format!("{}/mapping", self.base_url);
+        debug!("OpenFIGI request: {} job(s)", jobs.len());
+
+        let mut request = self.http.post(&url).json(jobs);
+        if let Some(key) = &self.api_key {
+            request = request.header("X-OPENFIGI-APIKEY", key);
+        }
+
+        let resp = request.send().await?;
+        let status = resp.status();
+        let bytes = resp.bytes().await?;
+
+        if !status.is_success() {
+            return Err(match status {
+                StatusCode::TOO_MANY_REQUESTS => FinanceError::RateLimited { retry_after: None },
+                // OpenFIGI rejects an oversized batch with 413.
+                StatusCode::PAYLOAD_TOO_LARGE => FinanceError::InvalidParameter {
+                    param: "identifiers".to_string(),
+                    reason: format!(
+                        "OpenFIGI accepts at most {MAX_JOBS_PER_REQUEST} identifiers per request"
+                    ),
+                },
+                s => FinanceError::ExternalApiError {
+                    api: "OpenFIGI".to_string(),
+                    status: s.as_u16(),
+                },
+            });
+        }
+
+        let results: Vec<MappingResult> =
+            serde_json::from_slice(&bytes).map_err(|e| FinanceError::ResponseStructureError {
+                field: "openfigi.mapping".to_string(),
+                context: format!("unrecognised OpenFIGI payload: {e}"),
+            })?;
+
+        if results.len() != jobs.len() {
+            return Err(FinanceError::ResponseStructureError {
+                field: "openfigi.mapping".to_string(),
+                context: format!(
+                    "OpenFIGI returned {} results for {} jobs; results are positional and \
+                     cannot be paired back",
+                    results.len(),
+                    jobs.len()
+                ),
+            });
+        }
+        Ok(results)
+    }
+}

--- a/src/adapters/openfigi/client.rs
+++ b/src/adapters/openfigi/client.rs
@@ -10,7 +10,7 @@ use reqwest::{Client, StatusCode};
 use tracing::debug;
 
 use super::models::{MappingJob, MappingResult};
-use crate::adapters::common::keyless_http_client;
+use crate::adapters::common::{keyless_http_client, status_error};
 use crate::error::{FinanceError, Result};
 use crate::rate_limiter::RateLimiter;
 
@@ -64,7 +64,6 @@ impl OpenFigiClient {
 
         if !status.is_success() {
             return Err(match status {
-                StatusCode::TOO_MANY_REQUESTS => FinanceError::RateLimited { retry_after: None },
                 // OpenFIGI rejects an oversized batch with 413.
                 StatusCode::PAYLOAD_TOO_LARGE => FinanceError::InvalidParameter {
                     param: "identifiers".to_string(),
@@ -72,10 +71,7 @@ impl OpenFigiClient {
                         "OpenFIGI accepts at most {MAX_JOBS_PER_REQUEST} identifiers per request"
                     ),
                 },
-                s => FinanceError::ExternalApiError {
-                    api: "OpenFIGI".to_string(),
-                    status: s.as_u16(),
-                },
+                s => status_error("OpenFIGI", s),
             });
         }
 

--- a/src/adapters/openfigi/mod.rs
+++ b/src/adapters/openfigi/mod.rs
@@ -1,0 +1,295 @@
+//! OpenFIGI — keyless CUSIP/ISIN/SEDOL/FIGI to ticker mapping.
+//!
+//! Requires the **`openfigi`** feature flag.
+//!
+//! Exposed through [`crate::openfigi`], alongside [`crate::edgar`] and
+//! [`crate::fred`], rather than through the Providers API: identifier
+//! resolution is not tied to a symbol handle and maps onto no existing
+//! [`Capability`](crate::Capability).
+//!
+//! # Keys
+//!
+//! None required. `OPENFIGI_API_KEY` is optional and only raises the quota
+//! (25 requests/minute keyless, 10 identifiers per request).
+
+pub(crate) mod client;
+pub(crate) mod models;
+
+use std::time::Duration;
+
+use crate::adapters::singleton::keyless_limiter;
+use crate::error::{FinanceError, Result};
+use crate::models::discovery::figi::{SecurityIdKind, SecurityMapping};
+use client::{MAX_JOBS_PER_REQUEST, OpenFigiClient};
+use models::{FigiRecord, MappingJob};
+
+/// Keyless quota is 25 requests/minute; a key raises it. Pace to the lower
+/// tier so the keyless path never trips the limit.
+const OPENFIGI_RATE_PER_SEC: f64 = 0.4;
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+keyless_limiter!(rate = OPENFIGI_RATE_PER_SEC);
+
+/// Build a client against the live API, reusing the shared token bucket.
+///
+/// The optional key is read per call, so exporting it mid-process takes
+/// effect immediately.
+fn client() -> Result<OpenFigiClient> {
+    let api_key = std::env::var("OPENFIGI_API_KEY")
+        .ok()
+        .filter(|k| !k.trim().is_empty());
+    OpenFigiClient::new(
+        DEFAULT_TIMEOUT,
+        shared_limiter(),
+        client::OPENFIGI_BASE,
+        api_key,
+    )
+}
+
+/// Map an OpenFIGI record onto the public [`SecurityMapping`].
+fn to_mapping(record: FigiRecord) -> SecurityMapping {
+    SecurityMapping {
+        figi: record.figi,
+        ticker: record.ticker,
+        name: record.name,
+        exchange_code: record.exch_code,
+        composite_figi: record.composite_figi,
+        share_class_figi: record.share_class_figi,
+        security_type: record.security_type,
+        market_sector: record.market_sector,
+    }
+}
+
+/// Resolve one identifier to every instrument carrying it.
+///
+/// An identifier that is well-formed but matches nothing yields an empty
+/// list; a malformed one is an error.
+pub(crate) async fn resolve(kind: SecurityIdKind, id: &str) -> Result<Vec<SecurityMapping>> {
+    let mut results = resolve_many(kind, std::slice::from_ref(&id)).await?;
+    Ok(results.pop().unwrap_or_default())
+}
+
+/// Resolve several identifiers of the same kind in as few requests as
+/// possible.
+///
+/// The returned vector is positional: element `i` answers `ids[i]`, with an
+/// empty list where nothing matched. A malformed identifier fails the whole
+/// call rather than silently reading as "no match".
+pub(crate) async fn resolve_many(
+    kind: SecurityIdKind,
+    ids: &[&str],
+) -> Result<Vec<Vec<SecurityMapping>>> {
+    if ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let client = client()?;
+    let mut out: Vec<Vec<SecurityMapping>> = Vec::with_capacity(ids.len());
+
+    for chunk in ids.chunks(MAX_JOBS_PER_REQUEST) {
+        let jobs: Vec<MappingJob<'_>> = chunk
+            .iter()
+            .map(|id| MappingJob {
+                id_type: kind.as_str(),
+                id_value: id,
+            })
+            .collect();
+
+        for (result, id) in client.map(&jobs).await?.into_iter().zip(chunk) {
+            if let Some(error) = result.error {
+                return Err(FinanceError::InvalidParameter {
+                    param: format!("{kind}"),
+                    reason: format!("OpenFIGI rejected '{id}': {error}"),
+                });
+            }
+            // A `warning` means the identifier was well-formed but matched
+            // nothing — an empty result, not a failure.
+            if let Some(warning) = result.warning {
+                tracing::debug!("OpenFIGI: {kind} '{id}' matched nothing ({warning})");
+            }
+            out.push(
+                result
+                    .data
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(to_mapping)
+                    .collect(),
+            );
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rate_limiter::RateLimiter;
+    use std::sync::Arc;
+
+    fn test_client(base_url: &str) -> OpenFigiClient {
+        OpenFigiClient::new(
+            Duration::from_secs(5),
+            Arc::new(RateLimiter::new(100.0)),
+            base_url,
+            None,
+        )
+        .unwrap()
+    }
+
+    fn apple_payload() -> String {
+        // Verbatim shape from api.openfigi.com/v3/mapping.
+        serde_json::json!([{
+            "data": [
+                { "figi": "BBG000B9XRY4", "name": "APPLE INC", "ticker": "AAPL",
+                  "exchCode": "US", "compositeFIGI": "BBG000B9XRY4",
+                  "securityType": "Common Stock", "marketSector": "Equity",
+                  "shareClassFIGI": "BBG001S5N8V8", "securityType2": "Common Stock",
+                  "securityDescription": "AAPL" },
+                { "figi": "BBG000B9XVV8", "name": "APPLE INC", "ticker": "AAPL",
+                  "exchCode": "UN", "compositeFIGI": "BBG000B9XRY4",
+                  "securityType": "Common Stock", "marketSector": "Equity",
+                  "shareClassFIGI": "BBG001S5N8V8", "securityType2": "Common Stock",
+                  "securityDescription": "AAPL" }
+            ]
+        }])
+        .to_string()
+    }
+
+    #[test]
+    fn id_kinds_use_openfigis_own_type_names() {
+        assert_eq!(SecurityIdKind::Cusip.as_str(), "ID_CUSIP");
+        assert_eq!(SecurityIdKind::Isin.as_str(), "ID_ISIN");
+        assert_eq!(SecurityIdKind::Sedol.as_str(), "ID_SEDOL");
+        // A FIGI is looked up under Bloomberg's own id type.
+        assert_eq!(SecurityIdKind::Figi.as_str(), "ID_BB_GLOBAL");
+        assert_eq!(SecurityIdKind::Ticker.as_str(), "TICKER");
+    }
+
+    #[tokio::test]
+    async fn a_cusip_resolves_to_every_listing_it_covers() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("POST", "/mapping")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!([{
+                "idType": "ID_CUSIP",
+                "idValue": "037833100"
+            }])))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(apple_payload())
+            .create_async()
+            .await;
+
+        let jobs = vec![MappingJob {
+            id_type: "ID_CUSIP",
+            id_value: "037833100",
+        }];
+        let results = test_client(&server.url()).map(&jobs).await.unwrap();
+        let mappings: Vec<_> = results[0]
+            .data
+            .clone()
+            .unwrap()
+            .into_iter()
+            .map(to_mapping)
+            .collect();
+
+        // One CUSIP covers many venue listings.
+        assert_eq!(mappings.len(), 2);
+        assert_eq!(mappings[0].figi, "BBG000B9XRY4");
+        assert_eq!(mappings[0].ticker.as_deref(), Some("AAPL"));
+        assert_eq!(mappings[0].name.as_deref(), Some("APPLE INC"));
+        assert_eq!(mappings[0].exchange_code.as_deref(), Some("US"));
+        assert_eq!(mappings[1].exchange_code.as_deref(), Some("UN"));
+        // Both roll up to the same composite and share class. Asserted
+        // against the literal values, not against each other: OpenFIGI
+        // capitalises these keys (`compositeFIGI`), so a rename bug would
+        // leave both `None` and pass an equality-only check.
+        assert_eq!(mappings[0].composite_figi.as_deref(), Some("BBG000B9XRY4"));
+        assert_eq!(mappings[1].composite_figi.as_deref(), Some("BBG000B9XRY4"));
+        assert_eq!(
+            mappings[0].share_class_figi.as_deref(),
+            Some("BBG001S5N8V8")
+        );
+    }
+
+    #[tokio::test]
+    async fn a_length_mismatch_is_rejected_rather_than_mispaired() {
+        // Results are positional; a short array would silently pair answers
+        // with the wrong identifiers.
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("POST", "/mapping")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(serde_json::json!([{ "warning": "No identifier found." }]).to_string())
+            .create_async()
+            .await;
+
+        let jobs = vec![
+            MappingJob {
+                id_type: "ID_CUSIP",
+                id_value: "037833100",
+            },
+            MappingJob {
+                id_type: "ID_CUSIP",
+                id_value: "594918104",
+            },
+        ];
+        let err = test_client(&server.url()).map(&jobs).await.unwrap_err();
+        assert!(
+            matches!(err, FinanceError::ResponseStructureError { .. }),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_oversized_batch_explains_the_limit() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("POST", "/mapping")
+            .with_status(413)
+            .create_async()
+            .await;
+
+        let jobs = vec![MappingJob {
+            id_type: "ID_CUSIP",
+            id_value: "037833100",
+        }];
+        let err = test_client(&server.url()).map(&jobs).await.unwrap_err();
+        match err {
+            FinanceError::InvalidParameter { reason, .. } => {
+                assert!(reason.contains("at most 10"), "got {reason}");
+            }
+            other => panic!("expected InvalidParameter, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn rate_limit_maps_to_rate_limited() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("POST", "/mapping")
+            .with_status(429)
+            .create_async()
+            .await;
+
+        let jobs = vec![MappingJob {
+            id_type: "ID_CUSIP",
+            id_value: "037833100",
+        }];
+        let err = test_client(&server.url()).map(&jobs).await.unwrap_err();
+        assert!(matches!(err, FinanceError::RateLimited { .. }), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn resolving_nothing_makes_no_request() {
+        // No mock server exists, so any HTTP call would fail the test.
+        assert!(
+            resolve_many(SecurityIdKind::Cusip, &[])
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+}

--- a/src/adapters/openfigi/models.rs
+++ b/src/adapters/openfigi/models.rs
@@ -1,0 +1,52 @@
+//! OpenFIGI v3 mapping wire types.
+
+use serde::{Deserialize, Serialize};
+
+/// One mapping job in a request body.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct MappingJob<'a> {
+    #[serde(rename = "idType")]
+    pub id_type: &'a str,
+    #[serde(rename = "idValue")]
+    pub id_value: &'a str,
+}
+
+/// One element of the response array, positionally paired with the job that
+/// produced it.
+///
+/// Exactly one of the three arms is present per element: `data` on a hit,
+/// `warning` when nothing matched, `error` when the job itself was malformed.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct MappingResult {
+    #[serde(default)]
+    pub data: Option<Vec<FigiRecord>>,
+    /// Set to `"No identifier found."` when the identifier is valid but
+    /// matches nothing — not an error.
+    #[serde(default)]
+    pub warning: Option<String>,
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+/// One instrument OpenFIGI knows about.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct FigiRecord {
+    pub figi: String,
+    #[serde(default)]
+    pub ticker: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default, rename = "exchCode")]
+    pub exch_code: Option<String>,
+    // OpenFIGI capitalises the acronym (`compositeFIGI`), which plain
+    // camelCase would render as `compositeFigi` and silently never match.
+    #[serde(default, rename = "compositeFIGI")]
+    pub composite_figi: Option<String>,
+    #[serde(default, rename = "shareClassFIGI")]
+    pub share_class_figi: Option<String>,
+    #[serde(default)]
+    pub security_type: Option<String>,
+    #[serde(default)]
+    pub market_sector: Option<String>,
+}

--- a/src/adapters/singleton.rs
+++ b/src/adapters/singleton.rs
@@ -117,6 +117,31 @@ macro_rules! provider_build_client {
     };
 }
 
+/// Generates the process-global shared rate limiter for a **keyless** adapter.
+///
+/// Keyless sources have no API key to store, so the only state that must
+/// outlive a single call is the token bucket. As with the keyed singletons the
+/// `reqwest::Client` is deliberately *not* cached: it is runtime-bound and a
+/// client built on a dropped runtime yields hyper `DispatchGone` errors.
+#[allow(unused_macros)]
+macro_rules! keyless_limiter {
+    (rate = $rate_const:expr $(,)?) => {
+        static SHARED_LIMITER: ::std::sync::OnceLock<
+            ::std::sync::Arc<crate::rate_limiter::RateLimiter>,
+        > = ::std::sync::OnceLock::new();
+
+        /// The process-global token bucket shared by every client this adapter
+        /// builds, so pacing is respected across calls.
+        pub(crate) fn shared_limiter() -> ::std::sync::Arc<crate::rate_limiter::RateLimiter> {
+            ::std::sync::Arc::clone(SHARED_LIMITER.get_or_init(|| {
+                ::std::sync::Arc::new(crate::rate_limiter::RateLimiter::new($rate_const))
+            }))
+        }
+    };
+}
+
+#[allow(unused_imports)]
+pub(crate) use keyless_limiter;
 #[allow(unused_imports)]
 pub(crate) use provider_build_client;
 #[allow(unused_imports)]

--- a/src/adapters/worldbank/client.rs
+++ b/src/adapters/worldbank/client.rs
@@ -7,11 +7,11 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use reqwest::{Client, StatusCode};
+use reqwest::Client;
 use tracing::debug;
 
 use super::models::{WorldBankObservation, WorldBankResponse};
-use crate::adapters::common::keyless_http_client;
+use crate::adapters::common::{check_status, keyless_http_client};
 use crate::error::{FinanceError, Result};
 use crate::rate_limiter::RateLimiter;
 
@@ -70,7 +70,7 @@ impl WorldBankClient {
             ])
             .send()
             .await?;
-        Self::check_status(resp.status())?;
+        check_status("World Bank", resp.status())?;
 
         let bytes = resp.bytes().await?;
         let parsed: WorldBankResponse =
@@ -100,16 +100,5 @@ impl WorldBankClient {
             });
         }
         Ok(observations)
-    }
-
-    fn check_status(status: StatusCode) -> Result<()> {
-        match status {
-            s if s.is_success() => Ok(()),
-            StatusCode::TOO_MANY_REQUESTS => Err(FinanceError::RateLimited { retry_after: None }),
-            s => Err(FinanceError::ExternalApiError {
-                api: "World Bank".to_string(),
-                status: s.as_u16(),
-            }),
-        }
     }
 }

--- a/src/adapters/worldbank/client.rs
+++ b/src/adapters/worldbank/client.rs
@@ -1,0 +1,115 @@
+//! World Bank Open Data HTTP client.
+//!
+//! Keyless and unauthenticated. The World Bank publishes no hard rate limit,
+//! so the client paces itself conservatively rather than relying on the
+//! service to push back.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use reqwest::{Client, StatusCode};
+use tracing::debug;
+
+use super::models::{WorldBankObservation, WorldBankResponse};
+use crate::adapters::common::keyless_http_client;
+use crate::error::{FinanceError, Result};
+use crate::rate_limiter::RateLimiter;
+
+pub(super) const WORLDBANK_BASE: &str = "https://api.worldbank.org/v2";
+
+/// One page big enough for any single-country indicator series (the longest
+/// run to date is ~65 annual observations), so pagination never kicks in.
+const PER_PAGE: u32 = 20_000;
+
+pub(super) struct WorldBankClient {
+    http: Client,
+    limiter: Arc<RateLimiter>,
+    base_url: String,
+}
+
+impl WorldBankClient {
+    pub(super) fn new(
+        timeout: Duration,
+        limiter: Arc<RateLimiter>,
+        base_url: impl Into<String>,
+    ) -> Result<Self> {
+        Ok(Self {
+            http: keyless_http_client(timeout)?,
+            limiter,
+            base_url: base_url.into(),
+        })
+    }
+
+    /// Fetch every observation of `indicator` for `country`, newest first (the
+    /// order the API returns).
+    ///
+    /// `country` is an ISO-2/ISO-3 code, an aggregate code such as `WLD` or
+    /// `EMU`, or `all`.
+    pub(super) async fn indicator(
+        &self,
+        country: &str,
+        indicator: &str,
+    ) -> Result<Vec<WorldBankObservation>> {
+        self.limiter.acquire().await;
+
+        let url = format!(
+            "{}/country/{}/indicator/{}",
+            self.base_url,
+            crate::adapters::common::encode_path_segment(country),
+            crate::adapters::common::encode_path_segment(indicator),
+        );
+        debug!("World Bank request: {url}");
+
+        let resp = self
+            .http
+            .get(&url)
+            .query(&[
+                ("format", "json"),
+                ("per_page", &PER_PAGE.to_string()),
+                ("page", "1"),
+            ])
+            .send()
+            .await?;
+        Self::check_status(resp.status())?;
+
+        let bytes = resp.bytes().await?;
+        let parsed: WorldBankResponse =
+            serde_json::from_slice(&bytes).map_err(|e| FinanceError::ResponseStructureError {
+                field: "worldbank.response".to_string(),
+                context: format!("unrecognised World Bank envelope: {e}"),
+            })?;
+
+        if let Some(messages) = parsed.0.message {
+            let detail = messages
+                .iter()
+                .map(|m| m.describe())
+                .collect::<Vec<_>>()
+                .join("; ");
+            return Err(FinanceError::MacroDataError {
+                provider: "World Bank".to_string(),
+                context: format!("{country}/{indicator}: {detail}"),
+            });
+        }
+
+        let observations = parsed.1.unwrap_or_default();
+        if observations.is_empty() {
+            return Err(FinanceError::SymbolNotFound {
+                symbol: Some(format!("{country}/{indicator}")),
+                context: "World Bank returned no observations for this country/indicator pair"
+                    .to_string(),
+            });
+        }
+        Ok(observations)
+    }
+
+    fn check_status(status: StatusCode) -> Result<()> {
+        match status {
+            s if s.is_success() => Ok(()),
+            StatusCode::TOO_MANY_REQUESTS => Err(FinanceError::RateLimited { retry_after: None }),
+            s => Err(FinanceError::ExternalApiError {
+                api: "World Bank".to_string(),
+                status: s.as_u16(),
+            }),
+        }
+    }
+}

--- a/src/adapters/worldbank/economic/mod.rs
+++ b/src/adapters/worldbank/economic/mod.rs
@@ -1,5 +1,6 @@
 //! `ECONOMIC` capability for World Bank Open Data.
 
+use crate::adapters::common::periods;
 use crate::error::Result;
 use crate::models::economic::{EconomicSeries, MacroObservation};
 
@@ -32,23 +33,26 @@ pub(crate) fn normalize_date(period: &str) -> String {
         && let Ok(q) = quarter.parse::<u32>()
         && (1..=4).contains(&q)
     {
-        return format!("{year}-{:02}-01", (q - 1) * 3 + 1);
+        return periods::quarter_start(year, q);
     }
     if let Some((year, month)) = period.split_once('M')
         && let Ok(m) = month.parse::<u32>()
         && (1..=12).contains(&m)
     {
-        return format!("{year}-{m:02}-01");
+        return periods::month_start(year, m);
     }
     if period.len() == 4 && period.chars().all(|c| c.is_ascii_digit()) {
-        return format!("{period}-01-01");
+        return periods::year_start(period);
     }
     period.to_string()
 }
 
 /// Infer the reporting frequency from the shape of a period label.
-pub(crate) fn infer_frequency(periods: &[String]) -> Option<String> {
-    let first = periods.first()?;
+///
+/// One label settles it — the World Bank never mixes base frequencies within
+/// a single country/indicator series.
+pub(crate) fn infer_frequency(period: Option<&str>) -> Option<String> {
+    let first = period?;
     if first.contains('Q') {
         Some("Quarterly".to_string())
     } else if first.contains('M') {
@@ -65,8 +69,7 @@ pub(crate) fn infer_frequency(periods: &[String]) -> Option<String> {
 /// The API returns newest-first; the canonical model documents chronological
 /// order, so observations are reversed here.
 pub(crate) fn to_canonical(series_id: &str, raw: Vec<WorldBankObservation>) -> EconomicSeries {
-    let periods: Vec<String> = raw.iter().map(|o| o.date.clone()).collect();
-    let frequency = infer_frequency(&periods);
+    let frequency = infer_frequency(raw.first().map(|o| o.date.as_str()));
 
     let title = raw
         .first()

--- a/src/adapters/worldbank/economic/mod.rs
+++ b/src/adapters/worldbank/economic/mod.rs
@@ -1,0 +1,113 @@
+//! `ECONOMIC` capability for World Bank Open Data.
+
+use crate::error::Result;
+use crate::models::economic::{EconomicSeries, MacroObservation};
+
+use super::models::WorldBankObservation;
+
+/// Country used when a series id names only an indicator — the World Bank's
+/// world aggregate, so a bare `"NY.GDP.MKTP.CD"` is still a valid series.
+pub(crate) const DEFAULT_COUNTRY: &str = "WLD";
+
+/// Split a `"<COUNTRY>/<INDICATOR>"` series id into its parts.
+///
+/// A bare indicator (no `/`) resolves against [`DEFAULT_COUNTRY`].
+pub(crate) fn split_series_id(series_id: &str) -> (String, String) {
+    match series_id.split_once('/') {
+        Some((country, indicator)) if !country.is_empty() && !indicator.is_empty() => {
+            (country.trim().to_uppercase(), indicator.trim().to_string())
+        }
+        _ => (DEFAULT_COUNTRY.to_string(), series_id.trim().to_string()),
+    }
+}
+
+/// Normalise a World Bank period label to the `YYYY-MM-DD` start of that
+/// period, which is what [`MacroObservation::date`] documents.
+///
+/// Accepts `"2023"`, `"2023Q3"`, and `"2023M04"`; anything else is passed
+/// through untouched rather than silently dropped.
+pub(crate) fn normalize_date(period: &str) -> String {
+    let period = period.trim();
+    if let Some((year, quarter)) = period.split_once('Q')
+        && let Ok(q) = quarter.parse::<u32>()
+        && (1..=4).contains(&q)
+    {
+        return format!("{year}-{:02}-01", (q - 1) * 3 + 1);
+    }
+    if let Some((year, month)) = period.split_once('M')
+        && let Ok(m) = month.parse::<u32>()
+        && (1..=12).contains(&m)
+    {
+        return format!("{year}-{m:02}-01");
+    }
+    if period.len() == 4 && period.chars().all(|c| c.is_ascii_digit()) {
+        return format!("{period}-01-01");
+    }
+    period.to_string()
+}
+
+/// Infer the reporting frequency from the shape of a period label.
+pub(crate) fn infer_frequency(periods: &[String]) -> Option<String> {
+    let first = periods.first()?;
+    if first.contains('Q') {
+        Some("Quarterly".to_string())
+    } else if first.contains('M') {
+        Some("Monthly".to_string())
+    } else if first.len() == 4 {
+        Some("Annual".to_string())
+    } else {
+        None
+    }
+}
+
+/// Map raw observations onto the canonical [`EconomicSeries`].
+///
+/// The API returns newest-first; the canonical model documents chronological
+/// order, so observations are reversed here.
+pub(crate) fn to_canonical(series_id: &str, raw: Vec<WorldBankObservation>) -> EconomicSeries {
+    let periods: Vec<String> = raw.iter().map(|o| o.date.clone()).collect();
+    let frequency = infer_frequency(&periods);
+
+    let title = raw
+        .first()
+        .and_then(|o| o.indicator.as_ref())
+        .and_then(|i| i.value.clone());
+    let country = raw
+        .first()
+        .and_then(|o| o.country.as_ref())
+        .and_then(|c| c.value.clone());
+    let units = raw
+        .iter()
+        .find_map(|o| o.unit.as_ref().filter(|u| !u.trim().is_empty()).cloned());
+
+    let mut observations: Vec<MacroObservation> = raw
+        .into_iter()
+        .map(|o| MacroObservation {
+            date: normalize_date(&o.date),
+            value: o.value,
+        })
+        .collect();
+    observations.reverse();
+
+    EconomicSeries {
+        series_id: series_id.to_string(),
+        // The indicator name alone ("GDP (current US$)") doesn't say which
+        // country it describes, and the series id may have defaulted to WLD.
+        title: match (title, country) {
+            (Some(t), Some(c)) => Some(format!("{t} — {c}")),
+            (Some(t), None) => Some(t),
+            (None, c) => c,
+        },
+        units,
+        frequency,
+        observations,
+    }
+}
+
+/// Fetch a World Bank indicator series as the canonical
+/// [`EconomicSeries`](crate::models::economic::EconomicSeries).
+pub(crate) async fn fetch_economic_series_response(series_id: &str) -> Result<EconomicSeries> {
+    let (country, indicator) = split_series_id(series_id);
+    let raw = super::client()?.indicator(&country, &indicator).await?;
+    Ok(to_canonical(series_id, raw))
+}

--- a/src/adapters/worldbank/mod.rs
+++ b/src/adapters/worldbank/mod.rs
@@ -1,0 +1,239 @@
+//! World Bank Open Data — keyless global development and macro indicators.
+//!
+//! Requires the **`worldbank`** feature flag.
+//!
+//! Complements FRED (US-centric, keyed) with ~1,600 indicators across 200+
+//! economies. No API key and no registration; the client paces itself since
+//! the World Bank publishes no documented quota.
+//!
+//! # Series identifiers
+//!
+//! The `ECONOMIC` capability takes a single string, so a World Bank series is
+//! addressed as `"<COUNTRY>/<INDICATOR>"` — for example
+//! `"USA/NY.GDP.MKTP.CD"` (US GDP in current US$). A bare indicator resolves
+//! against the world aggregate `WLD`.
+
+pub(crate) mod client;
+pub(crate) mod economic;
+pub(crate) mod models;
+
+use std::time::Duration;
+
+use crate::adapters::singleton::keyless_limiter;
+use crate::error::Result;
+use client::WorldBankClient;
+
+/// Self-imposed pacing. The World Bank documents no quota but does throttle
+/// abusive clients, so stay well under a burst.
+const WORLDBANK_RATE_PER_SEC: f64 = 5.0;
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+keyless_limiter!(rate = WORLDBANK_RATE_PER_SEC);
+
+/// Build a client against the live API, reusing the shared token bucket.
+fn client() -> Result<WorldBankClient> {
+    WorldBankClient::new(DEFAULT_TIMEOUT, shared_limiter(), client::WORLDBANK_BASE)
+}
+
+pub(crate) use economic::fetch_economic_series_response;
+
+#[cfg(test)]
+mod tests {
+    use super::economic::{normalize_date, split_series_id, to_canonical};
+    use super::*;
+    use crate::error::FinanceError;
+    use crate::rate_limiter::RateLimiter;
+    use std::sync::Arc;
+
+    fn test_client(base_url: &str) -> WorldBankClient {
+        WorldBankClient::new(
+            Duration::from_secs(5),
+            Arc::new(RateLimiter::new(100.0)),
+            base_url,
+        )
+        .unwrap()
+    }
+
+    fn payload() -> String {
+        serde_json::json!([
+            { "page": 1, "pages": 1, "per_page": 20000, "total": 3 },
+            [
+                {
+                    "indicator": { "id": "NY.GDP.MKTP.CD", "value": "GDP (current US$)" },
+                    "country": { "id": "US", "value": "United States" },
+                    "countryiso3code": "USA",
+                    "date": "2023",
+                    "value": 27_720_700_000_000.0_f64,
+                    "unit": "",
+                    "obs_status": "",
+                    "decimal": 0
+                },
+                {
+                    "indicator": { "id": "NY.GDP.MKTP.CD", "value": "GDP (current US$)" },
+                    "country": { "id": "US", "value": "United States" },
+                    "countryiso3code": "USA",
+                    "date": "2022",
+                    "value": 25_744_100_000_000.0_f64,
+                    "unit": "",
+                    "obs_status": "",
+                    "decimal": 0
+                },
+                {
+                    "indicator": { "id": "NY.GDP.MKTP.CD", "value": "GDP (current US$)" },
+                    "country": { "id": "US", "value": "United States" },
+                    "countryiso3code": "USA",
+                    "date": "2021",
+                    "value": null,
+                    "unit": "",
+                    "obs_status": "",
+                    "decimal": 0
+                }
+            ]
+        ])
+        .to_string()
+    }
+
+    #[test]
+    fn series_id_splits_country_from_indicator() {
+        assert_eq!(
+            split_series_id("USA/NY.GDP.MKTP.CD"),
+            ("USA".to_string(), "NY.GDP.MKTP.CD".to_string())
+        );
+        assert_eq!(
+            split_series_id("br/SP.POP.TOTL"),
+            ("BR".to_string(), "SP.POP.TOTL".to_string())
+        );
+    }
+
+    #[test]
+    fn bare_indicator_defaults_to_world_aggregate() {
+        assert_eq!(
+            split_series_id("NY.GDP.MKTP.CD"),
+            ("WLD".to_string(), "NY.GDP.MKTP.CD".to_string())
+        );
+    }
+
+    #[test]
+    fn periods_normalize_to_period_start_dates() {
+        assert_eq!(normalize_date("2023"), "2023-01-01");
+        assert_eq!(normalize_date("2023Q1"), "2023-01-01");
+        assert_eq!(normalize_date("2023Q4"), "2023-10-01");
+        assert_eq!(normalize_date("2023M04"), "2023-04-01");
+        // Unrecognised labels survive rather than being silently dropped.
+        assert_eq!(normalize_date("FY2023"), "FY2023");
+    }
+
+    #[tokio::test]
+    async fn indicator_response_maps_to_canonical_series() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/country/USA/indicator/NY.GDP.MKTP.CD")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(payload())
+            .create_async()
+            .await;
+
+        let raw = test_client(&server.url())
+            .indicator("USA", "NY.GDP.MKTP.CD")
+            .await
+            .unwrap();
+        let series = to_canonical("USA/NY.GDP.MKTP.CD", raw);
+
+        assert_eq!(series.series_id, "USA/NY.GDP.MKTP.CD");
+        assert_eq!(
+            series.title.as_deref(),
+            Some("GDP (current US$) — United States")
+        );
+        assert_eq!(series.frequency.as_deref(), Some("Annual"));
+        // Empty `unit` strings must not become an empty-string unit.
+        assert_eq!(series.units, None);
+        assert_eq!(series.observations.len(), 3);
+        // Reversed into chronological order.
+        assert_eq!(series.observations[0].date, "2021-01-01");
+        assert_eq!(series.observations[0].value, None);
+        assert_eq!(series.observations[2].date, "2023-01-01");
+        assert_eq!(series.observations[2].value, Some(27_720_700_000_000.0));
+    }
+
+    #[tokio::test]
+    async fn rejected_request_surfaces_the_api_message() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/country/USA/indicator/NOT.A.REAL.CODE")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!([{
+                    "message": [{
+                        "id": "120",
+                        "key": "Invalid value",
+                        "value": "The provided parameter value is not valid"
+                    }]
+                }])
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let err = test_client(&server.url())
+            .indicator("USA", "NOT.A.REAL.CODE")
+            .await
+            .unwrap_err();
+        match err {
+            FinanceError::MacroDataError { provider, context } => {
+                assert_eq!(provider, "World Bank");
+                assert!(context.contains("Invalid value"), "got {context}");
+            }
+            other => panic!("expected MacroDataError, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_observation_list_is_a_missing_symbol() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/country/ZZZ/indicator/NY.GDP.MKTP.CD")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!([{ "page": 1, "pages": 0, "per_page": 20000, "total": 0 }, null])
+                    .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let err = test_client(&server.url())
+            .indicator("ZZZ", "NY.GDP.MKTP.CD")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, FinanceError::SymbolNotFound { .. }),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn http_error_maps_to_external_api_error() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/country/USA/indicator/NY.GDP.MKTP.CD")
+            .match_query(mockito::Matcher::Any)
+            .with_status(503)
+            .create_async()
+            .await;
+
+        let err = test_client(&server.url())
+            .indicator("USA", "NY.GDP.MKTP.CD")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, FinanceError::ExternalApiError { status: 503, .. }),
+            "{err:?}"
+        );
+    }
+}

--- a/src/adapters/worldbank/models.rs
+++ b/src/adapters/worldbank/models.rs
@@ -1,0 +1,67 @@
+//! World Bank Open Data wire types.
+//!
+//! The v2 API answers every indicator query with a two-element JSON array:
+//! `[metadata, observations]` — or a single-element array carrying `message`
+//! when the request was rejected. Both shapes are modelled here.
+
+use serde::Deserialize;
+
+/// A `{ "id": ..., "value": ... }` pair — how the API names indicators and
+/// countries. Only the display half is kept; the id half is already known
+/// from the request.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct NamedRef {
+    pub value: Option<String>,
+}
+
+/// One observation of one indicator for one country in one period.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct WorldBankObservation {
+    pub indicator: Option<NamedRef>,
+    pub country: Option<NamedRef>,
+    /// Period label: `"2023"`, `"2023Q1"`, or `"2023M01"`.
+    pub date: String,
+    pub value: Option<f64>,
+    /// Usually empty — most indicators carry their unit inside the title.
+    #[serde(default)]
+    pub unit: Option<String>,
+}
+
+/// Header returned as the first array element. Its pagination fields are
+/// ignored — one page is requested large enough to hold any series.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct WorldBankPage {
+    /// Present instead of the pagination fields when the request was rejected.
+    #[serde(default)]
+    pub message: Option<Vec<WorldBankMessage>>,
+}
+
+/// An error entry from a rejected request.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct WorldBankMessage {
+    #[serde(default)]
+    pub key: Option<String>,
+    #[serde(default)]
+    pub value: Option<String>,
+}
+
+impl WorldBankMessage {
+    /// Human-readable form for error reporting, preferring the detail text.
+    pub(crate) fn describe(&self) -> String {
+        match (&self.key, &self.value) {
+            (Some(k), Some(v)) => format!("{k}: {v}"),
+            (Some(k), None) => k.clone(),
+            (None, Some(v)) => v.clone(),
+            (None, None) => "unspecified error".to_string(),
+        }
+    }
+}
+
+/// The full `[metadata, observations]` envelope.
+///
+/// The observations element is absent on error responses, hence the `Option`.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct WorldBankResponse(
+    pub WorldBankPage,
+    #[serde(default)] pub Option<Vec<WorldBankObservation>>,
+);

--- a/src/backtesting/resample.rs
+++ b/src/backtesting/resample.rs
@@ -127,21 +127,7 @@ fn bucket_id(candle: &Candle, interval: Interval, utc_offset_secs: i64) -> i64 {
             let (y, m, _) = ymd(ts);
             y * 10 + (m - 1) / 3 + 1
         }
-        _ => ts.div_euclid(interval_seconds(interval)),
-    }
-}
-
-const fn interval_seconds(interval: Interval) -> i64 {
-    match interval {
-        Interval::OneMinute => 60,
-        Interval::FiveMinutes => 300,
-        Interval::FifteenMinutes => 900,
-        Interval::ThirtyMinutes => 1_800,
-        Interval::OneHour => 3_600,
-        Interval::OneDay => 86_400,
-        Interval::OneWeek => 604_800,
-        Interval::OneMonth => 2_592_000,
-        Interval::ThreeMonths => 7_776_000,
+        _ => ts.div_euclid(interval.duration_secs()),
     }
 }
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -837,6 +837,25 @@ impl Interval {
             Interval::ThreeMonths => "3mo",
         }
     }
+
+    /// Approximate span one candle of this interval covers, in seconds.
+    ///
+    /// Calendar approximations match [`TimeRange::approx_duration_secs`]: a
+    /// month is 30 days, so a quarter is 90.
+    #[cfg(any(feature = "backtesting", feature = "binance", feature = "kraken"))]
+    pub(crate) const fn duration_secs(self) -> i64 {
+        match self {
+            Interval::OneMinute => 60,
+            Interval::FiveMinutes => 300,
+            Interval::FifteenMinutes => 900,
+            Interval::ThirtyMinutes => 1_800,
+            Interval::OneHour => 3_600,
+            Interval::OneDay => 86_400,
+            Interval::OneWeek => 604_800,
+            Interval::OneMonth => 2_592_000,
+            Interval::ThreeMonths => 7_776_000,
+        }
+    }
 }
 
 impl std::fmt::Display for Interval {
@@ -2308,5 +2327,23 @@ mod tests {
         assert_eq!(TimeRange::OneYear.default_interval(), Interval::OneDay);
         assert_eq!(TimeRange::TwoYears.default_interval(), Interval::OneWeek);
         assert_eq!(TimeRange::Max.default_interval(), Interval::OneMonth);
+    }
+
+    #[cfg(any(feature = "backtesting", feature = "binance", feature = "kraken"))]
+    #[test]
+    fn test_interval_duration_secs() {
+        assert_eq!(Interval::OneMinute.duration_secs(), 60);
+        assert_eq!(Interval::OneHour.duration_secs(), 3_600);
+        assert_eq!(Interval::OneDay.duration_secs(), 86_400);
+        assert_eq!(Interval::OneWeek.duration_secs(), 604_800);
+        // Calendar approximations agree with TimeRange's: 30-day months.
+        assert_eq!(
+            Interval::OneMonth.duration_secs(),
+            TimeRange::OneMonth.approx_duration_secs()
+        );
+        assert_eq!(
+            Interval::ThreeMonths.duration_secs(),
+            TimeRange::ThreeMonths.approx_duration_secs()
+        );
     }
 }

--- a/src/domains/crypto.rs
+++ b/src/domains/crypto.rs
@@ -11,7 +11,13 @@ domain_handle! {
     ///
     /// Created via [`Providers::crypto`](crate::Providers::crypto).
     pub struct CryptoCoin { id, id }
-    cache: crate::models::crypto::CryptoQuote, chart
+    cache: crate::models::crypto::CryptoQuote, chart,
+    extra: {
+        #[cfg(feature = "defi")]
+        tvl_cache: crate::models::crypto::defi::ProtocolTvl,
+        #[cfg(feature = "defi")]
+        tvl_history_cache: Vec<crate::models::crypto::defi::TvlPoint>,
+    }
 }
 
 impl CryptoCoin {
@@ -35,23 +41,20 @@ impl CryptoCoin {
     /// Routed through `Capability::CRYPTO`; only DefiLlama serves it, so route
     /// `CRYPTO` to include [`Provider::DefiLlama`](crate::Provider::DefiLlama).
     /// The id is a protocol slug here, not a coin id — most DefiLlama slugs
-    /// happen to match their CoinGecko id, but not all do.
+    /// happen to match their CoinGecko id, but not all do. The response is
+    /// cached on the handle, so a repeat call costs nothing.
     #[cfg(feature = "defi")]
     pub async fn tvl(&self) -> Result<crate::models::crypto::defi::ProtocolTvl> {
-        let __sym = self.id.clone();
-        let __providers = std::sync::Arc::clone(&self.providers);
-        __providers
-            .fetch(crate::providers::Capability::CRYPTO, move |p| {
-                let __s = __sym.clone();
-                let p = p.clone();
-                async move {
-                    p.as_crypto()
-                        .ok_or_else(|| p.not_supported(crate::providers::Operation::ProtocolTvl))?
-                        .fetch_protocol_tvl(&__s)
-                        .await
-                }
-            })
-            .await
+        fetch_via!(
+            cache: tvl_cache,
+            self,
+            id,
+            CRYPTO,
+            as_crypto,
+            ProtocolTvl,
+            fetch_protocol_tvl,
+            crate::models::crypto::defi::ProtocolTvl
+        )
     }
 
     /// Fetch this protocol's full TVL history, oldest first.
@@ -59,22 +62,16 @@ impl CryptoCoin {
     /// Same routing and slug semantics as [`tvl`](Self::tvl).
     #[cfg(feature = "defi")]
     pub async fn tvl_history(&self) -> Result<Vec<crate::models::crypto::defi::TvlPoint>> {
-        let __sym = self.id.clone();
-        let __providers = std::sync::Arc::clone(&self.providers);
-        __providers
-            .fetch(crate::providers::Capability::CRYPTO, move |p| {
-                let __s = __sym.clone();
-                let p = p.clone();
-                async move {
-                    p.as_crypto()
-                        .ok_or_else(|| {
-                            p.not_supported(crate::providers::Operation::ProtocolTvlHistory)
-                        })?
-                        .fetch_protocol_tvl_history(&__s)
-                        .await
-                }
-            })
-            .await
+        fetch_via!(
+            cache: tvl_history_cache,
+            self,
+            id,
+            CRYPTO,
+            as_crypto,
+            ProtocolTvlHistory,
+            fetch_protocol_tvl_history,
+            Vec<crate::models::crypto::defi::TvlPoint>
+        )
     }
 
     /// Fetch historical OHLCV candles for this coin priced in `vs_currency`.

--- a/src/domains/crypto.rs
+++ b/src/domains/crypto.rs
@@ -29,6 +29,54 @@ impl CryptoCoin {
         )
     }
 
+    /// Fetch total value locked for this handle read as a **DeFi protocol
+    /// slug** (e.g. `providers.crypto("aave")`).
+    ///
+    /// Routed through `Capability::CRYPTO`; only DefiLlama serves it, so route
+    /// `CRYPTO` to include [`Provider::DefiLlama`](crate::Provider::DefiLlama).
+    /// The id is a protocol slug here, not a coin id — most DefiLlama slugs
+    /// happen to match their CoinGecko id, but not all do.
+    #[cfg(feature = "defi")]
+    pub async fn tvl(&self) -> Result<crate::models::crypto::defi::ProtocolTvl> {
+        let __sym = self.id.clone();
+        let __providers = std::sync::Arc::clone(&self.providers);
+        __providers
+            .fetch(crate::providers::Capability::CRYPTO, move |p| {
+                let __s = __sym.clone();
+                let p = p.clone();
+                async move {
+                    p.as_crypto()
+                        .ok_or_else(|| p.not_supported(crate::providers::Operation::ProtocolTvl))?
+                        .fetch_protocol_tvl(&__s)
+                        .await
+                }
+            })
+            .await
+    }
+
+    /// Fetch this protocol's full TVL history, oldest first.
+    ///
+    /// Same routing and slug semantics as [`tvl`](Self::tvl).
+    #[cfg(feature = "defi")]
+    pub async fn tvl_history(&self) -> Result<Vec<crate::models::crypto::defi::TvlPoint>> {
+        let __sym = self.id.clone();
+        let __providers = std::sync::Arc::clone(&self.providers);
+        __providers
+            .fetch(crate::providers::Capability::CRYPTO, move |p| {
+                let __s = __sym.clone();
+                let p = p.clone();
+                async move {
+                    p.as_crypto()
+                        .ok_or_else(|| {
+                            p.not_supported(crate::providers::Operation::ProtocolTvlHistory)
+                        })?
+                        .fetch_protocol_tvl_history(&__s)
+                        .await
+                }
+            })
+            .await
+    }
+
     /// Fetch historical OHLCV candles for this coin priced in `vs_currency`.
     ///
     /// Unlike [`quote`](Self::quote) (which uses the coin *id*, e.g.

--- a/src/domains/mod.rs
+++ b/src/domains/mod.rs
@@ -445,6 +445,7 @@ pub(crate) mod crypto;
 pub(crate) mod discovery;
 #[cfg(any(
     feature = "alphavantage",
+    feature = "fiscaldata",
     feature = "fred",
     feature = "polygon",
     feature = "worldbank"
@@ -474,6 +475,7 @@ pub use crypto::CryptoCoin;
 pub use discovery::Discovery;
 #[cfg(any(
     feature = "alphavantage",
+    feature = "fiscaldata",
     feature = "fred",
     feature = "polygon",
     feature = "worldbank"

--- a/src/domains/mod.rs
+++ b/src/domains/mod.rs
@@ -438,6 +438,7 @@ pub(crate) mod commodities;
     feature = "alphavantage",
     feature = "binance",
     feature = "crypto",
+    feature = "defi",
     feature = "fmp",
     feature = "kraken",
     feature = "polygon"
@@ -476,6 +477,7 @@ pub use commodities::Commodity;
     feature = "alphavantage",
     feature = "binance",
     feature = "crypto",
+    feature = "defi",
     feature = "fmp",
     feature = "kraken",
     feature = "polygon"

--- a/src/domains/mod.rs
+++ b/src/domains/mod.rs
@@ -445,6 +445,7 @@ pub(crate) mod crypto;
 pub(crate) mod discovery;
 #[cfg(any(
     feature = "alphavantage",
+    feature = "bls",
     feature = "fiscaldata",
     feature = "fred",
     feature = "polygon",
@@ -475,6 +476,7 @@ pub use crypto::CryptoCoin;
 pub use discovery::Discovery;
 #[cfg(any(
     feature = "alphavantage",
+    feature = "bls",
     feature = "fiscaldata",
     feature = "fred",
     feature = "polygon",

--- a/src/domains/mod.rs
+++ b/src/domains/mod.rs
@@ -108,13 +108,21 @@ impl<V: Clone> DomainCache<V> {
 /// Callers add fetch methods manually.
 macro_rules! domain_handle {
     // Chartable variant — adds a `Chart` response cache read by `chart()`.
-    ($(#[$meta:meta])* pub struct $name:ident { $field:ident, $accessor:ident } cache: $val:ty, chart) => {
+    // `extra:` declares further per-response caches for methods whose return
+    // type differs from the handle's main one; `.cache(ttl)` covers them all.
+    (
+        $(#[$meta:meta])*
+        pub struct $name:ident { $field:ident, $accessor:ident }
+        cache: $val:ty, chart
+        $(, extra: { $( $(#[$ecfg:meta])* $ecache:ident: $eval:ty ),+ $(,)? } )?
+    ) => {
         $(#[$meta])*
         pub struct $name {
             $field: std::sync::Arc<str>,
             providers: std::sync::Arc<crate::providers::ProviderSet>,
             cache: crate::domains::DomainCache<$val>,
             chart_cache: crate::domains::DomainCache<crate::models::chart::Chart>,
+            $($( $(#[$ecfg])* $ecache: crate::domains::DomainCache<$eval>, )+)?
         }
 
         impl $name {
@@ -127,6 +135,10 @@ macro_rules! domain_handle {
                     providers,
                     cache: crate::domains::DomainCache::new(crate::utils::CacheMode::default()),
                     chart_cache: crate::domains::DomainCache::new(crate::utils::CacheMode::default()),
+                    $($(
+                        $(#[$ecfg])*
+                        $ecache: crate::domains::DomainCache::new(crate::utils::CacheMode::default()),
+                    )+)?
                 }
             }
 
@@ -136,6 +148,10 @@ macro_rules! domain_handle {
                 let mode = crate::utils::CacheMode::Ttl(ttl);
                 self.cache = crate::domains::DomainCache::new(mode);
                 self.chart_cache = crate::domains::DomainCache::new(mode);
+                $($(
+                    $(#[$ecfg])*
+                    { self.$ecache = crate::domains::DomainCache::new(mode); }
+                )+)?
                 self
             }
 
@@ -144,6 +160,10 @@ macro_rules! domain_handle {
                 let mode = crate::utils::CacheMode::Off;
                 self.cache = crate::domains::DomainCache::new(mode);
                 self.chart_cache = crate::domains::DomainCache::new(mode);
+                $($(
+                    $(#[$ecfg])*
+                    { self.$ecache = crate::domains::DomainCache::new(mode); }
+                )+)?
                 self
             }
 
@@ -264,11 +284,14 @@ macro_rules! domain_handle {
 /// and `$op` the [`Operation`](crate::providers::Operation) reported when a
 /// routed provider lacks it.
 macro_rules! fetch_via {
-    ($self:expr, $field:ident, $cap:ident, $acc:ident, $op:ident, $fetch:ident, $ret:ty) => {{
+    ($self:expr, $field:ident, $cap:ident, $acc:ident, $op:ident, $fetch:ident, $ret:ty) => {
+        fetch_via!(cache: cache, $self, $field, $cap, $acc, $op, $fetch, $ret)
+    };
+    (cache: $store:ident, $self:expr, $field:ident, $cap:ident, $acc:ident, $op:ident, $fetch:ident, $ret:ty) => {{
         let __sym = $self.$field.clone();
         let __providers = std::sync::Arc::clone(&$self.providers);
         $self
-            .cache
+            .$store
             .get_or_try(String::new(), move || async move {
                 __providers
                     .fetch(crate::providers::Capability::$cap, move |p| {

--- a/src/domains/mod.rs
+++ b/src/domains/mod.rs
@@ -443,7 +443,12 @@ pub(crate) mod commodities;
 pub(crate) mod crypto;
 #[cfg(any(feature = "fmp", feature = "polygon", feature = "alphavantage"))]
 pub(crate) mod discovery;
-#[cfg(any(feature = "fred", feature = "alphavantage", feature = "polygon"))]
+#[cfg(any(
+    feature = "alphavantage",
+    feature = "fred",
+    feature = "polygon",
+    feature = "worldbank"
+))]
 pub(crate) mod economic;
 pub(crate) mod filings;
 #[cfg(any(feature = "polygon", feature = "fmp", feature = "alphavantage"))]
@@ -467,7 +472,12 @@ pub use commodities::Commodity;
 pub use crypto::CryptoCoin;
 #[cfg(any(feature = "fmp", feature = "polygon", feature = "alphavantage"))]
 pub use discovery::Discovery;
-#[cfg(any(feature = "fred", feature = "alphavantage", feature = "polygon"))]
+#[cfg(any(
+    feature = "alphavantage",
+    feature = "fred",
+    feature = "polygon",
+    feature = "worldbank"
+))]
 pub use economic::EconomicIndicator;
 pub use filings::Filings;
 #[cfg(any(feature = "polygon", feature = "fmp", feature = "alphavantage"))]

--- a/src/domains/mod.rs
+++ b/src/domains/mod.rs
@@ -439,6 +439,7 @@ pub(crate) mod commodities;
     feature = "binance",
     feature = "crypto",
     feature = "fmp",
+    feature = "kraken",
     feature = "polygon"
 ))]
 pub(crate) mod crypto;
@@ -476,6 +477,7 @@ pub use commodities::Commodity;
     feature = "binance",
     feature = "crypto",
     feature = "fmp",
+    feature = "kraken",
     feature = "polygon"
 ))]
 pub use crypto::CryptoCoin;

--- a/src/domains/mod.rs
+++ b/src/domains/mod.rs
@@ -453,7 +453,12 @@ pub(crate) mod discovery;
 ))]
 pub(crate) mod economic;
 pub(crate) mod filings;
-#[cfg(any(feature = "polygon", feature = "fmp", feature = "alphavantage"))]
+#[cfg(any(
+    feature = "alphavantage",
+    feature = "fmp",
+    feature = "frankfurter",
+    feature = "polygon"
+))]
 pub(crate) mod forex;
 #[cfg(feature = "polygon")]
 pub(crate) mod futures;
@@ -484,7 +489,12 @@ pub use discovery::Discovery;
 ))]
 pub use economic::EconomicIndicator;
 pub use filings::Filings;
-#[cfg(any(feature = "polygon", feature = "fmp", feature = "alphavantage"))]
+#[cfg(any(
+    feature = "alphavantage",
+    feature = "fmp",
+    feature = "frankfurter",
+    feature = "polygon"
+))]
 pub use forex::ForexPair;
 #[cfg(feature = "polygon")]
 pub use futures::FuturesContract;

--- a/src/domains/mod.rs
+++ b/src/domains/mod.rs
@@ -436,6 +436,7 @@ macro_rules! impl_chartable_analytics {
 pub(crate) mod commodities;
 #[cfg(any(
     feature = "alphavantage",
+    feature = "binance",
     feature = "crypto",
     feature = "fmp",
     feature = "polygon"
@@ -472,6 +473,7 @@ pub(crate) mod market;
 pub use commodities::Commodity;
 #[cfg(any(
     feature = "alphavantage",
+    feature = "binance",
     feature = "crypto",
     feature = "fmp",
     feature = "polygon"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,48 @@ pub mod openfigi {
     }
 }
 
+#[cfg(feature = "defi")]
+pub mod defi {
+    //! Market-wide DeFi data via DefiLlama (requires `defi` feature, keyless).
+    //!
+    //! Chain rankings and stablecoin supplies describe the market as a whole,
+    //! not one asset, so there is no symbol handle to hang them off — they sit
+    //! at the crate root the way [`edgar`](crate::edgar) and
+    //! [`fred`](crate::fred) do.
+    //!
+    //! Protocol-shaped data *is* symbol-shaped and lives on
+    //! [`CryptoCoin::tvl`](crate::CryptoCoin::tvl) instead.
+    //!
+    //! ```no_run
+    //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    //! use finance_query::defi;
+    //!
+    //! for chain in defi::chains().await?.into_iter().take(5) {
+    //!     println!("{}: ${:?}", chain.name, chain.tvl);
+    //! }
+    //! # Ok(())
+    //! # }
+    //! ```
+
+    use crate::error::Result;
+    pub use crate::models::crypto::defi::{
+        ChainAllocation, ChainTvl, ProtocolTvl, StablecoinSupply, TvlPoint,
+    };
+
+    /// Fetch aggregate total value locked for every chain, largest first.
+    pub async fn chains() -> Result<Vec<ChainTvl>> {
+        crate::adapters::defillama::chains().await
+    }
+
+    /// Fetch circulating supply for every tracked stablecoin, largest first.
+    ///
+    /// Supplies are denominated in the coin's pegged asset — read `peg_type`
+    /// before summing across coins pegged to different currencies.
+    pub async fn stablecoins() -> Result<Vec<StablecoinSupply>> {
+        crate::adapters::defillama::stablecoins().await
+    }
+}
+
 pub mod feeds;
 
 #[cfg(feature = "risk")]
@@ -188,6 +230,7 @@ pub use ticker::{ClientHandle, Ticker, TickerBuilder};
     feature = "alphavantage",
     feature = "binance",
     feature = "crypto",
+    feature = "defi",
     feature = "fmp",
     feature = "kraken",
     feature = "polygon"
@@ -315,6 +358,7 @@ pub use models::commodities::CommodityQuote;
     feature = "alphavantage",
     feature = "binance",
     feature = "crypto",
+    feature = "defi",
     feature = "fmp",
     feature = "kraken",
     feature = "polygon"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,6 +121,7 @@ pub use ticker::{ClientHandle, Ticker, TickerBuilder};
     feature = "binance",
     feature = "crypto",
     feature = "fmp",
+    feature = "kraken",
     feature = "polygon"
 ))]
 pub use domains::CryptoCoin;
@@ -247,6 +248,7 @@ pub use models::commodities::CommodityQuote;
     feature = "binance",
     feature = "crypto",
     feature = "fmp",
+    feature = "kraken",
     feature = "polygon"
 ))]
 pub use models::crypto::CryptoQuote;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,7 @@ pub use ticker::{ClientHandle, Ticker, TickerBuilder};
 pub use domains::CryptoCoin;
 #[cfg(any(
     feature = "alphavantage",
+    feature = "bls",
     feature = "fiscaldata",
     feature = "fred",
     feature = "polygon",
@@ -244,6 +245,7 @@ pub use models::commodities::CommodityQuote;
 pub use models::crypto::CryptoQuote;
 #[cfg(any(
     feature = "alphavantage",
+    feature = "bls",
     feature = "fiscaldata",
     feature = "fred",
     feature = "polygon",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,12 @@ pub use ticker::{ClientHandle, Ticker, TickerBuilder};
     feature = "polygon"
 ))]
 pub use domains::CryptoCoin;
-#[cfg(any(feature = "alphavantage", feature = "polygon", feature = "fred"))]
+#[cfg(any(
+    feature = "alphavantage",
+    feature = "fred",
+    feature = "polygon",
+    feature = "worldbank"
+))]
 pub use domains::EconomicIndicator;
 #[cfg(any(feature = "alphavantage", feature = "fmp", feature = "polygon"))]
 pub use domains::ForexPair;
@@ -236,7 +241,12 @@ pub use models::commodities::CommodityQuote;
     feature = "polygon"
 ))]
 pub use models::crypto::CryptoQuote;
-#[cfg(any(feature = "fred", feature = "alphavantage", feature = "polygon"))]
+#[cfg(any(
+    feature = "alphavantage",
+    feature = "fred",
+    feature = "polygon",
+    feature = "worldbank"
+))]
 pub use models::economic::EconomicSeries;
 #[cfg(any(feature = "alphavantage", feature = "fmp", feature = "polygon"))]
 pub use models::forex::ForexQuote;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,12 @@ pub use domains::CryptoCoin;
     feature = "worldbank"
 ))]
 pub use domains::EconomicIndicator;
-#[cfg(any(feature = "alphavantage", feature = "fmp", feature = "polygon"))]
+#[cfg(any(
+    feature = "alphavantage",
+    feature = "fmp",
+    feature = "frankfurter",
+    feature = "polygon"
+))]
 pub use domains::ForexPair;
 
 // Remaining Capability handles — indices, futures, commodities, filings, discovery
@@ -252,7 +257,12 @@ pub use models::crypto::CryptoQuote;
     feature = "worldbank"
 ))]
 pub use models::economic::EconomicSeries;
-#[cfg(any(feature = "alphavantage", feature = "fmp", feature = "polygon"))]
+#[cfg(any(
+    feature = "alphavantage",
+    feature = "fmp",
+    feature = "frankfurter",
+    feature = "polygon"
+))]
 pub use models::forex::ForexQuote;
 #[cfg(feature = "polygon")]
 pub use models::futures::FuturesQuote;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,7 @@ pub use ticker::{ClientHandle, Ticker, TickerBuilder};
 // Domain-specific query handles — constructable via Providers factory methods.
 #[cfg(any(
     feature = "alphavantage",
+    feature = "binance",
     feature = "crypto",
     feature = "fmp",
     feature = "polygon"
@@ -242,8 +243,9 @@ pub use models::sentiment::{Sentiment, SentimentLabel, analyze as analyze_sentim
 #[cfg(any(feature = "fmp", feature = "alphavantage"))]
 pub use models::commodities::CommodityQuote;
 #[cfg(any(
-    feature = "crypto",
     feature = "alphavantage",
+    feature = "binance",
+    feature = "crypto",
     feature = "fmp",
     feature = "polygon"
 ))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,7 @@ pub use ticker::{ClientHandle, Ticker, TickerBuilder};
 pub use domains::CryptoCoin;
 #[cfg(any(
     feature = "alphavantage",
+    feature = "fiscaldata",
     feature = "fred",
     feature = "polygon",
     feature = "worldbank"
@@ -243,6 +244,7 @@ pub use models::commodities::CommodityQuote;
 pub use models::crypto::CryptoQuote;
 #[cfg(any(
     feature = "alphavantage",
+    feature = "fiscaldata",
     feature = "fred",
     feature = "polygon",
     feature = "worldbank"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,74 @@ pub mod crypto {
     pub use crate::adapters::coingecko::{CoinQuote, coin, coins};
 }
 
+#[cfg(feature = "openfigi")]
+pub mod openfigi {
+    //! Security-identifier resolution via OpenFIGI (requires `openfigi`
+    //! feature, keyless).
+    //!
+    //! Resolves a CUSIP, ISIN, SEDOL, or FIGI to the instruments carrying it —
+    //! the missing step for any dataset that identifies holdings by CUSIP
+    //! rather than ticker, such as 13F filings.
+    //!
+    //! Lives here rather than behind the Providers API because resolution is
+    //! not tied to a symbol handle and maps onto no
+    //! [`Capability`](crate::Capability), the same reasoning that puts
+    //! [`edgar`](crate::edgar) and [`fred`](crate::fred) at the crate root.
+    //!
+    //! No API key is required; `OPENFIGI_API_KEY` is optional and only raises
+    //! the quota.
+    //!
+    //! ```no_run
+    //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    //! use finance_query::openfigi;
+    //!
+    //! // One CUSIP maps to every venue listing of the security.
+    //! for listing in openfigi::resolve_cusip("037833100").await? {
+    //!     println!("{:?} on {:?}", listing.ticker, listing.exchange_code);
+    //! }
+    //! # Ok(())
+    //! # }
+    //! ```
+
+    use crate::error::Result;
+    pub use crate::models::discovery::figi::{SecurityIdKind, SecurityMapping};
+
+    /// Resolve a CUSIP to every instrument carrying it.
+    ///
+    /// Returns an empty list when the identifier is well-formed but matches
+    /// nothing; a malformed identifier is an error.
+    pub async fn resolve_cusip(cusip: &str) -> Result<Vec<SecurityMapping>> {
+        crate::adapters::openfigi::resolve(SecurityIdKind::Cusip, cusip).await
+    }
+
+    /// Resolve an ISIN to every instrument carrying it.
+    pub async fn resolve_isin(isin: &str) -> Result<Vec<SecurityMapping>> {
+        crate::adapters::openfigi::resolve(SecurityIdKind::Isin, isin).await
+    }
+
+    /// Resolve a SEDOL to every instrument carrying it.
+    pub async fn resolve_sedol(sedol: &str) -> Result<Vec<SecurityMapping>> {
+        crate::adapters::openfigi::resolve(SecurityIdKind::Sedol, sedol).await
+    }
+
+    /// Resolve an identifier of any supported [`SecurityIdKind`].
+    pub async fn resolve(kind: SecurityIdKind, id: &str) -> Result<Vec<SecurityMapping>> {
+        crate::adapters::openfigi::resolve(kind, id).await
+    }
+
+    /// Resolve many identifiers of the same kind in as few requests as
+    /// possible (OpenFIGI accepts 10 per request without a key).
+    ///
+    /// The result is positional: element `i` answers `ids[i]`, with an empty
+    /// list where nothing matched.
+    pub async fn resolve_many(
+        kind: SecurityIdKind,
+        ids: &[&str],
+    ) -> Result<Vec<Vec<SecurityMapping>>> {
+        crate::adapters::openfigi::resolve_many(kind, ids).await
+    }
+}
+
 pub mod feeds;
 
 #[cfg(feature = "risk")]

--- a/src/models/crypto/defi.rs
+++ b/src/models/crypto/defi.rs
@@ -1,0 +1,102 @@
+//! DeFi / on-chain models.
+//!
+//! Populated by the DefiLlama adapter. These describe *protocols and chains*
+//! rather than tradable instruments, so they live beside — not inside —
+//! [`CryptoQuote`](super::CryptoQuote).
+
+use serde::{Deserialize, Serialize};
+
+/// Total value locked in a DeFi protocol, with the metadata needed to
+/// identify it.
+///
+/// Obtain via [`CryptoCoin::tvl`](crate::CryptoCoin::tvl).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ProtocolTvl {
+    /// DefiLlama protocol slug, as queried (e.g. `"aave"`).
+    pub slug: String,
+    /// Display name (e.g. `"AAVE"`).
+    pub name: Option<String>,
+    /// Governance/token symbol, when the protocol has one.
+    pub symbol: Option<String>,
+    /// Project homepage.
+    pub url: Option<String>,
+    /// Chains the protocol is deployed on.
+    pub chains: Vec<String>,
+    /// Latest total value locked, in USD.
+    pub tvl: Option<f64>,
+    /// TVL broken down by chain, in USD.
+    pub tvl_by_chain: Vec<ChainAllocation>,
+    /// Change in TVL over the last day, as a percentage.
+    pub change_1d_percent: Option<f64>,
+    /// Change in TVL over the last seven days, as a percentage.
+    pub change_7d_percent: Option<f64>,
+    /// Market capitalisation of the protocol's token, in USD.
+    pub market_cap: Option<f64>,
+}
+
+/// One chain's share of a protocol's TVL.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ChainAllocation {
+    /// Chain name (e.g. `"Ethereum"`).
+    pub chain: String,
+    /// Value locked on that chain, in USD.
+    pub tvl: f64,
+}
+
+/// One point of a protocol's TVL history.
+///
+/// Obtain via [`CryptoCoin::tvl_history`](crate::CryptoCoin::tvl_history).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct TvlPoint {
+    /// Unix timestamp (seconds) of the snapshot.
+    pub timestamp: i64,
+    /// Total value locked at that moment, in USD.
+    pub tvl: f64,
+}
+
+/// Aggregate value locked on one blockchain.
+///
+/// Obtain via [`defi::chains`](crate::defi::chains).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ChainTvl {
+    /// Chain name (e.g. `"Ethereum"`).
+    pub name: String,
+    /// Native token symbol, when the chain has one.
+    pub token_symbol: Option<String>,
+    /// CoinGecko id of the native token, for cross-referencing a price.
+    pub gecko_id: Option<String>,
+    /// EVM chain id, where one exists.
+    pub chain_id: Option<i64>,
+    /// Total value locked across every protocol on the chain, in USD.
+    pub tvl: Option<f64>,
+}
+
+/// Circulating supply of one stablecoin.
+///
+/// Obtain via [`defi::stablecoins`](crate::defi::stablecoins).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct StablecoinSupply {
+    /// Stablecoin name (e.g. `"Tether"`).
+    pub name: String,
+    /// Ticker symbol (e.g. `"USDT"`).
+    pub symbol: Option<String>,
+    /// CoinGecko id, for cross-referencing a price.
+    pub gecko_id: Option<String>,
+    /// What the coin is pegged to, e.g. `"peggedUSD"`.
+    pub peg_type: Option<String>,
+    /// How the peg is maintained, e.g. `"fiat-backed"`, `"crypto-backed"`.
+    pub peg_mechanism: Option<String>,
+    /// Current circulating supply, denominated in the pegged asset.
+    pub circulating: Option<f64>,
+    /// Circulating supply one day ago, for change calculations.
+    pub circulating_prev_day: Option<f64>,
+    /// Circulating supply one week ago.
+    pub circulating_prev_week: Option<f64>,
+    /// Circulating supply one month ago.
+    pub circulating_prev_month: Option<f64>,
+}

--- a/src/models/crypto/mod.rs
+++ b/src/models/crypto/mod.rs
@@ -38,6 +38,7 @@ pub struct CryptoQuote {
 /// A cryptocurrency quote from CoinGecko.
 ///
 /// Obtain via [`crypto::coins`](crate::crypto::coins) or [`crypto::coin`](crate::crypto::coin).
+#[cfg(feature = "crypto")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct CoinQuote {

--- a/src/models/crypto/mod.rs
+++ b/src/models/crypto/mod.rs
@@ -2,6 +2,10 @@
 //!
 //! Canonical public types for cryptocurrency quotes from multiple providers.
 
+/// DeFi protocol and chain models — DefiLlama.
+#[cfg(feature = "defi")]
+pub mod defi;
+
 use serde::{Deserialize, Serialize};
 
 /// A provider-agnostic cryptocurrency quote.

--- a/src/models/discovery/figi.rs
+++ b/src/models/discovery/figi.rs
@@ -1,0 +1,74 @@
+//! Security-identifier mapping models.
+//!
+//! Populated by the OpenFIGI adapter, which resolves a CUSIP, ISIN, SEDOL, or
+//! FIGI to the instruments carrying it.
+
+use serde::{Deserialize, Serialize};
+
+/// One instrument matching a security identifier.
+///
+/// A single CUSIP or ISIN maps to **many** instruments — one per venue the
+/// security trades on — which is why resolution returns a list. Entries that
+/// share a `composite_figi` are the same security on different venues; the
+/// `share_class_figi` groups share classes across countries.
+///
+/// Obtain via [`openfigi::resolve_cusip`](crate::openfigi::resolve_cusip) and
+/// friends.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct SecurityMapping {
+    /// The instrument's Financial Instrument Global Identifier.
+    pub figi: String,
+    /// Ticker symbol, as the venue lists it.
+    pub ticker: Option<String>,
+    /// Security name (usually the issuer).
+    pub name: Option<String>,
+    /// Exchange code — `"US"` for the composite, otherwise a venue code.
+    pub exchange_code: Option<String>,
+    /// FIGI of the country-level composite this instrument rolls up to.
+    pub composite_figi: Option<String>,
+    /// FIGI shared by every listing of this share class worldwide.
+    pub share_class_figi: Option<String>,
+    /// Instrument type, e.g. `"Common Stock"`, `"ETP"`.
+    pub security_type: Option<String>,
+    /// Market sector, e.g. `"Equity"`, `"Corp"`, `"Govt"`.
+    pub market_sector: Option<String>,
+}
+
+/// The kind of identifier being resolved.
+///
+/// Maps onto OpenFIGI's `idType` values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum SecurityIdKind {
+    /// North American security identifier (9 characters).
+    Cusip,
+    /// International Securities Identification Number (12 characters).
+    Isin,
+    /// UK/Ireland security identifier (7 characters).
+    Sedol,
+    /// A FIGI, resolved to its siblings.
+    Figi,
+    /// Exchange ticker symbol.
+    Ticker,
+}
+
+impl SecurityIdKind {
+    /// The `idType` string OpenFIGI expects.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Cusip => "ID_CUSIP",
+            Self::Isin => "ID_ISIN",
+            Self::Sedol => "ID_SEDOL",
+            Self::Figi => "ID_BB_GLOBAL",
+            Self::Ticker => "TICKER",
+        }
+    }
+}
+
+impl std::fmt::Display for SecurityIdKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}

--- a/src/models/discovery/mod.rs
+++ b/src/models/discovery/mod.rs
@@ -2,6 +2,9 @@
 //!
 //! Search, lookup, screeners, and trending tickers.
 
+/// Security-identifier mapping (CUSIP/ISIN/SEDOL/FIGI → instruments).
+#[cfg(feature = "openfigi")]
+pub mod figi;
 /// Type-filtered symbol lookup.
 pub mod lookup;
 /// Provider-routed symbol reference data (search, details, exchanges, screener).

--- a/src/models/economic/mod.rs
+++ b/src/models/economic/mod.rs
@@ -36,6 +36,7 @@ pub struct MacroObservation {
 /// A FRED macro-economic time series with all its observations.
 ///
 /// Obtain via [`fred::series`](crate::fred::series).
+#[cfg(feature = "fred")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct MacroSeries {
@@ -49,6 +50,7 @@ pub struct MacroSeries {
 ///
 /// Maturities with no published rate on a given date are `None`.
 /// Obtain via [`fred::treasury_yields`](crate::fred::treasury_yields).
+#[cfg(feature = "fred")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct TreasuryYield {

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -41,6 +41,7 @@ pub mod commodities;
     feature = "alphavantage",
     feature = "binance",
     feature = "crypto",
+    feature = "defi",
     feature = "fmp",
     feature = "kraken",
     feature = "polygon"

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -55,7 +55,12 @@ pub mod crypto;
 ))]
 pub mod economic;
 /// Forex (foreign exchange) data models — Polygon / FMP / Alpha Vantage.
-#[cfg(any(feature = "polygon", feature = "fmp", feature = "alphavantage"))]
+#[cfg(any(
+    feature = "alphavantage",
+    feature = "fmp",
+    feature = "frankfurter",
+    feature = "polygon"
+))]
 pub mod forex;
 /// Futures market data models — Polygon.
 #[cfg(feature = "polygon")]

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -42,6 +42,7 @@ pub mod commodities;
     feature = "binance",
     feature = "crypto",
     feature = "fmp",
+    feature = "kraken",
     feature = "polygon"
 ))]
 pub mod crypto;

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -47,6 +47,7 @@ pub mod crypto;
 /// Macro-economic data — FRED, Alpha Vantage, Polygon.
 #[cfg(any(
     feature = "alphavantage",
+    feature = "fiscaldata",
     feature = "fred",
     feature = "polygon",
     feature = "worldbank"

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -45,7 +45,12 @@ pub mod commodities;
 ))]
 pub mod crypto;
 /// Macro-economic data — FRED, Alpha Vantage, Polygon.
-#[cfg(any(feature = "fred", feature = "alphavantage", feature = "polygon"))]
+#[cfg(any(
+    feature = "alphavantage",
+    feature = "fred",
+    feature = "polygon",
+    feature = "worldbank"
+))]
 pub mod economic;
 /// Forex (foreign exchange) data models — Polygon / FMP / Alpha Vantage.
 #[cfg(any(feature = "polygon", feature = "fmp", feature = "alphavantage"))]

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -38,8 +38,9 @@ pub mod sentiment;
 pub mod commodities;
 /// Cryptocurrency market data — CoinGecko, Alpha Vantage, FMP, Polygon.
 #[cfg(any(
-    feature = "crypto",
     feature = "alphavantage",
+    feature = "binance",
+    feature = "crypto",
     feature = "fmp",
     feature = "polygon"
 ))]

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -47,6 +47,7 @@ pub mod crypto;
 /// Macro-economic data — FRED, Alpha Vantage, Polygon.
 #[cfg(any(
     feature = "alphavantage",
+    feature = "bls",
     feature = "fiscaldata",
     feature = "fred",
     feature = "polygon",

--- a/src/providers/adapter.rs
+++ b/src/providers/adapter.rs
@@ -271,8 +271,9 @@ pub(crate) trait MarketProvider: ProviderCore {
 
 /// [`Capability::CRYPTO`] — cryptocurrency quotes.
 #[cfg(any(
-    feature = "crypto",
     feature = "alphavantage",
+    feature = "binance",
+    feature = "crypto",
     feature = "fmp",
     feature = "polygon"
 ))]
@@ -404,8 +405,9 @@ pub(crate) trait ProviderAdapter: ProviderCore {
         None
     }
     #[cfg(any(
-        feature = "crypto",
         feature = "alphavantage",
+        feature = "binance",
+        feature = "crypto",
         feature = "fmp",
         feature = "polygon"
     ))]
@@ -480,8 +482,9 @@ pub(crate) trait ProviderAdapter: ProviderCore {
             }
         }
         #[cfg(any(
-            feature = "crypto",
             feature = "alphavantage",
+            feature = "binance",
+            feature = "crypto",
             feature = "fmp",
             feature = "polygon"
         ))]

--- a/src/providers/adapter.rs
+++ b/src/providers/adapter.rs
@@ -275,6 +275,7 @@ pub(crate) trait MarketProvider: ProviderCore {
     feature = "binance",
     feature = "crypto",
     feature = "fmp",
+    feature = "kraken",
     feature = "polygon"
 ))]
 #[async_trait::async_trait]
@@ -409,6 +410,7 @@ pub(crate) trait ProviderAdapter: ProviderCore {
         feature = "binance",
         feature = "crypto",
         feature = "fmp",
+        feature = "kraken",
         feature = "polygon"
     ))]
     fn as_crypto(&self) -> Option<&dyn CryptoProvider> {
@@ -486,6 +488,7 @@ pub(crate) trait ProviderAdapter: ProviderCore {
             feature = "binance",
             feature = "crypto",
             feature = "fmp",
+            feature = "kraken",
             feature = "polygon"
         ))]
         if self.as_crypto().is_some() {

--- a/src/providers/adapter.rs
+++ b/src/providers/adapter.rs
@@ -274,6 +274,7 @@ pub(crate) trait MarketProvider: ProviderCore {
     feature = "alphavantage",
     feature = "binance",
     feature = "crypto",
+    feature = "defi",
     feature = "fmp",
     feature = "kraken",
     feature = "polygon"
@@ -285,6 +286,24 @@ pub(crate) trait CryptoProvider: ProviderCore {
         id: &str,
         vs_currency: &str,
     ) -> Result<crate::models::crypto::CryptoQuote>;
+
+    /// Fetch total value locked in a DeFi protocol.
+    #[cfg(feature = "defi")]
+    async fn fetch_protocol_tvl(
+        &self,
+        _protocol: &str,
+    ) -> Result<crate::models::crypto::defi::ProtocolTvl> {
+        Err(self.not_supported(Operation::ProtocolTvl))
+    }
+
+    /// Fetch a DeFi protocol's TVL history, oldest first.
+    #[cfg(feature = "defi")]
+    async fn fetch_protocol_tvl_history(
+        &self,
+        _protocol: &str,
+    ) -> Result<Vec<crate::models::crypto::defi::TvlPoint>> {
+        Err(self.not_supported(Operation::ProtocolTvlHistory))
+    }
 }
 
 /// [`Capability::ECONOMIC`] — macro-economic data series.
@@ -409,6 +428,7 @@ pub(crate) trait ProviderAdapter: ProviderCore {
         feature = "alphavantage",
         feature = "binance",
         feature = "crypto",
+        feature = "defi",
         feature = "fmp",
         feature = "kraken",
         feature = "polygon"
@@ -487,6 +507,7 @@ pub(crate) trait ProviderAdapter: ProviderCore {
             feature = "alphavantage",
             feature = "binance",
             feature = "crypto",
+            feature = "defi",
             feature = "fmp",
             feature = "kraken",
             feature = "polygon"

--- a/src/providers/adapter.rs
+++ b/src/providers/adapter.rs
@@ -288,6 +288,7 @@ pub(crate) trait CryptoProvider: ProviderCore {
 /// [`Capability::ECONOMIC`] — macro-economic data series.
 #[cfg(any(
     feature = "alphavantage",
+    feature = "bls",
     feature = "fiscaldata",
     feature = "fred",
     feature = "polygon",
@@ -408,6 +409,7 @@ pub(crate) trait ProviderAdapter: ProviderCore {
     }
     #[cfg(any(
         feature = "alphavantage",
+        feature = "bls",
         feature = "fiscaldata",
         feature = "fred",
         feature = "polygon",
@@ -478,6 +480,7 @@ pub(crate) trait ProviderAdapter: ProviderCore {
         }
         #[cfg(any(
             feature = "alphavantage",
+            feature = "bls",
             feature = "fiscaldata",
             feature = "fred",
             feature = "polygon",

--- a/src/providers/adapter.rs
+++ b/src/providers/adapter.rs
@@ -286,7 +286,12 @@ pub(crate) trait CryptoProvider: ProviderCore {
 }
 
 /// [`Capability::ECONOMIC`] — macro-economic data series.
-#[cfg(any(feature = "fred", feature = "alphavantage", feature = "polygon"))]
+#[cfg(any(
+    feature = "alphavantage",
+    feature = "fred",
+    feature = "polygon",
+    feature = "worldbank"
+))]
 #[async_trait::async_trait]
 pub(crate) trait EconomicProvider: ProviderCore {
     async fn fetch_economic_series(
@@ -400,7 +405,12 @@ pub(crate) trait ProviderAdapter: ProviderCore {
     fn as_crypto(&self) -> Option<&dyn CryptoProvider> {
         None
     }
-    #[cfg(any(feature = "fred", feature = "alphavantage", feature = "polygon"))]
+    #[cfg(any(
+        feature = "alphavantage",
+        feature = "fred",
+        feature = "polygon",
+        feature = "worldbank"
+    ))]
     fn as_economic(&self) -> Option<&dyn EconomicProvider> {
         None
     }
@@ -464,7 +474,12 @@ pub(crate) trait ProviderAdapter: ProviderCore {
         if self.as_crypto().is_some() {
             caps = caps | Capability::CRYPTO;
         }
-        #[cfg(any(feature = "fred", feature = "alphavantage", feature = "polygon"))]
+        #[cfg(any(
+            feature = "alphavantage",
+            feature = "fred",
+            feature = "polygon",
+            feature = "worldbank"
+        ))]
         if self.as_economic().is_some() {
             caps = caps | Capability::ECONOMIC;
         }

--- a/src/providers/adapter.rs
+++ b/src/providers/adapter.rs
@@ -303,7 +303,12 @@ pub(crate) trait EconomicProvider: ProviderCore {
 }
 
 /// [`Capability::FOREX`] — currency-pair quotes.
-#[cfg(any(feature = "polygon", feature = "fmp", feature = "alphavantage"))]
+#[cfg(any(
+    feature = "alphavantage",
+    feature = "fmp",
+    feature = "frankfurter",
+    feature = "polygon"
+))]
 #[async_trait::async_trait]
 pub(crate) trait ForexProvider: ProviderCore {
     async fn fetch_forex_quote(
@@ -418,7 +423,12 @@ pub(crate) trait ProviderAdapter: ProviderCore {
     fn as_economic(&self) -> Option<&dyn EconomicProvider> {
         None
     }
-    #[cfg(any(feature = "polygon", feature = "fmp", feature = "alphavantage"))]
+    #[cfg(any(
+        feature = "alphavantage",
+        feature = "fmp",
+        feature = "frankfurter",
+        feature = "polygon"
+    ))]
     fn as_forex(&self) -> Option<&dyn ForexProvider> {
         None
     }
@@ -489,7 +499,12 @@ pub(crate) trait ProviderAdapter: ProviderCore {
         if self.as_economic().is_some() {
             caps = caps | Capability::ECONOMIC;
         }
-        #[cfg(any(feature = "polygon", feature = "fmp", feature = "alphavantage"))]
+        #[cfg(any(
+            feature = "alphavantage",
+            feature = "fmp",
+            feature = "frankfurter",
+            feature = "polygon"
+        ))]
         if self.as_forex().is_some() {
             caps = caps | Capability::FOREX;
         }

--- a/src/providers/adapter.rs
+++ b/src/providers/adapter.rs
@@ -288,6 +288,7 @@ pub(crate) trait CryptoProvider: ProviderCore {
 /// [`Capability::ECONOMIC`] — macro-economic data series.
 #[cfg(any(
     feature = "alphavantage",
+    feature = "fiscaldata",
     feature = "fred",
     feature = "polygon",
     feature = "worldbank"
@@ -407,6 +408,7 @@ pub(crate) trait ProviderAdapter: ProviderCore {
     }
     #[cfg(any(
         feature = "alphavantage",
+        feature = "fiscaldata",
         feature = "fred",
         feature = "polygon",
         feature = "worldbank"
@@ -476,6 +478,7 @@ pub(crate) trait ProviderAdapter: ProviderCore {
         }
         #[cfg(any(
             feature = "alphavantage",
+            feature = "fiscaldata",
             feature = "fred",
             feature = "polygon",
             feature = "worldbank"

--- a/src/providers/adapter.rs
+++ b/src/providers/adapter.rs
@@ -22,11 +22,7 @@ pub(crate) trait ProviderCore: Send + Sync {
     fn id(&self) -> Provider;
 
     fn not_supported(&self, operation: Operation) -> FinanceError {
-        FinanceError::NotSupported {
-            provider: self.id(),
-            operation,
-            candidates: operation.capability().candidate_providers(),
-        }
+        operation.not_supported(self.id())
     }
 }
 

--- a/src/providers/binance.rs
+++ b/src/providers/binance.rs
@@ -1,0 +1,56 @@
+//! Binance public market-data provider implementation (keyless).
+
+use super::{ChartProvider, CryptoProvider, ProviderAdapter, ProviderCore};
+use crate::error::Result;
+
+pub(crate) struct BinanceProvider;
+
+impl ProviderCore for BinanceProvider {
+    fn id(&self) -> super::Provider {
+        super::Provider::Binance
+    }
+}
+
+#[async_trait::async_trait]
+impl CryptoProvider for BinanceProvider {
+    async fn fetch_crypto_quote(
+        &self,
+        id: &str,
+        vs_currency: &str,
+    ) -> Result<crate::models::crypto::CryptoQuote> {
+        crate::adapters::binance::fetch_crypto_quote_response(id, vs_currency).await
+    }
+}
+
+#[async_trait::async_trait]
+impl ChartProvider for BinanceProvider {
+    async fn fetch_chart(
+        &self,
+        symbol: &str,
+        interval: crate::Interval,
+        range: crate::TimeRange,
+    ) -> Result<crate::models::chart::Chart> {
+        crate::adapters::binance::fetch_chart_response(symbol, interval, range).await
+    }
+
+    async fn fetch_chart_range(
+        &self,
+        symbol: &str,
+        interval: crate::Interval,
+        start: i64,
+        end: i64,
+    ) -> Result<crate::models::chart::Chart> {
+        crate::adapters::binance::fetch_chart_range_response(symbol, interval, start, end).await
+    }
+}
+
+#[async_trait::async_trait]
+impl ProviderAdapter for BinanceProvider {
+    fn as_crypto(&self) -> Option<&dyn CryptoProvider> {
+        Some(self)
+    }
+
+    fn as_chart(&self) -> Option<&dyn ChartProvider> {
+        Some(self)
+    }
+}

--- a/src/providers/bls.rs
+++ b/src/providers/bls.rs
@@ -1,0 +1,31 @@
+//! BLS (Bureau of Labor Statistics) provider implementation.
+//!
+//! Keyless by default; `BLS_API_KEY` upgrades every call to the v2 tier.
+
+use super::{EconomicProvider, ProviderAdapter, ProviderCore};
+use crate::error::Result;
+
+pub(crate) struct BlsProvider;
+
+impl ProviderCore for BlsProvider {
+    fn id(&self) -> super::Provider {
+        super::Provider::Bls
+    }
+}
+
+#[async_trait::async_trait]
+impl EconomicProvider for BlsProvider {
+    async fn fetch_economic_series(
+        &self,
+        series_id: &str,
+    ) -> Result<crate::models::economic::EconomicSeries> {
+        crate::adapters::bls::fetch_economic_series_response(series_id).await
+    }
+}
+
+#[async_trait::async_trait]
+impl ProviderAdapter for BlsProvider {
+    fn as_economic(&self) -> Option<&dyn EconomicProvider> {
+        Some(self)
+    }
+}

--- a/src/providers/config.rs
+++ b/src/providers/config.rs
@@ -89,6 +89,7 @@ impl Providers {
         feature = "binance",
         feature = "crypto",
         feature = "fmp",
+        feature = "kraken",
         feature = "polygon"
     ))]
     pub fn crypto(&self, id: impl Into<String>) -> crate::domains::CryptoCoin {

--- a/src/providers/config.rs
+++ b/src/providers/config.rs
@@ -111,6 +111,7 @@ impl Providers {
     /// Create an [`EconomicIndicator`](crate::EconomicIndicator) handle backed by this provider set.
     #[cfg(any(
         feature = "alphavantage",
+        feature = "fiscaldata",
         feature = "fred",
         feature = "polygon",
         feature = "worldbank"

--- a/src/providers/config.rs
+++ b/src/providers/config.rs
@@ -88,6 +88,7 @@ impl Providers {
         feature = "alphavantage",
         feature = "binance",
         feature = "crypto",
+        feature = "defi",
         feature = "fmp",
         feature = "kraken",
         feature = "polygon"

--- a/src/providers/config.rs
+++ b/src/providers/config.rs
@@ -111,6 +111,7 @@ impl Providers {
     /// Create an [`EconomicIndicator`](crate::EconomicIndicator) handle backed by this provider set.
     #[cfg(any(
         feature = "alphavantage",
+        feature = "bls",
         feature = "fiscaldata",
         feature = "fred",
         feature = "polygon",

--- a/src/providers/config.rs
+++ b/src/providers/config.rs
@@ -95,7 +95,12 @@ impl Providers {
     }
 
     /// Create a [`ForexPair`](crate::ForexPair) handle backed by this provider set.
-    #[cfg(any(feature = "alphavantage", feature = "fmp", feature = "polygon"))]
+    #[cfg(any(
+        feature = "alphavantage",
+        feature = "fmp",
+        feature = "frankfurter",
+        feature = "polygon"
+    ))]
     pub fn forex(
         &self,
         from: impl Into<String>,

--- a/src/providers/config.rs
+++ b/src/providers/config.rs
@@ -86,6 +86,7 @@ impl Providers {
     /// Create a [`CryptoCoin`](crate::CryptoCoin) handle backed by this provider set.
     #[cfg(any(
         feature = "alphavantage",
+        feature = "binance",
         feature = "crypto",
         feature = "fmp",
         feature = "polygon"

--- a/src/providers/config.rs
+++ b/src/providers/config.rs
@@ -109,7 +109,12 @@ impl Providers {
     }
 
     /// Create an [`EconomicIndicator`](crate::EconomicIndicator) handle backed by this provider set.
-    #[cfg(any(feature = "alphavantage", feature = "polygon", feature = "fred"))]
+    #[cfg(any(
+        feature = "alphavantage",
+        feature = "fred",
+        feature = "polygon",
+        feature = "worldbank"
+    ))]
     pub fn economic(&self, series_id: impl Into<String>) -> crate::domains::EconomicIndicator {
         crate::domains::EconomicIndicator::with_providers(
             series_id.into().into(),

--- a/src/providers/defillama.rs
+++ b/src/providers/defillama.rs
@@ -1,0 +1,49 @@
+//! DefiLlama provider implementation (keyless).
+//!
+//! Serves the DeFi slice of `CRYPTO`. `fetch_crypto_quote` is the trait's
+//! required primary operation, but DefiLlama publishes TVL rather than prices,
+//! so it reports `NotSupported` and dispatch falls through to an exchange or
+//! aggregator route.
+
+use super::{CryptoProvider, Operation, ProviderAdapter, ProviderCore};
+use crate::error::Result;
+
+pub(crate) struct DefiLlamaProvider;
+
+impl ProviderCore for DefiLlamaProvider {
+    fn id(&self) -> super::Provider {
+        super::Provider::DefiLlama
+    }
+}
+
+#[async_trait::async_trait]
+impl CryptoProvider for DefiLlamaProvider {
+    async fn fetch_crypto_quote(
+        &self,
+        _id: &str,
+        _vs_currency: &str,
+    ) -> Result<crate::models::crypto::CryptoQuote> {
+        Err(self.not_supported(Operation::CryptoQuote))
+    }
+
+    async fn fetch_protocol_tvl(
+        &self,
+        protocol: &str,
+    ) -> Result<crate::models::crypto::defi::ProtocolTvl> {
+        crate::adapters::defillama::fetch_protocol_tvl_response(protocol).await
+    }
+
+    async fn fetch_protocol_tvl_history(
+        &self,
+        protocol: &str,
+    ) -> Result<Vec<crate::models::crypto::defi::TvlPoint>> {
+        crate::adapters::defillama::fetch_protocol_tvl_history_response(protocol).await
+    }
+}
+
+#[async_trait::async_trait]
+impl ProviderAdapter for DefiLlamaProvider {
+    fn as_crypto(&self) -> Option<&dyn CryptoProvider> {
+        Some(self)
+    }
+}

--- a/src/providers/finra.rs
+++ b/src/providers/finra.rs
@@ -1,0 +1,43 @@
+//! FINRA provider implementation (keyless).
+//!
+//! Serves the short-volume slice of `FUNDAMENTALS` only. `fetch_financials`
+//! is the trait's required primary operation but FINRA publishes no financial
+//! statements, so it reports `NotSupported` and dispatch falls through to the
+//! next routed provider.
+
+use super::{FundamentalsProvider, Operation, ProviderAdapter, ProviderCore};
+use crate::error::Result;
+
+pub(crate) struct FinraProvider;
+
+impl ProviderCore for FinraProvider {
+    fn id(&self) -> super::Provider {
+        super::Provider::Finra
+    }
+}
+
+#[async_trait::async_trait]
+impl FundamentalsProvider for FinraProvider {
+    async fn fetch_financials(
+        &self,
+        _symbol: &str,
+        _stmt_type: crate::StatementType,
+        _frequency: crate::Frequency,
+    ) -> Result<crate::models::fundamentals::FinancialStatement> {
+        Err(self.not_supported(Operation::Financials))
+    }
+
+    async fn fetch_short_volume(
+        &self,
+        symbol: &str,
+    ) -> Result<Vec<crate::models::fundamentals::ShortVolume>> {
+        crate::adapters::finra::fetch_short_volume_response(symbol).await
+    }
+}
+
+#[async_trait::async_trait]
+impl ProviderAdapter for FinraProvider {
+    fn as_fundamentals(&self) -> Option<&dyn FundamentalsProvider> {
+        Some(self)
+    }
+}

--- a/src/providers/fiscaldata.rs
+++ b/src/providers/fiscaldata.rs
@@ -1,0 +1,29 @@
+//! US Treasury FiscalData provider implementation (keyless).
+
+use super::{EconomicProvider, ProviderAdapter, ProviderCore};
+use crate::error::Result;
+
+pub(crate) struct FiscalDataProvider;
+
+impl ProviderCore for FiscalDataProvider {
+    fn id(&self) -> super::Provider {
+        super::Provider::FiscalData
+    }
+}
+
+#[async_trait::async_trait]
+impl EconomicProvider for FiscalDataProvider {
+    async fn fetch_economic_series(
+        &self,
+        series_id: &str,
+    ) -> Result<crate::models::economic::EconomicSeries> {
+        crate::adapters::fiscaldata::fetch_economic_series_response(series_id).await
+    }
+}
+
+#[async_trait::async_trait]
+impl ProviderAdapter for FiscalDataProvider {
+    fn as_economic(&self) -> Option<&dyn EconomicProvider> {
+        Some(self)
+    }
+}

--- a/src/providers/frankfurter.rs
+++ b/src/providers/frankfurter.rs
@@ -1,0 +1,30 @@
+//! Frankfurter (ECB reference rates) provider implementation (keyless).
+
+use super::{ForexProvider, ProviderAdapter, ProviderCore};
+use crate::error::Result;
+
+pub(crate) struct FrankfurterProvider;
+
+impl ProviderCore for FrankfurterProvider {
+    fn id(&self) -> super::Provider {
+        super::Provider::Frankfurter
+    }
+}
+
+#[async_trait::async_trait]
+impl ForexProvider for FrankfurterProvider {
+    async fn fetch_forex_quote(
+        &self,
+        from: &str,
+        to: &str,
+    ) -> Result<crate::models::forex::ForexQuote> {
+        crate::adapters::frankfurter::fetch_forex_quote_response(from, to).await
+    }
+}
+
+#[async_trait::async_trait]
+impl ProviderAdapter for FrankfurterProvider {
+    fn as_forex(&self) -> Option<&dyn ForexProvider> {
+        Some(self)
+    }
+}

--- a/src/providers/kraken.rs
+++ b/src/providers/kraken.rs
@@ -1,0 +1,56 @@
+//! Kraken public market-data provider implementation (keyless).
+
+use super::{ChartProvider, CryptoProvider, ProviderAdapter, ProviderCore};
+use crate::error::Result;
+
+pub(crate) struct KrakenProvider;
+
+impl ProviderCore for KrakenProvider {
+    fn id(&self) -> super::Provider {
+        super::Provider::Kraken
+    }
+}
+
+#[async_trait::async_trait]
+impl CryptoProvider for KrakenProvider {
+    async fn fetch_crypto_quote(
+        &self,
+        id: &str,
+        vs_currency: &str,
+    ) -> Result<crate::models::crypto::CryptoQuote> {
+        crate::adapters::kraken::fetch_crypto_quote_response(id, vs_currency).await
+    }
+}
+
+#[async_trait::async_trait]
+impl ChartProvider for KrakenProvider {
+    async fn fetch_chart(
+        &self,
+        symbol: &str,
+        interval: crate::Interval,
+        range: crate::TimeRange,
+    ) -> Result<crate::models::chart::Chart> {
+        crate::adapters::kraken::fetch_chart_response(symbol, interval, range).await
+    }
+
+    async fn fetch_chart_range(
+        &self,
+        symbol: &str,
+        interval: crate::Interval,
+        start: i64,
+        end: i64,
+    ) -> Result<crate::models::chart::Chart> {
+        crate::adapters::kraken::fetch_chart_range_response(symbol, interval, start, end).await
+    }
+}
+
+#[async_trait::async_trait]
+impl ProviderAdapter for KrakenProvider {
+    fn as_crypto(&self) -> Option<&dyn CryptoProvider> {
+        Some(self)
+    }
+
+    fn as_chart(&self) -> Option<&dyn ChartProvider> {
+        Some(self)
+    }
+}

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -23,6 +23,8 @@ pub(crate) mod fmp;
 pub(crate) mod frankfurter;
 #[cfg(feature = "fred")]
 pub(crate) mod fred;
+#[cfg(feature = "kraken")]
+pub(crate) mod kraken;
 #[cfg(feature = "polygon")]
 pub(crate) mod polygon;
 pub(crate) mod types;
@@ -78,6 +80,9 @@ pub enum Provider {
     /// Binance public market data (requires `binance` feature, keyless).
     #[cfg(feature = "binance")]
     Binance,
+    /// Kraken public market data (requires `kraken` feature, keyless).
+    #[cfg(feature = "kraken")]
+    Kraken,
     /// SEC EDGAR filings (always available, keyless).
     Edgar,
 }
@@ -109,6 +114,8 @@ impl Provider {
             "frankfurter" => Some(Self::Frankfurter),
             #[cfg(feature = "binance")]
             "binance" => Some(Self::Binance),
+            #[cfg(feature = "kraken")]
+            "kraken" => Some(Self::Kraken),
             "edgar" => Some(Self::Edgar),
             _ => None,
         }
@@ -138,6 +145,8 @@ impl Provider {
             Self::Frankfurter => "frankfurter",
             #[cfg(feature = "binance")]
             Self::Binance => "binance",
+            #[cfg(feature = "kraken")]
+            Self::Kraken => "kraken",
             Self::Edgar => "edgar",
         }
     }
@@ -168,6 +177,8 @@ impl Provider {
         v.push(Self::Frankfurter);
         #[cfg(feature = "binance")]
         v.push(Self::Binance);
+        #[cfg(feature = "kraken")]
+        v.push(Self::Kraken);
         v.push(Self::Edgar);
         v
     }
@@ -202,6 +213,8 @@ impl Provider {
             Self::Frankfurter => ProviderAdapter::capabilities(&frankfurter::FrankfurterProvider),
             #[cfg(feature = "binance")]
             Self::Binance => ProviderAdapter::capabilities(&binance::BinanceProvider),
+            #[cfg(feature = "kraken")]
+            Self::Kraken => ProviderAdapter::capabilities(&kraken::KrakenProvider),
             Self::Edgar => ProviderAdapter::capabilities(&edgar::EdgarProvider),
         }
     }
@@ -900,6 +913,8 @@ pub(crate) async fn build_providers(
             Provider::Frankfurter => Arc::new(frankfurter::FrankfurterProvider),
             #[cfg(feature = "binance")]
             Provider::Binance => Arc::new(binance::BinanceProvider),
+            #[cfg(feature = "kraken")]
+            Provider::Kraken => Arc::new(kraken::KrakenProvider),
             Provider::Edgar => Arc::new(edgar::EdgarProvider),
         };
         adapter.initialize().await?;

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -17,6 +17,8 @@ pub(crate) mod edgar;
 pub(crate) mod fiscaldata;
 #[cfg(feature = "fmp")]
 pub(crate) mod fmp;
+#[cfg(feature = "frankfurter")]
+pub(crate) mod frankfurter;
 #[cfg(feature = "fred")]
 pub(crate) mod fred;
 #[cfg(feature = "polygon")]
@@ -68,6 +70,9 @@ pub enum Provider {
     /// keyed v2 when `BLS_API_KEY` is set).
     #[cfg(feature = "bls")]
     Bls,
+    /// Frankfurter ECB reference exchange rates (requires `frankfurter` feature, keyless).
+    #[cfg(feature = "frankfurter")]
+    Frankfurter,
     /// SEC EDGAR filings (always available, keyless).
     Edgar,
 }
@@ -95,6 +100,8 @@ impl Provider {
             "fiscaldata" => Some(Self::FiscalData),
             #[cfg(feature = "bls")]
             "bls" => Some(Self::Bls),
+            #[cfg(feature = "frankfurter")]
+            "frankfurter" => Some(Self::Frankfurter),
             "edgar" => Some(Self::Edgar),
             _ => None,
         }
@@ -120,6 +127,8 @@ impl Provider {
             Self::FiscalData => "fiscaldata",
             #[cfg(feature = "bls")]
             Self::Bls => "bls",
+            #[cfg(feature = "frankfurter")]
+            Self::Frankfurter => "frankfurter",
             Self::Edgar => "edgar",
         }
     }
@@ -146,6 +155,8 @@ impl Provider {
         v.push(Self::FiscalData);
         #[cfg(feature = "bls")]
         v.push(Self::Bls);
+        #[cfg(feature = "frankfurter")]
+        v.push(Self::Frankfurter);
         v.push(Self::Edgar);
         v
     }
@@ -176,6 +187,8 @@ impl Provider {
             Self::FiscalData => ProviderAdapter::capabilities(&fiscaldata::FiscalDataProvider),
             #[cfg(feature = "bls")]
             Self::Bls => ProviderAdapter::capabilities(&bls::BlsProvider),
+            #[cfg(feature = "frankfurter")]
+            Self::Frankfurter => ProviderAdapter::capabilities(&frankfurter::FrankfurterProvider),
             Self::Edgar => ProviderAdapter::capabilities(&edgar::EdgarProvider),
         }
     }
@@ -870,6 +883,8 @@ pub(crate) async fn build_providers(
             Provider::FiscalData => Arc::new(fiscaldata::FiscalDataProvider),
             #[cfg(feature = "bls")]
             Provider::Bls => Arc::new(bls::BlsProvider),
+            #[cfg(feature = "frankfurter")]
+            Provider::Frankfurter => Arc::new(frankfurter::FrankfurterProvider),
             Provider::Edgar => Arc::new(edgar::EdgarProvider),
         };
         adapter.initialize().await?;

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -580,6 +580,19 @@ impl Operation {
             }
         }
     }
+
+    /// The error reported when `provider` does not serve this operation.
+    ///
+    /// Adapters reach for this when they detect the gap before dispatch has a
+    /// `&dyn ProviderAdapter` to hand (e.g. a symbol an exchange cannot name);
+    /// `ProviderCore::not_supported` is the same error built from an instance.
+    pub(crate) fn not_supported(self, provider: Provider) -> FinanceError {
+        FinanceError::NotSupported {
+            provider,
+            operation: self,
+            candidates: self.capability().candidate_providers(),
+        }
+    }
 }
 
 impl std::fmt::Display for Operation {

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -8,6 +8,8 @@ pub(crate) mod mock;
 
 #[cfg(feature = "alphavantage")]
 pub(crate) mod alphavantage;
+#[cfg(feature = "bls")]
+pub(crate) mod bls;
 #[cfg(feature = "crypto")]
 pub(crate) mod coingecko;
 pub(crate) mod edgar;
@@ -62,6 +64,10 @@ pub enum Provider {
     /// US Treasury FiscalData (requires `fiscaldata` feature, keyless).
     #[cfg(feature = "fiscaldata")]
     FiscalData,
+    /// US Bureau of Labor Statistics (requires `bls` feature; keyless v1,
+    /// keyed v2 when `BLS_API_KEY` is set).
+    #[cfg(feature = "bls")]
+    Bls,
     /// SEC EDGAR filings (always available, keyless).
     Edgar,
 }
@@ -87,6 +93,8 @@ impl Provider {
             "worldbank" => Some(Self::WorldBank),
             #[cfg(feature = "fiscaldata")]
             "fiscaldata" => Some(Self::FiscalData),
+            #[cfg(feature = "bls")]
+            "bls" => Some(Self::Bls),
             "edgar" => Some(Self::Edgar),
             _ => None,
         }
@@ -110,6 +118,8 @@ impl Provider {
             Self::WorldBank => "worldbank",
             #[cfg(feature = "fiscaldata")]
             Self::FiscalData => "fiscaldata",
+            #[cfg(feature = "bls")]
+            Self::Bls => "bls",
             Self::Edgar => "edgar",
         }
     }
@@ -134,6 +144,8 @@ impl Provider {
         v.push(Self::WorldBank);
         #[cfg(feature = "fiscaldata")]
         v.push(Self::FiscalData);
+        #[cfg(feature = "bls")]
+        v.push(Self::Bls);
         v.push(Self::Edgar);
         v
     }
@@ -162,6 +174,8 @@ impl Provider {
             Self::WorldBank => ProviderAdapter::capabilities(&worldbank::WorldBankProvider),
             #[cfg(feature = "fiscaldata")]
             Self::FiscalData => ProviderAdapter::capabilities(&fiscaldata::FiscalDataProvider),
+            #[cfg(feature = "bls")]
+            Self::Bls => ProviderAdapter::capabilities(&bls::BlsProvider),
             Self::Edgar => ProviderAdapter::capabilities(&edgar::EdgarProvider),
         }
     }
@@ -854,6 +868,8 @@ pub(crate) async fn build_providers(
             Provider::WorldBank => Arc::new(worldbank::WorldBankProvider),
             #[cfg(feature = "fiscaldata")]
             Provider::FiscalData => Arc::new(fiscaldata::FiscalDataProvider),
+            #[cfg(feature = "bls")]
+            Provider::Bls => Arc::new(bls::BlsProvider),
             Provider::Edgar => Arc::new(edgar::EdgarProvider),
         };
         adapter.initialize().await?;

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -8,6 +8,8 @@ pub(crate) mod mock;
 
 #[cfg(feature = "alphavantage")]
 pub(crate) mod alphavantage;
+#[cfg(feature = "binance")]
+pub(crate) mod binance;
 #[cfg(feature = "bls")]
 pub(crate) mod bls;
 #[cfg(feature = "crypto")]
@@ -73,6 +75,9 @@ pub enum Provider {
     /// Frankfurter ECB reference exchange rates (requires `frankfurter` feature, keyless).
     #[cfg(feature = "frankfurter")]
     Frankfurter,
+    /// Binance public market data (requires `binance` feature, keyless).
+    #[cfg(feature = "binance")]
+    Binance,
     /// SEC EDGAR filings (always available, keyless).
     Edgar,
 }
@@ -102,6 +107,8 @@ impl Provider {
             "bls" => Some(Self::Bls),
             #[cfg(feature = "frankfurter")]
             "frankfurter" => Some(Self::Frankfurter),
+            #[cfg(feature = "binance")]
+            "binance" => Some(Self::Binance),
             "edgar" => Some(Self::Edgar),
             _ => None,
         }
@@ -129,6 +136,8 @@ impl Provider {
             Self::Bls => "bls",
             #[cfg(feature = "frankfurter")]
             Self::Frankfurter => "frankfurter",
+            #[cfg(feature = "binance")]
+            Self::Binance => "binance",
             Self::Edgar => "edgar",
         }
     }
@@ -157,6 +166,8 @@ impl Provider {
         v.push(Self::Bls);
         #[cfg(feature = "frankfurter")]
         v.push(Self::Frankfurter);
+        #[cfg(feature = "binance")]
+        v.push(Self::Binance);
         v.push(Self::Edgar);
         v
     }
@@ -189,6 +200,8 @@ impl Provider {
             Self::Bls => ProviderAdapter::capabilities(&bls::BlsProvider),
             #[cfg(feature = "frankfurter")]
             Self::Frankfurter => ProviderAdapter::capabilities(&frankfurter::FrankfurterProvider),
+            #[cfg(feature = "binance")]
+            Self::Binance => ProviderAdapter::capabilities(&binance::BinanceProvider),
             Self::Edgar => ProviderAdapter::capabilities(&edgar::EdgarProvider),
         }
     }
@@ -885,6 +898,8 @@ pub(crate) async fn build_providers(
             Provider::Bls => Arc::new(bls::BlsProvider),
             #[cfg(feature = "frankfurter")]
             Provider::Frankfurter => Arc::new(frankfurter::FrankfurterProvider),
+            #[cfg(feature = "binance")]
+            Provider::Binance => Arc::new(binance::BinanceProvider),
             Provider::Edgar => Arc::new(edgar::EdgarProvider),
         };
         adapter.initialize().await?;

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -11,6 +11,8 @@ pub(crate) mod alphavantage;
 #[cfg(feature = "crypto")]
 pub(crate) mod coingecko;
 pub(crate) mod edgar;
+#[cfg(feature = "fiscaldata")]
+pub(crate) mod fiscaldata;
 #[cfg(feature = "fmp")]
 pub(crate) mod fmp;
 #[cfg(feature = "fred")]
@@ -57,6 +59,9 @@ pub enum Provider {
     /// World Bank Open Data global macro indicators (requires `worldbank` feature, keyless).
     #[cfg(feature = "worldbank")]
     WorldBank,
+    /// US Treasury FiscalData (requires `fiscaldata` feature, keyless).
+    #[cfg(feature = "fiscaldata")]
+    FiscalData,
     /// SEC EDGAR filings (always available, keyless).
     Edgar,
 }
@@ -80,6 +85,8 @@ impl Provider {
             "fred" => Some(Self::Fred),
             #[cfg(feature = "worldbank")]
             "worldbank" => Some(Self::WorldBank),
+            #[cfg(feature = "fiscaldata")]
+            "fiscaldata" => Some(Self::FiscalData),
             "edgar" => Some(Self::Edgar),
             _ => None,
         }
@@ -101,6 +108,8 @@ impl Provider {
             Self::Fred => "fred",
             #[cfg(feature = "worldbank")]
             Self::WorldBank => "worldbank",
+            #[cfg(feature = "fiscaldata")]
+            Self::FiscalData => "fiscaldata",
             Self::Edgar => "edgar",
         }
     }
@@ -123,6 +132,8 @@ impl Provider {
         v.push(Self::Fred);
         #[cfg(feature = "worldbank")]
         v.push(Self::WorldBank);
+        #[cfg(feature = "fiscaldata")]
+        v.push(Self::FiscalData);
         v.push(Self::Edgar);
         v
     }
@@ -149,6 +160,8 @@ impl Provider {
             Self::Fred => ProviderAdapter::capabilities(&fred::FredProvider),
             #[cfg(feature = "worldbank")]
             Self::WorldBank => ProviderAdapter::capabilities(&worldbank::WorldBankProvider),
+            #[cfg(feature = "fiscaldata")]
+            Self::FiscalData => ProviderAdapter::capabilities(&fiscaldata::FiscalDataProvider),
             Self::Edgar => ProviderAdapter::capabilities(&edgar::EdgarProvider),
         }
     }
@@ -839,6 +852,8 @@ pub(crate) async fn build_providers(
             Provider::Fred => Arc::new(fred::FredProvider),
             #[cfg(feature = "worldbank")]
             Provider::WorldBank => Arc::new(worldbank::WorldBankProvider),
+            #[cfg(feature = "fiscaldata")]
+            Provider::FiscalData => Arc::new(fiscaldata::FiscalDataProvider),
             Provider::Edgar => Arc::new(edgar::EdgarProvider),
         };
         adapter.initialize().await?;

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -15,6 +15,8 @@ pub(crate) mod bls;
 #[cfg(feature = "crypto")]
 pub(crate) mod coingecko;
 pub(crate) mod edgar;
+#[cfg(feature = "finra")]
+pub(crate) mod finra;
 #[cfg(feature = "fiscaldata")]
 pub(crate) mod fiscaldata;
 #[cfg(feature = "fmp")]
@@ -83,6 +85,9 @@ pub enum Provider {
     /// Kraken public market data (requires `kraken` feature, keyless).
     #[cfg(feature = "kraken")]
     Kraken,
+    /// FINRA daily short-sale volume (requires `finra` feature, keyless).
+    #[cfg(feature = "finra")]
+    Finra,
     /// SEC EDGAR filings (always available, keyless).
     Edgar,
 }
@@ -116,6 +121,8 @@ impl Provider {
             "binance" => Some(Self::Binance),
             #[cfg(feature = "kraken")]
             "kraken" => Some(Self::Kraken),
+            #[cfg(feature = "finra")]
+            "finra" => Some(Self::Finra),
             "edgar" => Some(Self::Edgar),
             _ => None,
         }
@@ -147,6 +154,8 @@ impl Provider {
             Self::Binance => "binance",
             #[cfg(feature = "kraken")]
             Self::Kraken => "kraken",
+            #[cfg(feature = "finra")]
+            Self::Finra => "finra",
             Self::Edgar => "edgar",
         }
     }
@@ -179,6 +188,8 @@ impl Provider {
         v.push(Self::Binance);
         #[cfg(feature = "kraken")]
         v.push(Self::Kraken);
+        #[cfg(feature = "finra")]
+        v.push(Self::Finra);
         v.push(Self::Edgar);
         v
     }
@@ -215,6 +226,8 @@ impl Provider {
             Self::Binance => ProviderAdapter::capabilities(&binance::BinanceProvider),
             #[cfg(feature = "kraken")]
             Self::Kraken => ProviderAdapter::capabilities(&kraken::KrakenProvider),
+            #[cfg(feature = "finra")]
+            Self::Finra => ProviderAdapter::capabilities(&finra::FinraProvider),
             Self::Edgar => ProviderAdapter::capabilities(&edgar::EdgarProvider),
         }
     }
@@ -915,6 +928,8 @@ pub(crate) async fn build_providers(
             Provider::Binance => Arc::new(binance::BinanceProvider),
             #[cfg(feature = "kraken")]
             Provider::Kraken => Arc::new(kraken::KrakenProvider),
+            #[cfg(feature = "finra")]
+            Provider::Finra => Arc::new(finra::FinraProvider),
             Provider::Edgar => Arc::new(edgar::EdgarProvider),
         };
         adapter.initialize().await?;

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -14,6 +14,8 @@ pub(crate) mod binance;
 pub(crate) mod bls;
 #[cfg(feature = "crypto")]
 pub(crate) mod coingecko;
+#[cfg(feature = "defi")]
+pub(crate) mod defillama;
 pub(crate) mod edgar;
 #[cfg(feature = "finra")]
 pub(crate) mod finra;
@@ -88,6 +90,9 @@ pub enum Provider {
     /// FINRA daily short-sale volume (requires `finra` feature, keyless).
     #[cfg(feature = "finra")]
     Finra,
+    /// DefiLlama DeFi TVL data (requires `defi` feature, keyless).
+    #[cfg(feature = "defi")]
+    DefiLlama,
     /// SEC EDGAR filings (always available, keyless).
     Edgar,
 }
@@ -123,6 +128,8 @@ impl Provider {
             "kraken" => Some(Self::Kraken),
             #[cfg(feature = "finra")]
             "finra" => Some(Self::Finra),
+            #[cfg(feature = "defi")]
+            "defillama" => Some(Self::DefiLlama),
             "edgar" => Some(Self::Edgar),
             _ => None,
         }
@@ -156,6 +163,8 @@ impl Provider {
             Self::Kraken => "kraken",
             #[cfg(feature = "finra")]
             Self::Finra => "finra",
+            #[cfg(feature = "defi")]
+            Self::DefiLlama => "defillama",
             Self::Edgar => "edgar",
         }
     }
@@ -190,6 +199,8 @@ impl Provider {
         v.push(Self::Kraken);
         #[cfg(feature = "finra")]
         v.push(Self::Finra);
+        #[cfg(feature = "defi")]
+        v.push(Self::DefiLlama);
         v.push(Self::Edgar);
         v
     }
@@ -228,6 +239,8 @@ impl Provider {
             Self::Kraken => ProviderAdapter::capabilities(&kraken::KrakenProvider),
             #[cfg(feature = "finra")]
             Self::Finra => ProviderAdapter::capabilities(&finra::FinraProvider),
+            #[cfg(feature = "defi")]
+            Self::DefiLlama => ProviderAdapter::capabilities(&defillama::DefiLlamaProvider),
             Self::Edgar => ProviderAdapter::capabilities(&edgar::EdgarProvider),
         }
     }
@@ -473,6 +486,12 @@ pub enum Operation {
     RiskFactors,
     /// Company press releases.
     PressReleases,
+    /// Total value locked in a DeFi protocol.
+    #[cfg(feature = "defi")]
+    ProtocolTvl,
+    /// Historical total value locked in a DeFi protocol.
+    #[cfg(feature = "defi")]
+    ProtocolTvlHistory,
 }
 
 impl Operation {
@@ -517,6 +536,10 @@ impl Operation {
             Self::FilingSections => "filing_sections",
             Self::RiskFactors => "risk_factors",
             Self::PressReleases => "press_releases",
+            #[cfg(feature = "defi")]
+            Self::ProtocolTvl => "protocol_tvl",
+            #[cfg(feature = "defi")]
+            Self::ProtocolTvlHistory => "protocol_tvl_history",
         }
     }
 
@@ -533,6 +556,8 @@ impl Operation {
             }
             Self::Options => Capability::OPTIONS,
             Self::CryptoQuote => Capability::CRYPTO,
+            #[cfg(feature = "defi")]
+            Self::ProtocolTvl | Self::ProtocolTvlHistory => Capability::CRYPTO,
             Self::EconomicSeries => Capability::ECONOMIC,
             Self::ForexQuote => Capability::FOREX,
             Self::IndicesQuote | Self::IndexConstituents | Self::IndexConstituentChanges => {
@@ -930,6 +955,8 @@ pub(crate) async fn build_providers(
             Provider::Kraken => Arc::new(kraken::KrakenProvider),
             #[cfg(feature = "finra")]
             Provider::Finra => Arc::new(finra::FinraProvider),
+            #[cfg(feature = "defi")]
+            Provider::DefiLlama => Arc::new(defillama::DefiLlamaProvider),
             Provider::Edgar => Arc::new(edgar::EdgarProvider),
         };
         adapter.initialize().await?;

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -18,6 +18,8 @@ pub(crate) mod fred;
 #[cfg(feature = "polygon")]
 pub(crate) mod polygon;
 pub(crate) mod types;
+#[cfg(feature = "worldbank")]
+pub(crate) mod worldbank;
 pub(crate) mod yahoo;
 
 use crate::adapters::yahoo::client::{ClientConfig, YahooClient};
@@ -52,6 +54,9 @@ pub enum Provider {
     /// FRED economic data (requires `fred` feature).
     #[cfg(feature = "fred")]
     Fred,
+    /// World Bank Open Data global macro indicators (requires `worldbank` feature, keyless).
+    #[cfg(feature = "worldbank")]
+    WorldBank,
     /// SEC EDGAR filings (always available, keyless).
     Edgar,
 }
@@ -73,6 +78,8 @@ impl Provider {
             "coingecko" => Some(Self::CoinGecko),
             #[cfg(feature = "fred")]
             "fred" => Some(Self::Fred),
+            #[cfg(feature = "worldbank")]
+            "worldbank" => Some(Self::WorldBank),
             "edgar" => Some(Self::Edgar),
             _ => None,
         }
@@ -92,6 +99,8 @@ impl Provider {
             Self::CoinGecko => "coingecko",
             #[cfg(feature = "fred")]
             Self::Fred => "fred",
+            #[cfg(feature = "worldbank")]
+            Self::WorldBank => "worldbank",
             Self::Edgar => "edgar",
         }
     }
@@ -112,6 +121,8 @@ impl Provider {
         v.push(Self::CoinGecko);
         #[cfg(feature = "fred")]
         v.push(Self::Fred);
+        #[cfg(feature = "worldbank")]
+        v.push(Self::WorldBank);
         v.push(Self::Edgar);
         v
     }
@@ -136,6 +147,8 @@ impl Provider {
             Self::CoinGecko => ProviderAdapter::capabilities(&coingecko::CoinGeckoProvider),
             #[cfg(feature = "fred")]
             Self::Fred => ProviderAdapter::capabilities(&fred::FredProvider),
+            #[cfg(feature = "worldbank")]
+            Self::WorldBank => ProviderAdapter::capabilities(&worldbank::WorldBankProvider),
             Self::Edgar => ProviderAdapter::capabilities(&edgar::EdgarProvider),
         }
     }
@@ -824,6 +837,8 @@ pub(crate) async fn build_providers(
             Provider::CoinGecko => Arc::new(coingecko::CoinGeckoProvider),
             #[cfg(feature = "fred")]
             Provider::Fred => Arc::new(fred::FredProvider),
+            #[cfg(feature = "worldbank")]
+            Provider::WorldBank => Arc::new(worldbank::WorldBankProvider),
             Provider::Edgar => Arc::new(edgar::EdgarProvider),
         };
         adapter.initialize().await?;

--- a/src/providers/worldbank.rs
+++ b/src/providers/worldbank.rs
@@ -1,0 +1,29 @@
+//! World Bank Open Data provider implementation (keyless).
+
+use super::{EconomicProvider, ProviderAdapter, ProviderCore};
+use crate::error::Result;
+
+pub(crate) struct WorldBankProvider;
+
+impl ProviderCore for WorldBankProvider {
+    fn id(&self) -> super::Provider {
+        super::Provider::WorldBank
+    }
+}
+
+#[async_trait::async_trait]
+impl EconomicProvider for WorldBankProvider {
+    async fn fetch_economic_series(
+        &self,
+        series_id: &str,
+    ) -> Result<crate::models::economic::EconomicSeries> {
+        crate::adapters::worldbank::fetch_economic_series_response(series_id).await
+    }
+}
+
+#[async_trait::async_trait]
+impl ProviderAdapter for WorldBankProvider {
+    fn as_economic(&self) -> Option<&dyn EconomicProvider> {
+        Some(self)
+    }
+}

--- a/tests/doc_binance.rs
+++ b/tests/doc_binance.rs
@@ -1,0 +1,113 @@
+//! Compile and runtime tests for docs/library/providers/binance.md
+//!
+//! Requires the `binance` feature flag:
+//!   cargo test --test doc_binance --features binance
+//!   cargo test --test doc_binance --features binance -- --ignored
+//!
+//! Offline behaviour (symbol normalisation, kline parsing, millisecond
+//! conversion, error mapping) is covered by the mock + unit tests in
+//! `src/adapters/binance/`.
+//!
+//! The network tests are additionally skipped by CI runners in a region
+//! Binance geo-blocks — they will fail with an HTTP 451 there, which is the
+//! documented behaviour rather than a bug.
+
+#![cfg(feature = "binance")]
+
+use finance_query::{Capability, Interval, Provider, Providers, TimeRange};
+
+#[test]
+fn binance_provider_id_round_trips() {
+    assert_eq!(Provider::Binance.as_str(), "binance");
+    assert_eq!(Provider::from_id_str("binance"), Some(Provider::Binance));
+}
+
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn keyless_quote_by_coin_id() {
+    let providers = Providers::builder()
+        .route(Capability::CRYPTO, [Provider::Binance])
+        .build()
+        .await
+        .expect("Binance public data needs no API key");
+
+    let quote = providers.crypto("bitcoin").quote("usd").await.unwrap();
+
+    assert_eq!(quote.id, "bitcoin");
+    assert_eq!(quote.symbol, "BTC");
+    assert_eq!(quote.name, "Bitcoin");
+    assert!(quote.price.is_some_and(|p| p > 0.0));
+    // An exchange reports flow, not supply.
+    assert_eq!(quote.market_cap, None);
+}
+
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn hourly_candles_come_back_in_seconds() {
+    let providers = Providers::builder()
+        .route(Capability::CRYPTO, [Provider::Binance])
+        .route(Capability::CHART, [Provider::Binance])
+        .build()
+        .await
+        .unwrap();
+
+    let chart = providers
+        .crypto("BTC")
+        .chart("usd", Interval::OneHour, TimeRange::FiveDays)
+        .await
+        .unwrap();
+
+    assert!(!chart.candles.is_empty());
+    // Seconds, not Binance's milliseconds.
+    assert!(chart.candles[0].timestamp < 100_000_000_000);
+    assert!(
+        chart
+            .candles
+            .windows(2)
+            .all(|w| w[0].timestamp < w[1].timestamp),
+        "candles are not in ascending time order"
+    );
+}
+
+/// A window longer than Binance's 1000-candle page cap must be walked, not
+/// truncated.
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn long_windows_page_past_the_thousand_candle_cap() {
+    let providers = Providers::builder()
+        .route(Capability::CRYPTO, [Provider::Binance])
+        .route(Capability::CHART, [Provider::Binance])
+        .build()
+        .await
+        .unwrap();
+
+    let chart = providers
+        .crypto("BTC")
+        .chart("usd", Interval::OneHour, TimeRange::SixMonths)
+        .await
+        .unwrap();
+
+    assert!(
+        chart.candles.len() > 1000,
+        "expected pagination past the 1000-candle cap, got {}",
+        chart.candles.len()
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn unlisted_market_is_an_error() {
+    let providers = Providers::builder()
+        .route(Capability::CRYPTO, [Provider::Binance])
+        .build()
+        .await
+        .unwrap();
+
+    assert!(
+        providers
+            .crypto("definitely-not-a-coin")
+            .quote("usd")
+            .await
+            .is_err()
+    );
+}

--- a/tests/doc_bls.rs
+++ b/tests/doc_bls.rs
@@ -1,0 +1,67 @@
+//! Compile and runtime tests for docs/library/providers/bls.md
+//!
+//! Requires the `bls` feature flag:
+//!   cargo test --test doc_bls --features bls
+//!   cargo test --test doc_bls --features bls -- --ignored   (network tests)
+//!
+//! Offline behaviour (period-code dating, the `"-"` sentinel, annual-aggregate
+//! rows, tier selection, error mapping) is covered by the mock + unit tests in
+//! `src/adapters/bls/mod.rs`.
+
+#![cfg(feature = "bls")]
+
+use finance_query::{Capability, Provider, Providers};
+
+#[test]
+fn bls_provider_id_round_trips() {
+    assert_eq!(Provider::Bls.as_str(), "bls");
+    assert_eq!(Provider::from_id_str("bls"), Some(Provider::Bls));
+}
+
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn keyless_build_succeeds() {
+    let providers = Providers::builder()
+        .route(Capability::ECONOMIC, [Provider::Bls])
+        .build()
+        .await
+        .expect("BLS works without a key on the v1 route");
+    let _ = providers.economic("CUUR0000SA0");
+}
+
+/// Burns one of the 25 keyless queries/day, so it stays behind `--ignored`.
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn cpi_series_is_monthly_and_chronological() {
+    let providers = Providers::builder()
+        .route(Capability::ECONOMIC, [Provider::Bls])
+        .build()
+        .await
+        .unwrap();
+
+    let series = providers.economic("CUUR0000SA0").series().await.unwrap();
+
+    assert_eq!(series.series_id, "CUUR0000SA0");
+    assert_eq!(series.frequency.as_deref(), Some("Monthly"));
+    assert!(!series.observations.is_empty());
+    assert!(
+        series
+            .observations
+            .windows(2)
+            .all(|w| w[0].date < w[1].date),
+        "observations are not strictly chronological — an annual-aggregate \
+         row may have leaked through"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn unknown_series_reports_not_found() {
+    let providers = Providers::builder()
+        .route(Capability::ECONOMIC, [Provider::Bls])
+        .build()
+        .await
+        .unwrap();
+
+    assert!(providers.economic("NOTASERIES").series().await.is_err());
+}

--- a/tests/doc_defillama.rs
+++ b/tests/doc_defillama.rs
@@ -1,0 +1,124 @@
+//! Compile and runtime tests for docs/library/providers/defillama.md
+//!
+//! Requires the `defi` feature flag:
+//!   cargo test --test doc_defillama --features defi
+//!   cargo test --test doc_defillama --features defi -- --ignored
+//!
+//! Offline behaviour (slug normalisation, breakdown-key exclusion, change
+//! computation, peg-keyed supply maps, error mapping) is covered by the mock +
+//! unit tests in `src/adapters/defillama/mod.rs`.
+
+#![cfg(feature = "defi")]
+
+use finance_query::defi::{ChainTvl, ProtocolTvl, StablecoinSupply, TvlPoint};
+use finance_query::{Capability, Provider, Providers};
+
+/// Verifies the fields documented on the page exist with the stated types.
+#[allow(dead_code)]
+fn _verify_model_fields(p: ProtocolTvl, c: ChainTvl, s: StablecoinSupply, t: TvlPoint) {
+    let _: String = p.slug;
+    let _: Option<f64> = p.tvl;
+    let _: Vec<String> = p.chains;
+    let _: Option<f64> = p.change_1d_percent;
+    let _: Option<f64> = p.change_7d_percent;
+    let _: Option<f64> = p.market_cap;
+
+    let _: String = c.name;
+    let _: Option<f64> = c.tvl;
+    let _: Option<i64> = c.chain_id;
+
+    let _: String = s.name;
+    let _: Option<String> = s.peg_type;
+    let _: Option<f64> = s.circulating;
+
+    let _: i64 = t.timestamp;
+    let _: f64 = t.tvl;
+}
+
+#[test]
+fn defillama_provider_id_round_trips() {
+    assert_eq!(Provider::DefiLlama.as_str(), "defillama");
+    assert_eq!(
+        Provider::from_id_str("defillama"),
+        Some(Provider::DefiLlama)
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn protocol_tvl_is_positive_and_chain_split_does_not_double_count() {
+    let providers = Providers::builder()
+        .route(Capability::CRYPTO, [Provider::DefiLlama])
+        .build()
+        .await
+        .expect("DefiLlama needs no API key");
+
+    let tvl = providers.crypto("aave").tvl().await.unwrap();
+
+    assert_eq!(tvl.slug, "aave");
+    assert!(tvl.tvl.is_some_and(|v| v > 0.0));
+    assert!(!tvl.chains.is_empty());
+    // Every allocation must name a chain the protocol reports — a leaked
+    // "-borrowed"/"pool2" breakdown key would fail this.
+    assert!(
+        tvl.tvl_by_chain
+            .iter()
+            .all(|a| tvl.chains.contains(&a.chain)),
+        "an allocation named something that is not one of the protocol's chains"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn tvl_history_is_chronological() {
+    let providers = Providers::builder()
+        .route(Capability::CRYPTO, [Provider::DefiLlama])
+        .build()
+        .await
+        .unwrap();
+
+    let history = providers.crypto("aave").tvl_history().await.unwrap();
+    assert!(history.len() > 100);
+    assert!(
+        history.windows(2).all(|w| w[0].timestamp <= w[1].timestamp),
+        "history is not chronological"
+    );
+}
+
+/// DefiLlama publishes no prices, so a quote must fall through to another
+/// routed provider rather than failing the chain.
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn quotes_are_not_supported_by_defillama_alone() {
+    let providers = Providers::builder()
+        .route(Capability::CRYPTO, [Provider::DefiLlama])
+        .build()
+        .await
+        .unwrap();
+
+    assert!(providers.crypto("aave").quote("usd").await.is_err());
+}
+
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn chains_are_ranked_largest_first() {
+    let chains = finance_query::defi::chains().await.unwrap();
+    assert!(chains.len() > 50);
+    let tvls: Vec<f64> = chains.iter().map(|c| c.tvl.unwrap_or(0.0)).collect();
+    assert!(
+        tvls.windows(2).all(|w| w[0] >= w[1]),
+        "chains are not sorted by TVL descending"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn stablecoins_are_ranked_and_carry_their_peg_type() {
+    let coins = finance_query::defi::stablecoins().await.unwrap();
+    assert!(!coins.is_empty());
+    assert!(coins[0].circulating.is_some_and(|c| c > 0.0));
+    assert!(
+        coins.iter().all(|c| c.peg_type.is_some()),
+        "peg_type is needed to interpret `circulating`"
+    );
+}

--- a/tests/doc_finra.rs
+++ b/tests/doc_finra.rs
@@ -1,0 +1,72 @@
+//! Compile and runtime tests for docs/library/providers/finra.md
+//!
+//! Requires the `finra` feature flag:
+//!   cargo test --test doc_finra --features finra
+//!   cargo test --test doc_finra --features finra -- --ignored
+//!
+//! Offline behaviour (per-facility consolidation, the 204 empty-series case,
+//! error mapping) is covered by the mock + unit tests in
+//! `src/adapters/finra/mod.rs`.
+
+#![cfg(feature = "finra")]
+
+use finance_query::{Capability, Provider, Providers};
+
+#[test]
+fn finra_provider_id_round_trips() {
+    assert_eq!(Provider::Finra.as_str(), "finra");
+    assert_eq!(Provider::from_id_str("finra"), Some(Provider::Finra));
+}
+
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn short_volume_series_is_daily_and_chronological() {
+    let providers = Providers::builder()
+        .route(Capability::FUNDAMENTALS, [Provider::Finra, Provider::Yahoo])
+        .build()
+        .await
+        .expect("FINRA needs no API key");
+
+    let ticker = providers.ticker("AAPL").build().await.unwrap();
+    let series = ticker.short_volume().await.unwrap();
+
+    assert!(!series.is_empty());
+    let dates: Vec<_> = series.iter().filter_map(|d| d.date.clone()).collect();
+    assert_eq!(dates.len(), series.len(), "every row must carry a date");
+    assert!(
+        dates.windows(2).all(|w| w[0] < w[1]),
+        "dates are not strictly ascending — per-facility rows may not have \
+         been consolidated"
+    );
+    assert!(
+        series
+            .iter()
+            .all(|d| match (d.short_volume, d.total_volume) {
+                (Some(short), Some(total)) => short <= total,
+                _ => true,
+            }),
+        "short volume exceeded total volume on some day"
+    );
+}
+
+/// FINRA serves no financial statements, so a chain must fall through to a
+/// provider that does.
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn financials_fall_through_past_finra() {
+    let providers = Providers::builder()
+        .route(Capability::FUNDAMENTALS, [Provider::Finra, Provider::Yahoo])
+        .build()
+        .await
+        .unwrap();
+
+    let ticker = providers.ticker("AAPL").build().await.unwrap();
+    let statement = ticker
+        .financials(
+            finance_query::StatementType::Income,
+            finance_query::Frequency::Annual,
+        )
+        .await
+        .unwrap();
+    assert!(!statement.statement.is_empty());
+}

--- a/tests/doc_fiscaldata.rs
+++ b/tests/doc_fiscaldata.rs
@@ -1,0 +1,96 @@
+//! Compile and runtime tests for docs/library/providers/fiscaldata.md
+//!
+//! Requires the `fiscaldata` feature flag:
+//!   cargo test --test doc_fiscaldata --features fiscaldata
+//!   cargo test --test doc_fiscaldata --features fiscaldata -- --ignored   (network tests)
+//!
+//! Offline behaviour (series-id resolution, string-encoded numbers, the
+//! `"null"` sentinel, pagination, API error mapping) is covered by the mock +
+//! unit tests in `src/adapters/fiscaldata/mod.rs`.
+
+#![cfg(feature = "fiscaldata")]
+
+use finance_query::{Capability, Provider, Providers};
+
+#[test]
+fn fiscaldata_provider_id_round_trips() {
+    assert_eq!(Provider::FiscalData.as_str(), "fiscaldata");
+    assert_eq!(
+        Provider::from_id_str("fiscaldata"),
+        Some(Provider::FiscalData)
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn keyless_build_succeeds() {
+    let providers = Providers::builder()
+        .route(Capability::ECONOMIC, [Provider::FiscalData])
+        .build()
+        .await
+        .expect("FiscalData needs no API key");
+    let _ = providers.economic("DEBT_TO_PENNY");
+}
+
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn debt_to_penny_is_a_daily_dollar_series() {
+    let providers = Providers::builder()
+        .route(Capability::ECONOMIC, [Provider::FiscalData])
+        .build()
+        .await
+        .unwrap();
+
+    let series = providers.economic("DEBT_TO_PENNY").series().await.unwrap();
+
+    assert_eq!(series.units.as_deref(), Some("US Dollars"));
+    assert_eq!(series.frequency.as_deref(), Some("Daily"));
+    assert!(series.observations.len() > 1000);
+    assert!(
+        series
+            .observations
+            .windows(2)
+            .all(|w| w[0].date <= w[1].date),
+        "observations are not in chronological order"
+    );
+    assert!(
+        series
+            .observations
+            .last()
+            .and_then(|o| o.value)
+            .is_some_and(|v| v > 1e13),
+        "expected the public debt to be in the tens of trillions"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn passthrough_form_reaches_an_uncurated_column() {
+    let providers = Providers::builder()
+        .route(Capability::ECONOMIC, [Provider::FiscalData])
+        .build()
+        .await
+        .unwrap();
+
+    let series = providers
+        .economic("v2/accounting/od/debt_to_penny:debt_held_public_amt")
+        .series()
+        .await
+        .unwrap();
+
+    assert!(!series.observations.is_empty());
+    // Passthrough series make no frequency claim.
+    assert_eq!(series.frequency, None);
+}
+
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn unknown_series_id_is_rejected_before_any_request() {
+    let providers = Providers::builder()
+        .route(Capability::ECONOMIC, [Provider::FiscalData])
+        .build()
+        .await
+        .unwrap();
+
+    assert!(providers.economic("NOT_A_SERIES").series().await.is_err());
+}

--- a/tests/doc_frankfurter.rs
+++ b/tests/doc_frankfurter.rs
@@ -1,0 +1,70 @@
+//! Compile and runtime tests for docs/library/providers/frankfurter.md
+//!
+//! Requires the `frankfurter` feature flag:
+//!   cargo test --test doc_frankfurter --features frankfurter
+//!   cargo test --test doc_frankfurter --features frankfurter -- --ignored
+//!
+//! Offline behaviour (change computation, chronological ordering, the
+//! same-currency short circuit, error mapping) is covered by the mock + unit
+//! tests in `src/adapters/frankfurter/mod.rs`.
+
+#![cfg(feature = "frankfurter")]
+
+use finance_query::{Capability, Provider, Providers};
+
+#[test]
+fn frankfurter_provider_id_round_trips() {
+    assert_eq!(Provider::Frankfurter.as_str(), "frankfurter");
+    assert_eq!(
+        Provider::from_id_str("frankfurter"),
+        Some(Provider::Frankfurter)
+    );
+}
+
+/// The point of the provider: `providers.forex()` works with nothing
+/// configured, which was impossible before.
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn forex_works_with_no_key_configured() {
+    let providers = Providers::builder()
+        .route(Capability::FOREX, [Provider::Frankfurter])
+        .build()
+        .await
+        .expect("Frankfurter needs no API key");
+
+    let quote = providers.forex("USD", "EUR").quote().await.unwrap();
+
+    assert_eq!(quote.symbol, "USDEUR");
+    assert_eq!(quote.base_currency.as_deref(), Some("USD"));
+    assert_eq!(quote.quote_currency.as_deref(), Some("EUR"));
+    assert!(quote.price.is_some_and(|p| p > 0.0));
+    // A reference fix has no two-way price.
+    assert_eq!(quote.bid, None);
+    assert_eq!(quote.ask, None);
+    assert!(quote.timestamp.is_some());
+}
+
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn identical_currencies_quote_at_one() {
+    let providers = Providers::builder()
+        .route(Capability::FOREX, [Provider::Frankfurter])
+        .build()
+        .await
+        .unwrap();
+
+    let quote = providers.forex("USD", "USD").quote().await.unwrap();
+    assert_eq!(quote.price, Some(1.0));
+}
+
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn currency_outside_ecb_coverage_is_not_found() {
+    let providers = Providers::builder()
+        .route(Capability::FOREX, [Provider::Frankfurter])
+        .build()
+        .await
+        .unwrap();
+
+    assert!(providers.forex("USD", "ZZZ").quote().await.is_err());
+}

--- a/tests/doc_kraken.rs
+++ b/tests/doc_kraken.rs
@@ -1,0 +1,101 @@
+//! Compile and runtime tests for docs/library/providers/kraken.md
+//!
+//! Requires the `kraken` feature flag:
+//!   cargo test --test doc_kraken --features kraken
+//!   cargo test --test doc_kraken --features kraken -- --ignored
+//!
+//! Offline behaviour (XBT/XDG aliasing, X/Z prefix stripping, the HTTP-200
+//! error envelope, the `last` cursor) is covered by the mock + unit tests in
+//! `src/adapters/kraken/`.
+
+#![cfg(feature = "kraken")]
+
+use finance_query::{Capability, Interval, Provider, Providers, TimeRange};
+
+#[test]
+fn kraken_provider_id_round_trips() {
+    assert_eq!(Provider::Kraken.as_str(), "kraken");
+    assert_eq!(Provider::from_id_str("kraken"), Some(Provider::Kraken));
+}
+
+/// The point of this provider: keyless *and* reachable from the US, unlike
+/// Binance.
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn keyless_quote_by_coin_id() {
+    let providers = Providers::builder()
+        .route(Capability::CRYPTO, [Provider::Kraken])
+        .build()
+        .await
+        .expect("Kraken public data needs no API key");
+
+    let quote = providers.crypto("bitcoin").quote("usd").await.unwrap();
+
+    assert_eq!(quote.id, "bitcoin");
+    // Kraken calls it XBT internally; callers see BTC.
+    assert_eq!(quote.symbol, "BTC");
+    assert_eq!(quote.name, "Bitcoin");
+    assert!(quote.price.is_some_and(|p| p > 0.0));
+    assert!(quote.high_24h.is_some());
+    assert_eq!(quote.market_cap, None);
+}
+
+/// A modern pair with no legacy prefixes must work the same as a legacy one.
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn modern_pairs_need_no_aliasing() {
+    let providers = Providers::builder()
+        .route(Capability::CRYPTO, [Provider::Kraken])
+        .build()
+        .await
+        .unwrap();
+
+    let quote = providers.crypto("solana").quote("usd").await.unwrap();
+    assert_eq!(quote.symbol, "SOL");
+    assert!(quote.price.is_some_and(|p| p > 0.0));
+}
+
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn daily_candles_are_already_in_seconds() {
+    let providers = Providers::builder()
+        .route(Capability::CRYPTO, [Provider::Kraken])
+        .route(Capability::CHART, [Provider::Kraken])
+        .build()
+        .await
+        .unwrap();
+
+    let chart = providers
+        .crypto("BTC")
+        .chart("usd", Interval::OneDay, TimeRange::OneMonth)
+        .await
+        .unwrap();
+
+    assert!(!chart.candles.is_empty());
+    assert!(chart.candles[0].timestamp < 100_000_000_000);
+    assert!(
+        chart
+            .candles
+            .windows(2)
+            .all(|w| w[0].timestamp < w[1].timestamp),
+        "candles are not in ascending time order"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn unknown_pair_is_an_error_despite_kraken_returning_http_200() {
+    let providers = Providers::builder()
+        .route(Capability::CRYPTO, [Provider::Kraken])
+        .build()
+        .await
+        .unwrap();
+
+    assert!(
+        providers
+            .crypto("definitely-not-a-coin")
+            .quote("usd")
+            .await
+            .is_err()
+    );
+}

--- a/tests/doc_openfigi.rs
+++ b/tests/doc_openfigi.rs
@@ -1,0 +1,87 @@
+//! Compile and runtime tests for docs/library/providers/openfigi.md
+//!
+//! Requires the `openfigi` feature flag:
+//!   cargo test --test doc_openfigi --features openfigi
+//!   cargo test --test doc_openfigi --features openfigi -- --ignored
+//!
+//! Offline behaviour (positional pairing, the capitalised `compositeFIGI`
+//! keys, batch limits, error mapping) is covered by the mock + unit tests in
+//! `src/adapters/openfigi/mod.rs`.
+
+#![cfg(feature = "openfigi")]
+
+use finance_query::openfigi::{self, SecurityIdKind, SecurityMapping};
+
+/// Verifies the fields documented on the page exist with the stated types.
+#[allow(dead_code)]
+fn _verify_security_mapping_fields(m: SecurityMapping) {
+    let _: String = m.figi;
+    let _: Option<String> = m.ticker;
+    let _: Option<String> = m.name;
+    let _: Option<String> = m.exchange_code;
+    let _: Option<String> = m.composite_figi;
+    let _: Option<String> = m.share_class_figi;
+    let _: Option<String> = m.security_type;
+    let _: Option<String> = m.market_sector;
+}
+
+#[test]
+fn id_kinds_expose_openfigis_type_names() {
+    assert_eq!(SecurityIdKind::Cusip.to_string(), "ID_CUSIP");
+    assert_eq!(SecurityIdKind::Isin.to_string(), "ID_ISIN");
+}
+
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn apples_cusip_resolves_to_a_us_listing() {
+    let listings = openfigi::resolve_cusip("037833100").await.unwrap();
+
+    assert!(!listings.is_empty());
+    let composite = listings
+        .iter()
+        .find(|l| l.exchange_code.as_deref() == Some("US"))
+        .expect("expected a US composite listing");
+    assert_eq!(composite.ticker.as_deref(), Some("AAPL"));
+    // The capitalised `compositeFIGI` key must actually be read.
+    assert!(composite.composite_figi.is_some());
+    assert!(composite.share_class_figi.is_some());
+}
+
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn isin_and_cusip_agree_on_the_same_security() {
+    let by_cusip = openfigi::resolve_cusip("037833100").await.unwrap();
+    let by_isin = openfigi::resolve_isin("US0378331005").await.unwrap();
+
+    let cusip_composite = by_cusip.iter().find_map(|l| l.composite_figi.clone());
+    let isin_composite = by_isin.iter().find_map(|l| l.composite_figi.clone());
+    assert_eq!(cusip_composite, isin_composite);
+}
+
+/// The result must be positional, including for identifiers that match
+/// nothing.
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn batch_results_pair_positionally_with_their_inputs() {
+    let ids = ["037833100", "000000000", "594918104"];
+    let results = openfigi::resolve_many(SecurityIdKind::Cusip, &ids)
+        .await
+        .unwrap();
+
+    assert_eq!(results.len(), ids.len());
+    assert!(!results[0].is_empty(), "Apple should resolve");
+    // A well-formed CUSIP matching nothing is an empty list, not an error.
+    assert!(results[1].is_empty(), "000000000 should match nothing");
+    assert!(!results[2].is_empty(), "Microsoft should resolve");
+}
+
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn resolving_an_empty_batch_is_a_no_op() {
+    assert!(
+        openfigi::resolve_many(SecurityIdKind::Cusip, &[])
+            .await
+            .unwrap()
+            .is_empty()
+    );
+}

--- a/tests/doc_worldbank.rs
+++ b/tests/doc_worldbank.rs
@@ -1,0 +1,80 @@
+//! Compile and runtime tests for docs/library/providers/worldbank.md
+//!
+//! Requires the `worldbank` feature flag:
+//!   cargo test --test doc_worldbank --features worldbank
+//!   cargo test --test doc_worldbank --features worldbank -- --ignored   (network tests)
+//!
+//! Offline behaviour of the series path (envelope parsing, error messages,
+//! period normalisation, chronological ordering) is covered by the mock +
+//! unit tests in `src/adapters/worldbank/mod.rs`.
+
+#![cfg(feature = "worldbank")]
+
+use finance_query::{Capability, Provider, Providers};
+
+/// The provider id round-trips through the string form documented in the page.
+#[test]
+fn worldbank_provider_id_round_trips() {
+    assert_eq!(Provider::WorldBank.as_str(), "worldbank");
+    assert_eq!(
+        Provider::from_id_str("worldbank"),
+        Some(Provider::WorldBank)
+    );
+}
+
+/// Routing `ECONOMIC` to World Bank must not need any key or env var, so
+/// `build()` succeeds on a machine with nothing configured.
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn keyless_build_succeeds() {
+    let providers = Providers::builder()
+        .route(Capability::ECONOMIC, [Provider::WorldBank])
+        .build()
+        .await
+        .expect("World Bank needs no API key");
+    let _ = providers.economic("USA/NY.GDP.MKTP.CD");
+}
+
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn us_gdp_series_has_chronological_annual_observations() {
+    let providers = Providers::builder()
+        .route(Capability::ECONOMIC, [Provider::WorldBank])
+        .build()
+        .await
+        .unwrap();
+
+    let series = providers
+        .economic("USA/NY.GDP.MKTP.CD")
+        .series()
+        .await
+        .unwrap();
+
+    assert_eq!(series.series_id, "USA/NY.GDP.MKTP.CD");
+    assert_eq!(series.frequency.as_deref(), Some("Annual"));
+    assert!(series.observations.len() > 50);
+    assert!(
+        series
+            .observations
+            .windows(2)
+            .all(|w| w[0].date <= w[1].date),
+        "observations are not in chronological order"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires network access"]
+async fn bare_indicator_resolves_against_the_world_aggregate() {
+    let providers = Providers::builder()
+        .route(Capability::ECONOMIC, [Provider::WorldBank])
+        .build()
+        .await
+        .unwrap();
+
+    let series = providers.economic("SP.POP.TOTL").series().await.unwrap();
+    assert!(
+        series.title.as_deref().is_some_and(|t| t.contains("World")),
+        "expected the world aggregate, got {:?}",
+        series.title
+    );
+}


### PR DESCRIPTION
## Description

Adds nine new data providers that need no API key. Between them they close the
last capabilities that were key-only: forex now works out of the box, crypto has
a real fallback chain, and short-sale volume no longer requires Polygon.

Bottom of a 3-PR stack: **#303 → #304 → #305**.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Changes

Each provider is behind its own feature flag and is off by default.

| Feature | Provider | What you get |
|---------|----------|--------------|
| `worldbank` | World Bank Open Data | ~1,600 global macro indicators across 200+ economies, addressed as `"USA/NY.GDP.MKTP.CD"` |
| `fiscaldata` | US Treasury FiscalData | Federal debt, average interest rates, Daily Treasury Statement balances |
| `bls` | Bureau of Labor Statistics | CPI, unemployment, payrolls, wages, PPI by native series id. Keyless v1, or v2 with `BLS_API_KEY` |
| `frankfurter` | Frankfurter / ECB | `providers.forex("USD", "EUR").quote()` with nothing configured — the first keyless FOREX route |
| `binance` | Binance public data | 24h crypto quotes and arbitrary-interval OHLCV |
| `kraken` | Kraken public data | Same, from a US-reachable host, so CRYPTO gets a real `Fetch::Sequential` fallback |
| `finra` | FINRA | Daily short-sale volume from the primary source, summed across reporting facilities |
| `openfigi` | OpenFIGI | `openfigi::resolve_cusip / resolve_isin / resolve_sedol / resolve_many` |
| `defi` | DefiLlama | `CryptoCoin::tvl()` / `.tvl_history()`, plus `defi::chains()` and `defi::stablecoins()` |

New public models: `ProtocolTvl`, `ChainAllocation`, `TvlPoint`, `ChainTvl`,
`StablecoinSupply`, `SecurityMapping`, `SecurityIdKind`.

Two of these sit at the crate root (`openfigi`, `defi`) rather than behind the
Providers API, because they aren't tied to a symbol handle and map onto no
`Capability` — the same placement as `edgar` and `fred`.

The final commit is a cleanup pass over the nine adapters: one shared HTTP-status
mapper instead of nine, one shared coin table and chart builder instead of a
binance/kraken copy each, one `Interval::duration_secs()` instead of three
seconds-per-interval tables, concurrent FiscalData pagination, and DefiLlama TVL
routed through the handle cache.

## Breaking Changes

None. All new surface is behind new feature flags.

## Testing
- [x] Unit tests added/updated
- [x] All tests pass (`cargo test`)

`cargo test --features full`: 1273 passed, 0 failed. Also ran clippy per feature
flag individually (`worldbank`, `fiscaldata`, `bls`, `frankfurter`, `binance`,
`kraken`, `finra`, `openfigi`, `defi`) plus `--no-default-features`, since the
new `cfg(any(...))` gates make single-feature builds easy to break.

## Documentation
- [x] Code documentation updated (doc comments)
- [x] CHANGELOG.md updated

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy --workspace --all-targets --features full -- -D warnings`)
- [x] Commit messages follow Conventional Commits

## Related Issues

Closes #251
Closes #252
Closes #257
Closes #258
Closes #260
Closes #261
Closes #262
Closes #268
Closes #269
