### PR TITLE
feat: provider depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`-borrowed`, `pool2`, `staking`), which describe the same capital and would
   double-count. DefiLlama serves no prices, so `quote()` falls through to
   another routed provider.
+- Keyless crypto price history: `Provider::CoinGecko` now serves
+  `Capability::CHART`, so `.route(Capability::CHART, [Provider::CoinGecko])`
+  makes `providers.crypto("bitcoin").history("usd", range)` work without an API
+  key. CoinGecko picks bar granularity from the range (so `interval` is
+  advisory) and its OHLC endpoint reports no volume, so those candles carry
+  `volume: 0` rather than an interpolated figure.
 - Primary-source ownership data from EDGAR, keyless:
   `providers.filings("AAPL").insider_trades(limit)` parses Form 3/4/5 ownership
   XML into typed `InsiderTrade` rows (insider, role, transaction code, shares,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`-borrowed`, `pool2`, `staking`), which describe the same capital and would
   double-count. DefiLlama serves no prices, so `quote()` falls through to
   another routed provider.
+- Analyst consensus on `Ticker`: `price_target_consensus()` (high/low/mean/median
+  target), `price_target_summary()` (how many targets were published last
+  month/quarter/year/all time and their averages), and `rating_consensus()`
+  (grade distribution plus a headline label) via the `FUNDAMENTALS` route (FMP).
+  These are the provider's own panel-wide rollups, not the raw per-analyst grade
+  actions already available through `UpgradeDowngradeHistory`.
 - Index constituents: `providers.index("^GSPC").constituents()` and
   `.constituent_changes()` list the current members and membership history of
   the S&P 500, Nasdaq 100, and Dow Jones (FMP; changes are S&P 500 only).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `FUNDAMENTALS` route (FMP), instead of requiring callers to fetch the latest
   fiscal period and reason about whether it is still current. New public models
   `KeyMetricsTtm` and `FinancialRatiosTtm`.
+- Ownership/governance on `Ticker`: `executive_compensation()` and
+  `employee_count()` via the `CORPORATE` route (FMP), both extracted from the
+  company's own SEC filings and returned newest-first. FMP also now serves
+  `share_float()` on the `FUNDAMENTALS` route, so it works when FMP is routed
+  ahead of Yahoo. New public models `ExecutiveCompensation` and `EmployeeCount`.
 - Index constituents: `providers.index("^GSPC").constituents()` and
   `.constituent_changes()` list the current members and membership history of
   the S&P 500, Nasdaq 100, and Dow Jones (FMP; changes are S&P 500 only).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`-borrowed`, `pool2`, `staking`), which describe the same capital and would
   double-count. DefiLlama serves no prices, so `quote()` falls through to
   another routed provider.
+- Routed EDGAR full-text search: `providers.filings("AAPL").search(query,
+  filters)` searches filing *text* within that filer, and `.search_all(..)`
+  across every filer, through the `FILINGS` capability. Returns the flattened
+  `FilingSearchHit` (with a derived archive URL per hit) rather than EDGAR's raw
+  Elasticsearch envelope, which `edgar::search` still exposes unchanged. New
+  public models `FilingSearchHit` and `FilingSearchFilters`.
 - Cross-market snapshots: `providers.snapshot().get(&["AAPL", "X:BTCUSD",
   "I:SPX"])` answers a mixed watchlist in one request through the `QUOTE` route
   (Polygon's `/v3/snapshot`, max 250 symbols) instead of one request per asset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`-borrowed`, `pool2`, `staking`), which describe the same capital and would
   double-count. DefiLlama serves no prices, so `quote()` falls through to
   another routed provider.
+- FRED series discovery and point-in-time data:
+  `providers.economic_catalog()` is a new market-wide handle with `.search(query,
+  limit)`, `.categories(parent_id)`, and `.releases()`, so a series id no longer
+  has to be known up front. `providers.economic("GDPC1").as_of("2020-06-30")`
+  returns the series as it was actually published on that date (ALFRED vintage)
+  rather than as currently revised — backtesting against revised macro data is
+  look-ahead bias. New public models `EconomicSeriesMatch`, `EconomicCategory`,
+  and `EconomicRelease`.
 - Keyless crypto price history: `Provider::CoinGecko` now serves
   `Capability::CHART`, so `.route(Capability::CHART, [Provider::CoinGecko])`
   makes `providers.crypto("bitcoin").history("usd", range)` work without an API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`-borrowed`, `pool2`, `staking`), which describe the same capital and would
   double-count. DefiLlama serves no prices, so `quote()` falls through to
   another routed provider.
+- Primary-source ownership data from EDGAR, keyless:
+  `providers.filings("AAPL").insider_trades(limit)` parses Form 3/4/5 ownership
+  XML into typed `InsiderTrade` rows (insider, role, transaction code, shares,
+  price, post-transaction holdings, derivative flag), and
+  `providers.filings("BRK-B").institutional_holdings()` parses the latest 13F-HR
+  information table into `InstitutionalHolding` rows (issuer, CUSIP, value,
+  shares, voting authority). XML is read by a small in-crate element reader —
+  no new dependency, same reasoning as the RSS/Atom parser.
 - Routed EDGAR full-text search: `providers.filings("AAPL").search(query,
   filters)` searches filing *text* within that filer, and `.search_all(..)`
   across every filer, through the `FILINGS` capability. Returns the flattened

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`-borrowed`, `pool2`, `staking`), which describe the same capital and would
   double-count. DefiLlama serves no prices, so `quote()` falls through to
   another routed provider.
+- Cross-market snapshots: `providers.snapshot().get(&["AAPL", "X:BTCUSD",
+  "I:SPX"])` answers a mixed watchlist in one request through the `QUOTE` route
+  (Polygon's `/v3/snapshot`, max 250 symbols) instead of one request per asset
+  class. Unresolvable symbols come back as rows with `error` set rather than
+  being dropped. New public models `MarketSnapshot` and `AssetClass`, and a new
+  `Snapshot` handle.
 - Analyst consensus on `Ticker`: `price_target_consensus()` (high/low/mean/median
   target), `price_target_summary()` (how many targets were published last
   month/quarter/year/all time and their averages), and `rating_consensus()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (grade distribution plus a headline label) via the `FUNDAMENTALS` route (FMP).
   These are the provider's own panel-wide rollups, not the raw per-analyst grade
   actions already available through `UpgradeDowngradeHistory`.
+- TTM fundamentals snapshots on `Ticker`: `key_metrics_ttm()` and `ratios_ttm()`
+  return a single always-current trailing-twelve-month rollup via the
+  `FUNDAMENTALS` route (FMP), instead of requiring callers to fetch the latest
+  fiscal period and reason about whether it is still current. New public models
+  `KeyMetricsTtm` and `FinancialRatiosTtm`.
 - Index constituents: `providers.index("^GSPC").constituents()` and
   `.constituent_changes()` list the current members and membership history of
   the S&P 500, Nasdaq 100, and Dow Jones (FMP; changes are S&P 500 only).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`-borrowed`, `pool2`, `staking`), which describe the same capital and would
   double-count. DefiLlama serves no prices, so `quote()` falls through to
   another routed provider.
+- Alpha Vantage gains the `DISCOVERY` capability and ETF coverage:
+  `Ticker::etf_profile()` returns a fund's profile and portfolio holdings
+  (heaviest first) — no other wired provider serves ETF composition —
+  and `providers.discovery()` now routes to Alpha Vantage for `.search(..)`,
+  `.exchanges()`, and the new `.listing_status(active)`, which returns the whole
+  listed (or delisted) universe. New public models `EtfProfile` and
+  `EtfHolding`.
 - FRED series discovery and point-in-time data:
   `providers.economic_catalog()` is a new market-wide handle with `.search(query,
   limit)`, `.categories(parent_id)`, and `.releases()`, so a series id no longer

--- a/docs/library/providers/alphavantage.md
+++ b/docs/library/providers/alphavantage.md
@@ -43,8 +43,8 @@ let quote = ticker.quote::<Raw>().await?;
 | Fundamentals | ✓ |
 | Corporate | ✓ |
 | Options | ✓ |
-| Market | — |
-| Discovery | — |
+| Market | ✓ |
+| Discovery | ✓ |
 | Indices | — |
 | Commodities | ✓ |
 | Forex | ✓ |
@@ -54,6 +54,44 @@ let quote = ticker.quote::<Raw>().await?;
 | Economic | ✓ |
 | Filings | — |
 | Sentiment | — |
+
+## Alpha Vantage-only methods
+
+ETF composition has no other wired source; symbol search and the listing
+universe route through `Capability::DISCOVERY`.
+
+```rust,ignore
+use finance_query::{Capability, Provider, Providers};
+
+let providers = Providers::builder()
+    .route(Capability::FUNDAMENTALS, [Provider::AlphaVantage, Provider::Yahoo])
+    .route(Capability::DISCOVERY, [Provider::AlphaVantage])
+    .build()
+    .await?;
+
+// Fund profile plus portfolio holdings, heaviest first.
+let etf = providers.ticker("QQQ").build().await?.etf_profile().await?;
+for h in etf.holdings.iter().take(10) {
+    println!("{:?} {:?}", h.symbol, h.weight);
+}
+
+let disco = providers.discovery();
+let hits = disco.search("tesco", 10).await?;
+let listed = disco.listing_status(true).await?;   // every active listing
+let delisted = disco.listing_status(false).await?;
+```
+
+| Method | Returns | Alpha Vantage function |
+|--------|---------|------------------------|
+| `Ticker::etf_profile()` | `EtfProfile` | `ETF_PROFILE` |
+| `Discovery::search(query, limit)` | `Vec<SymbolMatch>` | `SYMBOL_SEARCH` |
+| `Discovery::listing_status(active)` | `Vec<SymbolMatch>` | `LISTING_STATUS` |
+| `Discovery::exchanges()` | `Vec<ExchangeInfo>` | `LISTING_STATUS` (derived) |
+
+`listing_status` is an unfiltered dump of the whole universe — thousands of
+rows in one response — so prefer `search` when you have a query. Alpha Vantage
+has no exchange endpoint, so `exchanges()` derives the distinct venue list from
+that same CSV and can only populate `name`.
 
 ## See Also
 

--- a/docs/library/providers/coingecko.md
+++ b/docs/library/providers/coingecko.md
@@ -74,6 +74,39 @@ To discover IDs programmatically, call the CoinGecko `/coins/list` endpoint.
 | `circulating_supply` | `Option<f64>` | Circulating supply |
 | `image` | `Option<String>` | URL to the coin's logo image |
 
+## Price History (keyless `CHART` route)
+
+Route `Capability::CHART` to CoinGecko and `CryptoCoin` serves OHLC history by
+coin id, without any API key:
+
+```rust,ignore
+use finance_query::{Capability, Interval, Provider, Providers, TimeRange};
+
+let providers = Providers::builder()
+    .route(Capability::CHART, [Provider::CoinGecko])
+    .build()
+    .await?;
+
+let chart = providers
+    .crypto("bitcoin")
+    .history("usd", TimeRange::ThreeMonths)
+    .await?;
+println!("{} candles", chart.candles.len());
+```
+
+Two properties of CoinGecko's public `/ohlc` endpoint carry through:
+
+- **`interval` is advisory.** CoinGecko selects bar granularity from the day
+  span alone — 30 minutes for 1–2 days, 4 hours for 3–30 days, 4 days beyond
+  that. Ranges are mapped onto its accepted spans (`1`, `7`, `30`, `90`, `180`,
+  `365`, `max`); anything past a year becomes `max`.
+- **Candles have no volume.** `/ohlc` does not report it, so `volume` is `0`
+  rather than a figure interpolated from a differently-bucketed series. Volume
+  ratio indicators (OBV, VWMA) are meaningless on these candles.
+
+The handle's id and quote currency are recombined as `"{id}-{vs}"` and split on
+the last hyphen, so hyphenated CoinGecko ids (`usd-coin`, `staked-ether`) work.
+
 ## Rate Limits
 
 The CoinGecko free tier allows **30 requests per minute**. The client enforces this automatically — calls that would exceed the limit will wait until the window resets.

--- a/docs/library/providers/edgar.md
+++ b/docs/library/providers/edgar.md
@@ -276,6 +276,37 @@ edgar::search("query", Some(&["8-K"]), None, None).await?;
 edgar::search("query", Some(&["10-K", "10-Q", "8-K"]), None, None).await?;
 ```
 
+### Routed Search (`Filings` handle)
+
+The same EFTS index is reachable through the `FILINGS` capability, which returns
+the flattened `FilingSearchHit` model instead of EDGAR's raw Elasticsearch
+envelope — and derives a direct archive URL per hit where possible.
+
+```rust,ignore
+use finance_query::{FilingSearchFilters, Providers};
+
+let providers = Providers::builder().build().await?;
+let sec = providers.filings("AAPL");
+
+// Scoped to AAPL — the handle's symbol is resolved to a CIK filter.
+let hits = sec.search(
+    "artificial intelligence",
+    FilingSearchFilters::default().forms(["10-K"]).from("2024-01-01"),
+).await?;
+
+// Across every filer.
+let all = sec.search_all(
+    "artificial intelligence",
+    FilingSearchFilters::default().forms(["10-K"]).limit(50),
+).await?;
+
+for hit in hits {
+    println!("{:?} {:?} {:?}", hit.form, hit.filed_date, hit.url);
+}
+```
+
+EFTS caps a page at 100 hits, so `limit` above that is clamped.
+
 ## Complete Example
 
 Here's a complete example combining all EDGAR features:

--- a/docs/library/providers/edgar.md
+++ b/docs/library/providers/edgar.md
@@ -307,6 +307,44 @@ for hit in hits {
 
 EFTS caps a page at 100 hits, so `limit` above that is clamped.
 
+## Ownership (Forms 3/4/5 and 13F-HR)
+
+Both are parsed straight from the filed XML — primary-source data, keyless, and
+structurally typed rather than scraped.
+
+```rust,ignore
+use finance_query::Providers;
+
+let providers = Providers::builder().build().await?;
+
+// Insider transactions from the most recent 10 Form 3/4/5 filings.
+for trade in providers.filings("AAPL").insider_trades(10).await? {
+    println!(
+        "{:?} {:?} {:?} shares @ {:?}",
+        trade.insider_name, trade.transaction_code, trade.shares, trade.price_per_share
+    );
+}
+
+// The latest 13F-HR information table filed by a listed manager.
+for position in providers.filings("BRK-B").institutional_holdings().await? {
+    println!("{:?} {:?}", position.issuer_name, position.shares);
+}
+```
+
+Notes:
+
+- `limit` on `insider_trades` caps how many *filings* are read, not how many
+  transactions come back — one Form 4 can report several lines. Each filing
+  costs an index lookup plus a document fetch, so keep it modest.
+- A Form 3 states initial holdings rather than transactions, so it contributes
+  no rows. A filing whose XML cannot be parsed is skipped rather than failing
+  the whole call — ownership schemas vary across two decades of filings.
+- `institutional_holdings` treats the handle's symbol as the *filer*, so it is
+  only meaningful for listed institutional managers. An issuer that files no
+  13F returns an error rather than an empty list.
+- `value` on a holding is passed through unscaled: filings before 2023 report
+  thousands of dollars, later ones report whole dollars.
+
 ## Complete Example
 
 Here's a complete example combining all EDGAR features:

--- a/docs/library/providers/fmp.md
+++ b/docs/library/providers/fmp.md
@@ -82,6 +82,13 @@ let ratios = ticker.ratios_ttm().await?;              // current TTM margins/ret
 | `rating_consensus()` | `RatingConsensus` | `/api/v4/upgrades-downgrades-consensus` |
 | `key_metrics_ttm()` | `KeyMetricsTtm` | `/api/v3/key-metrics-ttm/{symbol}` |
 | `ratios_ttm()` | `FinancialRatiosTtm` | `/api/v3/ratios-ttm/{symbol}` |
+| `executive_compensation()` | `Vec<ExecutiveCompensation>` | `/api/v4/governance/executive_compensation` |
+| `employee_count()` | `Vec<EmployeeCount>` | `/api/v4/historical/employee_count` |
+
+`executive_compensation()` and `employee_count()` route through
+`Capability::CORPORATE` instead. FMP also serves `share_float()`, which the
+default Yahoo route already covers — routing `FUNDAMENTALS` to FMP just changes
+which source answers it.
 
 The TTM snapshots are single always-current rollups; `financials(..)` remains the
 period-indexed series. FMP computes the trailing window server-side, so partial

--- a/docs/library/providers/fmp.md
+++ b/docs/library/providers/fmp.md
@@ -55,6 +55,29 @@ let quote = ticker.quote::<Raw>().await?;
 | Filings | — |
 | Sentiment | — |
 
+## FMP-only `Ticker` methods
+
+These route through `Capability::FUNDAMENTALS`, so FMP must be first in that
+route for them to resolve — no other wired provider serves them.
+
+```rust,ignore
+let providers = Providers::builder()
+    .route(Capability::FUNDAMENTALS, [Provider::Fmp, Provider::Yahoo])
+    .build()
+    .await?;
+let ticker = providers.ticker("AAPL").build().await?;
+
+let target = ticker.price_target_consensus().await?;  // high / low / mean / median
+let activity = ticker.price_target_summary().await?;  // targets published per window
+let rating = ticker.rating_consensus().await?;        // grade distribution + label
+```
+
+| Method | Returns | FMP endpoint |
+|--------|---------|--------------|
+| `price_target_consensus()` | `PriceTargetConsensus` | `/api/v4/price-target-consensus` |
+| `price_target_summary()` | `PriceTargetSummary` | `/api/v4/price-target-summary` |
+| `rating_consensus()` | `RatingConsensus` | `/api/v4/upgrades-downgrades-consensus` |
+
 ## See Also
 
 - [Multi-Provider Architecture](index.md) — Provider configuration and strategies

--- a/docs/library/providers/fmp.md
+++ b/docs/library/providers/fmp.md
@@ -70,6 +70,9 @@ let ticker = providers.ticker("AAPL").build().await?;
 let target = ticker.price_target_consensus().await?;  // high / low / mean / median
 let activity = ticker.price_target_summary().await?;  // targets published per window
 let rating = ticker.rating_consensus().await?;        // grade distribution + label
+
+let metrics = ticker.key_metrics_ttm().await?;        // current TTM per-share/valuation
+let ratios = ticker.ratios_ttm().await?;              // current TTM margins/returns
 ```
 
 | Method | Returns | FMP endpoint |
@@ -77,6 +80,13 @@ let rating = ticker.rating_consensus().await?;        // grade distribution + la
 | `price_target_consensus()` | `PriceTargetConsensus` | `/api/v4/price-target-consensus` |
 | `price_target_summary()` | `PriceTargetSummary` | `/api/v4/price-target-summary` |
 | `rating_consensus()` | `RatingConsensus` | `/api/v4/upgrades-downgrades-consensus` |
+| `key_metrics_ttm()` | `KeyMetricsTtm` | `/api/v3/key-metrics-ttm/{symbol}` |
+| `ratios_ttm()` | `FinancialRatiosTtm` | `/api/v3/ratios-ttm/{symbol}` |
+
+The TTM snapshots are single always-current rollups; `financials(..)` remains the
+period-indexed series. FMP computes the trailing window server-side, so partial
+periods and restatements are handled there rather than by summing four quarters
+client-side.
 
 ## See Also
 

--- a/docs/library/providers/fred.md
+++ b/docs/library/providers/fred.md
@@ -84,6 +84,48 @@ for obs in cpi.observations.iter().rev().take(5) {
 
 **Rate limit:** 2 requests/second (enforced automatically).
 
+## Finding Series (`EconomicCatalog`)
+
+`fred::series(id)` and `providers.economic(id)` both require an id you already
+know. `providers.economic_catalog()` is how you find one:
+
+```rust,ignore
+use finance_query::Providers;
+
+let providers = Providers::builder().build().await?;
+let catalog = providers.economic_catalog();
+
+// Free-text search, most popular first.
+for hit in catalog.search("real gross domestic product", 10).await? {
+    println!("{} — {:?} ({:?})", hit.id, hit.title, hit.frequency);
+}
+
+// Browse the category tree; 0 is the root.
+for cat in catalog.categories(0).await? {
+    println!("{} {:?}", cat.id, cat.name);
+}
+
+// Every scheduled release FRED publishes.
+let releases = catalog.releases().await?;
+```
+
+## Point-in-Time Data (ALFRED vintages)
+
+FRED revises macro data after publication, so backtesting a rule against
+today's `GDPC1` is look-ahead bias — the values it trades on were not knowable
+at the time. `.as_of(date)` asks for the vintage that was actually published:
+
+```rust,ignore
+let gdp = providers.economic("GDPC1");
+
+let revised = gdp.series().await?;              // as currently revised
+let vintage = gdp.as_of("2020-06-30").await?;   // as published on that date
+```
+
+Both realtime bounds are pinned to `date`, so the response contains exactly the
+values in force that day rather than a range of revisions. Results are cached
+per date.
+
 ## US Treasury Yields
 
 No initialization required. Fetches directly from the US Treasury Department:

--- a/docs/library/providers/index.md
+++ b/docs/library/providers/index.md
@@ -191,7 +191,7 @@ let cat   = providers.economic_catalog(); // → EconomicCatalog: find macro ser
 | `FuturesContract` | `.quote()` · `.chart(interval, range)` · `.history(range)` | `FuturesQuote` · `Chart` |
 | `Commodity` | `.quote()` · `.chart(interval, range)` · `.history(range)` | `CommodityQuote` · `Chart` |
 | `Filings` | `.get()` · `.search(query, filters)` · `.search_all(query, filters)` · `.insider_trades(limit)` · `.institutional_holdings()` · `.sections(accession, form)` · `.risk_factors()` | `ProviderFilings` · `Vec<FilingSearchHit>` · `Vec<InsiderTrade>` · `Vec<InstitutionalHolding>` · `Vec<FilingSection>` · `Vec<RiskFactor>` |
-| `Discovery` | `.search(query, limit)` · `.details(symbol)` · `.exchanges()` · `.screener(filters)` | `Vec<SymbolMatch>` · `SymbolDetails` · `Vec<ExchangeInfo>` · `Vec<ScreenerMatch>` |
+| `Discovery` | `.search(query, limit)` · `.details(symbol)` · `.exchanges()` · `.listing_status(active)` · `.screener(filters)` | `Vec<SymbolMatch>` · `SymbolDetails` · `Vec<ExchangeInfo>` · `Vec<SymbolMatch>` · `Vec<ScreenerMatch>` |
 | `MarketCalendar` | `.earnings(from, to)` · `.ipos(..)` · `.dividends(..)` · `.splits(..)` · `.economic(..)` · `.holidays()` | `Vec<MarketCalendarEntry>` |
 | `Market` | `.sector_performance()` · `.sector_performance_history(limit)` · `.sector_pe()` · `.industry_pe()` · `.gainers()` · `.losers()` · `.most_active()` | `Vec<SectorPerformance>` · `Vec<SectorPerformanceHistory>` · `Vec<SectorPe>` · `Vec<IndustryPe>` · `Vec<MoverQuote>` |
 | `Snapshot` | `.get(symbols)` | `Vec<MarketSnapshot>` |

--- a/docs/library/providers/index.md
+++ b/docs/library/providers/index.md
@@ -166,15 +166,16 @@ let wheat = providers.commodity("WHEAT");                     // → Commodity
 let sec   = providers.filings("AAPL");                        // → Filings
 ```
 
-Three handles are market-wide rather than symbol-scoped, so their factories take
-no argument. `market()` is always available (movers are served keylessly from
-Yahoo's screeners); `discovery()` and `calendar()` require at least one of the
-`fmp`, `polygon`, or `alphavantage` features:
+Four handles are market-wide rather than symbol-scoped, so their factories take
+no argument. `market()` and `snapshot()` are always available (movers are served
+keylessly from Yahoo's screeners); `discovery()` and `calendar()` require at
+least one of the `fmp`, `polygon`, or `alphavantage` features:
 
 ```rust,ignore
 let disco = providers.discovery();   // → Discovery: symbol search, reference data, screeners
 let cal   = providers.calendar();    // → MarketCalendar: earnings/IPO/dividend/split/economic calendars
 let mkt   = providers.market();      // → Market: sector performance, movers
+let snap  = providers.snapshot();    // → Snapshot: cross-market watchlist snapshots
 ```
 
 ### Domain Handle Methods
@@ -191,6 +192,14 @@ let mkt   = providers.market();      // → Market: sector performance, movers
 | `Discovery` | `.search(query, limit)` · `.details(symbol)` · `.exchanges()` · `.screener(filters)` | `Vec<SymbolMatch>` · `SymbolDetails` · `Vec<ExchangeInfo>` · `Vec<ScreenerMatch>` |
 | `MarketCalendar` | `.earnings(from, to)` · `.ipos(..)` · `.dividends(..)` · `.splits(..)` · `.economic(..)` · `.holidays()` | `Vec<MarketCalendarEntry>` |
 | `Market` | `.sector_performance()` · `.sector_performance_history(limit)` · `.sector_pe()` · `.industry_pe()` · `.gainers()` · `.losers()` · `.most_active()` | `Vec<SectorPerformance>` · `Vec<SectorPerformanceHistory>` · `Vec<SectorPe>` · `Vec<IndustryPe>` · `Vec<MoverQuote>` |
+| `Snapshot` | `.get(symbols)` | `Vec<MarketSnapshot>` |
+
+`Snapshot::get` takes provider-spelled symbols from any market in one list
+(`"AAPL"`, `"X:BTCUSD"`, `"I:SPX"`, `"C:EURUSD"`, `"O:NCLH221014C00005000"`) and
+answers them in a single request — one rate-limit unit instead of one per asset
+class. Symbols the provider cannot resolve come back as rows with `error` set,
+so the result stays aligned with the request. Polygon (max 250 symbols) is
+currently the only provider whose snapshot endpoint spans markets.
 
 All chart-capable handles route through `Capability::CHART` (Yahoo by default) and cache per `(symbol, interval, range)` when `.cache(ttl)` is set. `history(range)` is sugar for `chart(range.default_interval(), range)`. The handle's identifier is passed to the chart route as-is, so it must be a chart-route symbol (e.g. `^GSPC`, `NQ=F`, `GC=F`); `CryptoCoin` builds `"{ID}-{VS}"` (e.g. `"BTC-USD"`), which resolves on Yahoo only for ticker-style ids.
 

--- a/docs/library/providers/index.md
+++ b/docs/library/providers/index.md
@@ -188,7 +188,7 @@ let snap  = providers.snapshot();    // → Snapshot: cross-market watchlist sna
 | `Index` | `.quote()` · `.chart(interval, range)` · `.history(range)` · `.constituents()` · `.constituent_changes()` | `IndexQuote` · `Chart` · `Vec<IndexConstituent>` · `Vec<IndexConstituentChange>` |
 | `FuturesContract` | `.quote()` · `.chart(interval, range)` · `.history(range)` | `FuturesQuote` · `Chart` |
 | `Commodity` | `.quote()` · `.chart(interval, range)` · `.history(range)` | `CommodityQuote` · `Chart` |
-| `Filings` | `.get()` · `.sections(accession, form)` · `.risk_factors()` | `ProviderFilings` · `Vec<FilingSection>` · `Vec<RiskFactor>` |
+| `Filings` | `.get()` · `.search(query, filters)` · `.search_all(query, filters)` · `.sections(accession, form)` · `.risk_factors()` | `ProviderFilings` · `Vec<FilingSearchHit>` · `Vec<FilingSection>` · `Vec<RiskFactor>` |
 | `Discovery` | `.search(query, limit)` · `.details(symbol)` · `.exchanges()` · `.screener(filters)` | `Vec<SymbolMatch>` · `SymbolDetails` · `Vec<ExchangeInfo>` · `Vec<ScreenerMatch>` |
 | `MarketCalendar` | `.earnings(from, to)` · `.ipos(..)` · `.dividends(..)` · `.splits(..)` · `.economic(..)` · `.holidays()` | `Vec<MarketCalendarEntry>` |
 | `Market` | `.sector_performance()` · `.sector_performance_history(limit)` · `.sector_pe()` · `.industry_pe()` · `.gainers()` · `.losers()` · `.most_active()` | `Vec<SectorPerformance>` · `Vec<SectorPerformanceHistory>` · `Vec<SectorPe>` · `Vec<IndustryPe>` · `Vec<MoverQuote>` |

--- a/docs/library/providers/index.md
+++ b/docs/library/providers/index.md
@@ -188,7 +188,7 @@ let snap  = providers.snapshot();    // → Snapshot: cross-market watchlist sna
 | `Index` | `.quote()` · `.chart(interval, range)` · `.history(range)` · `.constituents()` · `.constituent_changes()` | `IndexQuote` · `Chart` · `Vec<IndexConstituent>` · `Vec<IndexConstituentChange>` |
 | `FuturesContract` | `.quote()` · `.chart(interval, range)` · `.history(range)` | `FuturesQuote` · `Chart` |
 | `Commodity` | `.quote()` · `.chart(interval, range)` · `.history(range)` | `CommodityQuote` · `Chart` |
-| `Filings` | `.get()` · `.search(query, filters)` · `.search_all(query, filters)` · `.sections(accession, form)` · `.risk_factors()` | `ProviderFilings` · `Vec<FilingSearchHit>` · `Vec<FilingSection>` · `Vec<RiskFactor>` |
+| `Filings` | `.get()` · `.search(query, filters)` · `.search_all(query, filters)` · `.insider_trades(limit)` · `.institutional_holdings()` · `.sections(accession, form)` · `.risk_factors()` | `ProviderFilings` · `Vec<FilingSearchHit>` · `Vec<InsiderTrade>` · `Vec<InstitutionalHolding>` · `Vec<FilingSection>` · `Vec<RiskFactor>` |
 | `Discovery` | `.search(query, limit)` · `.details(symbol)` · `.exchanges()` · `.screener(filters)` | `Vec<SymbolMatch>` · `SymbolDetails` · `Vec<ExchangeInfo>` · `Vec<ScreenerMatch>` |
 | `MarketCalendar` | `.earnings(from, to)` · `.ipos(..)` · `.dividends(..)` · `.splits(..)` · `.economic(..)` · `.holidays()` | `Vec<MarketCalendarEntry>` |
 | `Market` | `.sector_performance()` · `.sector_performance_history(limit)` · `.sector_pe()` · `.industry_pe()` · `.gainers()` · `.losers()` · `.most_active()` | `Vec<SectorPerformance>` · `Vec<SectorPerformanceHistory>` · `Vec<SectorPe>` · `Vec<IndustryPe>` · `Vec<MoverQuote>` |

--- a/docs/library/providers/index.md
+++ b/docs/library/providers/index.md
@@ -176,6 +176,7 @@ let disco = providers.discovery();   // → Discovery: symbol search, reference 
 let cal   = providers.calendar();    // → MarketCalendar: earnings/IPO/dividend/split/economic calendars
 let mkt   = providers.market();      // → Market: sector performance, movers
 let snap  = providers.snapshot();    // → Snapshot: cross-market watchlist snapshots
+let cat   = providers.economic_catalog(); // → EconomicCatalog: find macro series (needs fred/alphavantage/polygon)
 ```
 
 ### Domain Handle Methods
@@ -184,7 +185,8 @@ let snap  = providers.snapshot();    // → Snapshot: cross-market watchlist sna
 |--------|--------|---------|
 | `ForexPair` | `.quote()` · `.chart(interval, range)` · `.history(range)` | `ForexQuote` · `Chart` |
 | `CryptoCoin` | `.quote(vs_currency)` · `.chart(vs_currency, interval, range)` · `.history(vs_currency, range)` | `CryptoQuote` · `Chart` |
-| `EconomicIndicator` | `.series()` | `EconomicSeries` |
+| `EconomicIndicator` | `.series()` · `.as_of(date)` | `EconomicSeries` |
+| `EconomicCatalog` | `.search(query, limit)` · `.categories(parent_id)` · `.releases()` | `Vec<EconomicSeriesMatch>` · `Vec<EconomicCategory>` · `Vec<EconomicRelease>` |
 | `Index` | `.quote()` · `.chart(interval, range)` · `.history(range)` · `.constituents()` · `.constituent_changes()` | `IndexQuote` · `Chart` · `Vec<IndexConstituent>` · `Vec<IndexConstituentChange>` |
 | `FuturesContract` | `.quote()` · `.chart(interval, range)` · `.history(range)` | `FuturesQuote` · `Chart` |
 | `Commodity` | `.quote()` · `.chart(interval, range)` · `.history(range)` | `CommodityQuote` · `Chart` |

--- a/src/adapters/alphavantage/discovery/mod.rs
+++ b/src/adapters/alphavantage/discovery/mod.rs
@@ -1,0 +1,154 @@
+//! DISCOVERY capability: symbol search and the listed-security universe.
+
+use std::collections::BTreeSet;
+
+use crate::adapters::alphavantage::models::{ListingEntryDTO, SymbolMatchDTO};
+use crate::error::Result;
+use crate::models::discovery::reference::{ExchangeInfo, SymbolMatch};
+
+pub(crate) fn to_symbol_match(dto: SymbolMatchDTO) -> SymbolMatch {
+    SymbolMatch {
+        symbol: dto.symbol,
+        name: Some(dto.name),
+        exchange: Some(dto.region),
+        asset_type: Some(dto.asset_type),
+        currency: Some(dto.currency),
+        // SYMBOL_SEARCH only returns tradable symbols, so a hit is active.
+        active: Some(true),
+    }
+}
+
+/// Search Alpha Vantage's symbol universe.
+pub async fn fetch_symbol_search_response(query: &str, limit: u32) -> Result<Vec<SymbolMatch>> {
+    let matches = crate::adapters::alphavantage::quote::symbol_search(query).await?;
+    Ok(matches
+        .into_iter()
+        .take(limit as usize)
+        .map(to_symbol_match)
+        .collect())
+}
+
+pub(crate) fn to_symbol_match_from_listing(dto: ListingEntryDTO) -> SymbolMatch {
+    let active = dto
+        .status
+        .as_deref()
+        .map(|s| s.eq_ignore_ascii_case("active"));
+    SymbolMatch {
+        symbol: dto.symbol,
+        name: dto.name,
+        exchange: dto.exchange,
+        asset_type: dto.asset_type,
+        currency: None,
+        active,
+    }
+}
+
+/// Derive the distinct venue list from the listing-status universe.
+///
+/// Alpha Vantage has no exchange endpoint; the listed-security CSV is the only
+/// place it names venues. Only `name` can be populated — the CSV carries no
+/// MIC, locale, or venue type.
+pub(crate) fn listings_to_exchanges(listings: Vec<ListingEntryDTO>) -> Vec<ExchangeInfo> {
+    let names: BTreeSet<String> = listings
+        .into_iter()
+        .filter_map(|l| l.exchange)
+        .filter(|e| !e.trim().is_empty())
+        .collect();
+
+    names
+        .into_iter()
+        .map(|name| ExchangeInfo {
+            name: Some(name),
+            ..Default::default()
+        })
+        .collect()
+}
+
+/// Fetch the distinct exchanges represented in the active listing universe.
+pub async fn fetch_exchanges_response() -> Result<Vec<ExchangeInfo>> {
+    let listings =
+        crate::adapters::alphavantage::fundamentals::listing_status(Some("active")).await?;
+    Ok(listings_to_exchanges(listings))
+}
+
+/// Fetch the listed-security universe as symbol matches.
+///
+/// * `active` — `true` for currently listed securities, `false` for delisted.
+pub async fn fetch_listing_status_response(active: bool) -> Result<Vec<SymbolMatch>> {
+    let state = if active { "active" } else { "delisted" };
+    let listings = crate::adapters::alphavantage::fundamentals::listing_status(Some(state)).await?;
+    Ok(listings
+        .into_iter()
+        .map(to_symbol_match_from_listing)
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn listing(symbol: &str, exchange: Option<&str>, status: &str) -> ListingEntryDTO {
+        serde_json::from_value(serde_json::json!({
+            "symbol": symbol,
+            "name": format!("{symbol} Inc"),
+            "exchange": exchange,
+            "asset_type": "Stock",
+            "ipo_date": "1999-01-01",
+            "delisting_date": null,
+            "status": status
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn maps_a_search_hit_onto_the_neutral_model() {
+        let dto: SymbolMatchDTO = serde_json::from_value(serde_json::json!({
+            "symbol": "TSCO.LON",
+            "name": "Tesco PLC",
+            "asset_type": "Equity",
+            "region": "United Kingdom",
+            "market_open": "08:00",
+            "market_close": "16:30",
+            "timezone": "UTC+01",
+            "currency": "GBX",
+            "match_score": 0.7273
+        }))
+        .unwrap();
+
+        let out = to_symbol_match(dto);
+        assert_eq!(out.symbol, "TSCO.LON");
+        assert_eq!(out.name.as_deref(), Some("Tesco PLC"));
+        assert_eq!(out.exchange.as_deref(), Some("United Kingdom"));
+        assert_eq!(out.currency.as_deref(), Some("GBX"));
+        assert_eq!(out.active, Some(true));
+    }
+
+    #[test]
+    fn listing_status_maps_active_flag_case_insensitively() {
+        assert_eq!(
+            to_symbol_match_from_listing(listing("AAPL", Some("NASDAQ"), "Active")).active,
+            Some(true)
+        );
+        assert_eq!(
+            to_symbol_match_from_listing(listing("ENRN", Some("NYSE"), "delisted")).active,
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn exchanges_are_deduplicated_and_blank_entries_dropped() {
+        let listings = vec![
+            listing("AAPL", Some("NASDAQ"), "Active"),
+            listing("MSFT", Some("NASDAQ"), "Active"),
+            listing("IBM", Some("NYSE"), "Active"),
+            listing("XXX", Some("  "), "Active"),
+            listing("YYY", None, "Active"),
+        ];
+
+        let names: Vec<String> = listings_to_exchanges(listings)
+            .into_iter()
+            .filter_map(|e| e.name)
+            .collect();
+        assert_eq!(names, vec!["NASDAQ".to_string(), "NYSE".to_string()]);
+    }
+}

--- a/src/adapters/alphavantage/fundamentals/etf.rs
+++ b/src/adapters/alphavantage/fundamentals/etf.rs
@@ -1,0 +1,102 @@
+//! Canonical conversion for Alpha Vantage's `ETF_PROFILE`.
+//!
+//! The only wired source of ETF holdings — no other integrated provider serves
+//! fund composition.
+
+use crate::adapters::alphavantage::models::{EtfHoldingDTO, EtfProfileDTO};
+use crate::error::Result;
+use crate::models::fundamentals::{EtfHolding, EtfProfile};
+
+pub(crate) fn to_etf_holding(dto: EtfHoldingDTO) -> EtfHolding {
+    EtfHolding {
+        symbol: dto.symbol,
+        description: dto.description,
+        weight: dto.weight,
+    }
+}
+
+pub(crate) fn to_etf_profile(dto: EtfProfileDTO) -> EtfProfile {
+    let mut holdings: Vec<EtfHolding> = dto.holdings.into_iter().map(to_etf_holding).collect();
+    // Alpha Vantage returns holdings in portfolio order, which is usually but
+    // not always weight-descending; sorting makes the contract explicit.
+    holdings.sort_by(|a, b| {
+        b.weight
+            .partial_cmp(&a.weight)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    EtfProfile {
+        symbol: Some(dto.symbol),
+        name: dto.name,
+        asset_type: dto.asset_type,
+        net_assets: dto.net_assets,
+        net_expense_ratio: dto.net_expense_ratio,
+        portfolio_turnover: dto.portfolio_turnover,
+        dividend_yield: dto.dividend_yield,
+        inception_date: dto.inception_date,
+        holdings,
+    }
+}
+
+/// Fetch the canonical ETF profile and holdings for a symbol.
+pub async fn fetch_etf_profile_response(symbol: &str) -> Result<EtfProfile> {
+    let dto = super::etf_profile(symbol).await?;
+    Ok(to_etf_profile(dto))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn profile_dto() -> EtfProfileDTO {
+        serde_json::from_value(serde_json::json!({
+            "symbol": "QQQ",
+            "name": "Invesco QQQ Trust",
+            "asset_type": "ETF",
+            "net_assets": 300_000_000_000.0,
+            "net_expense_ratio": 0.002,
+            "portfolio_turnover": 0.07,
+            "dividend_yield": 0.0058,
+            "inception_date": "1999-03-10",
+            "holdings": [
+                { "symbol": "MSFT", "description": "MICROSOFT CORP", "weight": 0.081 },
+                { "symbol": "AAPL", "description": "APPLE INC", "weight": 0.089 },
+                { "symbol": "NVDA", "description": "NVIDIA CORP", "weight": null }
+            ]
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn maps_profile_fields() {
+        let out = to_etf_profile(profile_dto());
+        assert_eq!(out.symbol.as_deref(), Some("QQQ"));
+        assert_eq!(out.name.as_deref(), Some("Invesco QQQ Trust"));
+        assert_eq!(out.net_assets, Some(300_000_000_000.0));
+        assert_eq!(out.net_expense_ratio, Some(0.002));
+        assert_eq!(out.inception_date.as_deref(), Some("1999-03-10"));
+        assert_eq!(out.holdings.len(), 3);
+    }
+
+    #[test]
+    fn sorts_holdings_by_weight_and_keeps_unweighted_ones_last() {
+        let out = to_etf_profile(profile_dto());
+        assert_eq!(out.holdings[0].symbol.as_deref(), Some("AAPL"));
+        assert_eq!(out.holdings[0].weight, Some(0.089));
+        assert_eq!(out.holdings[1].symbol.as_deref(), Some("MSFT"));
+        // A `None` weight can't be ordered against a number, so it settles last
+        // rather than being dropped.
+        assert_eq!(out.holdings[2].symbol.as_deref(), Some("NVDA"));
+        assert_eq!(out.holdings[2].weight, None);
+    }
+
+    #[test]
+    fn empty_holdings_are_not_an_error() {
+        let dto: EtfProfileDTO = serde_json::from_value(serde_json::json!({
+            "symbol": "XYZ",
+            "holdings": []
+        }))
+        .unwrap();
+        assert!(to_etf_profile(dto).holdings.is_empty());
+    }
+}

--- a/src/adapters/alphavantage/fundamentals/mod.rs
+++ b/src/adapters/alphavantage/fundamentals/mod.rs
@@ -6,6 +6,8 @@ use std::collections::HashMap;
 use super::build_client;
 use super::models::*;
 
+pub mod etf;
+
 /// Fetch company overview and fundamentals.
 #[allow(dead_code)] // unrouted: remaining Alpha Vantage endpoints land with #264
 pub async fn company_overview(symbol: &str) -> Result<CompanyOverviewDTO> {
@@ -80,7 +82,6 @@ pub async fn company_overview(symbol: &str) -> Result<CompanyOverviewDTO> {
 }
 
 /// Fetch ETF profile and top holdings.
-#[allow(dead_code)] // unrouted: remaining Alpha Vantage endpoints land with #264
 pub async fn etf_profile(symbol: &str) -> Result<EtfProfileDTO> {
     let client = build_client()?;
     let json = client.get("ETF_PROFILE", &[("symbol", symbol)]).await?;
@@ -285,7 +286,6 @@ fn parse_split_csv(csv: &str) -> Result<Vec<SplitEventDTO>> {
 /// Fetch listing status (active or delisted).
 ///
 /// * `status` - `"active"` (default) or `"delisted"`
-#[allow(dead_code)] // unrouted: remaining Alpha Vantage endpoints land with #264
 pub async fn listing_status(status: Option<&str>) -> Result<Vec<ListingEntryDTO>> {
     let client = build_client()?;
     let params: Vec<(&str, &str)> = match status {

--- a/src/adapters/alphavantage/mod.rs
+++ b/src/adapters/alphavantage/mod.rs
@@ -34,6 +34,7 @@ pub(crate) mod models;
 pub(crate) mod commodities;
 pub(crate) mod corporate;
 pub(crate) mod crypto;
+pub(crate) mod discovery;
 pub(crate) mod economic;
 pub(crate) mod forex;
 pub(crate) mod fundamentals;

--- a/src/adapters/alphavantage/quote/mod.rs
+++ b/src/adapters/alphavantage/quote/mod.rs
@@ -351,7 +351,6 @@ pub async fn realtime_bulk_quotes(symbols: &str) -> Result<Vec<BulkQuoteDTO>> {
 }
 
 /// Search for symbols matching the given keywords.
-#[allow(dead_code)] // unrouted: remaining Alpha Vantage endpoints land with #264
 pub async fn symbol_search(keywords: &str) -> Result<Vec<SymbolMatchDTO>> {
     let client = build_client()?;
     let json = client

--- a/src/adapters/coingecko/chart/mod.rs
+++ b/src/adapters/coingecko/chart/mod.rs
@@ -1,0 +1,158 @@
+//! CoinGecko historical OHLC candles — the keyless `CHART` route for crypto.
+//!
+//! CoinGecko's public tier serves `/coins/{id}/ohlc`, which picks its own bar
+//! granularity from the requested day span (30m for 1–2 days, 4h for 3–30,
+//! 4d beyond that) and carries no volume. The requested [`Interval`] is
+//! therefore advisory, and candles come back with `volume: 0` rather than a
+//! number invented from a differently-bucketed series.
+
+use serde::Deserialize;
+
+use crate::constants::{Interval, TimeRange};
+use crate::error::{FinanceError, Result};
+use crate::models::chart::{Candle, Chart};
+use crate::providers::Provider;
+
+/// `/coins/{id}/ohlc` rows are `[timestamp_ms, open, high, low, close]`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct OhlcRowDTO(pub f64, pub f64, pub f64, pub f64, pub f64);
+
+/// Day spans the public tier accepts on `/ohlc`.
+pub(crate) fn range_to_days(range: TimeRange) -> &'static str {
+    match range {
+        TimeRange::OneDay => "1",
+        TimeRange::FiveDays => "7",
+        TimeRange::OneMonth => "30",
+        TimeRange::ThreeMonths => "90",
+        TimeRange::SixMonths => "180",
+        // The public tier's `days` is an enum, so a partial year rounds up to
+        // the nearest accepted span rather than being rejected.
+        TimeRange::OneYear | TimeRange::YearToDate => "365",
+        TimeRange::TwoYears | TimeRange::FiveYears | TimeRange::TenYears | TimeRange::Max => "max",
+    }
+}
+
+/// Split a chart symbol such as `"BTC-USD"` or `"USD-COIN-USD"` back into the
+/// CoinGecko coin id and quote currency.
+///
+/// Splitting on the *last* hyphen matters: CoinGecko ids frequently contain
+/// hyphens (`usd-coin`, `staked-ether`), and splitting on the first would
+/// truncate them.
+pub(crate) fn split_chart_symbol(symbol: &str) -> Result<(String, String)> {
+    symbol
+        .rsplit_once('-')
+        .filter(|(id, vs)| !id.is_empty() && !vs.is_empty())
+        .map(|(id, vs)| (id.to_ascii_lowercase(), vs.to_ascii_lowercase()))
+        .ok_or_else(|| FinanceError::InvalidParameter {
+            param: "symbol".to_string(),
+            reason: format!(
+                "CoinGecko charts need a '{{id}}-{{vs_currency}}' symbol (e.g. 'bitcoin-usd'), got '{symbol}'"
+            ),
+        })
+}
+
+pub(crate) fn rows_to_candles(rows: Vec<OhlcRowDTO>) -> Vec<Candle> {
+    rows.into_iter()
+        .map(|OhlcRowDTO(ts_ms, open, high, low, close)| Candle {
+            timestamp: (ts_ms / 1000.0) as i64,
+            open,
+            high,
+            low,
+            close,
+            volume: 0,
+            adj_close: None,
+            provider_id: Some(Provider::CoinGecko),
+        })
+        .collect()
+}
+
+/// Fetch OHLC candles for a `"{id}-{vs_currency}"` chart symbol.
+pub async fn fetch_chart_response(
+    symbol: &str,
+    interval: Interval,
+    range: TimeRange,
+) -> Result<Chart> {
+    let (id, vs_currency) = split_chart_symbol(symbol)?;
+    let rows = super::client()?
+        .ohlc(&id, &vs_currency, range_to_days(range))
+        .await?;
+
+    Ok(Chart {
+        symbol: symbol.to_string(),
+        meta: Default::default(),
+        candles: rows_to_candles(rows),
+        interval: Some(interval),
+        range: Some(range),
+        provider_id: Some(Provider::CoinGecko),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn splits_on_the_last_hyphen_so_hyphenated_ids_survive() {
+        assert_eq!(
+            split_chart_symbol("BTC-USD").unwrap(),
+            ("btc".to_string(), "usd".to_string())
+        );
+        assert_eq!(
+            split_chart_symbol("USD-COIN-USD").unwrap(),
+            ("usd-coin".to_string(), "usd".to_string())
+        );
+        assert_eq!(
+            split_chart_symbol("staked-ether-eur").unwrap(),
+            ("staked-ether".to_string(), "eur".to_string())
+        );
+    }
+
+    #[test]
+    fn rejects_symbols_without_a_quote_currency() {
+        for bad in ["BTC", "", "-USD", "BTC-"] {
+            assert!(
+                split_chart_symbol(bad).is_err(),
+                "{bad} should not parse as a CoinGecko chart symbol"
+            );
+        }
+    }
+
+    #[test]
+    fn maps_ranges_onto_the_public_tiers_day_enum() {
+        assert_eq!(range_to_days(TimeRange::OneDay), "1");
+        assert_eq!(range_to_days(TimeRange::FiveDays), "7");
+        assert_eq!(range_to_days(TimeRange::OneMonth), "30");
+        assert_eq!(range_to_days(TimeRange::ThreeMonths), "90");
+        assert_eq!(range_to_days(TimeRange::SixMonths), "180");
+        assert_eq!(range_to_days(TimeRange::OneYear), "365");
+        assert_eq!(range_to_days(TimeRange::YearToDate), "365");
+        assert_eq!(range_to_days(TimeRange::Max), "max");
+        assert_eq!(range_to_days(TimeRange::TenYears), "max");
+    }
+
+    #[test]
+    fn converts_millisecond_rows_into_candles() {
+        let rows: Vec<OhlcRowDTO> = serde_json::from_value(serde_json::json!([
+            [1704067200000.0, 42000.0, 42500.0, 41800.0, 42300.0],
+            [1704081600000.0, 42300.0, 42900.0, 42200.0, 42800.0]
+        ]))
+        .unwrap();
+
+        let candles = rows_to_candles(rows);
+        assert_eq!(candles.len(), 2);
+        assert_eq!(candles[0].timestamp, 1_704_067_200);
+        assert_eq!(candles[0].open, 42000.0);
+        assert_eq!(candles[0].high, 42500.0);
+        assert_eq!(candles[0].low, 41800.0);
+        assert_eq!(candles[0].close, 42300.0);
+        // `/ohlc` carries no volume; 0 is honest, an invented figure would not be.
+        assert_eq!(candles[0].volume, 0);
+        assert_eq!(candles[0].provider_id, Some(Provider::CoinGecko));
+    }
+
+    #[test]
+    fn empty_response_yields_no_candles() {
+        let rows: Vec<OhlcRowDTO> = serde_json::from_value(serde_json::json!([])).unwrap();
+        assert!(rows_to_candles(rows).is_empty());
+    }
+}

--- a/src/adapters/coingecko/client.rs
+++ b/src/adapters/coingecko/client.rs
@@ -76,6 +76,26 @@ impl CoinGeckoClient {
         })
     }
 
+    /// Fetch OHLC candles for a coin.
+    ///
+    /// `days` must be one of the public tier's accepted spans
+    /// (`1`/`7`/`14`/`30`/`90`/`180`/`365`/`max`); granularity is chosen by
+    /// CoinGecko from that span.
+    pub async fn ohlc(
+        &self,
+        id: &str,
+        vs_currency: &str,
+        days: &str,
+    ) -> Result<Vec<super::chart::OhlcRowDTO>> {
+        self.limiter.acquire().await;
+
+        let url = format!("{COINGECKO_BASE}/coins/{id}/ohlc?vs_currency={vs_currency}&days={days}");
+        debug!("CoinGecko request: ohlc(id={id}, vs={vs_currency}, days={days})");
+        let resp = self.http.get(&url).send().await?;
+        CoinGeckoClient::check_status(&resp)?;
+        Ok(resp.json().await?)
+    }
+
     fn check_status(resp: &reqwest::Response) -> Result<()> {
         match resp.status() {
             StatusCode::OK => Ok(()),

--- a/src/adapters/coingecko/mod.rs
+++ b/src/adapters/coingecko/mod.rs
@@ -24,6 +24,7 @@
 //! # }
 //! ```
 
+pub(crate) mod chart; // CHART
 mod client;
 mod models;
 

--- a/src/adapters/edgar/client.rs
+++ b/src/adapters/edgar/client.rs
@@ -112,6 +112,14 @@ impl EdgarClient {
         Ok(response)
     }
 
+    /// Fetch an arbitrary EDGAR archive document as bytes.
+    ///
+    /// Used for the filed XML (Forms 3/4/5, 13F information tables), which the
+    /// JSON APIs only point at rather than serve.
+    pub async fn get_document(&self, url: &str) -> Result<Vec<u8>> {
+        Ok(self.get(url).await?.bytes().await?.to_vec())
+    }
+
     /// Make a rate-limited GET request with query parameters.
     async fn get_with_params<T: serde::Serialize + ?Sized>(
         &self,

--- a/src/adapters/edgar/client.rs
+++ b/src/adapters/edgar/client.rs
@@ -318,6 +318,23 @@ impl EdgarClient {
         from: Option<usize>,
         size: Option<usize>,
     ) -> Result<EdgarSearchResults> {
+        self.search_filtered(query, forms, start_date, end_date, from, size, None)
+            .await
+    }
+
+    /// [`search`](Self::search) with an optional `ciks` filter restricting the
+    /// query to one filer.
+    #[allow(clippy::too_many_arguments)] // mirrors EFTS's flat query-parameter set
+    pub async fn search_filtered(
+        &self,
+        query: &str,
+        forms: Option<&[&str]>,
+        start_date: Option<&str>,
+        end_date: Option<&str>,
+        from: Option<usize>,
+        size: Option<usize>,
+        ciks: Option<&str>,
+    ) -> Result<EdgarSearchResults> {
         let mut params: Vec<(&str, String)> = vec![("q", query.to_string())];
 
         // Add optional parameters
@@ -330,6 +347,7 @@ impl EdgarClient {
                 end_date.map(|e| ("enddt", e.to_string())),
                 from.map(|f| ("from", f.to_string())),
                 size.map(|s| ("size", s.to_string())),
+                ciks.map(|c| ("ciks", c.to_string())),
             ]
             .into_iter()
             .flatten(),

--- a/src/adapters/edgar/filings/full_text.rs
+++ b/src/adapters/edgar/filings/full_text.rs
@@ -1,0 +1,176 @@
+//! EDGAR full-text search (EFTS) mapped onto the routed FILINGS capability.
+//!
+//! EFTS indexes filing *text* across every filer, so it answers a different
+//! question from the per-CIK submissions endpoint: "which filings mention X"
+//! rather than "what has this company filed".
+
+use crate::adapters::edgar::build_client;
+use crate::error::Result;
+use crate::models::filings::{
+    EdgarSearchHit, EdgarSearchResults, FilingSearchFilters, FilingSearchHit,
+};
+
+/// EFTS refuses page sizes above 100.
+const MAX_SIZE: u32 = 100;
+
+/// EFTS hit ids are `"{accession}:{document}"`; the document half is what makes
+/// a direct archive URL possible, so a hit without it gets no URL rather than a
+/// guessed one.
+fn hit_url(id: Option<&str>, ciks: &[String]) -> Option<String> {
+    let (accession, document) = id?.split_once(':')?;
+    if document.is_empty() {
+        return None;
+    }
+    let cik = ciks.first()?.trim_start_matches('0');
+    if cik.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "https://www.sec.gov/Archives/edgar/data/{}/{}/{}",
+        cik,
+        accession.replace('-', ""),
+        document
+    ))
+}
+
+pub(crate) fn to_search_hit(hit: EdgarSearchHit) -> FilingSearchHit {
+    let source = hit._source;
+    let ciks = source.as_ref().map(|s| s.ciks.clone()).unwrap_or_default();
+    FilingSearchHit {
+        accession_number: source.as_ref().and_then(|s| s.adsh.clone()),
+        form: source.as_ref().and_then(|s| s.form.clone()),
+        filed_date: source.as_ref().and_then(|s| s.file_date.clone()),
+        period_ending: source.as_ref().and_then(|s| s.period_ending.clone()),
+        company_names: source
+            .as_ref()
+            .map(|s| s.display_names.clone())
+            .unwrap_or_default(),
+        url: hit_url(hit._id.as_deref(), &ciks),
+        ciks,
+        score: hit._score,
+    }
+}
+
+pub(crate) fn to_search_hits(results: EdgarSearchResults) -> Vec<FilingSearchHit> {
+    results
+        .hits
+        .map(|h| h.hits)
+        .unwrap_or_default()
+        .into_iter()
+        .map(to_search_hit)
+        .collect()
+}
+
+/// Run a full-text search over EDGAR filings and return canonical hits.
+pub async fn fetch_filing_search_response(
+    query: &str,
+    filters: &FilingSearchFilters,
+) -> Result<Vec<FilingSearchHit>> {
+    let forms: Option<Vec<&str>> = filters
+        .forms
+        .as_ref()
+        .map(|f| f.iter().map(String::as_str).collect());
+    let size = filters.limit.map(|l| l.min(MAX_SIZE) as usize);
+
+    let results = build_client()?
+        .search_filtered(
+            query,
+            forms.as_deref(),
+            filters.start_date.as_deref(),
+            filters.end_date.as_deref(),
+            None,
+            size,
+            filters.cik.as_deref(),
+        )
+        .await?;
+
+    Ok(to_search_hits(results))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn results_json() -> serde_json::Value {
+        serde_json::json!({
+            "hits": {
+                "total": { "value": 2, "relation": "eq" },
+                "max_score": 1.5,
+                "hits": [
+                    {
+                        "_index": "edgar-filings",
+                        "_id": "0000320193-24-000123:aapl-20240928.htm",
+                        "_score": 1.5,
+                        "_source": {
+                            "ciks": ["0000320193"],
+                            "file_date": "2024-11-01",
+                            "form": "10-K",
+                            "adsh": "0000320193-24-000123",
+                            "display_names": ["Apple Inc. (AAPL)"],
+                            "period_ending": "2024-09-28",
+                            "root_forms": ["10-K"],
+                            "sics": ["3571"]
+                        }
+                    },
+                    {
+                        "_id": "0000789019-24-000090",
+                        "_score": 1.1,
+                        "_source": {
+                            "ciks": ["0000789019"],
+                            "form": "8-K",
+                            "adsh": "0000789019-24-000090",
+                            "display_names": ["MICROSOFT CORP (MSFT)"]
+                        }
+                    }
+                ]
+            }
+        })
+    }
+
+    #[test]
+    fn flattens_efts_hits_into_canonical_shape() {
+        let results: EdgarSearchResults = serde_json::from_value(results_json()).unwrap();
+        let hits = to_search_hits(results);
+
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].form.as_deref(), Some("10-K"));
+        assert_eq!(
+            hits[0].accession_number.as_deref(),
+            Some("0000320193-24-000123")
+        );
+        assert_eq!(hits[0].filed_date.as_deref(), Some("2024-11-01"));
+        assert_eq!(hits[0].period_ending.as_deref(), Some("2024-09-28"));
+        assert_eq!(hits[0].company_names, vec!["Apple Inc. (AAPL)"]);
+        assert_eq!(hits[0].score, Some(1.5));
+    }
+
+    #[test]
+    fn derives_the_archive_url_from_the_hit_id() {
+        let results: EdgarSearchResults = serde_json::from_value(results_json()).unwrap();
+        let hits = to_search_hits(results);
+
+        assert_eq!(
+            hits[0].url.as_deref(),
+            Some(
+                "https://www.sec.gov/Archives/edgar/data/320193/000032019324000123/aapl-20240928.htm"
+            )
+        );
+        // Second hit's id carries no document half, so no URL is invented.
+        assert_eq!(hits[1].url, None);
+    }
+
+    #[test]
+    fn hit_url_declines_incomplete_inputs() {
+        let ciks = vec!["0000320193".to_string()];
+        assert_eq!(hit_url(None, &ciks), None);
+        assert_eq!(hit_url(Some("0000320193-24-000123:"), &ciks), None);
+        assert_eq!(hit_url(Some("a:b.htm"), &[]), None);
+        assert_eq!(hit_url(Some("a:b.htm"), &["0000".to_string()]), None);
+    }
+
+    #[test]
+    fn empty_results_yield_no_hits() {
+        let results: EdgarSearchResults = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert!(to_search_hits(results).is_empty());
+    }
+}

--- a/src/adapters/edgar/filings/full_text.rs
+++ b/src/adapters/edgar/filings/full_text.rs
@@ -34,17 +34,26 @@ fn hit_url(id: Option<&str>, ciks: &[String]) -> Option<String> {
 }
 
 pub(crate) fn to_search_hit(hit: EdgarSearchHit) -> FilingSearchHit {
-    let source = hit._source;
-    let ciks = source.as_ref().map(|s| s.ciks.clone()).unwrap_or_default();
+    // Destructure once so each field moves out; EFTS returns up to 100 hits per
+    // search and cloning every field off a borrowed source adds up.
+    let (accession_number, form, filed_date, period_ending, company_names, ciks) = match hit._source
+    {
+        Some(s) => (
+            s.adsh,
+            s.form,
+            s.file_date,
+            s.period_ending,
+            s.display_names,
+            s.ciks,
+        ),
+        None => (None, None, None, None, Vec::new(), Vec::new()),
+    };
     FilingSearchHit {
-        accession_number: source.as_ref().and_then(|s| s.adsh.clone()),
-        form: source.as_ref().and_then(|s| s.form.clone()),
-        filed_date: source.as_ref().and_then(|s| s.file_date.clone()),
-        period_ending: source.as_ref().and_then(|s| s.period_ending.clone()),
-        company_names: source
-            .as_ref()
-            .map(|s| s.display_names.clone())
-            .unwrap_or_default(),
+        accession_number,
+        form,
+        filed_date,
+        period_ending,
+        company_names,
         url: hit_url(hit._id.as_deref(), &ciks),
         ciks,
         score: hit._score,
@@ -62,7 +71,11 @@ pub(crate) fn to_search_hits(results: EdgarSearchResults) -> Vec<FilingSearchHit
 }
 
 /// Run a full-text search over EDGAR filings and return canonical hits.
+///
+/// `symbol` scopes the search to one filer. EFTS is keyed by CIK, so resolving
+/// it is EDGAR's own business — the routed handle never sees the identifier.
 pub async fn fetch_filing_search_response(
+    symbol: Option<&str>,
     query: &str,
     filters: &FilingSearchFilters,
 ) -> Result<Vec<FilingSearchHit>> {
@@ -72,7 +85,13 @@ pub async fn fetch_filing_search_response(
         .map(|f| f.iter().map(String::as_str).collect());
     let size = filters.limit.map(|l| l.min(MAX_SIZE) as usize);
 
-    let results = build_client()?
+    let client = build_client()?;
+    let resolved_cik = match (&filters.cik, symbol) {
+        (None, Some(sym)) => Some(format!("{:010}", client.resolve_cik(sym).await?)),
+        _ => None,
+    };
+
+    let results = client
         .search_filtered(
             query,
             forms.as_deref(),
@@ -80,7 +99,7 @@ pub async fn fetch_filing_search_response(
             filters.end_date.as_deref(),
             None,
             size,
-            filters.cik.as_deref(),
+            resolved_cik.as_deref().or(filters.cik.as_deref()),
         )
         .await?;
 

--- a/src/adapters/edgar/filings/insider.rs
+++ b/src/adapters/edgar/filings/insider.rs
@@ -1,0 +1,314 @@
+//! Form 3/4/5 insider transactions parsed from the filed ownership XML.
+//!
+//! EDGAR's JSON APIs only list these filings; the transaction detail lives in
+//! the filing's XML document, so each filing costs one index lookup plus one
+//! document fetch on top of the shared submissions call.
+
+use futures::stream::{self, StreamExt};
+
+use super::xml::{self, XmlNode};
+use crate::adapters::edgar::{build_client, submissions_for_symbol};
+use crate::error::Result;
+use crate::models::filings::InsiderTrade;
+
+/// Forms that report insider ownership changes, amendments included.
+const OWNERSHIP_FORMS: [&str; 6] = ["3", "4", "5", "3/A", "4/A", "5/A"];
+
+/// EDGAR allows 10 req/sec; each filing costs two, so stay well under.
+const CONCURRENCY: usize = 4;
+
+/// A flag element is `1`/`true` when set; anything else (including absent) is false.
+fn flag(node: &XmlNode, path: &[&str]) -> bool {
+    matches!(
+        node.text_at(path).as_deref(),
+        Some("1") | Some("true") | Some("TRUE")
+    )
+}
+
+/// Map one `<nonDerivativeTransaction>` / `<derivativeTransaction>` element.
+fn transaction_to_trade(tx: &XmlNode, header: &InsiderTrade, is_derivative: bool) -> InsiderTrade {
+    InsiderTrade {
+        security_title: tx.text_at(&["securityTitle", "value"]),
+        transaction_date: tx.text_at(&["transactionDate", "value"]),
+        transaction_code: tx.text_at(&["transactionCoding", "transactionCode"]),
+        acquired_disposed: tx.text_at(&[
+            "transactionAmounts",
+            "transactionAcquiredDisposedCode",
+            "value",
+        ]),
+        shares: tx
+            .number_at(&["transactionAmounts", "transactionShares", "value"])
+            .or_else(|| tx.number_at(&["transactionAmounts", "transactionTotalValue", "value"])),
+        price_per_share: tx.number_at(&["transactionAmounts", "transactionPricePerShare", "value"]),
+        shares_owned_after: tx.number_at(&[
+            "postTransactionAmounts",
+            "sharesOwnedFollowingTransaction",
+            "value",
+        ]),
+        is_derivative,
+        ..header.clone()
+    }
+}
+
+/// Parse one ownership document into its transaction lines.
+///
+/// A Form 3 (initial statement of holdings) reports positions rather than
+/// transactions, so it legitimately yields no rows.
+pub(crate) fn parse_ownership_document(
+    bytes: &[u8],
+    accession_number: Option<String>,
+    url: Option<String>,
+) -> Result<Vec<InsiderTrade>> {
+    let doc = xml::parse(bytes)?;
+
+    let owner = doc.child("reportingOwner");
+    let header = InsiderTrade {
+        symbol: doc.text_at(&["issuer", "issuerTradingSymbol"]),
+        issuer_name: doc.text_at(&["issuer", "issuerName"]),
+        insider_name: owner.and_then(|o| o.text_at(&["reportingOwnerId", "rptOwnerName"])),
+        insider_cik: owner.and_then(|o| o.text_at(&["reportingOwnerId", "rptOwnerCik"])),
+        is_director: owner.is_some_and(|o| flag(o, &["reportingOwnerRelationship", "isDirector"])),
+        is_officer: owner.is_some_and(|o| flag(o, &["reportingOwnerRelationship", "isOfficer"])),
+        is_ten_percent_owner: owner
+            .is_some_and(|o| flag(o, &["reportingOwnerRelationship", "isTenPercentOwner"])),
+        officer_title: owner
+            .and_then(|o| o.text_at(&["reportingOwnerRelationship", "officerTitle"])),
+        form_type: doc.text_at(&["documentType"]),
+        accession_number,
+        url,
+        ..Default::default()
+    };
+
+    let mut trades = Vec::new();
+    for (table, derivative) in [("nonDerivativeTable", false), ("derivativeTable", true)] {
+        let Some(table) = doc.child(table) else {
+            continue;
+        };
+        let element = if derivative {
+            "derivativeTransaction"
+        } else {
+            "nonDerivativeTransaction"
+        };
+        trades.extend(
+            table
+                .children_named(element)
+                .map(|tx| transaction_to_trade(tx, &header, derivative)),
+        );
+    }
+    Ok(trades)
+}
+
+/// Pick the filed ownership XML from a filing's index listing.
+///
+/// The `xsl*/` entries are SEC's human-readable renderings of the same
+/// document, and `*-index.xml` is the directory itself — neither parses as an
+/// ownership document.
+pub(crate) fn pick_ownership_xml(names: &[String]) -> Option<&String> {
+    names.iter().find(|n| {
+        let lower = n.to_ascii_lowercase();
+        lower.ends_with(".xml") && !lower.starts_with("xsl") && !lower.ends_with("-index.xml")
+    })
+}
+
+/// Fetch and parse recent Form 3/4/5 filings for a symbol, newest first.
+pub async fn fetch_insider_trades_response(symbol: &str, limit: u32) -> Result<Vec<InsiderTrade>> {
+    let subs = submissions_for_symbol(symbol).await?;
+    let cik = subs.cik.clone().unwrap_or_default();
+    let filings = subs
+        .filings
+        .and_then(|f| f.recent)
+        .map(|r| r.to_filings())
+        .unwrap_or_default();
+
+    let wanted: Vec<_> = filings
+        .into_iter()
+        .filter(|f| OWNERSHIP_FORMS.contains(&f.form.as_str()))
+        .take(limit as usize)
+        .collect();
+
+    let trades: Vec<Vec<InsiderTrade>> = stream::iter(wanted)
+        .map(|filing| {
+            let cik = cik.clone();
+            async move {
+                let accession = filing.accession_number.clone();
+                match fetch_one(&cik, &accession).await {
+                    Ok(t) => t,
+                    // One unparseable filing must not sink the whole history —
+                    // ownership XML schemas vary across two decades of filings.
+                    Err(e) => {
+                        tracing::debug!("EDGAR insider filing {accession} skipped: {e}");
+                        Vec::new()
+                    }
+                }
+            }
+        })
+        .buffered(CONCURRENCY)
+        .collect()
+        .await;
+
+    Ok(trades.into_iter().flatten().collect())
+}
+
+async fn fetch_one(cik: &str, accession: &str) -> Result<Vec<InsiderTrade>> {
+    let index = crate::adapters::edgar::filing_index(accession).await?;
+    let names: Vec<String> = index
+        .directory
+        .item
+        .into_iter()
+        .map(|item| item.name)
+        .collect();
+    let Some(doc_name) = pick_ownership_xml(&names) else {
+        return Ok(Vec::new());
+    };
+
+    let url = format!(
+        "https://www.sec.gov/Archives/edgar/data/{}/{}/{}",
+        cik.trim_start_matches('0'),
+        accession.replace('-', ""),
+        doc_name
+    );
+    let bytes = build_client()?.get_document(&url).await?;
+    parse_ownership_document(&bytes, Some(accession.to_string()), Some(url))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FORM4: &[u8] = br#"<?xml version="1.0"?>
+    <ownershipDocument>
+      <documentType>4</documentType>
+      <issuer>
+        <issuerCik>0000320193</issuerCik>
+        <issuerName>Apple Inc.</issuerName>
+        <issuerTradingSymbol>AAPL</issuerTradingSymbol>
+      </issuer>
+      <reportingOwner>
+        <reportingOwnerId>
+          <rptOwnerCik>0001214128</rptOwnerCik>
+          <rptOwnerName>COOK TIMOTHY D</rptOwnerName>
+        </reportingOwnerId>
+        <reportingOwnerRelationship>
+          <isDirector>1</isDirector>
+          <isOfficer>1</isOfficer>
+          <isTenPercentOwner>0</isTenPercentOwner>
+          <officerTitle>Chief Executive Officer</officerTitle>
+        </reportingOwnerRelationship>
+      </reportingOwner>
+      <nonDerivativeTable>
+        <nonDerivativeTransaction>
+          <securityTitle><value>Common Stock</value></securityTitle>
+          <transactionDate><value>2024-04-01</value></transactionDate>
+          <transactionCoding><transactionFormType>4</transactionFormType><transactionCode>S</transactionCode></transactionCoding>
+          <transactionAmounts>
+            <transactionShares><value>511000</value></transactionShares>
+            <transactionPricePerShare><value>170.1234</value></transactionPricePerShare>
+            <transactionAcquiredDisposedCode><value>D</value></transactionAcquiredDisposedCode>
+          </transactionAmounts>
+          <postTransactionAmounts>
+            <sharesOwnedFollowingTransaction><value>3280000</value></sharesOwnedFollowingTransaction>
+          </postTransactionAmounts>
+        </nonDerivativeTransaction>
+      </nonDerivativeTable>
+      <derivativeTable>
+        <derivativeTransaction>
+          <securityTitle><value>Restricted Stock Unit</value></securityTitle>
+          <transactionDate><value>2024-04-01</value></transactionDate>
+          <transactionCoding><transactionCode>M</transactionCode></transactionCoding>
+          <transactionAmounts>
+            <transactionShares><value>1000</value></transactionShares>
+            <transactionAcquiredDisposedCode><value>A</value></transactionAcquiredDisposedCode>
+          </transactionAmounts>
+        </derivativeTransaction>
+      </derivativeTable>
+    </ownershipDocument>"#;
+
+    #[test]
+    fn parses_both_transaction_tables_with_shared_header() {
+        let trades =
+            parse_ownership_document(FORM4, Some("0000320193-24-000123".into()), None).unwrap();
+
+        assert_eq!(trades.len(), 2);
+        for t in &trades {
+            assert_eq!(t.symbol.as_deref(), Some("AAPL"));
+            assert_eq!(t.insider_name.as_deref(), Some("COOK TIMOTHY D"));
+            assert_eq!(t.form_type.as_deref(), Some("4"));
+            assert_eq!(t.accession_number.as_deref(), Some("0000320193-24-000123"));
+            assert!(t.is_director && t.is_officer && !t.is_ten_percent_owner);
+            assert_eq!(t.officer_title.as_deref(), Some("Chief Executive Officer"));
+        }
+    }
+
+    #[test]
+    fn maps_transaction_detail_and_flags_derivatives() {
+        let trades = parse_ownership_document(FORM4, None, None).unwrap();
+
+        let sale = &trades[0];
+        assert!(!sale.is_derivative);
+        assert_eq!(sale.security_title.as_deref(), Some("Common Stock"));
+        assert_eq!(sale.transaction_date.as_deref(), Some("2024-04-01"));
+        assert_eq!(sale.transaction_code.as_deref(), Some("S"));
+        assert_eq!(sale.acquired_disposed.as_deref(), Some("D"));
+        assert_eq!(sale.shares, Some(511_000.0));
+        assert_eq!(sale.price_per_share, Some(170.1234));
+        assert_eq!(sale.shares_owned_after, Some(3_280_000.0));
+
+        let exercise = &trades[1];
+        assert!(exercise.is_derivative);
+        assert_eq!(exercise.transaction_code.as_deref(), Some("M"));
+        assert_eq!(exercise.acquired_disposed.as_deref(), Some("A"));
+        assert_eq!(exercise.price_per_share, None);
+    }
+
+    /// A Form 3 lists holdings, not transactions — an empty result is correct,
+    /// not a parse failure.
+    #[test]
+    fn form_3_without_transactions_yields_no_rows() {
+        let form3 = br#"<ownershipDocument>
+            <documentType>3</documentType>
+            <issuer><issuerTradingSymbol>AAPL</issuerTradingSymbol></issuer>
+            <nonDerivativeTable>
+              <nonDerivativeHolding>
+                <securityTitle><value>Common Stock</value></securityTitle>
+              </nonDerivativeHolding>
+            </nonDerivativeTable>
+        </ownershipDocument>"#;
+        assert!(
+            parse_ownership_document(form3, None, None)
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn picks_the_filed_xml_over_the_rendered_and_index_ones() {
+        let names: Vec<String> = [
+            "xslF345X03/wf-form4_171.xml",
+            "0000320193-24-000123-index.xml",
+            "wf-form4_171.xml",
+            "primary_doc.html",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        assert_eq!(
+            pick_ownership_xml(&names).map(String::as_str),
+            Some("wf-form4_171.xml")
+        );
+        assert_eq!(pick_ownership_xml(&[]), None);
+    }
+
+    #[test]
+    fn missing_owner_block_degrades_to_empty_fields() {
+        let doc = br#"<ownershipDocument><documentType>4</documentType>
+            <nonDerivativeTable><nonDerivativeTransaction>
+              <transactionAmounts><transactionShares><value>5</value></transactionShares></transactionAmounts>
+            </nonDerivativeTransaction></nonDerivativeTable>
+        </ownershipDocument>"#;
+        let trades = parse_ownership_document(doc, None, None).unwrap();
+        assert_eq!(trades.len(), 1);
+        assert_eq!(trades[0].insider_name, None);
+        assert!(!trades[0].is_officer);
+        assert_eq!(trades[0].shares, Some(5.0));
+    }
+}

--- a/src/adapters/edgar/filings/insider.rs
+++ b/src/adapters/edgar/filings/insider.rs
@@ -7,7 +7,8 @@
 use futures::stream::{self, StreamExt};
 
 use super::xml::{self, XmlNode};
-use crate::adapters::edgar::{build_client, submissions_for_symbol};
+use crate::adapters::edgar::client::EdgarClient;
+use crate::adapters::edgar::{build_client, submissions_for_symbol_with};
 use crate::error::Result;
 use crate::models::filings::InsiderTrade;
 
@@ -112,7 +113,11 @@ pub(crate) fn pick_ownership_xml(names: &[String]) -> Option<&String> {
 
 /// Fetch and parse recent Form 3/4/5 filings for a symbol, newest first.
 pub async fn fetch_insider_trades_response(symbol: &str, limit: u32) -> Result<Vec<InsiderTrade>> {
-    let subs = submissions_for_symbol(symbol).await?;
+    // One client for the whole call: `limit` filings cost two requests each, and
+    // a fresh client per request discards the pool before it is ever reused.
+    let client = build_client()?;
+    let client = &client;
+    let subs = submissions_for_symbol_with(client, symbol).await?;
     let cik = subs.cik.clone().unwrap_or_default();
     let filings = subs
         .filings
@@ -131,7 +136,7 @@ pub async fn fetch_insider_trades_response(symbol: &str, limit: u32) -> Result<V
             let cik = cik.clone();
             async move {
                 let accession = filing.accession_number.clone();
-                match fetch_one(&cik, &accession).await {
+                match fetch_one(client, &cik, &accession).await {
                     Ok(t) => t,
                     // One unparseable filing must not sink the whole history —
                     // ownership XML schemas vary across two decades of filings.
@@ -149,8 +154,8 @@ pub async fn fetch_insider_trades_response(symbol: &str, limit: u32) -> Result<V
     Ok(trades.into_iter().flatten().collect())
 }
 
-async fn fetch_one(cik: &str, accession: &str) -> Result<Vec<InsiderTrade>> {
-    let index = crate::adapters::edgar::filing_index(accession).await?;
+async fn fetch_one(client: &EdgarClient, cik: &str, accession: &str) -> Result<Vec<InsiderTrade>> {
+    let index = client.filing_index(accession).await?;
     let names: Vec<String> = index
         .directory
         .item
@@ -167,7 +172,7 @@ async fn fetch_one(cik: &str, accession: &str) -> Result<Vec<InsiderTrade>> {
         accession.replace('-', ""),
         doc_name
     );
-    let bytes = build_client()?.get_document(&url).await?;
+    let bytes = client.get_document(&url).await?;
     parse_ownership_document(&bytes, Some(accession.to_string()), Some(url))
 }
 

--- a/src/adapters/edgar/filings/mod.rs
+++ b/src/adapters/edgar/filings/mod.rs
@@ -4,3 +4,6 @@
 //! and still live in the parent module; new routed operations land here.
 
 pub mod full_text;
+pub mod insider;
+pub mod thirteen_f;
+pub(crate) mod xml;

--- a/src/adapters/edgar/filings/mod.rs
+++ b/src/adapters/edgar/filings/mod.rs
@@ -1,0 +1,6 @@
+//! FILINGS capability endpoints layered on the EDGAR client.
+//!
+//! The submissions / company-facts / filing-index calls predate this directory
+//! and still live in the parent module; new routed operations land here.
+
+pub mod full_text;

--- a/src/adapters/edgar/filings/thirteen_f.rs
+++ b/src/adapters/edgar/filings/thirteen_f.rs
@@ -1,0 +1,230 @@
+//! 13F-HR institutional holdings parsed from the filed information table XML.
+//!
+//! The information table is a sibling document of the 13F cover page, so a
+//! fetch costs one submissions call, one index lookup, and one document fetch.
+
+use super::xml::{self, XmlNode};
+use crate::adapters::edgar::{build_client, submissions_for_symbol};
+use crate::error::{FinanceError, Result};
+use crate::models::filings::InstitutionalHolding;
+
+/// Forms carrying an information table. `13F-NT` (notice) never does.
+const HOLDINGS_FORMS: [&str; 2] = ["13F-HR", "13F-HR/A"];
+
+fn info_table_to_holding(
+    row: &XmlNode,
+    accession_number: &Option<String>,
+    report_date: &Option<String>,
+) -> InstitutionalHolding {
+    InstitutionalHolding {
+        issuer_name: row.text_at(&["nameOfIssuer"]),
+        title_of_class: row.text_at(&["titleOfClass"]),
+        cusip: row.text_at(&["cusip"]),
+        value: row.number_at(&["value"]),
+        shares: row.number_at(&["shrsOrPrnAmt", "sshPrnamt"]),
+        share_type: row.text_at(&["shrsOrPrnAmt", "sshPrnamtType"]),
+        put_call: row.text_at(&["putCall"]),
+        investment_discretion: row.text_at(&["investmentDiscretion"]),
+        voting_sole: row.number_at(&["votingAuthority", "Sole"]),
+        voting_shared: row.number_at(&["votingAuthority", "Shared"]),
+        voting_none: row.number_at(&["votingAuthority", "None"]),
+        accession_number: accession_number.clone(),
+        report_date: report_date.clone(),
+    }
+}
+
+/// Parse a 13F information table into its position rows.
+pub(crate) fn parse_information_table(
+    bytes: &[u8],
+    accession_number: Option<String>,
+    report_date: Option<String>,
+) -> Result<Vec<InstitutionalHolding>> {
+    let doc = xml::parse(bytes)?;
+    // `infoTable` sits directly under the root in practice, but scanning
+    // descendants keeps the parse working if a wrapper element is added.
+    let mut rows = Vec::new();
+    doc.descendants("infoTable", &mut rows);
+    Ok(rows
+        .into_iter()
+        .map(|row| info_table_to_holding(row, &accession_number, &report_date))
+        .collect())
+}
+
+/// Pick the information table from a 13F filing's index listing.
+///
+/// The cover page (`primary_doc.xml`) is the other XML in the directory and
+/// carries no positions, so it is excluded by name rather than by guessing.
+pub(crate) fn pick_information_table(names: &[String]) -> Option<&String> {
+    let is_candidate = |n: &&String| {
+        let lower = n.to_ascii_lowercase();
+        lower.ends_with(".xml") && !lower.starts_with("xsl") && !lower.ends_with("-index.xml")
+    };
+    names
+        .iter()
+        .filter(is_candidate)
+        .find(|n| n.to_ascii_lowercase().contains("infotable"))
+        .or_else(|| {
+            names
+                .iter()
+                .filter(is_candidate)
+                .find(|n| !n.to_ascii_lowercase().contains("primary_doc"))
+        })
+}
+
+/// Fetch and parse the latest 13F-HR information table filed by `symbol`'s CIK.
+pub async fn fetch_institutional_holdings_response(
+    symbol: &str,
+) -> Result<Vec<InstitutionalHolding>> {
+    let subs = submissions_for_symbol(symbol).await?;
+    let cik = subs.cik.clone().unwrap_or_default();
+    let filing = subs
+        .filings
+        .and_then(|f| f.recent)
+        .map(|r| r.to_filings())
+        .unwrap_or_default()
+        .into_iter()
+        .find(|f| HOLDINGS_FORMS.contains(&f.form.as_str()))
+        .ok_or_else(|| FinanceError::SymbolNotFound {
+            symbol: Some(symbol.to_string()),
+            context: format!("{symbol} has no 13F-HR filing on EDGAR"),
+        })?;
+
+    let accession = filing.accession_number.clone();
+    let index = crate::adapters::edgar::filing_index(&accession).await?;
+    let names: Vec<String> = index
+        .directory
+        .item
+        .into_iter()
+        .map(|item| item.name)
+        .collect();
+    let doc_name =
+        pick_information_table(&names).ok_or_else(|| FinanceError::ResponseStructureError {
+            field: "informationTable".to_string(),
+            context: format!("13F filing {accession} has no information table document"),
+        })?;
+
+    let url = format!(
+        "https://www.sec.gov/Archives/edgar/data/{}/{}/{}",
+        cik.trim_start_matches('0'),
+        accession.replace('-', ""),
+        doc_name
+    );
+    let bytes = build_client()?.get_document(&url).await?;
+    let report_date = (!filing.report_date.is_empty()).then(|| filing.report_date.clone());
+    parse_information_table(&bytes, Some(accession), report_date)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TABLE: &[u8] = br#"<?xml version="1.0"?>
+    <informationTable xmlns="http://www.sec.gov/edgar/document/thirteenf/informationtable">
+      <infoTable>
+        <nameOfIssuer>APPLE INC</nameOfIssuer>
+        <titleOfClass>COM</titleOfClass>
+        <cusip>037833100</cusip>
+        <value>174346000</value>
+        <shrsOrPrnAmt><sshPrnamt>915560382</sshPrnamt><sshPrnamtType>SH</sshPrnamtType></shrsOrPrnAmt>
+        <investmentDiscretion>DFND</investmentDiscretion>
+        <votingAuthority><Sole>915560382</Sole><Shared>0</Shared><None>0</None></votingAuthority>
+      </infoTable>
+      <infoTable>
+        <nameOfIssuer>COCA COLA CO</nameOfIssuer>
+        <titleOfClass>COM</titleOfClass>
+        <cusip>191216100</cusip>
+        <value>25464000</value>
+        <shrsOrPrnAmt><sshPrnamt>400000000</sshPrnamt><sshPrnamtType>SH</sshPrnamtType></shrsOrPrnAmt>
+        <putCall>CALL</putCall>
+        <votingAuthority><Sole>0</Sole><Shared>400000000</Shared><None>0</None></votingAuthority>
+      </infoTable>
+    </informationTable>"#;
+
+    #[test]
+    fn parses_every_position_row() {
+        let rows = parse_information_table(
+            TABLE,
+            Some("0000950123-24-001".into()),
+            Some("2024-03-31".into()),
+        )
+        .unwrap();
+
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].issuer_name.as_deref(), Some("APPLE INC"));
+        assert_eq!(rows[0].cusip.as_deref(), Some("037833100"));
+        assert_eq!(rows[0].value, Some(174_346_000.0));
+        assert_eq!(rows[0].shares, Some(915_560_382.0));
+        assert_eq!(rows[0].share_type.as_deref(), Some("SH"));
+        assert_eq!(rows[0].investment_discretion.as_deref(), Some("DFND"));
+        assert_eq!(rows[0].voting_sole, Some(915_560_382.0));
+        assert_eq!(rows[0].report_date.as_deref(), Some("2024-03-31"));
+        assert_eq!(
+            rows[0].accession_number.as_deref(),
+            Some("0000950123-24-001")
+        );
+    }
+
+    #[test]
+    fn carries_option_and_shared_voting_details() {
+        let rows = parse_information_table(TABLE, None, None).unwrap();
+        assert_eq!(rows[1].put_call.as_deref(), Some("CALL"));
+        assert_eq!(rows[1].voting_shared, Some(400_000_000.0));
+        assert_eq!(rows[1].voting_sole, Some(0.0));
+        assert_eq!(rows[1].investment_discretion, None);
+    }
+
+    #[test]
+    fn parses_namespace_prefixed_tables() {
+        let prefixed = br#"<ns1:informationTable xmlns:ns1="x">
+          <ns1:infoTable><ns1:cusip>037833100</ns1:cusip><ns1:value>5</ns1:value></ns1:infoTable>
+        </ns1:informationTable>"#;
+        let rows = parse_information_table(prefixed, None, None).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].cusip.as_deref(), Some("037833100"));
+    }
+
+    #[test]
+    fn prefers_the_information_table_over_the_cover_page() {
+        let names: Vec<String> = [
+            "xslForm13F_X02/infotable.xml",
+            "0000950123-24-001-index.xml",
+            "primary_doc.xml",
+            "form13fInfoTable.xml",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        assert_eq!(
+            pick_information_table(&names).map(String::as_str),
+            Some("form13fInfoTable.xml")
+        );
+    }
+
+    /// Older filings name the table arbitrarily; anything that is not the cover
+    /// page is still a better guess than giving up.
+    #[test]
+    fn falls_back_to_the_non_cover_xml() {
+        let names: Vec<String> = ["primary_doc.xml", "holdings2019.xml"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert_eq!(
+            pick_information_table(&names).map(String::as_str),
+            Some("holdings2019.xml")
+        );
+        assert_eq!(
+            pick_information_table(&["primary_doc.xml".to_string()]),
+            None
+        );
+    }
+
+    #[test]
+    fn empty_table_yields_no_rows() {
+        let empty = br#"<informationTable></informationTable>"#;
+        assert!(
+            parse_information_table(empty, None, None)
+                .unwrap()
+                .is_empty()
+        );
+    }
+}

--- a/src/adapters/edgar/filings/thirteen_f.rs
+++ b/src/adapters/edgar/filings/thirteen_f.rs
@@ -4,7 +4,7 @@
 //! fetch costs one submissions call, one index lookup, and one document fetch.
 
 use super::xml::{self, XmlNode};
-use crate::adapters::edgar::{build_client, submissions_for_symbol};
+use crate::adapters::edgar::{build_client, submissions_for_symbol_with};
 use crate::error::{FinanceError, Result};
 use crate::models::filings::InstitutionalHolding;
 
@@ -75,7 +75,10 @@ pub(crate) fn pick_information_table(names: &[String]) -> Option<&String> {
 pub async fn fetch_institutional_holdings_response(
     symbol: &str,
 ) -> Result<Vec<InstitutionalHolding>> {
-    let subs = submissions_for_symbol(symbol).await?;
+    // One client for all three requests (CIK lookup, index, document) so the
+    // connection pool survives the whole call.
+    let client = build_client()?;
+    let subs = submissions_for_symbol_with(&client, symbol).await?;
     let cik = subs.cik.clone().unwrap_or_default();
     let filing = subs
         .filings
@@ -90,7 +93,7 @@ pub async fn fetch_institutional_holdings_response(
         })?;
 
     let accession = filing.accession_number.clone();
-    let index = crate::adapters::edgar::filing_index(&accession).await?;
+    let index = client.filing_index(&accession).await?;
     let names: Vec<String> = index
         .directory
         .item
@@ -109,7 +112,7 @@ pub async fn fetch_institutional_holdings_response(
         accession.replace('-', ""),
         doc_name
     );
-    let bytes = build_client()?.get_document(&url).await?;
+    let bytes = client.get_document(&url).await?;
     let report_date = (!filing.report_date.is_empty()).then(|| filing.report_date.clone());
     parse_information_table(&bytes, Some(accession), report_date)
 }

--- a/src/adapters/edgar/filings/xml.rs
+++ b/src/adapters/edgar/filings/xml.rs
@@ -8,7 +8,7 @@
 //! because EDGAR ownership/13F schemas have no colliding local names.
 
 use crate::error::{FinanceError, Result};
-use crate::feeds::parser::{find_byte, trim_ascii, unescape};
+use crate::feeds::parser::{find, find_byte, trim_ascii, unescape};
 
 /// One element: its local name, its own text, and its child elements.
 #[derive(Debug, Default, Clone)]
@@ -109,11 +109,11 @@ pub(crate) fn parse(bytes: &[u8]) -> Result<XmlNode> {
         // Comments, CDATA, doctypes, and processing instructions carry no
         // structure we need; skip to their own terminator.
         if bytes[open..].starts_with(b"<!--") {
-            i = find_seq(bytes, open + 4, b"-->").ok_or_else(|| err("unterminated comment"))? + 3;
+            i = find(bytes, open + 4, b"-->").ok_or_else(|| err("unterminated comment"))? + 3;
             continue;
         }
         if bytes[open..].starts_with(b"<![CDATA[") {
-            let end = find_seq(bytes, open + 9, b"]]>").ok_or_else(|| err("unterminated CDATA"))?;
+            let end = find(bytes, open + 9, b"]]>").ok_or_else(|| err("unterminated CDATA"))?;
             if let Some(node) = stack.last_mut() {
                 node.text
                     .push_str(&String::from_utf8_lossy(&bytes[open + 9..end]));
@@ -177,16 +177,6 @@ pub(crate) fn parse(bytes: &[u8]) -> Result<XmlNode> {
         return Err(err("unclosed elements at end of document"));
     }
     root.ok_or_else(|| err("no root element"))
-}
-
-fn find_seq(haystack: &[u8], from: usize, needle: &[u8]) -> Option<usize> {
-    if from > haystack.len() {
-        return None;
-    }
-    haystack[from..]
-        .windows(needle.len())
-        .position(|w| w == needle)
-        .map(|p| p + from)
 }
 
 #[cfg(test)]

--- a/src/adapters/edgar/filings/xml.rs
+++ b/src/adapters/edgar/filings/xml.rs
@@ -1,0 +1,269 @@
+//! Minimal element-tree reader for EDGAR's ownership and 13F XML documents.
+//!
+//! Deliberately dependency-free for the same reason [`crate::feeds::parser`]
+//! is (RUSTSEC-2026-0195 lived in a third-party XML crate's namespace
+//! handling): these documents need element nesting and text, nothing else —
+//! no DTDs, no entity expansion beyond the five predefined entities, no
+//! namespace resolution. Prefixes are simply stripped, which is correct here
+//! because EDGAR ownership/13F schemas have no colliding local names.
+
+use crate::error::{FinanceError, Result};
+use crate::feeds::parser::{find_byte, trim_ascii, unescape};
+
+/// One element: its local name, its own text, and its child elements.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct XmlNode {
+    pub(crate) name: String,
+    pub(crate) text: String,
+    pub(crate) children: Vec<XmlNode>,
+}
+
+impl XmlNode {
+    /// First direct child named `name`.
+    pub(crate) fn child(&self, name: &str) -> Option<&XmlNode> {
+        self.children.iter().find(|c| c.name == name)
+    }
+
+    /// Every direct child named `name`.
+    pub(crate) fn children_named<'a>(
+        &'a self,
+        name: &'a str,
+    ) -> impl Iterator<Item = &'a XmlNode> + 'a {
+        self.children.iter().filter(move |c| c.name == name)
+    }
+
+    /// Every descendant named `name`, at any depth.
+    pub(crate) fn descendants<'a>(&'a self, name: &'a str, out: &mut Vec<&'a XmlNode>) {
+        for child in &self.children {
+            if child.name == name {
+                out.push(child);
+            }
+            child.descendants(name, out);
+        }
+    }
+
+    /// Trimmed text at a nested path of element names.
+    pub(crate) fn text_at(&self, path: &[&str]) -> Option<String> {
+        let mut node = self;
+        for step in path {
+            node = node.child(step)?;
+        }
+        let text = node.text.trim();
+        (!text.is_empty()).then(|| text.to_string())
+    }
+
+    /// [`text_at`](Self::text_at) parsed as `f64`. EDGAR writes numbers with
+    /// thousands separators and stray currency symbols in places, so those are
+    /// stripped before parsing.
+    pub(crate) fn number_at(&self, path: &[&str]) -> Option<f64> {
+        let raw = self.text_at(path)?;
+        let cleaned: String = raw
+            .chars()
+            .filter(|c| c.is_ascii_digit() || *c == '.' || *c == '-')
+            .collect();
+        cleaned.parse().ok()
+    }
+}
+
+/// Strip a namespace prefix (`ns1:infoTable` → `infoTable`).
+fn local_name(raw: &[u8]) -> String {
+    let name = match raw.iter().position(|&b| b == b':') {
+        Some(i) => &raw[i + 1..],
+        None => raw,
+    };
+    String::from_utf8_lossy(name).to_string()
+}
+
+/// Parse an XML document into its root element.
+///
+/// Errors only on structurally broken input (unterminated tag, mismatched
+/// close, no root) — unknown elements and attributes are ignored, so schema
+/// drift degrades to missing fields rather than a hard failure.
+pub(crate) fn parse(bytes: &[u8]) -> Result<XmlNode> {
+    let err = |context: &str| -> FinanceError {
+        FinanceError::ResponseStructureError {
+            field: "xml".to_string(),
+            context: context.to_string(),
+        }
+    };
+
+    let mut stack: Vec<XmlNode> = Vec::new();
+    let mut root: Option<XmlNode> = None;
+    let mut i = 0usize;
+
+    while i < bytes.len() {
+        let Some(open) = find_byte(bytes, i, b'<') else {
+            break;
+        };
+
+        // Text between the previous tag and this one belongs to the open element.
+        if open > i
+            && let Some(node) = stack.last_mut()
+        {
+            let raw = trim_ascii(&bytes[i..open]);
+            if !raw.is_empty() {
+                node.text.push_str(&unescape(raw));
+            }
+        }
+
+        // Comments, CDATA, doctypes, and processing instructions carry no
+        // structure we need; skip to their own terminator.
+        if bytes[open..].starts_with(b"<!--") {
+            i = find_seq(bytes, open + 4, b"-->").ok_or_else(|| err("unterminated comment"))? + 3;
+            continue;
+        }
+        if bytes[open..].starts_with(b"<![CDATA[") {
+            let end = find_seq(bytes, open + 9, b"]]>").ok_or_else(|| err("unterminated CDATA"))?;
+            if let Some(node) = stack.last_mut() {
+                node.text
+                    .push_str(&String::from_utf8_lossy(&bytes[open + 9..end]));
+            }
+            i = end + 3;
+            continue;
+        }
+        if bytes[open..].starts_with(b"<?") || bytes[open..].starts_with(b"<!") {
+            i = find_byte(bytes, open, b'>').ok_or_else(|| err("unterminated declaration"))? + 1;
+            continue;
+        }
+
+        let close = find_byte(bytes, open, b'>').ok_or_else(|| err("unterminated tag"))?;
+        let inner = &bytes[open + 1..close];
+        i = close + 1;
+
+        if inner.first() == Some(&b'/') {
+            let name = local_name(trim_ascii(&inner[1..]));
+            let node = stack
+                .pop()
+                .ok_or_else(|| err("closing tag without opener"))?;
+            if node.name != name {
+                return Err(err(&format!(
+                    "mismatched closing tag: expected </{}>, found </{name}>",
+                    node.name
+                )));
+            }
+            match stack.last_mut() {
+                Some(parent) => parent.children.push(node),
+                None => root = Some(node),
+            }
+            continue;
+        }
+
+        let self_closing = inner.last() == Some(&b'/');
+        let body = if self_closing {
+            &inner[..inner.len() - 1]
+        } else {
+            inner
+        };
+        let name_end = body
+            .iter()
+            .position(u8::is_ascii_whitespace)
+            .unwrap_or(body.len());
+        let node = XmlNode {
+            name: local_name(&body[..name_end]),
+            ..Default::default()
+        };
+
+        if self_closing {
+            match stack.last_mut() {
+                Some(parent) => parent.children.push(node),
+                None => root = Some(node),
+            }
+        } else {
+            stack.push(node);
+        }
+    }
+
+    if !stack.is_empty() {
+        return Err(err("unclosed elements at end of document"));
+    }
+    root.ok_or_else(|| err("no root element"))
+}
+
+fn find_seq(haystack: &[u8], from: usize, needle: &[u8]) -> Option<usize> {
+    if from > haystack.len() {
+        return None;
+    }
+    haystack[from..]
+        .windows(needle.len())
+        .position(|w| w == needle)
+        .map(|p| p + from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_nesting_text_and_repeated_children() {
+        let xml = br#"<?xml version="1.0"?>
+            <root>
+              <item><name>a</name><qty>1</qty></item>
+              <item><name>b</name><qty>2</qty></item>
+            </root>"#;
+        let root = parse(xml).unwrap();
+
+        assert_eq!(root.name, "root");
+        let items: Vec<_> = root.children_named("item").collect();
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].text_at(&["name"]).as_deref(), Some("a"));
+        assert_eq!(items[1].number_at(&["qty"]), Some(2.0));
+    }
+
+    #[test]
+    fn strips_namespace_prefixes() {
+        let xml = br#"<ns1:informationTable xmlns:ns1="http://www.sec.gov/edgar">
+            <ns1:infoTable><ns1:cusip>037833100</ns1:cusip></ns1:infoTable>
+        </ns1:informationTable>"#;
+        let root = parse(xml).unwrap();
+
+        assert_eq!(root.name, "informationTable");
+        let info = root.child("infoTable").unwrap();
+        assert_eq!(info.text_at(&["cusip"]).as_deref(), Some("037833100"));
+    }
+
+    #[test]
+    fn handles_comments_cdata_and_self_closing_tags() {
+        let xml = br#"<root>
+            <!-- ignored -->
+            <empty/>
+            <note><![CDATA[raw <text> & stuff]]></note>
+        </root>"#;
+        let root = parse(xml).unwrap();
+
+        assert!(root.child("empty").is_some());
+        assert_eq!(
+            root.text_at(&["note"]).as_deref(),
+            Some("raw <text> & stuff")
+        );
+    }
+
+    #[test]
+    fn decodes_predefined_entities_in_text() {
+        let root = parse(br#"<root><name>AT&amp;T &lt;Inc&gt;</name></root>"#).unwrap();
+        assert_eq!(root.text_at(&["name"]).as_deref(), Some("AT&T <Inc>"));
+    }
+
+    #[test]
+    fn number_at_tolerates_separators_and_rejects_junk() {
+        let root = parse(br#"<r><a>1,234,567</a><b>$12.50</b><c>n/a</c></r>"#).unwrap();
+        assert_eq!(root.number_at(&["a"]), Some(1_234_567.0));
+        assert_eq!(root.number_at(&["b"]), Some(12.50));
+        assert_eq!(root.number_at(&["c"]), None);
+    }
+
+    #[test]
+    fn descendants_finds_nodes_at_any_depth() {
+        let root = parse(br#"<a><b><c>1</c></b><d><e><c>2</c></e></d></a>"#).unwrap();
+        let mut found = Vec::new();
+        root.descendants("c", &mut found);
+        assert_eq!(found.len(), 2);
+    }
+
+    #[test]
+    fn structural_breakage_is_an_error() {
+        assert!(parse(b"<a><b></a>").is_err(), "mismatched close");
+        assert!(parse(b"<a>").is_err(), "unclosed element");
+        assert!(parse(b"<a").is_err(), "unterminated tag");
+        assert!(parse(b"text only").is_err(), "no root");
+    }
+}

--- a/src/adapters/edgar/mod.rs
+++ b/src/adapters/edgar/mod.rs
@@ -37,6 +37,7 @@
 
 mod client;
 mod endpoints;
+pub(crate) mod filings; // FILINGS
 
 use crate::error::{FinanceError, Result};
 use crate::models::filings::{

--- a/src/adapters/edgar/mod.rs
+++ b/src/adapters/edgar/mod.rs
@@ -341,7 +341,17 @@ pub async fn search(
 /// Collapses the two HTTP connection pools (and TLS handshakes) that calling
 /// [`resolve_cik`] then [`submissions`] would otherwise pay for into one.
 pub(crate) async fn submissions_for_symbol(symbol: &str) -> Result<EdgarSubmissions> {
-    let client = build_client()?;
+    submissions_for_symbol_with(&build_client()?, symbol).await
+}
+
+/// [`submissions_for_symbol`] against a caller-supplied client.
+///
+/// Callers that make further EDGAR requests off the same submissions list keep
+/// one connection pool for the whole sequence instead of one per request.
+async fn submissions_for_symbol_with(
+    client: &client::EdgarClient,
+    symbol: &str,
+) -> Result<EdgarSubmissions> {
     let cik = client.resolve_cik(symbol).await?;
     client.submissions(cik).await
 }

--- a/src/adapters/fmp/corporate/mod.rs
+++ b/src/adapters/fmp/corporate/mod.rs
@@ -3,6 +3,7 @@ pub mod insider_trading;
 #[allow(dead_code)] // unrouted: FMP ownership/governance surface lands with #243
 pub mod institutional;
 pub mod news;
+pub mod ownership;
 
 pub use dividends_splits::*;
 pub use news::*;

--- a/src/adapters/fmp/corporate/ownership.rs
+++ b/src/adapters/fmp/corporate/ownership.rs
@@ -1,0 +1,250 @@
+//! FMP governance endpoints: executive compensation and employee headcount.
+//!
+//! Both are extracted from the company's own SEC filings (DEF 14A proxies and
+//! 10-K cover pages), so figures are annual and lag the filing date.
+
+use serde::{Deserialize, Serialize};
+
+use crate::adapters::fmp::build_client;
+use crate::error::Result;
+use crate::models::corporate::governance::{EmployeeCount, ExecutiveCompensation};
+
+// ============================================================================
+// Response types
+// ============================================================================
+
+/// Executive compensation entry (`/api/v4/governance/executive_compensation`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ExecutiveCompensationDTO {
+    /// Ticker symbol.
+    pub symbol: Option<String>,
+    /// SEC Central Index Key.
+    pub cik: Option<String>,
+    /// Company name.
+    #[serde(rename = "companyName")]
+    pub company_name: Option<String>,
+    /// Executive name and position.
+    #[serde(rename = "nameAndPosition")]
+    pub name_and_position: Option<String>,
+    /// Fiscal year.
+    pub year: Option<i32>,
+    /// Base salary.
+    pub salary: Option<f64>,
+    /// Cash bonus.
+    pub bonus: Option<f64>,
+    /// Stock awards.
+    #[serde(rename = "stock_award")]
+    pub stock_award: Option<f64>,
+    /// Option awards.
+    #[serde(rename = "option_award")]
+    pub option_award: Option<f64>,
+    /// Non-equity incentive plan compensation.
+    #[serde(rename = "incentive_plan_compensation")]
+    pub incentive_plan_compensation: Option<f64>,
+    /// All other compensation.
+    #[serde(rename = "all_other_compensation")]
+    pub all_other_compensation: Option<f64>,
+    /// Total compensation.
+    pub total: Option<f64>,
+    /// Filing date.
+    #[serde(rename = "filingDate")]
+    pub filing_date: Option<String>,
+    /// Source filing URL.
+    pub url: Option<String>,
+}
+
+/// Employee headcount entry (`/api/v4/historical/employee_count`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct EmployeeCountDTO {
+    /// Ticker symbol.
+    pub symbol: Option<String>,
+    /// SEC Central Index Key.
+    pub cik: Option<String>,
+    /// Company name.
+    #[serde(rename = "companyName")]
+    pub company_name: Option<String>,
+    /// Employee count.
+    #[serde(rename = "employeeCount")]
+    pub employee_count: Option<i64>,
+    /// Period the count is as of.
+    #[serde(rename = "periodOfReport")]
+    pub period_of_report: Option<String>,
+    /// Form type the count was reported on.
+    #[serde(rename = "formType")]
+    pub form_type: Option<String>,
+    /// Filing date.
+    #[serde(rename = "filingDate")]
+    pub filing_date: Option<String>,
+    /// Source filing URL.
+    pub source: Option<String>,
+}
+
+// ============================================================================
+// Query functions
+// ============================================================================
+
+/// Fetch executive compensation history for a symbol.
+pub async fn executive_compensation(symbol: &str) -> Result<Vec<ExecutiveCompensationDTO>> {
+    build_client()?
+        .get(
+            "/api/v4/governance/executive_compensation",
+            &[("symbol", symbol)],
+        )
+        .await
+}
+
+/// Fetch historical employee headcount for a symbol.
+pub async fn employee_count(symbol: &str) -> Result<Vec<EmployeeCountDTO>> {
+    build_client()?
+        .get("/api/v4/historical/employee_count", &[("symbol", symbol)])
+        .await
+}
+
+// ============================================================================
+// Canonical conversions
+// ============================================================================
+
+pub(crate) fn to_executive_compensation(
+    dto: ExecutiveCompensationDTO,
+    symbol: &str,
+) -> ExecutiveCompensation {
+    ExecutiveCompensation {
+        symbol: dto.symbol.or_else(|| Some(symbol.to_string())),
+        cik: dto.cik,
+        company_name: dto.company_name,
+        name_and_position: dto.name_and_position,
+        year: dto.year,
+        salary: dto.salary,
+        bonus: dto.bonus,
+        stock_award: dto.stock_award,
+        option_award: dto.option_award,
+        incentive_plan_compensation: dto.incentive_plan_compensation,
+        other_compensation: dto.all_other_compensation,
+        total: dto.total,
+        filing_date: dto.filing_date,
+        url: dto.url,
+    }
+}
+
+pub(crate) fn to_employee_count(dto: EmployeeCountDTO, symbol: &str) -> EmployeeCount {
+    EmployeeCount {
+        symbol: dto.symbol.or_else(|| Some(symbol.to_string())),
+        cik: dto.cik,
+        company_name: dto.company_name,
+        employee_count: dto.employee_count,
+        period_of_report: dto.period_of_report,
+        form_type: dto.form_type,
+        filing_date: dto.filing_date,
+        source: dto.source,
+    }
+}
+
+/// Fetch canonical executive compensation, most recent fiscal year first.
+pub async fn fetch_executive_compensation_response(
+    symbol: &str,
+) -> Result<Vec<ExecutiveCompensation>> {
+    let dtos = executive_compensation(symbol).await?;
+    let mut out: Vec<_> = dtos
+        .into_iter()
+        .map(|d| to_executive_compensation(d, symbol))
+        .collect();
+    out.sort_by(|a, b| b.year.cmp(&a.year));
+    Ok(out)
+}
+
+/// Fetch canonical employee headcount history, most recent period first.
+pub async fn fetch_employee_count_response(symbol: &str) -> Result<Vec<EmployeeCount>> {
+    let dtos = employee_count(symbol).await?;
+    let mut out: Vec<_> = dtos
+        .into_iter()
+        .map(|d| to_employee_count(d, symbol))
+        .collect();
+    out.sort_by(|a, b| b.period_of_report.cmp(&a.period_of_report));
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn comp_dto(year: i32) -> ExecutiveCompensationDTO {
+        serde_json::from_value(serde_json::json!({
+            "symbol": "AAPL",
+            "cik": "0000320193",
+            "companyName": "Apple Inc.",
+            "nameAndPosition": "Timothy D. Cook Chief Executive Officer",
+            "year": year,
+            "salary": 3_000_000.0,
+            "bonus": 0.0,
+            "stock_award": 46_970_283.0,
+            "option_award": 0.0,
+            "incentive_plan_compensation": 10_713_450.0,
+            "all_other_compensation": 2_521_124.0,
+            "total": 63_209_845.0,
+            "filingDate": "2024-01-11",
+            "url": "https://www.sec.gov/Archives/..."
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn executive_compensation_maps_snake_case_award_keys() {
+        let out = to_executive_compensation(comp_dto(2023), "AAPL");
+        assert_eq!(
+            out.name_and_position.as_deref(),
+            Some("Timothy D. Cook Chief Executive Officer")
+        );
+        assert_eq!(out.year, Some(2023));
+        assert_eq!(out.salary, Some(3_000_000.0));
+        assert_eq!(out.stock_award, Some(46_970_283.0));
+        assert_eq!(out.incentive_plan_compensation, Some(10_713_450.0));
+        // `all_other_compensation` is exposed under the shorter public name.
+        assert_eq!(out.other_compensation, Some(2_521_124.0));
+        assert_eq!(out.total, Some(63_209_845.0));
+    }
+
+    #[test]
+    fn employee_count_maps_filing_metadata() {
+        let dto: EmployeeCountDTO = serde_json::from_value(serde_json::json!({
+            "symbol": "AAPL",
+            "cik": "0000320193",
+            "companyName": "Apple Inc.",
+            "employeeCount": 161_000,
+            "periodOfReport": "2023-09-30",
+            "formType": "10-K",
+            "filingDate": "2023-11-03",
+            "source": "https://www.sec.gov/Archives/..."
+        }))
+        .unwrap();
+
+        let out = to_employee_count(dto, "AAPL");
+        assert_eq!(out.employee_count, Some(161_000));
+        assert_eq!(out.period_of_report.as_deref(), Some("2023-09-30"));
+        assert_eq!(out.form_type.as_deref(), Some("10-K"));
+    }
+
+    /// FMP returns compensation oldest-first; the canonical order is newest-first.
+    #[test]
+    fn executive_compensation_is_sorted_newest_year_first() {
+        let mut rows: Vec<_> = [2019, 2023, 2021]
+            .into_iter()
+            .map(|y| to_executive_compensation(comp_dto(y), "AAPL"))
+            .collect();
+        rows.sort_by(|a, b| b.year.cmp(&a.year));
+        assert_eq!(
+            rows.iter().map(|r| r.year).collect::<Vec<_>>(),
+            vec![Some(2023), Some(2021), Some(2019)]
+        );
+    }
+
+    #[test]
+    fn missing_symbol_falls_back_to_the_requested_one() {
+        let dto: EmployeeCountDTO = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert_eq!(
+            to_employee_count(dto, "MSFT").symbol.as_deref(),
+            Some("MSFT")
+        );
+    }
+}

--- a/src/adapters/fmp/corporate/ownership.rs
+++ b/src/adapters/fmp/corporate/ownership.rs
@@ -150,7 +150,7 @@ pub async fn fetch_executive_compensation_response(
         .into_iter()
         .map(|d| to_executive_compensation(d, symbol))
         .collect();
-    out.sort_by(|a, b| b.year.cmp(&a.year));
+    out.sort_by_key(|r| std::cmp::Reverse(r.year));
     Ok(out)
 }
 
@@ -232,7 +232,7 @@ mod tests {
             .into_iter()
             .map(|y| to_executive_compensation(comp_dto(y), "AAPL"))
             .collect();
-        rows.sort_by(|a, b| b.year.cmp(&a.year));
+        rows.sort_by_key(|r| std::cmp::Reverse(r.year));
         assert_eq!(
             rows.iter().map(|r| r.year).collect::<Vec<_>>(),
             vec![Some(2023), Some(2021), Some(2019)]

--- a/src/adapters/fmp/fundamentals/consensus.rs
+++ b/src/adapters/fmp/fundamentals/consensus.rs
@@ -1,0 +1,286 @@
+//! FMP aggregated analyst-consensus endpoints (price targets, rating rollup).
+//!
+//! These are the v4 consensus endpoints — server-side rollups over the whole
+//! analyst panel, as opposed to the raw per-analyst grade actions served by
+//! [`estimates`](super::estimates).
+
+use serde::{Deserialize, Serialize};
+
+use crate::adapters::fmp::build_client;
+use crate::error::{FinanceError, Result};
+use crate::models::fundamentals::{PriceTargetConsensus, PriceTargetSummary, RatingConsensus};
+
+// ============================================================================
+// Response types
+// ============================================================================
+
+/// Consensus price target entry (`/api/v4/price-target-consensus`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct PriceTargetConsensusDTO {
+    /// Ticker symbol.
+    pub symbol: Option<String>,
+    /// Highest analyst target.
+    #[serde(rename = "targetHigh")]
+    pub target_high: Option<f64>,
+    /// Lowest analyst target.
+    #[serde(rename = "targetLow")]
+    pub target_low: Option<f64>,
+    /// Mean analyst target.
+    #[serde(rename = "targetConsensus")]
+    pub target_consensus: Option<f64>,
+    /// Median analyst target.
+    #[serde(rename = "targetMedian")]
+    pub target_median: Option<f64>,
+}
+
+/// Price-target activity summary entry (`/api/v4/price-target-summary`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct PriceTargetSummaryDTO {
+    /// Ticker symbol.
+    pub symbol: Option<String>,
+    /// Targets published in the last month.
+    #[serde(rename = "lastMonth")]
+    pub last_month: Option<i64>,
+    /// Average target published in the last month.
+    #[serde(rename = "lastMonthAvgPriceTarget")]
+    pub last_month_avg_price_target: Option<f64>,
+    /// Targets published in the last quarter.
+    #[serde(rename = "lastQuarter")]
+    pub last_quarter: Option<i64>,
+    /// Average target published in the last quarter.
+    #[serde(rename = "lastQuarterAvgPriceTarget")]
+    pub last_quarter_avg_price_target: Option<f64>,
+    /// Targets published in the last year.
+    #[serde(rename = "lastYear")]
+    pub last_year: Option<i64>,
+    /// Average target published in the last year.
+    #[serde(rename = "lastYearAvgPriceTarget")]
+    pub last_year_avg_price_target: Option<f64>,
+    /// Targets published all time.
+    #[serde(rename = "allTime")]
+    pub all_time: Option<i64>,
+    /// Average target published all time.
+    #[serde(rename = "allTimeAvgPriceTarget")]
+    pub all_time_avg_price_target: Option<f64>,
+}
+
+/// Upgrades/downgrades consensus entry (`/api/v4/upgrades-downgrades-consensus`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct RatingConsensusDTO {
+    /// Ticker symbol.
+    pub symbol: Option<String>,
+    /// Strong-buy ratings.
+    #[serde(rename = "strongBuy")]
+    pub strong_buy: Option<i64>,
+    /// Buy ratings.
+    pub buy: Option<i64>,
+    /// Hold ratings.
+    pub hold: Option<i64>,
+    /// Sell ratings.
+    pub sell: Option<i64>,
+    /// Strong-sell ratings.
+    #[serde(rename = "strongSell")]
+    pub strong_sell: Option<i64>,
+    /// Headline consensus label.
+    pub consensus: Option<String>,
+}
+
+// ============================================================================
+// Query functions
+// ============================================================================
+
+/// Fetch the consensus price target for a symbol.
+pub async fn price_target_consensus(symbol: &str) -> Result<Vec<PriceTargetConsensusDTO>> {
+    build_client()?
+        .get("/api/v4/price-target-consensus", &[("symbol", symbol)])
+        .await
+}
+
+/// Fetch the price-target activity summary for a symbol.
+pub async fn price_target_summary(symbol: &str) -> Result<Vec<PriceTargetSummaryDTO>> {
+    build_client()?
+        .get("/api/v4/price-target-summary", &[("symbol", symbol)])
+        .await
+}
+
+/// Fetch the aggregated upgrades/downgrades consensus for a symbol.
+pub async fn upgrades_downgrades_consensus(symbol: &str) -> Result<Vec<RatingConsensusDTO>> {
+    build_client()?
+        .get(
+            "/api/v4/upgrades-downgrades-consensus",
+            &[("symbol", symbol)],
+        )
+        .await
+}
+
+// ============================================================================
+// Canonical conversions
+// ============================================================================
+
+/// FMP wraps each consensus rollup in a single-element array; an empty one
+/// means the symbol has no analyst coverage in FMP's universe.
+fn first_or_missing<T>(rows: Vec<T>, symbol: &str, field: &str) -> Result<T> {
+    rows.into_iter()
+        .next()
+        .ok_or_else(|| FinanceError::SymbolNotFound {
+            symbol: Some(symbol.to_string()),
+            context: format!("FMP returned no {field} for {symbol}"),
+        })
+}
+
+pub(crate) fn to_price_target_consensus(
+    dto: PriceTargetConsensusDTO,
+    symbol: &str,
+) -> PriceTargetConsensus {
+    PriceTargetConsensus {
+        symbol: dto.symbol.or_else(|| Some(symbol.to_string())),
+        target_high: dto.target_high,
+        target_low: dto.target_low,
+        target_consensus: dto.target_consensus,
+        target_median: dto.target_median,
+    }
+}
+
+pub(crate) fn to_price_target_summary(
+    dto: PriceTargetSummaryDTO,
+    symbol: &str,
+) -> PriceTargetSummary {
+    PriceTargetSummary {
+        symbol: dto.symbol.or_else(|| Some(symbol.to_string())),
+        last_month_count: dto.last_month,
+        last_month_avg: dto.last_month_avg_price_target,
+        last_quarter_count: dto.last_quarter,
+        last_quarter_avg: dto.last_quarter_avg_price_target,
+        last_year_count: dto.last_year,
+        last_year_avg: dto.last_year_avg_price_target,
+        all_time_count: dto.all_time,
+        all_time_avg: dto.all_time_avg_price_target,
+    }
+}
+
+pub(crate) fn to_rating_consensus(dto: RatingConsensusDTO, symbol: &str) -> RatingConsensus {
+    RatingConsensus {
+        symbol: dto.symbol.or_else(|| Some(symbol.to_string())),
+        strong_buy: dto.strong_buy,
+        buy: dto.buy,
+        hold: dto.hold,
+        sell: dto.sell,
+        strong_sell: dto.strong_sell,
+        consensus: dto.consensus,
+    }
+}
+
+/// Fetch the canonical consensus price target for a symbol.
+pub async fn fetch_price_target_consensus_response(symbol: &str) -> Result<PriceTargetConsensus> {
+    let rows = price_target_consensus(symbol).await?;
+    let dto = first_or_missing(rows, symbol, "price target consensus")?;
+    Ok(to_price_target_consensus(dto, symbol))
+}
+
+/// Fetch the canonical price-target activity summary for a symbol.
+pub async fn fetch_price_target_summary_response(symbol: &str) -> Result<PriceTargetSummary> {
+    let rows = price_target_summary(symbol).await?;
+    let dto = first_or_missing(rows, symbol, "price target summary")?;
+    Ok(to_price_target_summary(dto, symbol))
+}
+
+/// Fetch the canonical rating consensus for a symbol.
+pub async fn fetch_rating_consensus_response(symbol: &str) -> Result<RatingConsensus> {
+    let rows = upgrades_downgrades_consensus(symbol).await?;
+    let dto = first_or_missing(rows, symbol, "rating consensus")?;
+    Ok(to_rating_consensus(dto, symbol))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn price_target_consensus_maps_every_field() {
+        let dto: PriceTargetConsensusDTO = serde_json::from_value(serde_json::json!({
+            "symbol": "AAPL",
+            "targetHigh": 300.0,
+            "targetLow": 150.0,
+            "targetConsensus": 225.5,
+            "targetMedian": 230.0
+        }))
+        .unwrap();
+
+        let out = to_price_target_consensus(dto, "AAPL");
+        assert_eq!(out.symbol.as_deref(), Some("AAPL"));
+        assert_eq!(out.target_high, Some(300.0));
+        assert_eq!(out.target_low, Some(150.0));
+        assert_eq!(out.target_consensus, Some(225.5));
+        assert_eq!(out.target_median, Some(230.0));
+    }
+
+    #[test]
+    fn price_target_summary_maps_every_window() {
+        let dto: PriceTargetSummaryDTO = serde_json::from_value(serde_json::json!({
+            "symbol": "AAPL",
+            "lastMonth": 5,
+            "lastMonthAvgPriceTarget": 220.5,
+            "lastQuarter": 12,
+            "lastQuarterAvgPriceTarget": 210.0,
+            "lastYear": 45,
+            "lastYearAvgPriceTarget": 200.0,
+            "allTime": 300,
+            "allTimeAvgPriceTarget": 190.0
+        }))
+        .unwrap();
+
+        let out = to_price_target_summary(dto, "AAPL");
+        assert_eq!(out.last_month_count, Some(5));
+        assert_eq!(out.last_month_avg, Some(220.5));
+        assert_eq!(out.last_quarter_count, Some(12));
+        assert_eq!(out.last_quarter_avg, Some(210.0));
+        assert_eq!(out.last_year_count, Some(45));
+        assert_eq!(out.last_year_avg, Some(200.0));
+        assert_eq!(out.all_time_count, Some(300));
+        assert_eq!(out.all_time_avg, Some(190.0));
+    }
+
+    #[test]
+    fn rating_consensus_maps_grade_distribution() {
+        let dto: RatingConsensusDTO = serde_json::from_value(serde_json::json!({
+            "symbol": "AAPL",
+            "strongBuy": 10,
+            "buy": 20,
+            "hold": 5,
+            "sell": 1,
+            "strongSell": 0,
+            "consensus": "Buy"
+        }))
+        .unwrap();
+
+        let out = to_rating_consensus(dto, "AAPL");
+        assert_eq!(out.strong_buy, Some(10));
+        assert_eq!(out.buy, Some(20));
+        assert_eq!(out.hold, Some(5));
+        assert_eq!(out.sell, Some(1));
+        assert_eq!(out.strong_sell, Some(0));
+        assert_eq!(out.consensus.as_deref(), Some("Buy"));
+    }
+
+    #[test]
+    fn missing_symbol_falls_back_to_the_requested_one() {
+        let dto: RatingConsensusDTO = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert_eq!(
+            to_rating_consensus(dto, "MSFT").symbol.as_deref(),
+            Some("MSFT")
+        );
+    }
+
+    #[test]
+    fn empty_response_is_an_error_not_a_panic() {
+        let err =
+            first_or_missing::<RatingConsensusDTO>(vec![], "AAPL", "rating consensus").unwrap_err();
+        assert!(
+            matches!(err, FinanceError::SymbolNotFound { .. }),
+            "got {err:?}"
+        );
+    }
+}

--- a/src/adapters/fmp/fundamentals/consensus.rs
+++ b/src/adapters/fmp/fundamentals/consensus.rs
@@ -6,8 +6,8 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::adapters::fmp::build_client;
-use crate::error::{FinanceError, Result};
+use crate::adapters::fmp::{build_client, first_or_missing};
+use crate::error::Result;
 use crate::models::fundamentals::{PriceTargetConsensus, PriceTargetSummary, RatingConsensus};
 
 // ============================================================================
@@ -120,17 +120,6 @@ pub async fn upgrades_downgrades_consensus(symbol: &str) -> Result<Vec<RatingCon
 // Canonical conversions
 // ============================================================================
 
-/// FMP wraps each consensus rollup in a single-element array; an empty one
-/// means the symbol has no analyst coverage in FMP's universe.
-fn first_or_missing<T>(rows: Vec<T>, symbol: &str, field: &str) -> Result<T> {
-    rows.into_iter()
-        .next()
-        .ok_or_else(|| FinanceError::SymbolNotFound {
-            symbol: Some(symbol.to_string()),
-            context: format!("FMP returned no {field} for {symbol}"),
-        })
-}
-
 pub(crate) fn to_price_target_consensus(
     dto: PriceTargetConsensusDTO,
     symbol: &str,
@@ -197,6 +186,7 @@ pub async fn fetch_rating_consensus_response(symbol: &str) -> Result<RatingConse
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::FinanceError;
 
     #[test]
     fn price_target_consensus_maps_every_field() {

--- a/src/adapters/fmp/fundamentals/float.rs
+++ b/src/adapters/fmp/fundamentals/float.rs
@@ -1,0 +1,103 @@
+//! FMP share-float endpoint (`/api/v4/shares_float`).
+//!
+//! Lives under `fundamentals/` rather than `corporate/` because float routes
+//! through `Capability::FUNDAMENTALS`, alongside the short-interest data it is
+//! normally read with.
+
+use serde::{Deserialize, Serialize};
+
+use crate::adapters::fmp::build_client;
+use crate::error::{FinanceError, Result};
+use crate::models::fundamentals::ShareFloat;
+
+/// Share float entry (`/api/v4/shares_float`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct SharesFloatDTO {
+    /// Ticker symbol.
+    pub symbol: Option<String>,
+    /// Free float as a percentage of shares outstanding.
+    #[serde(rename = "freeFloat")]
+    pub free_float: Option<f64>,
+    /// Freely tradable shares.
+    #[serde(rename = "floatShares")]
+    pub float_shares: Option<f64>,
+    /// Total shares outstanding.
+    #[serde(rename = "outstandingShares")]
+    pub outstanding_shares: Option<f64>,
+    /// As-of timestamp, sometimes with a time component.
+    pub date: Option<String>,
+}
+
+/// Fetch the share float for a symbol.
+pub async fn shares_float(symbol: &str) -> Result<Vec<SharesFloatDTO>> {
+    build_client()?
+        .get("/api/v4/shares_float", &[("symbol", symbol)])
+        .await
+}
+
+/// FMP dates on this endpoint arrive as `YYYY-MM-DD HH:MM:SS`; the model's
+/// contract is a plain date, matching the other `ShareFloat` routes.
+fn date_only(raw: Option<String>) -> Option<String> {
+    raw.map(|d| match d.split_once([' ', 'T']) {
+        Some((date, _)) => date.to_string(),
+        None => d,
+    })
+}
+
+pub(crate) fn to_share_float(dto: SharesFloatDTO, symbol: &str) -> ShareFloat {
+    ShareFloat {
+        symbol: dto.symbol.or_else(|| Some(symbol.to_string())),
+        float_shares: dto.float_shares,
+        outstanding_shares: dto.outstanding_shares,
+        date: date_only(dto.date),
+    }
+}
+
+/// Fetch the canonical share float for a symbol.
+pub async fn fetch_share_float_response(symbol: &str) -> Result<ShareFloat> {
+    let dto = shares_float(symbol)
+        .await?
+        .into_iter()
+        .next()
+        .ok_or_else(|| FinanceError::SymbolNotFound {
+            symbol: Some(symbol.to_string()),
+            context: format!("FMP returned no share float for {symbol}"),
+        })?;
+    Ok(to_share_float(dto, symbol))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn share_float_maps_and_trims_the_timestamp() {
+        let dto: SharesFloatDTO = serde_json::from_value(serde_json::json!({
+            "symbol": "AAPL",
+            "freeFloat": 99.89,
+            "floatShares": 15_200_000_000.0,
+            "outstandingShares": 15_300_000_000.0,
+            "date": "2024-05-01 00:00:00"
+        }))
+        .unwrap();
+
+        let out = to_share_float(dto, "AAPL");
+        assert_eq!(out.float_shares, Some(15_200_000_000.0));
+        assert_eq!(out.outstanding_shares, Some(15_300_000_000.0));
+        assert_eq!(out.date.as_deref(), Some("2024-05-01"));
+    }
+
+    #[test]
+    fn date_only_passes_plain_dates_and_none_through() {
+        assert_eq!(
+            date_only(Some("2024-05-01".into())).as_deref(),
+            Some("2024-05-01")
+        );
+        assert_eq!(
+            date_only(Some("2024-05-01T12:00:00Z".into())).as_deref(),
+            Some("2024-05-01")
+        );
+        assert_eq!(date_only(None), None);
+    }
+}

--- a/src/adapters/fmp/fundamentals/mod.rs
+++ b/src/adapters/fmp/fundamentals/mod.rs
@@ -5,6 +5,7 @@ pub mod core;
 pub mod estimates;
 #[allow(dead_code)] // unrouted: ETF/fund data has no capability route yet
 pub mod etf_mutual_funds;
+pub mod float;
 #[allow(dead_code)] // unrouted: ETF/fund data has no capability route yet
 pub mod fund_holdings;
 pub mod ttm;

--- a/src/adapters/fmp/fundamentals/mod.rs
+++ b/src/adapters/fmp/fundamentals/mod.rs
@@ -1,5 +1,6 @@
 #[allow(dead_code)] // unrouted: TTM key-metrics/ratios snapshot lands with #242
 pub mod analysis;
+pub mod consensus;
 pub mod core;
 pub mod estimates;
 #[allow(dead_code)] // unrouted: ETF/fund data has no capability route yet

--- a/src/adapters/fmp/fundamentals/mod.rs
+++ b/src/adapters/fmp/fundamentals/mod.rs
@@ -1,4 +1,4 @@
-#[allow(dead_code)] // unrouted: TTM key-metrics/ratios snapshot lands with #242
+#[allow(dead_code)] // unrouted: period-based metrics/ratios have no capability route yet
 pub mod analysis;
 pub mod consensus;
 pub mod core;
@@ -7,4 +7,5 @@ pub mod estimates;
 pub mod etf_mutual_funds;
 #[allow(dead_code)] // unrouted: ETF/fund data has no capability route yet
 pub mod fund_holdings;
+pub mod ttm;
 pub use core::*;

--- a/src/adapters/fmp/fundamentals/ttm.rs
+++ b/src/adapters/fmp/fundamentals/ttm.rs
@@ -1,0 +1,378 @@
+//! FMP trailing-twelve-month snapshot endpoints (`key-metrics-ttm`, `ratios-ttm`).
+//!
+//! Distinct from the period-based endpoints in [`analysis`](super::analysis):
+//! these return one always-current rollup rather than a fiscal-period series,
+//! and FMP handles partial periods and restatements server-side.
+
+use serde::{Deserialize, Serialize};
+
+use crate::adapters::common::encode_path_segment;
+use crate::adapters::fmp::build_client;
+use crate::error::{FinanceError, Result};
+use crate::models::fundamentals::{FinancialRatiosTtm, KeyMetricsTtm};
+
+// ============================================================================
+// Response types
+// ============================================================================
+
+/// TTM key-metrics entry (`/api/v3/key-metrics-ttm/{symbol}`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct KeyMetricsTtmDTO {
+    /// Ticker symbol (absent on some FMP plans).
+    pub symbol: Option<String>,
+    /// Revenue per share.
+    #[serde(rename = "revenuePerShareTTM")]
+    pub revenue_per_share: Option<f64>,
+    /// Net income per share.
+    #[serde(rename = "netIncomePerShareTTM")]
+    pub net_income_per_share: Option<f64>,
+    /// Operating cash flow per share.
+    #[serde(rename = "operatingCashFlowPerShareTTM")]
+    pub operating_cash_flow_per_share: Option<f64>,
+    /// Free cash flow per share.
+    #[serde(rename = "freeCashFlowPerShareTTM")]
+    pub free_cash_flow_per_share: Option<f64>,
+    /// Cash per share.
+    #[serde(rename = "cashPerShareTTM")]
+    pub cash_per_share: Option<f64>,
+    /// Book value per share.
+    #[serde(rename = "bookValuePerShareTTM")]
+    pub book_value_per_share: Option<f64>,
+    /// Tangible book value per share.
+    #[serde(rename = "tangibleBookValuePerShareTTM")]
+    pub tangible_book_value_per_share: Option<f64>,
+    /// Shareholders' equity per share.
+    #[serde(rename = "shareholdersEquityPerShareTTM")]
+    pub shareholders_equity_per_share: Option<f64>,
+    /// Interest-bearing debt per share.
+    #[serde(rename = "interestDebtPerShareTTM")]
+    pub interest_debt_per_share: Option<f64>,
+    /// Market capitalization.
+    #[serde(rename = "marketCapTTM")]
+    pub market_cap: Option<f64>,
+    /// Enterprise value.
+    #[serde(rename = "enterpriseValueTTM")]
+    pub enterprise_value: Option<f64>,
+    /// PE ratio.
+    #[serde(rename = "peRatioTTM")]
+    pub pe_ratio: Option<f64>,
+    /// PB ratio.
+    #[serde(rename = "pbRatioTTM")]
+    pub pb_ratio: Option<f64>,
+    /// EV to sales.
+    #[serde(rename = "evToSalesTTM")]
+    pub ev_to_sales: Option<f64>,
+    /// EV to EBITDA.
+    #[serde(rename = "enterpriseValueOverEBITDATTM")]
+    pub enterprise_value_over_ebitda: Option<f64>,
+    /// EV to operating cash flow.
+    #[serde(rename = "evToOperatingCashFlowTTM")]
+    pub ev_to_operating_cash_flow: Option<f64>,
+    /// EV to free cash flow.
+    #[serde(rename = "evToFreeCashFlowTTM")]
+    pub ev_to_free_cash_flow: Option<f64>,
+    /// Earnings yield.
+    #[serde(rename = "earningsYieldTTM")]
+    pub earnings_yield: Option<f64>,
+    /// Free cash flow yield.
+    #[serde(rename = "freeCashFlowYieldTTM")]
+    pub free_cash_flow_yield: Option<f64>,
+    /// Debt to equity.
+    #[serde(rename = "debtToEquityTTM")]
+    pub debt_to_equity: Option<f64>,
+    /// Debt to assets.
+    #[serde(rename = "debtToAssetsTTM")]
+    pub debt_to_assets: Option<f64>,
+    /// Net debt to EBITDA.
+    #[serde(rename = "netDebtToEBITDATTM")]
+    pub net_debt_to_ebitda: Option<f64>,
+    /// Current ratio.
+    #[serde(rename = "currentRatioTTM")]
+    pub current_ratio: Option<f64>,
+    /// Interest coverage.
+    #[serde(rename = "interestCoverageTTM")]
+    pub interest_coverage: Option<f64>,
+    /// Return on equity.
+    #[serde(rename = "roeTTM")]
+    pub roe: Option<f64>,
+    /// Return on invested capital.
+    #[serde(rename = "roicTTM")]
+    pub roic: Option<f64>,
+    /// Dividend yield.
+    #[serde(rename = "dividendYieldTTM")]
+    pub dividend_yield: Option<f64>,
+    /// Payout ratio.
+    #[serde(rename = "payoutRatioTTM")]
+    pub payout_ratio: Option<f64>,
+    /// Graham number.
+    #[serde(rename = "grahamNumberTTM")]
+    pub graham_number: Option<f64>,
+}
+
+/// TTM ratios entry (`/api/v3/ratios-ttm/{symbol}`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct FinancialRatiosTtmDTO {
+    /// Ticker symbol (absent on some FMP plans).
+    pub symbol: Option<String>,
+    /// Current ratio.
+    #[serde(rename = "currentRatioTTM")]
+    pub current_ratio: Option<f64>,
+    /// Quick ratio.
+    #[serde(rename = "quickRatioTTM")]
+    pub quick_ratio: Option<f64>,
+    /// Cash ratio.
+    #[serde(rename = "cashRatioTTM")]
+    pub cash_ratio: Option<f64>,
+    /// Gross profit margin.
+    #[serde(rename = "grossProfitMarginTTM")]
+    pub gross_profit_margin: Option<f64>,
+    /// Operating profit margin.
+    #[serde(rename = "operatingProfitMarginTTM")]
+    pub operating_profit_margin: Option<f64>,
+    /// Net profit margin.
+    #[serde(rename = "netProfitMarginTTM")]
+    pub net_profit_margin: Option<f64>,
+    /// Return on assets.
+    #[serde(rename = "returnOnAssetsTTM")]
+    pub return_on_assets: Option<f64>,
+    /// Return on equity.
+    #[serde(rename = "returnOnEquityTTM")]
+    pub return_on_equity: Option<f64>,
+    /// Return on capital employed.
+    #[serde(rename = "returnOnCapitalEmployedTTM")]
+    pub return_on_capital_employed: Option<f64>,
+    /// Debt ratio.
+    #[serde(rename = "debtRatioTTM")]
+    pub debt_ratio: Option<f64>,
+    /// Debt-to-equity ratio.
+    #[serde(rename = "debtEquityRatioTTM")]
+    pub debt_equity_ratio: Option<f64>,
+    /// Interest coverage.
+    #[serde(rename = "interestCoverageTTM")]
+    pub interest_coverage: Option<f64>,
+    /// Price-to-earnings ratio.
+    #[serde(rename = "priceEarningsRatioTTM")]
+    pub price_earnings_ratio: Option<f64>,
+    /// Price/earnings-to-growth ratio.
+    #[serde(rename = "pegRatioTTM")]
+    pub peg_ratio: Option<f64>,
+    /// Price-to-book ratio.
+    #[serde(rename = "priceToBookRatioTTM")]
+    pub price_to_book_ratio: Option<f64>,
+    /// Price-to-sales ratio.
+    #[serde(rename = "priceToSalesRatioTTM")]
+    pub price_to_sales_ratio: Option<f64>,
+    /// Price-to-free-cash-flow ratio.
+    #[serde(rename = "priceToFreeCashFlowsRatioTTM")]
+    pub price_to_free_cash_flows_ratio: Option<f64>,
+    /// Enterprise value multiple.
+    #[serde(rename = "enterpriseValueMultipleTTM")]
+    pub enterprise_value_multiple: Option<f64>,
+    /// Dividend yield. FMP spells the canonical key `dividendYielTTM` (sic) on
+    /// this endpoint; the alias covers plans that return the corrected spelling.
+    #[serde(rename = "dividendYielTTM", alias = "dividendYieldTTM")]
+    pub dividend_yield: Option<f64>,
+    /// Payout ratio.
+    #[serde(rename = "payoutRatioTTM")]
+    pub payout_ratio: Option<f64>,
+}
+
+// ============================================================================
+// Query functions
+// ============================================================================
+
+/// Fetch the TTM key-metrics snapshot for a symbol.
+pub async fn key_metrics_ttm(symbol: &str) -> Result<Vec<KeyMetricsTtmDTO>> {
+    build_client()?
+        .get(
+            &format!("/api/v3/key-metrics-ttm/{}", encode_path_segment(symbol)),
+            &[],
+        )
+        .await
+}
+
+/// Fetch the TTM ratios snapshot for a symbol.
+pub async fn ratios_ttm(symbol: &str) -> Result<Vec<FinancialRatiosTtmDTO>> {
+    build_client()?
+        .get(
+            &format!("/api/v3/ratios-ttm/{}", encode_path_segment(symbol)),
+            &[],
+        )
+        .await
+}
+
+// ============================================================================
+// Canonical conversions
+// ============================================================================
+
+fn first_or_missing<T>(rows: Vec<T>, symbol: &str, field: &str) -> Result<T> {
+    rows.into_iter()
+        .next()
+        .ok_or_else(|| FinanceError::SymbolNotFound {
+            symbol: Some(symbol.to_string()),
+            context: format!("FMP returned no {field} for {symbol}"),
+        })
+}
+
+pub(crate) fn to_key_metrics_ttm(dto: KeyMetricsTtmDTO, symbol: &str) -> KeyMetricsTtm {
+    KeyMetricsTtm {
+        symbol: dto.symbol.or_else(|| Some(symbol.to_string())),
+        revenue_per_share: dto.revenue_per_share,
+        net_income_per_share: dto.net_income_per_share,
+        operating_cash_flow_per_share: dto.operating_cash_flow_per_share,
+        free_cash_flow_per_share: dto.free_cash_flow_per_share,
+        cash_per_share: dto.cash_per_share,
+        book_value_per_share: dto.book_value_per_share,
+        tangible_book_value_per_share: dto.tangible_book_value_per_share,
+        shareholders_equity_per_share: dto.shareholders_equity_per_share,
+        interest_debt_per_share: dto.interest_debt_per_share,
+        market_cap: dto.market_cap,
+        enterprise_value: dto.enterprise_value,
+        pe_ratio: dto.pe_ratio,
+        pb_ratio: dto.pb_ratio,
+        ev_to_sales: dto.ev_to_sales,
+        ev_to_ebitda: dto.enterprise_value_over_ebitda,
+        ev_to_operating_cash_flow: dto.ev_to_operating_cash_flow,
+        ev_to_free_cash_flow: dto.ev_to_free_cash_flow,
+        earnings_yield: dto.earnings_yield,
+        free_cash_flow_yield: dto.free_cash_flow_yield,
+        debt_to_equity: dto.debt_to_equity,
+        debt_to_assets: dto.debt_to_assets,
+        net_debt_to_ebitda: dto.net_debt_to_ebitda,
+        current_ratio: dto.current_ratio,
+        interest_coverage: dto.interest_coverage,
+        return_on_equity: dto.roe,
+        return_on_invested_capital: dto.roic,
+        dividend_yield: dto.dividend_yield,
+        payout_ratio: dto.payout_ratio,
+        graham_number: dto.graham_number,
+    }
+}
+
+pub(crate) fn to_financial_ratios_ttm(
+    dto: FinancialRatiosTtmDTO,
+    symbol: &str,
+) -> FinancialRatiosTtm {
+    FinancialRatiosTtm {
+        symbol: dto.symbol.or_else(|| Some(symbol.to_string())),
+        current_ratio: dto.current_ratio,
+        quick_ratio: dto.quick_ratio,
+        cash_ratio: dto.cash_ratio,
+        gross_profit_margin: dto.gross_profit_margin,
+        operating_profit_margin: dto.operating_profit_margin,
+        net_profit_margin: dto.net_profit_margin,
+        return_on_assets: dto.return_on_assets,
+        return_on_equity: dto.return_on_equity,
+        return_on_capital_employed: dto.return_on_capital_employed,
+        debt_ratio: dto.debt_ratio,
+        debt_equity_ratio: dto.debt_equity_ratio,
+        interest_coverage: dto.interest_coverage,
+        price_earnings_ratio: dto.price_earnings_ratio,
+        peg_ratio: dto.peg_ratio,
+        price_to_book_ratio: dto.price_to_book_ratio,
+        price_to_sales_ratio: dto.price_to_sales_ratio,
+        price_to_free_cash_flows_ratio: dto.price_to_free_cash_flows_ratio,
+        enterprise_value_multiple: dto.enterprise_value_multiple,
+        dividend_yield: dto.dividend_yield,
+        payout_ratio: dto.payout_ratio,
+    }
+}
+
+/// Fetch the canonical TTM key-metrics snapshot for a symbol.
+pub async fn fetch_key_metrics_ttm_response(symbol: &str) -> Result<KeyMetricsTtm> {
+    let rows = key_metrics_ttm(symbol).await?;
+    let dto = first_or_missing(rows, symbol, "TTM key metrics")?;
+    Ok(to_key_metrics_ttm(dto, symbol))
+}
+
+/// Fetch the canonical TTM ratios snapshot for a symbol.
+pub async fn fetch_ratios_ttm_response(symbol: &str) -> Result<FinancialRatiosTtm> {
+    let rows = ratios_ttm(symbol).await?;
+    let dto = first_or_missing(rows, symbol, "TTM ratios")?;
+    Ok(to_financial_ratios_ttm(dto, symbol))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn key_metrics_ttm_maps_suffixed_keys() {
+        let dto: KeyMetricsTtmDTO = serde_json::from_value(serde_json::json!({
+            "revenuePerShareTTM": 25.5,
+            "netIncomePerShareTTM": 6.5,
+            "marketCapTTM": 3.4e12,
+            "peRatioTTM": 34.1,
+            "enterpriseValueOverEBITDATTM": 26.2,
+            "roeTTM": 1.6,
+            "roicTTM": 0.55,
+            "dividendYieldTTM": 0.0044,
+            "grahamNumberTTM": 42.1
+        }))
+        .unwrap();
+
+        let out = to_key_metrics_ttm(dto, "AAPL");
+        assert_eq!(out.symbol.as_deref(), Some("AAPL"));
+        assert_eq!(out.revenue_per_share, Some(25.5));
+        assert_eq!(out.market_cap, Some(3.4e12));
+        assert_eq!(out.pe_ratio, Some(34.1));
+        // `enterpriseValueOverEBITDATTM` is renamed to the shorter public name.
+        assert_eq!(out.ev_to_ebitda, Some(26.2));
+        assert_eq!(out.return_on_equity, Some(1.6));
+        assert_eq!(out.return_on_invested_capital, Some(0.55));
+        assert_eq!(out.graham_number, Some(42.1));
+    }
+
+    #[test]
+    fn ratios_ttm_accepts_fmps_misspelled_dividend_yield() {
+        let misspelled: FinancialRatiosTtmDTO = serde_json::from_value(serde_json::json!({
+            "dividendYielTTM": 0.0044
+        }))
+        .unwrap();
+        assert_eq!(misspelled.dividend_yield, Some(0.0044));
+
+        let corrected: FinancialRatiosTtmDTO = serde_json::from_value(serde_json::json!({
+            "dividendYieldTTM": 0.0051
+        }))
+        .unwrap();
+        assert_eq!(corrected.dividend_yield, Some(0.0051));
+    }
+
+    #[test]
+    fn ratios_ttm_maps_margins_and_multiples() {
+        let dto: FinancialRatiosTtmDTO = serde_json::from_value(serde_json::json!({
+            "symbol": "AAPL",
+            "currentRatioTTM": 0.87,
+            "grossProfitMarginTTM": 0.462,
+            "netProfitMarginTTM": 0.239,
+            "priceEarningsRatioTTM": 34.12,
+            "pegRatioTTM": 2.4,
+            "enterpriseValueMultipleTTM": 26.2,
+            "payoutRatioTTM": 0.15
+        }))
+        .unwrap();
+
+        let out = to_financial_ratios_ttm(dto, "MSFT");
+        // Provider-supplied symbol wins over the requested one.
+        assert_eq!(out.symbol.as_deref(), Some("AAPL"));
+        assert_eq!(out.current_ratio, Some(0.87));
+        assert_eq!(out.gross_profit_margin, Some(0.462));
+        assert_eq!(out.net_profit_margin, Some(0.239));
+        assert_eq!(out.price_earnings_ratio, Some(34.12));
+        assert_eq!(out.peg_ratio, Some(2.4));
+        assert_eq!(out.enterprise_value_multiple, Some(26.2));
+        assert_eq!(out.payout_ratio, Some(0.15));
+    }
+
+    #[test]
+    fn empty_response_is_an_error_not_a_panic() {
+        let err =
+            first_or_missing::<KeyMetricsTtmDTO>(vec![], "AAPL", "TTM key metrics").unwrap_err();
+        assert!(
+            matches!(err, FinanceError::SymbolNotFound { .. }),
+            "got {err:?}"
+        );
+    }
+}

--- a/src/adapters/fmp/fundamentals/ttm.rs
+++ b/src/adapters/fmp/fundamentals/ttm.rs
@@ -3,188 +3,21 @@
 //! Distinct from the period-based endpoints in [`analysis`](super::analysis):
 //! these return one always-current rollup rather than a fiscal-period series,
 //! and FMP handles partial periods and restatements server-side.
-
-use serde::{Deserialize, Serialize};
+//!
+//! FMP's `*TTM`-suffixed keys deserialize straight into the public models via
+//! their `serde` aliases — see [`crate::models::fundamentals::ttm`].
 
 use crate::adapters::common::encode_path_segment;
-use crate::adapters::fmp::build_client;
-use crate::error::{FinanceError, Result};
+use crate::adapters::fmp::{build_client, first_or_missing};
+use crate::error::Result;
 use crate::models::fundamentals::{FinancialRatiosTtm, KeyMetricsTtm};
-
-// ============================================================================
-// Response types
-// ============================================================================
-
-/// TTM key-metrics entry (`/api/v3/key-metrics-ttm/{symbol}`).
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[non_exhaustive]
-pub struct KeyMetricsTtmDTO {
-    /// Ticker symbol (absent on some FMP plans).
-    pub symbol: Option<String>,
-    /// Revenue per share.
-    #[serde(rename = "revenuePerShareTTM")]
-    pub revenue_per_share: Option<f64>,
-    /// Net income per share.
-    #[serde(rename = "netIncomePerShareTTM")]
-    pub net_income_per_share: Option<f64>,
-    /// Operating cash flow per share.
-    #[serde(rename = "operatingCashFlowPerShareTTM")]
-    pub operating_cash_flow_per_share: Option<f64>,
-    /// Free cash flow per share.
-    #[serde(rename = "freeCashFlowPerShareTTM")]
-    pub free_cash_flow_per_share: Option<f64>,
-    /// Cash per share.
-    #[serde(rename = "cashPerShareTTM")]
-    pub cash_per_share: Option<f64>,
-    /// Book value per share.
-    #[serde(rename = "bookValuePerShareTTM")]
-    pub book_value_per_share: Option<f64>,
-    /// Tangible book value per share.
-    #[serde(rename = "tangibleBookValuePerShareTTM")]
-    pub tangible_book_value_per_share: Option<f64>,
-    /// Shareholders' equity per share.
-    #[serde(rename = "shareholdersEquityPerShareTTM")]
-    pub shareholders_equity_per_share: Option<f64>,
-    /// Interest-bearing debt per share.
-    #[serde(rename = "interestDebtPerShareTTM")]
-    pub interest_debt_per_share: Option<f64>,
-    /// Market capitalization.
-    #[serde(rename = "marketCapTTM")]
-    pub market_cap: Option<f64>,
-    /// Enterprise value.
-    #[serde(rename = "enterpriseValueTTM")]
-    pub enterprise_value: Option<f64>,
-    /// PE ratio.
-    #[serde(rename = "peRatioTTM")]
-    pub pe_ratio: Option<f64>,
-    /// PB ratio.
-    #[serde(rename = "pbRatioTTM")]
-    pub pb_ratio: Option<f64>,
-    /// EV to sales.
-    #[serde(rename = "evToSalesTTM")]
-    pub ev_to_sales: Option<f64>,
-    /// EV to EBITDA.
-    #[serde(rename = "enterpriseValueOverEBITDATTM")]
-    pub enterprise_value_over_ebitda: Option<f64>,
-    /// EV to operating cash flow.
-    #[serde(rename = "evToOperatingCashFlowTTM")]
-    pub ev_to_operating_cash_flow: Option<f64>,
-    /// EV to free cash flow.
-    #[serde(rename = "evToFreeCashFlowTTM")]
-    pub ev_to_free_cash_flow: Option<f64>,
-    /// Earnings yield.
-    #[serde(rename = "earningsYieldTTM")]
-    pub earnings_yield: Option<f64>,
-    /// Free cash flow yield.
-    #[serde(rename = "freeCashFlowYieldTTM")]
-    pub free_cash_flow_yield: Option<f64>,
-    /// Debt to equity.
-    #[serde(rename = "debtToEquityTTM")]
-    pub debt_to_equity: Option<f64>,
-    /// Debt to assets.
-    #[serde(rename = "debtToAssetsTTM")]
-    pub debt_to_assets: Option<f64>,
-    /// Net debt to EBITDA.
-    #[serde(rename = "netDebtToEBITDATTM")]
-    pub net_debt_to_ebitda: Option<f64>,
-    /// Current ratio.
-    #[serde(rename = "currentRatioTTM")]
-    pub current_ratio: Option<f64>,
-    /// Interest coverage.
-    #[serde(rename = "interestCoverageTTM")]
-    pub interest_coverage: Option<f64>,
-    /// Return on equity.
-    #[serde(rename = "roeTTM")]
-    pub roe: Option<f64>,
-    /// Return on invested capital.
-    #[serde(rename = "roicTTM")]
-    pub roic: Option<f64>,
-    /// Dividend yield.
-    #[serde(rename = "dividendYieldTTM")]
-    pub dividend_yield: Option<f64>,
-    /// Payout ratio.
-    #[serde(rename = "payoutRatioTTM")]
-    pub payout_ratio: Option<f64>,
-    /// Graham number.
-    #[serde(rename = "grahamNumberTTM")]
-    pub graham_number: Option<f64>,
-}
-
-/// TTM ratios entry (`/api/v3/ratios-ttm/{symbol}`).
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[non_exhaustive]
-pub struct FinancialRatiosTtmDTO {
-    /// Ticker symbol (absent on some FMP plans).
-    pub symbol: Option<String>,
-    /// Current ratio.
-    #[serde(rename = "currentRatioTTM")]
-    pub current_ratio: Option<f64>,
-    /// Quick ratio.
-    #[serde(rename = "quickRatioTTM")]
-    pub quick_ratio: Option<f64>,
-    /// Cash ratio.
-    #[serde(rename = "cashRatioTTM")]
-    pub cash_ratio: Option<f64>,
-    /// Gross profit margin.
-    #[serde(rename = "grossProfitMarginTTM")]
-    pub gross_profit_margin: Option<f64>,
-    /// Operating profit margin.
-    #[serde(rename = "operatingProfitMarginTTM")]
-    pub operating_profit_margin: Option<f64>,
-    /// Net profit margin.
-    #[serde(rename = "netProfitMarginTTM")]
-    pub net_profit_margin: Option<f64>,
-    /// Return on assets.
-    #[serde(rename = "returnOnAssetsTTM")]
-    pub return_on_assets: Option<f64>,
-    /// Return on equity.
-    #[serde(rename = "returnOnEquityTTM")]
-    pub return_on_equity: Option<f64>,
-    /// Return on capital employed.
-    #[serde(rename = "returnOnCapitalEmployedTTM")]
-    pub return_on_capital_employed: Option<f64>,
-    /// Debt ratio.
-    #[serde(rename = "debtRatioTTM")]
-    pub debt_ratio: Option<f64>,
-    /// Debt-to-equity ratio.
-    #[serde(rename = "debtEquityRatioTTM")]
-    pub debt_equity_ratio: Option<f64>,
-    /// Interest coverage.
-    #[serde(rename = "interestCoverageTTM")]
-    pub interest_coverage: Option<f64>,
-    /// Price-to-earnings ratio.
-    #[serde(rename = "priceEarningsRatioTTM")]
-    pub price_earnings_ratio: Option<f64>,
-    /// Price/earnings-to-growth ratio.
-    #[serde(rename = "pegRatioTTM")]
-    pub peg_ratio: Option<f64>,
-    /// Price-to-book ratio.
-    #[serde(rename = "priceToBookRatioTTM")]
-    pub price_to_book_ratio: Option<f64>,
-    /// Price-to-sales ratio.
-    #[serde(rename = "priceToSalesRatioTTM")]
-    pub price_to_sales_ratio: Option<f64>,
-    /// Price-to-free-cash-flow ratio.
-    #[serde(rename = "priceToFreeCashFlowsRatioTTM")]
-    pub price_to_free_cash_flows_ratio: Option<f64>,
-    /// Enterprise value multiple.
-    #[serde(rename = "enterpriseValueMultipleTTM")]
-    pub enterprise_value_multiple: Option<f64>,
-    /// Dividend yield. FMP spells the canonical key `dividendYielTTM` (sic) on
-    /// this endpoint; the alias covers plans that return the corrected spelling.
-    #[serde(rename = "dividendYielTTM", alias = "dividendYieldTTM")]
-    pub dividend_yield: Option<f64>,
-    /// Payout ratio.
-    #[serde(rename = "payoutRatioTTM")]
-    pub payout_ratio: Option<f64>,
-}
 
 // ============================================================================
 // Query functions
 // ============================================================================
 
 /// Fetch the TTM key-metrics snapshot for a symbol.
-pub async fn key_metrics_ttm(symbol: &str) -> Result<Vec<KeyMetricsTtmDTO>> {
+pub async fn key_metrics_ttm(symbol: &str) -> Result<Vec<KeyMetricsTtm>> {
     build_client()?
         .get(
             &format!("/api/v3/key-metrics-ttm/{}", encode_path_segment(symbol)),
@@ -194,7 +27,7 @@ pub async fn key_metrics_ttm(symbol: &str) -> Result<Vec<KeyMetricsTtmDTO>> {
 }
 
 /// Fetch the TTM ratios snapshot for a symbol.
-pub async fn ratios_ttm(symbol: &str) -> Result<Vec<FinancialRatiosTtmDTO>> {
+pub async fn ratios_ttm(symbol: &str) -> Result<Vec<FinancialRatiosTtm>> {
     build_client()?
         .get(
             &format!("/api/v3/ratios-ttm/{}", encode_path_segment(symbol)),
@@ -204,103 +37,33 @@ pub async fn ratios_ttm(symbol: &str) -> Result<Vec<FinancialRatiosTtmDTO>> {
 }
 
 // ============================================================================
-// Canonical conversions
+// Canonical responses
 // ============================================================================
-
-fn first_or_missing<T>(rows: Vec<T>, symbol: &str, field: &str) -> Result<T> {
-    rows.into_iter()
-        .next()
-        .ok_or_else(|| FinanceError::SymbolNotFound {
-            symbol: Some(symbol.to_string()),
-            context: format!("FMP returned no {field} for {symbol}"),
-        })
-}
-
-pub(crate) fn to_key_metrics_ttm(dto: KeyMetricsTtmDTO, symbol: &str) -> KeyMetricsTtm {
-    KeyMetricsTtm {
-        symbol: dto.symbol.or_else(|| Some(symbol.to_string())),
-        revenue_per_share: dto.revenue_per_share,
-        net_income_per_share: dto.net_income_per_share,
-        operating_cash_flow_per_share: dto.operating_cash_flow_per_share,
-        free_cash_flow_per_share: dto.free_cash_flow_per_share,
-        cash_per_share: dto.cash_per_share,
-        book_value_per_share: dto.book_value_per_share,
-        tangible_book_value_per_share: dto.tangible_book_value_per_share,
-        shareholders_equity_per_share: dto.shareholders_equity_per_share,
-        interest_debt_per_share: dto.interest_debt_per_share,
-        market_cap: dto.market_cap,
-        enterprise_value: dto.enterprise_value,
-        pe_ratio: dto.pe_ratio,
-        pb_ratio: dto.pb_ratio,
-        ev_to_sales: dto.ev_to_sales,
-        ev_to_ebitda: dto.enterprise_value_over_ebitda,
-        ev_to_operating_cash_flow: dto.ev_to_operating_cash_flow,
-        ev_to_free_cash_flow: dto.ev_to_free_cash_flow,
-        earnings_yield: dto.earnings_yield,
-        free_cash_flow_yield: dto.free_cash_flow_yield,
-        debt_to_equity: dto.debt_to_equity,
-        debt_to_assets: dto.debt_to_assets,
-        net_debt_to_ebitda: dto.net_debt_to_ebitda,
-        current_ratio: dto.current_ratio,
-        interest_coverage: dto.interest_coverage,
-        return_on_equity: dto.roe,
-        return_on_invested_capital: dto.roic,
-        dividend_yield: dto.dividend_yield,
-        payout_ratio: dto.payout_ratio,
-        graham_number: dto.graham_number,
-    }
-}
-
-pub(crate) fn to_financial_ratios_ttm(
-    dto: FinancialRatiosTtmDTO,
-    symbol: &str,
-) -> FinancialRatiosTtm {
-    FinancialRatiosTtm {
-        symbol: dto.symbol.or_else(|| Some(symbol.to_string())),
-        current_ratio: dto.current_ratio,
-        quick_ratio: dto.quick_ratio,
-        cash_ratio: dto.cash_ratio,
-        gross_profit_margin: dto.gross_profit_margin,
-        operating_profit_margin: dto.operating_profit_margin,
-        net_profit_margin: dto.net_profit_margin,
-        return_on_assets: dto.return_on_assets,
-        return_on_equity: dto.return_on_equity,
-        return_on_capital_employed: dto.return_on_capital_employed,
-        debt_ratio: dto.debt_ratio,
-        debt_equity_ratio: dto.debt_equity_ratio,
-        interest_coverage: dto.interest_coverage,
-        price_earnings_ratio: dto.price_earnings_ratio,
-        peg_ratio: dto.peg_ratio,
-        price_to_book_ratio: dto.price_to_book_ratio,
-        price_to_sales_ratio: dto.price_to_sales_ratio,
-        price_to_free_cash_flows_ratio: dto.price_to_free_cash_flows_ratio,
-        enterprise_value_multiple: dto.enterprise_value_multiple,
-        dividend_yield: dto.dividend_yield,
-        payout_ratio: dto.payout_ratio,
-    }
-}
 
 /// Fetch the canonical TTM key-metrics snapshot for a symbol.
 pub async fn fetch_key_metrics_ttm_response(symbol: &str) -> Result<KeyMetricsTtm> {
     let rows = key_metrics_ttm(symbol).await?;
-    let dto = first_or_missing(rows, symbol, "TTM key metrics")?;
-    Ok(to_key_metrics_ttm(dto, symbol))
+    let mut metrics = first_or_missing(rows, symbol, "TTM key metrics")?;
+    metrics.symbol = metrics.symbol.or_else(|| Some(symbol.to_string()));
+    Ok(metrics)
 }
 
 /// Fetch the canonical TTM ratios snapshot for a symbol.
 pub async fn fetch_ratios_ttm_response(symbol: &str) -> Result<FinancialRatiosTtm> {
     let rows = ratios_ttm(symbol).await?;
-    let dto = first_or_missing(rows, symbol, "TTM ratios")?;
-    Ok(to_financial_ratios_ttm(dto, symbol))
+    let mut ratios = first_or_missing(rows, symbol, "TTM ratios")?;
+    ratios.symbol = ratios.symbol.or_else(|| Some(symbol.to_string()));
+    Ok(ratios)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::FinanceError;
 
     #[test]
     fn key_metrics_ttm_maps_suffixed_keys() {
-        let dto: KeyMetricsTtmDTO = serde_json::from_value(serde_json::json!({
+        let out: KeyMetricsTtm = serde_json::from_value(serde_json::json!({
             "revenuePerShareTTM": 25.5,
             "netIncomePerShareTTM": 6.5,
             "marketCapTTM": 3.4e12,
@@ -313,12 +76,10 @@ mod tests {
         }))
         .unwrap();
 
-        let out = to_key_metrics_ttm(dto, "AAPL");
-        assert_eq!(out.symbol.as_deref(), Some("AAPL"));
         assert_eq!(out.revenue_per_share, Some(25.5));
         assert_eq!(out.market_cap, Some(3.4e12));
         assert_eq!(out.pe_ratio, Some(34.1));
-        // `enterpriseValueOverEBITDATTM` is renamed to the shorter public name.
+        // `enterpriseValueOverEBITDATTM` is aliased to the shorter public name.
         assert_eq!(out.ev_to_ebitda, Some(26.2));
         assert_eq!(out.return_on_equity, Some(1.6));
         assert_eq!(out.return_on_invested_capital, Some(0.55));
@@ -327,13 +88,13 @@ mod tests {
 
     #[test]
     fn ratios_ttm_accepts_fmps_misspelled_dividend_yield() {
-        let misspelled: FinancialRatiosTtmDTO = serde_json::from_value(serde_json::json!({
+        let misspelled: FinancialRatiosTtm = serde_json::from_value(serde_json::json!({
             "dividendYielTTM": 0.0044
         }))
         .unwrap();
         assert_eq!(misspelled.dividend_yield, Some(0.0044));
 
-        let corrected: FinancialRatiosTtmDTO = serde_json::from_value(serde_json::json!({
+        let corrected: FinancialRatiosTtm = serde_json::from_value(serde_json::json!({
             "dividendYieldTTM": 0.0051
         }))
         .unwrap();
@@ -342,7 +103,7 @@ mod tests {
 
     #[test]
     fn ratios_ttm_maps_margins_and_multiples() {
-        let dto: FinancialRatiosTtmDTO = serde_json::from_value(serde_json::json!({
+        let out: FinancialRatiosTtm = serde_json::from_value(serde_json::json!({
             "symbol": "AAPL",
             "currentRatioTTM": 0.87,
             "grossProfitMarginTTM": 0.462,
@@ -354,8 +115,6 @@ mod tests {
         }))
         .unwrap();
 
-        let out = to_financial_ratios_ttm(dto, "MSFT");
-        // Provider-supplied symbol wins over the requested one.
         assert_eq!(out.symbol.as_deref(), Some("AAPL"));
         assert_eq!(out.current_ratio, Some(0.87));
         assert_eq!(out.gross_profit_margin, Some(0.462));
@@ -366,10 +125,19 @@ mod tests {
         assert_eq!(out.payout_ratio, Some(0.15));
     }
 
+    /// Aliases are deserialize-only, so the emitted JSON shape is unchanged.
+    #[test]
+    fn serialized_output_stays_snake_case() {
+        let parsed: KeyMetricsTtm =
+            serde_json::from_value(serde_json::json!({ "marketCapTTM": 3.4e12 })).unwrap();
+        let json = serde_json::to_value(&parsed).unwrap();
+        assert!(json.get("market_cap").is_some());
+        assert!(json.get("marketCapTTM").is_none());
+    }
+
     #[test]
     fn empty_response_is_an_error_not_a_panic() {
-        let err =
-            first_or_missing::<KeyMetricsTtmDTO>(vec![], "AAPL", "TTM key metrics").unwrap_err();
+        let err = first_or_missing::<KeyMetricsTtm>(vec![], "AAPL", "TTM key metrics").unwrap_err();
         assert!(
             matches!(err, FinanceError::SymbolNotFound { .. }),
             "got {err:?}"

--- a/src/adapters/fmp/mod.rs
+++ b/src/adapters/fmp/mod.rs
@@ -40,10 +40,23 @@ pub(crate) mod market; // CALENDAR + MARKET
 pub(crate) mod quote; // QUOTE
 
 use crate::adapters::singleton::{provider_build_client, provider_singleton_state};
-use crate::error::Result;
+use crate::error::{FinanceError, Result};
 use std::time::Duration;
 
 pub use models::*;
+
+/// Take the first row of a single-row FMP response.
+///
+/// FMP wraps per-symbol rollups in a single-element array; an empty one means
+/// the symbol is absent from FMP's universe rather than that the call failed.
+pub(crate) fn first_or_missing<T>(rows: Vec<T>, symbol: &str, field: &str) -> Result<T> {
+    rows.into_iter()
+        .next()
+        .ok_or_else(|| FinanceError::SymbolNotFound {
+            symbol: Some(symbol.to_string()),
+            context: format!("FMP returned no {field} for {symbol}"),
+        })
+}
 
 /// FMP default rate limit: 5 req/sec.
 const FMP_RATE_PER_SEC: f64 = 5.0;

--- a/src/adapters/fred/client.rs
+++ b/src/adapters/fred/client.rs
@@ -73,6 +73,57 @@ pub(crate) struct FredClient {
 }
 
 impl FredClient {
+    /// Map a FRED HTTP status onto a `FinanceError`.
+    fn check_status(status: StatusCode) -> Result<()> {
+        match status {
+            StatusCode::OK => Ok(()),
+            StatusCode::BAD_REQUEST => Err(FinanceError::InvalidParameter {
+                param: "request".to_string(),
+                reason: "FRED rejected the request parameters".to_string(),
+            }),
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
+                Err(FinanceError::AuthenticationFailed {
+                    context: "FRED API key invalid or missing. Call fred::init(key) first."
+                        .to_string(),
+                })
+            }
+            StatusCode::TOO_MANY_REQUESTS => Err(FinanceError::RateLimited {
+                retry_after: Some(60),
+            }),
+            s => Err(FinanceError::ExternalApiError {
+                api: "FRED".to_string(),
+                status: s.as_u16(),
+            }),
+        }
+    }
+
+    /// Rate-limited GET against a FRED path, deserialized into `T`.
+    ///
+    /// The api key and `file_type=json` are always appended, so callers pass
+    /// only the endpoint-specific parameters.
+    pub async fn get_json<T: serde::de::DeserializeOwned>(
+        &self,
+        path: &str,
+        params: &[(&str, &str)],
+    ) -> Result<T> {
+        self.limiter.acquire().await;
+
+        let url = format!("{}/{path}", self.base_url);
+        let mut query: Vec<(&str, &str)> = vec![("api_key", &self.api_key), ("file_type", "json")];
+        query.extend_from_slice(params);
+
+        debug!("FRED request: {path}");
+        let resp = self.http.get(&url).query(&query).send().await?;
+        Self::check_status(resp.status())?;
+
+        resp.json()
+            .await
+            .map_err(|e| FinanceError::ResponseStructureError {
+                field: path.to_string(),
+                context: format!("Failed to deserialize FRED response: {e}"),
+            })
+    }
+
     /// Fetch all observations for a FRED series by ID (e.g., `"FEDFUNDS"`, `"CPIAUCSL"`).
     pub async fn series(&self, series_id: &str) -> Result<MacroSeries> {
         self.limiter.acquire().await;

--- a/src/adapters/fred/economic/catalog.rs
+++ b/src/adapters/fred/economic/catalog.rs
@@ -18,36 +18,15 @@ use crate::models::economic::{
 // Response types
 // ============================================================================
 
+// FRED's entry payloads are already snake_case and field-for-field identical
+// to the public models, so the envelopes deserialize straight into them.
+
 /// `/series/search` and `/series` envelope.
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct SeriesSearchResponseDTO {
     /// Matching series. FRED spells the key `seriess` (sic).
     #[serde(default)]
-    pub seriess: Vec<SeriesDTO>,
-}
-
-/// One series entry.
-#[derive(Debug, Clone, Deserialize)]
-pub struct SeriesDTO {
-    /// Series id.
-    pub id: String,
-    /// Title.
-    pub title: Option<String>,
-    /// Reporting frequency, long form.
-    pub frequency: Option<String>,
-    /// Units, long form.
-    pub units: Option<String>,
-    /// Seasonal adjustment, long form.
-    pub seasonal_adjustment: Option<String>,
-    /// Earliest observation date.
-    pub observation_start: Option<String>,
-    /// Latest observation date.
-    pub observation_end: Option<String>,
-    /// FRED popularity score.
-    pub popularity: Option<i64>,
-    /// Free-text notes.
-    pub notes: Option<String>,
+    pub seriess: Vec<EconomicSeriesMatch>,
 }
 
 /// `/category/children` envelope.
@@ -55,18 +34,7 @@ pub struct SeriesDTO {
 pub struct CategoriesResponseDTO {
     /// Child categories.
     #[serde(default)]
-    pub categories: Vec<CategoryDTO>,
-}
-
-/// One category entry.
-#[derive(Debug, Clone, Deserialize)]
-pub struct CategoryDTO {
-    /// Category id.
-    pub id: i64,
-    /// Category name.
-    pub name: Option<String>,
-    /// Parent category id.
-    pub parent_id: Option<i64>,
+    pub categories: Vec<EconomicCategory>,
 }
 
 /// `/releases` envelope.
@@ -74,20 +42,7 @@ pub struct CategoryDTO {
 pub struct ReleasesResponseDTO {
     /// Releases.
     #[serde(default)]
-    pub releases: Vec<ReleaseDTO>,
-}
-
-/// One release entry.
-#[derive(Debug, Clone, Deserialize)]
-pub struct ReleaseDTO {
-    /// Release id.
-    pub id: i64,
-    /// Release name.
-    pub name: Option<String>,
-    /// Whether a press release accompanies it.
-    pub press_release: Option<bool>,
-    /// Publisher link.
-    pub link: Option<String>,
+    pub releases: Vec<EconomicRelease>,
 }
 
 /// `/series/observations` envelope.
@@ -108,39 +63,8 @@ pub struct ObservationDTO {
 }
 
 // ============================================================================
-// Canonical conversions
+// Observation conversion
 // ============================================================================
-
-pub(crate) fn to_series_match(dto: SeriesDTO) -> EconomicSeriesMatch {
-    EconomicSeriesMatch {
-        id: dto.id,
-        title: dto.title,
-        frequency: dto.frequency,
-        units: dto.units,
-        seasonal_adjustment: dto.seasonal_adjustment,
-        observation_start: dto.observation_start,
-        observation_end: dto.observation_end,
-        popularity: dto.popularity,
-        notes: dto.notes,
-    }
-}
-
-pub(crate) fn to_category(dto: CategoryDTO) -> EconomicCategory {
-    EconomicCategory {
-        id: dto.id,
-        name: dto.name,
-        parent_id: dto.parent_id,
-    }
-}
-
-pub(crate) fn to_release(dto: ReleaseDTO) -> EconomicRelease {
-    EconomicRelease {
-        id: dto.id,
-        name: dto.name,
-        press_release: dto.press_release,
-        link: dto.link,
-    }
-}
 
 pub(crate) fn to_observations(dto: ObservationsResponseDTO) -> Vec<MacroObservation> {
     dto.observations
@@ -172,7 +96,7 @@ pub async fn search(query: &str, limit: u32) -> Result<Vec<EconomicSeriesMatch>>
             ],
         )
         .await?;
-    Ok(resp.seriess.into_iter().map(to_series_match).collect())
+    Ok(resp.seriess)
 }
 
 /// List the child categories of `parent_id`. FRED's root category is `0`.
@@ -181,13 +105,13 @@ pub async fn categories(parent_id: i64) -> Result<Vec<EconomicCategory>> {
     let resp: CategoriesResponseDTO = build_client()?
         .get_json("category/children", &[("category_id", &id)])
         .await?;
-    Ok(resp.categories.into_iter().map(to_category).collect())
+    Ok(resp.categories)
 }
 
 /// List every economic-data release FRED publishes.
 pub async fn releases() -> Result<Vec<EconomicRelease>> {
     let resp: ReleasesResponseDTO = build_client()?.get_json("releases", &[]).await?;
-    Ok(resp.releases.into_iter().map(to_release).collect())
+    Ok(resp.releases)
 }
 
 /// Fetch a series as it stood on `date` (`YYYY-MM-DD`) — ALFRED's vintage view.
@@ -236,7 +160,7 @@ mod tests {
         }))
         .unwrap();
 
-        let out = to_series_match(resp.seriess.into_iter().next().unwrap());
+        let out = resp.seriess.into_iter().next().unwrap();
         assert_eq!(out.id, "GDPC1");
         assert_eq!(out.title.as_deref(), Some("Real Gross Domestic Product"));
         assert_eq!(out.frequency.as_deref(), Some("Quarterly"));
@@ -261,7 +185,7 @@ mod tests {
             "categories": [{ "id": 32992, "name": "Money, Banking, & Finance", "parent_id": 0 }]
         }))
         .unwrap();
-        let cat = to_category(cats.categories.into_iter().next().unwrap());
+        let cat = cats.categories.into_iter().next().unwrap();
         assert_eq!(cat.id, 32992);
         assert_eq!(cat.parent_id, Some(0));
 
@@ -274,7 +198,7 @@ mod tests {
             }]
         }))
         .unwrap();
-        let rel = to_release(rels.releases.into_iter().next().unwrap());
+        let rel = rels.releases.into_iter().next().unwrap();
         assert_eq!(rel.name.as_deref(), Some("Employment Situation"));
         assert_eq!(rel.press_release, Some(true));
     }

--- a/src/adapters/fred/economic/catalog.rs
+++ b/src/adapters/fred/economic/catalog.rs
@@ -1,0 +1,302 @@
+//! FRED series discovery (search, category and release browsing) and ALFRED
+//! vintages.
+//!
+//! Without these, a caller has to already know a series id exists. The vintage
+//! parameters matter separately: FRED revises macro data, so backtesting a
+//! strategy against today's `GDPC1` is look-ahead bias — `as_of` asks for the
+//! series as it stood on a past date.
+
+use serde::Deserialize;
+
+use crate::adapters::fred::build_client;
+use crate::error::Result;
+use crate::models::economic::{
+    EconomicCategory, EconomicRelease, EconomicSeries, EconomicSeriesMatch, MacroObservation,
+};
+
+// ============================================================================
+// Response types
+// ============================================================================
+
+/// `/series/search` and `/series` envelope.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SeriesSearchResponseDTO {
+    /// Matching series. FRED spells the key `seriess` (sic).
+    #[serde(default)]
+    pub seriess: Vec<SeriesDTO>,
+}
+
+/// One series entry.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SeriesDTO {
+    /// Series id.
+    pub id: String,
+    /// Title.
+    pub title: Option<String>,
+    /// Reporting frequency, long form.
+    pub frequency: Option<String>,
+    /// Units, long form.
+    pub units: Option<String>,
+    /// Seasonal adjustment, long form.
+    pub seasonal_adjustment: Option<String>,
+    /// Earliest observation date.
+    pub observation_start: Option<String>,
+    /// Latest observation date.
+    pub observation_end: Option<String>,
+    /// FRED popularity score.
+    pub popularity: Option<i64>,
+    /// Free-text notes.
+    pub notes: Option<String>,
+}
+
+/// `/category/children` envelope.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CategoriesResponseDTO {
+    /// Child categories.
+    #[serde(default)]
+    pub categories: Vec<CategoryDTO>,
+}
+
+/// One category entry.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CategoryDTO {
+    /// Category id.
+    pub id: i64,
+    /// Category name.
+    pub name: Option<String>,
+    /// Parent category id.
+    pub parent_id: Option<i64>,
+}
+
+/// `/releases` envelope.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ReleasesResponseDTO {
+    /// Releases.
+    #[serde(default)]
+    pub releases: Vec<ReleaseDTO>,
+}
+
+/// One release entry.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ReleaseDTO {
+    /// Release id.
+    pub id: i64,
+    /// Release name.
+    pub name: Option<String>,
+    /// Whether a press release accompanies it.
+    pub press_release: Option<bool>,
+    /// Publisher link.
+    pub link: Option<String>,
+}
+
+/// `/series/observations` envelope.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ObservationsResponseDTO {
+    /// Observations.
+    #[serde(default)]
+    pub observations: Vec<ObservationDTO>,
+}
+
+/// One observation. FRED sends values as strings, using `"."` for missing.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ObservationDTO {
+    /// Observation date.
+    pub date: String,
+    /// Observation value as filed.
+    pub value: String,
+}
+
+// ============================================================================
+// Canonical conversions
+// ============================================================================
+
+pub(crate) fn to_series_match(dto: SeriesDTO) -> EconomicSeriesMatch {
+    EconomicSeriesMatch {
+        id: dto.id,
+        title: dto.title,
+        frequency: dto.frequency,
+        units: dto.units,
+        seasonal_adjustment: dto.seasonal_adjustment,
+        observation_start: dto.observation_start,
+        observation_end: dto.observation_end,
+        popularity: dto.popularity,
+        notes: dto.notes,
+    }
+}
+
+pub(crate) fn to_category(dto: CategoryDTO) -> EconomicCategory {
+    EconomicCategory {
+        id: dto.id,
+        name: dto.name,
+        parent_id: dto.parent_id,
+    }
+}
+
+pub(crate) fn to_release(dto: ReleaseDTO) -> EconomicRelease {
+    EconomicRelease {
+        id: dto.id,
+        name: dto.name,
+        press_release: dto.press_release,
+        link: dto.link,
+    }
+}
+
+pub(crate) fn to_observations(dto: ObservationsResponseDTO) -> Vec<MacroObservation> {
+    dto.observations
+        .into_iter()
+        .map(|o| MacroObservation {
+            date: o.date,
+            // "." is FRED's missing marker; anything unparseable is treated the
+            // same way rather than dropping the observation's date entirely.
+            value: (o.value != ".").then(|| o.value.parse().ok()).flatten(),
+        })
+        .collect()
+}
+
+// ============================================================================
+// Query functions
+// ============================================================================
+
+/// Search the FRED series catalog by free text.
+pub async fn search(query: &str, limit: u32) -> Result<Vec<EconomicSeriesMatch>> {
+    let limit = limit.clamp(1, 1000).to_string();
+    let resp: SeriesSearchResponseDTO = build_client()?
+        .get_json(
+            "series/search",
+            &[
+                ("search_text", query),
+                ("limit", &limit),
+                ("order_by", "popularity"),
+                ("sort_order", "desc"),
+            ],
+        )
+        .await?;
+    Ok(resp.seriess.into_iter().map(to_series_match).collect())
+}
+
+/// List the child categories of `parent_id`. FRED's root category is `0`.
+pub async fn categories(parent_id: i64) -> Result<Vec<EconomicCategory>> {
+    let id = parent_id.to_string();
+    let resp: CategoriesResponseDTO = build_client()?
+        .get_json("category/children", &[("category_id", &id)])
+        .await?;
+    Ok(resp.categories.into_iter().map(to_category).collect())
+}
+
+/// List every economic-data release FRED publishes.
+pub async fn releases() -> Result<Vec<EconomicRelease>> {
+    let resp: ReleasesResponseDTO = build_client()?.get_json("releases", &[]).await?;
+    Ok(resp.releases.into_iter().map(to_release).collect())
+}
+
+/// Fetch a series as it stood on `date` (`YYYY-MM-DD`) — ALFRED's vintage view.
+///
+/// Both realtime bounds are pinned to `date` so the response contains exactly
+/// the values published as of that day, not a range of revisions.
+pub async fn series_as_of(series_id: &str, date: &str) -> Result<EconomicSeries> {
+    let resp: ObservationsResponseDTO = build_client()?
+        .get_json(
+            "series/observations",
+            &[
+                ("series_id", series_id),
+                ("realtime_start", date),
+                ("realtime_end", date),
+            ],
+        )
+        .await?;
+
+    Ok(EconomicSeries {
+        series_id: series_id.to_string(),
+        title: None,
+        units: None,
+        frequency: None,
+        observations: to_observations(resp),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_a_search_hit_including_fmts_misspelled_envelope_key() {
+        let resp: SeriesSearchResponseDTO = serde_json::from_value(serde_json::json!({
+            "seriess": [{
+                "id": "GDPC1",
+                "title": "Real Gross Domestic Product",
+                "frequency": "Quarterly",
+                "units": "Billions of Chained 2017 Dollars",
+                "seasonal_adjustment": "Seasonally Adjusted Annual Rate",
+                "observation_start": "1947-01-01",
+                "observation_end": "2024-07-01",
+                "popularity": 93,
+                "notes": "BEA Account Code: A191RX"
+            }]
+        }))
+        .unwrap();
+
+        let out = to_series_match(resp.seriess.into_iter().next().unwrap());
+        assert_eq!(out.id, "GDPC1");
+        assert_eq!(out.title.as_deref(), Some("Real Gross Domestic Product"));
+        assert_eq!(out.frequency.as_deref(), Some("Quarterly"));
+        assert_eq!(out.observation_start.as_deref(), Some("1947-01-01"));
+        assert_eq!(out.popularity, Some(93));
+    }
+
+    #[test]
+    fn missing_envelope_arrays_yield_empty_results() {
+        let search: SeriesSearchResponseDTO =
+            serde_json::from_value(serde_json::json!({})).unwrap();
+        assert!(search.seriess.is_empty());
+        let cats: CategoriesResponseDTO = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert!(cats.categories.is_empty());
+        let rels: ReleasesResponseDTO = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert!(rels.releases.is_empty());
+    }
+
+    #[test]
+    fn maps_categories_and_releases() {
+        let cats: CategoriesResponseDTO = serde_json::from_value(serde_json::json!({
+            "categories": [{ "id": 32992, "name": "Money, Banking, & Finance", "parent_id": 0 }]
+        }))
+        .unwrap();
+        let cat = to_category(cats.categories.into_iter().next().unwrap());
+        assert_eq!(cat.id, 32992);
+        assert_eq!(cat.parent_id, Some(0));
+
+        let rels: ReleasesResponseDTO = serde_json::from_value(serde_json::json!({
+            "releases": [{
+                "id": 50,
+                "name": "Employment Situation",
+                "press_release": true,
+                "link": "https://www.bls.gov/news.release/empsit.htm"
+            }]
+        }))
+        .unwrap();
+        let rel = to_release(rels.releases.into_iter().next().unwrap());
+        assert_eq!(rel.name.as_deref(), Some("Employment Situation"));
+        assert_eq!(rel.press_release, Some(true));
+    }
+
+    /// FRED encodes a missing observation as `"."`; keeping the date with a
+    /// `None` value preserves the series' spacing.
+    #[test]
+    fn missing_observations_keep_their_date() {
+        let resp: ObservationsResponseDTO = serde_json::from_value(serde_json::json!({
+            "observations": [
+                { "date": "2020-01-01", "value": "21538.032" },
+                { "date": "2020-04-01", "value": "." },
+                { "date": "2020-07-01", "value": "not-a-number" }
+            ]
+        }))
+        .unwrap();
+
+        let obs = to_observations(resp);
+        assert_eq!(obs.len(), 3);
+        assert_eq!(obs[0].value, Some(21538.032));
+        assert_eq!(obs[1].date, "2020-04-01");
+        assert_eq!(obs[1].value, None);
+        assert_eq!(obs[2].value, None);
+    }
+}

--- a/src/adapters/fred/economic/mod.rs
+++ b/src/adapters/fred/economic/mod.rs
@@ -1,1 +1,2 @@
+pub(crate) mod catalog;
 pub(crate) mod treasury;

--- a/src/adapters/fred/mod.rs
+++ b/src/adapters/fred/mod.rs
@@ -32,8 +32,8 @@
 //! # }
 //! ```
 
-mod client;
-mod economic;
+pub(crate) mod client;
+pub(crate) mod economic;
 pub mod models;
 
 use crate::adapters::singleton::provider_singleton_state;
@@ -100,16 +100,23 @@ pub fn init_with_timeout(api_key: impl Into<String>, timeout: Duration) -> Resul
 ///
 /// Returns [`FinanceError::InvalidParameter`] if FRED has not been initialized.
 pub async fn series(series_id: &str) -> Result<MacroSeries> {
+    build_client()?.series(series_id).await
+}
+
+/// Build a FRED client from the initialized singleton.
+///
+/// A fresh `reqwest::Client` per call is deliberate (see the singleton note
+/// above); the rate limiter is shared so the 2 req/sec ceiling still holds.
+pub(crate) fn build_client() -> Result<client::FredClient> {
     let s = FRED_SINGLETON
         .get()
         .ok_or_else(|| FinanceError::InvalidParameter {
             param: "fred".to_string(),
             reason: "FRED not initialized. Call fred::init(api_key) first.".to_string(),
         })?;
-    let c = FredClientBuilder::new(&s.api_key)
+    FredClientBuilder::new(&s.api_key)
         .timeout(s.timeout)
-        .build_with_limiter(Arc::clone(&s.limiter))?;
-    c.series(series_id).await
+        .build_with_limiter(Arc::clone(&s.limiter))
 }
 
 /// Fetch upcoming scheduled economic-data release dates (CPI, NFP, GDP, FOMC, …).
@@ -120,17 +127,8 @@ pub async fn series(series_id: &str) -> Result<MacroSeries> {
 ///
 /// Returns [`FinanceError::InvalidParameter`] if FRED has not been initialized.
 pub async fn release_dates() -> Result<Vec<ReleaseDate>> {
-    let s = FRED_SINGLETON
-        .get()
-        .ok_or_else(|| FinanceError::InvalidParameter {
-            param: "fred".to_string(),
-            reason: "FRED not initialized. Call fred::init(api_key) first.".to_string(),
-        })?;
     let today = chrono::Utc::now().format("%Y-%m-%d").to_string();
-    let c = FredClientBuilder::new(&s.api_key)
-        .timeout(s.timeout)
-        .build_with_limiter(Arc::clone(&s.limiter))?;
-    c.release_dates(&today).await
+    build_client()?.release_dates(&today).await
 }
 
 /// Fetch US Treasury yield curve data for the given year.

--- a/src/adapters/polygon/quote/mod.rs
+++ b/src/adapters/polygon/quote/mod.rs
@@ -9,6 +9,7 @@ use super::models::*;
 
 #[allow(dead_code)] // unrouted: tick-level trades land with #250
 pub mod trades;
+pub mod unified;
 
 /// Fetch snapshot for a single stock ticker.
 pub async fn stock_snapshot(ticker: &str) -> Result<SingleSnapshotResponseDTO> {

--- a/src/adapters/polygon/quote/unified.rs
+++ b/src/adapters/polygon/quote/unified.rs
@@ -1,0 +1,276 @@
+//! Polygon's unified cross-market snapshot (`GET /v3/snapshot`).
+//!
+//! One request covers stocks, options, FX, crypto, and indices — the
+//! per-market snapshot endpoints each cost their own request and rate-limit
+//! unit, which matters on the 5 req/sec free tier.
+
+use serde::{Deserialize, Serialize};
+
+use crate::adapters::polygon::build_client;
+use crate::error::{FinanceError, Result};
+use crate::models::quote::snapshot::{AssetClass, MarketSnapshot};
+
+/// Polygon caps `ticker.any_of` at 250 symbols per request.
+const MAX_SYMBOLS: usize = 250;
+
+// ============================================================================
+// Response types
+// ============================================================================
+
+/// `GET /v3/snapshot` envelope.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct UnifiedSnapshotResponseDTO {
+    /// Snapshot rows, one per resolved (or failed) ticker.
+    pub results: Option<Vec<UnifiedSnapshotDTO>>,
+    /// Cursor URL for the next page.
+    pub next_url: Option<String>,
+    /// Request identifier.
+    pub request_id: Option<String>,
+    /// Response status.
+    pub status: Option<String>,
+}
+
+/// One row of a unified snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct UnifiedSnapshotDTO {
+    /// Ticker symbol.
+    pub ticker: Option<String>,
+    /// Instrument name.
+    pub name: Option<String>,
+    /// Asset class (`stocks`, `options`, `fx`, `crypto`, `indices`).
+    #[serde(rename = "type")]
+    pub asset_type: Option<String>,
+    /// Market trading status.
+    pub market_status: Option<String>,
+    /// Most recent trade.
+    pub last_trade: Option<UnifiedTradeDTO>,
+    /// Most recent quote.
+    pub last_quote: Option<UnifiedQuoteDTO>,
+    /// Current trading session aggregates.
+    pub session: Option<UnifiedSessionDTO>,
+    /// Per-ticker error code (e.g. `"NOT_FOUND"`).
+    pub error: Option<String>,
+    /// Per-ticker error message.
+    pub message: Option<String>,
+}
+
+/// Last-trade block of a unified snapshot row.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct UnifiedTradeDTO {
+    /// Trade price.
+    pub price: Option<f64>,
+    /// Trade size.
+    pub size: Option<f64>,
+}
+
+/// Last-quote block of a unified snapshot row.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct UnifiedQuoteDTO {
+    /// Best bid.
+    pub bid: Option<f64>,
+    /// Best ask.
+    pub ask: Option<f64>,
+}
+
+/// Session block of a unified snapshot row.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct UnifiedSessionDTO {
+    /// Session open.
+    pub open: Option<f64>,
+    /// Session high.
+    pub high: Option<f64>,
+    /// Session low.
+    pub low: Option<f64>,
+    /// Session close.
+    pub close: Option<f64>,
+    /// Previous session close.
+    pub previous_close: Option<f64>,
+    /// Session volume.
+    pub volume: Option<f64>,
+    /// Absolute session change.
+    pub change: Option<f64>,
+    /// Percentage session change.
+    pub change_percent: Option<f64>,
+}
+
+// ============================================================================
+// Query function
+// ============================================================================
+
+/// Fetch a unified snapshot for a mixed list of tickers.
+pub async fn unified_snapshot(tickers: &[&str]) -> Result<UnifiedSnapshotResponseDTO> {
+    let joined = tickers.join(",");
+    let limit = tickers.len().to_string();
+    build_client()?
+        .get_as(
+            "/v3/snapshot",
+            &[("ticker.any_of", &joined), ("limit", &limit)],
+            "unified_snapshot",
+            "unified snapshot response",
+        )
+        .await
+}
+
+// ============================================================================
+// Canonical conversion
+// ============================================================================
+
+fn parse_asset_class(raw: Option<&str>) -> Option<AssetClass> {
+    match raw? {
+        "stocks" => Some(AssetClass::Stocks),
+        "options" => Some(AssetClass::Options),
+        "fx" => Some(AssetClass::Fx),
+        "crypto" => Some(AssetClass::Crypto),
+        "indices" => Some(AssetClass::Indices),
+        _ => None,
+    }
+}
+
+pub(crate) fn to_market_snapshot(dto: UnifiedSnapshotDTO) -> MarketSnapshot {
+    let session = dto.session;
+    MarketSnapshot {
+        symbol: dto.ticker,
+        name: dto.name,
+        asset_class: parse_asset_class(dto.asset_type.as_deref()),
+        market_status: dto.market_status,
+        last_price: dto.last_trade.and_then(|t| t.price),
+        bid: dto.last_quote.as_ref().and_then(|q| q.bid),
+        ask: dto.last_quote.and_then(|q| q.ask),
+        open: session.as_ref().and_then(|s| s.open),
+        high: session.as_ref().and_then(|s| s.high),
+        low: session.as_ref().and_then(|s| s.low),
+        close: session.as_ref().and_then(|s| s.close),
+        previous_close: session.as_ref().and_then(|s| s.previous_close),
+        volume: session.as_ref().and_then(|s| s.volume),
+        change: session.as_ref().and_then(|s| s.change),
+        change_percent: session.and_then(|s| s.change_percent),
+        error: dto.error,
+        message: dto.message,
+    }
+}
+
+/// Fetch canonical cross-market snapshots for a mixed list of symbols.
+///
+/// Rows for symbols Polygon could not resolve are returned with `error` set
+/// rather than dropped, so the caller can tell "no data" from "not requested".
+pub async fn fetch_unified_snapshot_response(symbols: &[&str]) -> Result<Vec<MarketSnapshot>> {
+    if symbols.is_empty() {
+        return Ok(Vec::new());
+    }
+    if symbols.len() > MAX_SYMBOLS {
+        return Err(FinanceError::InvalidParameter {
+            param: "symbols".to_string(),
+            reason: format!(
+                "Polygon's unified snapshot accepts at most {MAX_SYMBOLS} symbols per request, got {}",
+                symbols.len()
+            ),
+        });
+    }
+
+    let resp = unified_snapshot(symbols).await?;
+    Ok(resp
+        .results
+        .unwrap_or_default()
+        .into_iter()
+        .map(to_market_snapshot)
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_a_stock_row_across_trade_quote_and_session() {
+        let dto: UnifiedSnapshotDTO = serde_json::from_value(serde_json::json!({
+            "ticker": "AAPL",
+            "name": "Apple Inc.",
+            "type": "stocks",
+            "market_status": "closed",
+            "last_trade": { "price": 227.5, "size": 2.0 },
+            "last_quote": { "bid": 227.4, "ask": 227.6 },
+            "session": {
+                "open": 225.0,
+                "high": 228.0,
+                "low": 224.5,
+                "close": 227.5,
+                "previous_close": 226.0,
+                "volume": 51_000_000.0,
+                "change": 1.5,
+                "change_percent": 0.66
+            }
+        }))
+        .unwrap();
+
+        let out = to_market_snapshot(dto);
+        assert_eq!(out.symbol.as_deref(), Some("AAPL"));
+        assert_eq!(out.asset_class, Some(AssetClass::Stocks));
+        assert_eq!(out.last_price, Some(227.5));
+        assert_eq!(out.bid, Some(227.4));
+        assert_eq!(out.ask, Some(227.6));
+        assert_eq!(out.previous_close, Some(226.0));
+        assert_eq!(out.change_percent, Some(0.66));
+        assert!(out.error.is_none());
+    }
+
+    /// A failed lookup must survive as a row so callers can align results with
+    /// their request list rather than guessing which symbol went missing.
+    #[test]
+    fn preserves_per_ticker_errors() {
+        let dto: UnifiedSnapshotDTO = serde_json::from_value(serde_json::json!({
+            "ticker": "TSLAAPL",
+            "error": "NOT_FOUND",
+            "message": "Ticker not found."
+        }))
+        .unwrap();
+
+        let out = to_market_snapshot(dto);
+        assert_eq!(out.symbol.as_deref(), Some("TSLAAPL"));
+        assert_eq!(out.error.as_deref(), Some("NOT_FOUND"));
+        assert_eq!(out.message.as_deref(), Some("Ticker not found."));
+        assert!(out.last_price.is_none());
+    }
+
+    #[test]
+    fn parses_every_asset_class_and_rejects_unknown() {
+        assert_eq!(parse_asset_class(Some("stocks")), Some(AssetClass::Stocks));
+        assert_eq!(
+            parse_asset_class(Some("options")),
+            Some(AssetClass::Options)
+        );
+        assert_eq!(parse_asset_class(Some("fx")), Some(AssetClass::Fx));
+        assert_eq!(parse_asset_class(Some("crypto")), Some(AssetClass::Crypto));
+        assert_eq!(
+            parse_asset_class(Some("indices")),
+            Some(AssetClass::Indices)
+        );
+        assert_eq!(parse_asset_class(Some("bonds")), None);
+        assert_eq!(parse_asset_class(None), None);
+    }
+
+    #[tokio::test]
+    async fn rejects_batches_over_polygons_cap_before_the_request() {
+        let symbols: Vec<String> = (0..MAX_SYMBOLS + 1).map(|i| format!("T{i}")).collect();
+        let refs: Vec<&str> = symbols.iter().map(String::as_str).collect();
+        let err = fetch_unified_snapshot_response(&refs).await.unwrap_err();
+        assert!(
+            matches!(err, FinanceError::InvalidParameter { ref param, .. } if param == "symbols"),
+            "got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_request_short_circuits_without_a_call() {
+        assert!(
+            fetch_unified_snapshot_response(&[])
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+}

--- a/src/domains/crypto.rs
+++ b/src/domains/crypto.rs
@@ -82,6 +82,12 @@ impl CryptoCoin {
     /// the default Yahoo route only when the handle's id is the coin's *ticker*
     /// (`providers.crypto("BTC")`); coins identified by a CoinGecko id should
     /// route `Capability::CHART` to a crypto-aware provider.
+    ///
+    /// With the `crypto` feature, `.route(Capability::CHART,
+    /// [Provider::CoinGecko])` serves history keylessly by coin id. CoinGecko
+    /// picks its own bar granularity from the requested range, so `interval` is
+    /// advisory there, and its OHLC endpoint carries no volume — those candles
+    /// report `volume: 0`.
     pub async fn chart(
         &self,
         vs_currency: &str,

--- a/src/domains/discovery.rs
+++ b/src/domains/discovery.rs
@@ -117,6 +117,36 @@ impl Discovery {
             .await
     }
 
+    /// Fetch the providers' whole listed-security universe.
+    ///
+    /// `active = false` asks for delisted securities instead. This is an
+    /// unfiltered dump — expect thousands of rows in one response — so prefer
+    /// [`search`](Self::search) when you have a query. Cached per `active`.
+    /// Currently Alpha Vantage only.
+    pub async fn listing_status(&self, active: bool) -> Result<Vec<SymbolMatch>> {
+        let providers = Arc::clone(&self.providers);
+        self.cache
+            .get_or_try(
+                format!("listing_status\u{1f}{active}"),
+                move || async move {
+                    providers
+                        .fetch(Capability::DISCOVERY, move |p| {
+                            let p = p.clone();
+                            async move {
+                                p.as_discovery()
+                                    .ok_or_else(|| {
+                                        p.not_supported(crate::providers::Operation::ListingStatus)
+                                    })?
+                                    .fetch_listing_status(active)
+                                    .await
+                            }
+                        })
+                        .await
+                },
+            )
+            .await
+    }
+
     /// Run a screener query over the providers' universe.
     ///
     /// Not cached — screener filters are open-ended and results are

--- a/src/domains/discovery.rs
+++ b/src/domains/discovery.rs
@@ -8,48 +8,25 @@ use crate::error::Result;
 use crate::models::discovery::reference::{
     ExchangeInfo, ScreenerFilters, ScreenerMatch, SymbolDetails, SymbolMatch,
 };
-use crate::providers::{Capability, ProviderSet};
+use crate::providers::Capability;
 
-/// Symbol discovery backed by configured data providers.
-///
-/// Unlike [`crate::finance::search`] — a Yahoo-only convenience shortcut —
-/// this routes through [`Capability::DISCOVERY`], so it honours the provider
-/// priority configured on [`Providers::builder`](crate::Providers::builder)
-/// and falls back across providers.
-///
-/// Created via [`Providers::discovery`](crate::Providers::discovery).
-pub struct Discovery {
-    providers: Arc<ProviderSet>,
-    cache: crate::domains::DomainCache<Vec<SymbolMatch>>,
-    details_cache: crate::domains::DomainCache<SymbolDetails>,
+domain_handle! {
+    /// Symbol discovery backed by configured data providers.
+    ///
+    /// Unlike [`crate::finance::search`] — a Yahoo-only convenience shortcut —
+    /// this routes through [`Capability::DISCOVERY`], so it honours the provider
+    /// priority configured on [`Providers::builder`](crate::Providers::builder)
+    /// and falls back across providers.
+    ///
+    /// Created via [`Providers::discovery`](crate::Providers::discovery).
+    pub struct Discovery
+    caches: {
+        cache: Vec<SymbolMatch>,
+        details_cache: SymbolDetails,
+    }
 }
 
 impl Discovery {
-    pub(crate) fn with_providers(providers: Arc<ProviderSet>) -> Self {
-        Self {
-            providers,
-            cache: crate::domains::DomainCache::new(crate::utils::CacheMode::default()),
-            details_cache: crate::domains::DomainCache::new(crate::utils::CacheMode::default()),
-        }
-    }
-
-    /// Cache responses for `ttl` instead of for the handle's lifetime,
-    /// deduplicating concurrent identical requests.
-    pub fn cache(mut self, ttl: std::time::Duration) -> Self {
-        let mode = crate::utils::CacheMode::Ttl(ttl);
-        self.cache = crate::domains::DomainCache::new(mode);
-        self.details_cache = crate::domains::DomainCache::new(mode);
-        self
-    }
-
-    /// Disable caching — every call fetches fresh data.
-    pub fn no_cache(mut self) -> Self {
-        let mode = crate::utils::CacheMode::Off;
-        self.cache = crate::domains::DomainCache::new(mode);
-        self.details_cache = crate::domains::DomainCache::new(mode);
-        self
-    }
-
     /// Search the configured providers' symbol universe.
     ///
     /// Results are cached per `(query, limit)` pair.
@@ -104,17 +81,14 @@ impl Discovery {
 
     /// Fetch the tradable exchange listing.
     pub async fn exchanges(&self) -> Result<Vec<ExchangeInfo>> {
-        self.providers
-            .fetch(Capability::DISCOVERY, |p| {
-                let p = p.clone();
-                async move {
-                    p.as_discovery()
-                        .ok_or_else(|| p.not_supported(crate::providers::Operation::Exchanges))?
-                        .fetch_exchanges()
-                        .await
-                }
-            })
-            .await
+        dispatch_via!(
+            self,
+            DISCOVERY,
+            as_discovery,
+            Exchanges,
+            fetch_exchanges,
+            []
+        )
     }
 
     /// Fetch the providers' whole listed-security universe.
@@ -152,17 +126,15 @@ impl Discovery {
     /// Not cached — screener filters are open-ended and results are
     /// price-sensitive, so every call fetches fresh.
     pub async fn screener(&self, filters: &ScreenerFilters) -> Result<Vec<ScreenerMatch>> {
-        self.providers
-            .fetch(Capability::DISCOVERY, |p| {
-                let p = p.clone();
-                let filters = filters.clone();
-                async move {
-                    p.as_discovery()
-                        .ok_or_else(|| p.not_supported(crate::providers::Operation::Screener))?
-                        .fetch_screener(&filters)
-                        .await
-                }
-            })
-            .await
+        let filters = filters.clone();
+        dispatch_via!(
+            self,
+            DISCOVERY,
+            as_discovery,
+            Screener,
+            fetch_screener,
+            [filters],
+            &filters
+        )
     }
 }

--- a/src/domains/economic.rs
+++ b/src/domains/economic.rs
@@ -79,47 +79,40 @@ impl EconomicCatalog {
     /// Search the series catalog by free text, most popular first.
     pub async fn search(&self, query: &str, limit: u32) -> Result<Vec<EconomicSeriesMatch>> {
         let query = query.to_string();
-        self.providers
-            .fetch(Capability::ECONOMIC, move |p| {
-                let query = query.clone();
-                let p = p.clone();
-                async move {
-                    p.as_economic()
-                        .ok_or_else(|| p.not_supported(Operation::EconomicSearch))?
-                        .fetch_economic_search(&query, limit)
-                        .await
-                }
-            })
-            .await
+        dispatch_via!(
+            self,
+            ECONOMIC,
+            as_economic,
+            EconomicSearch,
+            fetch_economic_search,
+            [query],
+            &query,
+            limit
+        )
     }
 
     /// List the child categories of `parent_id`. Pass `0` for the root.
     pub async fn categories(&self, parent_id: i64) -> Result<Vec<EconomicCategory>> {
-        self.providers
-            .fetch(Capability::ECONOMIC, move |p| {
-                let p = p.clone();
-                async move {
-                    p.as_economic()
-                        .ok_or_else(|| p.not_supported(Operation::EconomicCategories))?
-                        .fetch_economic_categories(parent_id)
-                        .await
-                }
-            })
-            .await
+        dispatch_via!(
+            self,
+            ECONOMIC,
+            as_economic,
+            EconomicCategories,
+            fetch_economic_categories,
+            [],
+            parent_id
+        )
     }
 
     /// List every scheduled data release the provider publishes.
     pub async fn releases(&self) -> Result<Vec<EconomicRelease>> {
-        self.providers
-            .fetch(Capability::ECONOMIC, move |p| {
-                let p = p.clone();
-                async move {
-                    p.as_economic()
-                        .ok_or_else(|| p.not_supported(Operation::EconomicReleases))?
-                        .fetch_economic_releases()
-                        .await
-                }
-            })
-            .await
+        dispatch_via!(
+            self,
+            ECONOMIC,
+            as_economic,
+            EconomicReleases,
+            fetch_economic_releases,
+            []
+        )
     }
 }

--- a/src/domains/economic.rs
+++ b/src/domains/economic.rs
@@ -2,7 +2,11 @@
 //!
 //! Created via [`Providers::economic`](crate::Providers::economic).
 
+use std::sync::Arc;
+
 use crate::error::Result;
+use crate::models::economic::{EconomicCategory, EconomicRelease, EconomicSeriesMatch};
+use crate::providers::{Capability, Operation, ProviderSet};
 
 domain_handle! {
     /// A macro-economic data series backed by configured data providers.
@@ -24,5 +28,98 @@ impl EconomicIndicator {
             fetch_economic_series,
             crate::models::economic::EconomicSeries
         )
+    }
+
+    /// Fetch this series as it stood on `date` (`YYYY-MM-DD`) instead of as
+    /// currently revised (FRED only, via ALFRED's realtime window).
+    ///
+    /// Macro data is revised after publication, so backtesting a rule against
+    /// today's series is look-ahead bias: the values it trades on were not
+    /// knowable at the time. This returns the vintage actually published as of
+    /// `date`. Cached per date.
+    pub async fn as_of(&self, date: &str) -> Result<crate::models::economic::EconomicSeries> {
+        let series_id: String = self.series_id().to_string();
+        let date = date.to_string();
+        let providers = Arc::clone(&self.providers);
+        self.cache
+            .get_or_try(format!("as_of\u{1f}{date}"), move || async move {
+                providers
+                    .fetch(Capability::ECONOMIC, move |p| {
+                        let (series_id, date) = (series_id.clone(), date.clone());
+                        let p = p.clone();
+                        async move {
+                            p.as_economic()
+                                .ok_or_else(|| p.not_supported(Operation::EconomicSeriesAsOf))?
+                                .fetch_economic_series_as_of(&series_id, &date)
+                                .await
+                        }
+                    })
+                    .await
+            })
+            .await
+    }
+}
+
+/// The macro-economic series catalog: search and browse rather than fetch.
+///
+/// Routes through [`Capability::ECONOMIC`]. [`EconomicIndicator`] needs a
+/// series id you already know; this handle is how you find one. FRED is
+/// currently the only provider.
+///
+/// Created via [`Providers::economic_catalog`](crate::Providers::economic_catalog).
+pub struct EconomicCatalog {
+    providers: Arc<ProviderSet>,
+}
+
+impl EconomicCatalog {
+    pub(crate) fn with_providers(providers: Arc<ProviderSet>) -> Self {
+        Self { providers }
+    }
+
+    /// Search the series catalog by free text, most popular first.
+    pub async fn search(&self, query: &str, limit: u32) -> Result<Vec<EconomicSeriesMatch>> {
+        let query = query.to_string();
+        self.providers
+            .fetch(Capability::ECONOMIC, move |p| {
+                let query = query.clone();
+                let p = p.clone();
+                async move {
+                    p.as_economic()
+                        .ok_or_else(|| p.not_supported(Operation::EconomicSearch))?
+                        .fetch_economic_search(&query, limit)
+                        .await
+                }
+            })
+            .await
+    }
+
+    /// List the child categories of `parent_id`. Pass `0` for the root.
+    pub async fn categories(&self, parent_id: i64) -> Result<Vec<EconomicCategory>> {
+        self.providers
+            .fetch(Capability::ECONOMIC, move |p| {
+                let p = p.clone();
+                async move {
+                    p.as_economic()
+                        .ok_or_else(|| p.not_supported(Operation::EconomicCategories))?
+                        .fetch_economic_categories(parent_id)
+                        .await
+                }
+            })
+            .await
+    }
+
+    /// List every scheduled data release the provider publishes.
+    pub async fn releases(&self) -> Result<Vec<EconomicRelease>> {
+        self.providers
+            .fetch(Capability::ECONOMIC, move |p| {
+                let p = p.clone();
+                async move {
+                    p.as_economic()
+                        .ok_or_else(|| p.not_supported(Operation::EconomicReleases))?
+                        .fetch_economic_releases()
+                        .await
+                }
+            })
+            .await
     }
 }

--- a/src/domains/filings.rs
+++ b/src/domains/filings.rs
@@ -98,6 +98,57 @@ impl Filings {
             .await
     }
 
+    /// Insider transactions reported on this issuer's Forms 3/4/5, parsed from
+    /// the filed XML, via the FILINGS route (currently EDGAR only).
+    ///
+    /// `limit` caps how many *filings* are read, not how many transactions come
+    /// back — one Form 4 can report several lines. Each filing costs two extra
+    /// requests, so keep it modest. Not cached.
+    pub async fn insider_trades(
+        &self,
+        limit: u32,
+    ) -> Result<Vec<crate::models::filings::InsiderTrade>> {
+        let symbol: String = self.symbol().to_string();
+        self.providers
+            .fetch(crate::providers::Capability::FILINGS, move |p| {
+                let symbol = symbol.clone();
+                let p = p.clone();
+                async move {
+                    p.as_filings()
+                        .ok_or_else(|| p.not_supported(crate::providers::Operation::InsiderTrades))?
+                        .fetch_insider_trades(&symbol, limit)
+                        .await
+                }
+            })
+            .await
+    }
+
+    /// The latest 13F-HR information table filed by this symbol's CIK, via the
+    /// FILINGS route (currently EDGAR only).
+    ///
+    /// The handle's symbol identifies the *filer*, so this is only meaningful
+    /// for listed institutional managers (e.g. `BRK-B`) — an issuer that files
+    /// no 13F errors rather than returning an empty list. Not cached.
+    pub async fn institutional_holdings(
+        &self,
+    ) -> Result<Vec<crate::models::filings::InstitutionalHolding>> {
+        let symbol: String = self.symbol().to_string();
+        self.providers
+            .fetch(crate::providers::Capability::FILINGS, move |p| {
+                let symbol = symbol.clone();
+                let p = p.clone();
+                async move {
+                    p.as_filings()
+                        .ok_or_else(|| {
+                            p.not_supported(crate::providers::Operation::InstitutionalHoldings)
+                        })?
+                        .fetch_institutional_holdings(&symbol)
+                        .await
+                }
+            })
+            .await
+    }
+
     /// Fetch risk factors extracted from this symbol's SEC filings via the
     /// FILINGS route (currently Polygon only). Not cached.
     pub async fn risk_factors(&self) -> Result<Vec<crate::models::filings::RiskFactor>> {

--- a/src/domains/filings.rs
+++ b/src/domains/filings.rs
@@ -54,20 +54,16 @@ impl Filings {
     /// Full-text search over this filer's filings via the FILINGS route
     /// (currently EDGAR only). Not cached.
     ///
-    /// The handle's symbol is resolved to a CIK and applied as a filter unless
-    /// `filters` already names one. Use [`search_all`](Self::search_all) to
-    /// search every filer instead.
+    /// The handle's symbol scopes the search unless `filters` already names a
+    /// filer identifier; the routed provider resolves it however its own index
+    /// requires. Use [`search_all`](Self::search_all) to search every filer.
     pub async fn search(
         &self,
         query: &str,
         filters: crate::models::filings::FilingSearchFilters,
     ) -> Result<Vec<crate::models::filings::FilingSearchHit>> {
-        let mut filters = filters;
-        if filters.cik.is_none() {
-            let cik = crate::adapters::edgar::resolve_cik(self.symbol()).await?;
-            filters.cik = Some(format!("{cik:010}"));
-        }
-        self.search_all(query, filters).await
+        let symbol: String = self.symbol().to_string();
+        self.dispatch_search(Some(symbol), query, filters).await
     }
 
     /// Full-text search across every filer via the FILINGS route (currently
@@ -81,17 +77,27 @@ impl Filings {
         query: &str,
         filters: crate::models::filings::FilingSearchFilters,
     ) -> Result<Vec<crate::models::filings::FilingSearchHit>> {
+        self.dispatch_search(None, query, filters).await
+    }
+
+    async fn dispatch_search(
+        &self,
+        symbol: Option<String>,
+        query: &str,
+        filters: crate::models::filings::FilingSearchFilters,
+    ) -> Result<Vec<crate::models::filings::FilingSearchHit>> {
         let query = query.to_string();
         let filters = std::sync::Arc::new(filters);
         self.providers
             .fetch(crate::providers::Capability::FILINGS, move |p| {
+                let symbol = symbol.clone();
                 let query = query.clone();
                 let filters = std::sync::Arc::clone(&filters);
                 let p = p.clone();
                 async move {
                     p.as_filings()
                         .ok_or_else(|| p.not_supported(crate::providers::Operation::FilingSearch))?
-                        .fetch_filing_search(&query, &filters)
+                        .fetch_filing_search(symbol.as_deref(), &query, &filters)
                         .await
                 }
             })

--- a/src/domains/filings.rs
+++ b/src/domains/filings.rs
@@ -51,6 +51,53 @@ impl Filings {
             .await
     }
 
+    /// Full-text search over this filer's filings via the FILINGS route
+    /// (currently EDGAR only). Not cached.
+    ///
+    /// The handle's symbol is resolved to a CIK and applied as a filter unless
+    /// `filters` already names one. Use [`search_all`](Self::search_all) to
+    /// search every filer instead.
+    pub async fn search(
+        &self,
+        query: &str,
+        filters: crate::models::filings::FilingSearchFilters,
+    ) -> Result<Vec<crate::models::filings::FilingSearchHit>> {
+        let mut filters = filters;
+        if filters.cik.is_none() {
+            let cik = crate::adapters::edgar::resolve_cik(self.symbol()).await?;
+            filters.cik = Some(format!("{cik:010}"));
+        }
+        self.search_all(query, filters).await
+    }
+
+    /// Full-text search across every filer via the FILINGS route (currently
+    /// EDGAR only). Not cached.
+    ///
+    /// Searches filing *text*, so it answers "which filings mention this"
+    /// rather than "what has this company filed" — the query shape
+    /// [`get`](Self::get) cannot express.
+    pub async fn search_all(
+        &self,
+        query: &str,
+        filters: crate::models::filings::FilingSearchFilters,
+    ) -> Result<Vec<crate::models::filings::FilingSearchHit>> {
+        let query = query.to_string();
+        let filters = std::sync::Arc::new(filters);
+        self.providers
+            .fetch(crate::providers::Capability::FILINGS, move |p| {
+                let query = query.clone();
+                let filters = std::sync::Arc::clone(&filters);
+                let p = p.clone();
+                async move {
+                    p.as_filings()
+                        .ok_or_else(|| p.not_supported(crate::providers::Operation::FilingSearch))?
+                        .fetch_filing_search(&query, &filters)
+                        .await
+                }
+            })
+            .await
+    }
+
     /// Fetch risk factors extracted from this symbol's SEC filings via the
     /// FILINGS route (currently Polygon only). Not cached.
     pub async fn risk_factors(&self) -> Result<Vec<crate::models::filings::RiskFactor>> {

--- a/src/domains/market.rs
+++ b/src/domains/market.rs
@@ -11,43 +11,25 @@ use crate::models::calendar::market::{CalendarKind, MarketCalendarEntry};
 use crate::models::market::performance::{
     IndustryPe, MoverDirection, MoverQuote, SectorPe, SectorPerformance,
 };
-use crate::providers::{Capability, ProviderSet};
-
-/// Market-wide event calendars backed by configured data providers.
-///
-/// Routes through [`Capability::CALENDAR`]. Unlike
-/// [`Ticker::calendar`](crate::Ticker::calendar), which builds a per-symbol
-/// timeline, these span the whole market over a date range.
-///
-/// Created via [`Providers::calendar`](crate::Providers::calendar).
 #[cfg(any(feature = "fmp", feature = "polygon", feature = "alphavantage"))]
-pub struct MarketCalendar {
-    providers: Arc<ProviderSet>,
-    cache: crate::domains::DomainCache<Vec<MarketCalendarEntry>>,
+use crate::providers::Capability;
+use crate::providers::ProviderSet;
+
+domain_handle! {
+    /// Market-wide event calendars backed by configured data providers.
+    ///
+    /// Routes through [`Capability::CALENDAR`]. Unlike
+    /// [`Ticker::calendar`](crate::Ticker::calendar), which builds a per-symbol
+    /// timeline, these span the whole market over a date range.
+    ///
+    /// Created via [`Providers::calendar`](crate::Providers::calendar).
+    pub struct MarketCalendar
+    cfg: any(feature = "fmp", feature = "polygon", feature = "alphavantage"),
+    caches: { cache: Vec<MarketCalendarEntry> }
 }
 
 #[cfg(any(feature = "fmp", feature = "polygon", feature = "alphavantage"))]
 impl MarketCalendar {
-    pub(crate) fn with_providers(providers: Arc<ProviderSet>) -> Self {
-        Self {
-            providers,
-            cache: crate::domains::DomainCache::new(crate::utils::CacheMode::default()),
-        }
-    }
-
-    /// Cache responses for `ttl` instead of for the handle's lifetime,
-    /// deduplicating concurrent identical requests.
-    pub fn cache(mut self, ttl: std::time::Duration) -> Self {
-        self.cache = crate::domains::DomainCache::new(crate::utils::CacheMode::Ttl(ttl));
-        self
-    }
-
-    /// Disable caching — every call fetches fresh data.
-    pub fn no_cache(mut self) -> Self {
-        self.cache = crate::domains::DomainCache::new(crate::utils::CacheMode::Off);
-        self
-    }
-
     /// Fetch a calendar of `kind` over `[from, to]` (`YYYY-MM-DD` dates).
     ///
     /// Cached per `(kind, from, to)`.
@@ -128,19 +110,14 @@ impl Market {
 
     /// Aggregate performance for every sector.
     pub async fn sector_performance(&self) -> Result<Vec<SectorPerformance>> {
-        self.providers
-            .fetch(Capability::MARKET, |p| {
-                let p = p.clone();
-                async move {
-                    p.as_market()
-                        .ok_or_else(|| {
-                            p.not_supported(crate::providers::Operation::SectorPerformance)
-                        })?
-                        .fetch_sector_performance()
-                        .await
-                }
-            })
-            .await
+        dispatch_via!(
+            self,
+            MARKET,
+            as_market,
+            SectorPerformance,
+            fetch_sector_performance,
+            []
+        )
     }
 
     /// Historical aggregate sector performance, most recent first.
@@ -148,68 +125,52 @@ impl Market {
         &self,
         limit: u32,
     ) -> Result<Vec<crate::models::market::performance::SectorPerformanceHistory>> {
-        self.providers
-            .fetch(Capability::MARKET, move |p| {
-                let p = p.clone();
-                async move {
-                    p.as_market()
-                        .ok_or_else(|| {
-                            p.not_supported(crate::providers::Operation::SectorPerformanceHistory)
-                        })?
-                        .fetch_sector_performance_history(limit)
-                        .await
-                }
-            })
-            .await
+        dispatch_via!(
+            self,
+            MARKET,
+            as_market,
+            SectorPerformanceHistory,
+            fetch_sector_performance_history,
+            [],
+            limit
+        )
     }
 
     /// Price/earnings ratios by sector.
     pub async fn sector_pe(&self) -> Result<Vec<SectorPe>> {
-        self.providers
-            .fetch(Capability::MARKET, |p| {
-                let p = p.clone();
-                async move {
-                    p.as_market()
-                        .ok_or_else(|| {
-                            p.not_supported(crate::providers::Operation::SectorPerformance)
-                        })?
-                        .fetch_sector_pe()
-                        .await
-                }
-            })
-            .await
+        dispatch_via!(
+            self,
+            MARKET,
+            as_market,
+            SectorPerformance,
+            fetch_sector_pe,
+            []
+        )
     }
 
     /// Price/earnings ratios by industry.
     pub async fn industry_pe(&self) -> Result<Vec<IndustryPe>> {
-        self.providers
-            .fetch(Capability::MARKET, |p| {
-                let p = p.clone();
-                async move {
-                    p.as_market()
-                        .ok_or_else(|| {
-                            p.not_supported(crate::providers::Operation::SectorPerformance)
-                        })?
-                        .fetch_industry_pe()
-                        .await
-                }
-            })
-            .await
+        dispatch_via!(
+            self,
+            MARKET,
+            as_market,
+            SectorPerformance,
+            fetch_industry_pe,
+            []
+        )
     }
 
     /// Market movers for `direction`.
     pub async fn movers(&self, direction: MoverDirection) -> Result<Vec<MoverQuote>> {
-        self.providers
-            .fetch(Capability::MARKET, |p| {
-                let p = p.clone();
-                async move {
-                    p.as_market()
-                        .ok_or_else(|| p.not_supported(crate::providers::Operation::MarketMovers))?
-                        .fetch_market_movers(direction)
-                        .await
-                }
-            })
-            .await
+        dispatch_via!(
+            self,
+            MARKET,
+            as_market,
+            MarketMovers,
+            fetch_market_movers,
+            [],
+            direction
+        )
     }
 
     /// Largest percentage gainers.

--- a/src/domains/mod.rs
+++ b/src/domains/mod.rs
@@ -491,6 +491,7 @@ pub(crate) mod futures;
 #[cfg(any(feature = "polygon", feature = "fmp"))]
 pub(crate) mod indices;
 pub(crate) mod market;
+pub(crate) mod snapshot;
 
 // ── Re-exports ──────────────────────────────────────────────────────
 
@@ -532,6 +533,7 @@ pub use indices::Index;
 pub use market::Market;
 #[cfg(any(feature = "fmp", feature = "polygon", feature = "alphavantage"))]
 pub use market::MarketCalendar;
+pub use snapshot::Snapshot;
 
 // ── Tests ───────────────────────────────────────────────────────────
 

--- a/src/domains/mod.rs
+++ b/src/domains/mod.rs
@@ -517,7 +517,7 @@ pub use discovery::Discovery;
     feature = "polygon",
     feature = "worldbank"
 ))]
-pub use economic::EconomicIndicator;
+pub use economic::{EconomicCatalog, EconomicIndicator};
 pub use filings::Filings;
 #[cfg(any(
     feature = "alphavantage",

--- a/src/domains/mod.rs
+++ b/src/domains/mod.rs
@@ -276,6 +276,79 @@ macro_rules! domain_handle {
             }
         }
     };
+
+    // Market-wide variant — no identifier field, since these handles describe
+    // the market rather than one instrument. Takes one or more named response
+    // caches; `.cache(ttl)` / `.no_cache()` reset all of them together. `cfg:`
+    // is a slot rather than a plain attribute because the gate has to reach the
+    // generated `impl` block too, not just the struct.
+    (
+        $(#[$meta:meta])*
+        pub struct $name:ident
+        $(cfg: $cfg:meta,)?
+        caches: { $($cache:ident : $val:ty),+ $(,)? }
+    ) => {
+        $(#[$meta])*
+        $(#[cfg($cfg)])?
+        pub struct $name {
+            providers: std::sync::Arc<crate::providers::ProviderSet>,
+            $($cache: crate::domains::DomainCache<$val>,)+
+        }
+
+        $(#[cfg($cfg)])?
+        impl $name {
+            pub(crate) fn with_providers(
+                providers: std::sync::Arc<crate::providers::ProviderSet>,
+            ) -> Self {
+                Self {
+                    providers,
+                    $($cache: crate::domains::DomainCache::new(
+                        crate::utils::CacheMode::default(),
+                    ),)+
+                }
+            }
+
+            /// Cache responses for `ttl` instead of for the handle's lifetime,
+            /// deduplicating concurrent identical requests.
+            pub fn cache(mut self, ttl: std::time::Duration) -> Self {
+                let mode = crate::utils::CacheMode::Ttl(ttl);
+                $(self.$cache = crate::domains::DomainCache::new(mode);)+
+                self
+            }
+
+            /// Disable caching — every call fetches fresh data.
+            pub fn no_cache(mut self) -> Self {
+                let mode = crate::utils::CacheMode::Off;
+                $(self.$cache = crate::domains::DomainCache::new(mode);)+
+                self
+            }
+        }
+    };
+}
+
+/// Dispatch an uncached provider call. `$owned` names values cloned per
+/// attempt (dispatch may try several providers); `$arg`s are the call's own
+/// arguments and may borrow those clones.
+#[allow(unused_macros)]
+macro_rules! dispatch_via {
+    (
+        $self:expr, $cap:ident, $acc:ident, $op:ident, $fetch:ident,
+        [$($owned:ident),* $(,)?] $(, $arg:expr)* $(,)?
+    ) => {{
+        $self
+            .providers
+            .fetch(crate::providers::Capability::$cap, move |p| {
+                $(let $owned = $owned.clone();)*
+                let p = p.clone();
+                async move {
+                    p.$acc()
+                        .ok_or_else(|| p.not_supported(crate::providers::Operation::$op))?
+                        .$fetch($($arg),*)
+                        .await
+                }
+            })
+            .await
+    }};
 }
 
 /// Fetch via the provider dispatch — single symbol field, no extra args.
@@ -491,6 +564,7 @@ pub(crate) mod futures;
 #[cfg(any(feature = "polygon", feature = "fmp"))]
 pub(crate) mod indices;
 pub(crate) mod market;
+#[cfg(feature = "polygon")]
 pub(crate) mod snapshot;
 
 // ── Re-exports ──────────────────────────────────────────────────────
@@ -533,6 +607,7 @@ pub use indices::Index;
 pub use market::Market;
 #[cfg(any(feature = "fmp", feature = "polygon", feature = "alphavantage"))]
 pub use market::MarketCalendar;
+#[cfg(feature = "polygon")]
 pub use snapshot::Snapshot;
 
 // ── Tests ───────────────────────────────────────────────────────────

--- a/src/domains/snapshot.rs
+++ b/src/domains/snapshot.rs
@@ -1,0 +1,75 @@
+//! Cross-market snapshot handle.
+//!
+//! Created via [`Providers::snapshot`](crate::Providers::snapshot).
+
+use std::sync::Arc;
+
+use crate::error::Result;
+use crate::models::quote::snapshot::MarketSnapshot;
+use crate::providers::{Capability, Operation, ProviderSet};
+
+/// Snapshots for a watchlist spanning several asset classes, from one request.
+///
+/// Routes through [`Capability::QUOTE`]. Unlike
+/// [`Tickers`](crate::Tickers) — which is equity-shaped and returns full quote
+/// summaries — this takes provider-spelled symbols from any market (`"AAPL"`,
+/// `"X:BTCUSD"`, `"I:SPX"`, `"C:EURUSD"`, `"O:NCLH221014C00005000"`) and
+/// returns one flattened row each. Polygon is currently the only provider whose
+/// snapshot endpoint spans markets.
+///
+/// Created via [`Providers::snapshot`](crate::Providers::snapshot).
+pub struct Snapshot {
+    providers: Arc<ProviderSet>,
+    cache: crate::domains::DomainCache<Vec<MarketSnapshot>>,
+}
+
+impl Snapshot {
+    pub(crate) fn with_providers(providers: Arc<ProviderSet>) -> Self {
+        Self {
+            providers,
+            cache: crate::domains::DomainCache::new(crate::utils::CacheMode::default()),
+        }
+    }
+
+    /// Cache responses for `ttl` instead of for the handle's lifetime,
+    /// deduplicating concurrent identical requests.
+    pub fn cache(mut self, ttl: std::time::Duration) -> Self {
+        self.cache = crate::domains::DomainCache::new(crate::utils::CacheMode::Ttl(ttl));
+        self
+    }
+
+    /// Disable caching — every call fetches fresh data.
+    pub fn no_cache(mut self) -> Self {
+        self.cache = crate::domains::DomainCache::new(crate::utils::CacheMode::Off);
+        self
+    }
+
+    /// Fetch snapshots for `symbols`, which may span asset classes.
+    ///
+    /// Cached per symbol list. Symbols the provider could not resolve come back
+    /// as rows with [`MarketSnapshot::error`] set rather than being dropped, so
+    /// the result can be aligned with the request.
+    pub async fn get<S: AsRef<str>>(&self, symbols: &[S]) -> Result<Vec<MarketSnapshot>> {
+        let owned: Vec<String> = symbols.iter().map(|s| s.as_ref().to_string()).collect();
+        let key = owned.join("\u{1f}");
+        let providers = Arc::clone(&self.providers);
+
+        self.cache
+            .get_or_try(key, move || async move {
+                providers
+                    .fetch(Capability::QUOTE, move |p| {
+                        let owned = owned.clone();
+                        let p = p.clone();
+                        async move {
+                            let refs: Vec<&str> = owned.iter().map(String::as_str).collect();
+                            p.as_quote()
+                                .ok_or_else(|| p.not_supported(Operation::UnifiedSnapshot))?
+                                .fetch_unified_snapshot(&refs)
+                                .await
+                        }
+                    })
+                    .await
+            })
+            .await
+    }
+}

--- a/src/domains/snapshot.rs
+++ b/src/domains/snapshot.rs
@@ -6,44 +6,24 @@ use std::sync::Arc;
 
 use crate::error::Result;
 use crate::models::quote::snapshot::MarketSnapshot;
-use crate::providers::{Capability, Operation, ProviderSet};
+use crate::providers::{Capability, Operation};
 
-/// Snapshots for a watchlist spanning several asset classes, from one request.
-///
-/// Routes through [`Capability::QUOTE`]. Unlike
-/// [`Tickers`](crate::Tickers) — which is equity-shaped and returns full quote
-/// summaries — this takes provider-spelled symbols from any market (`"AAPL"`,
-/// `"X:BTCUSD"`, `"I:SPX"`, `"C:EURUSD"`, `"O:NCLH221014C00005000"`) and
-/// returns one flattened row each. Polygon is currently the only provider whose
-/// snapshot endpoint spans markets.
-///
-/// Created via [`Providers::snapshot`](crate::Providers::snapshot).
-pub struct Snapshot {
-    providers: Arc<ProviderSet>,
-    cache: crate::domains::DomainCache<Vec<MarketSnapshot>>,
+domain_handle! {
+    /// Snapshots for a watchlist spanning several asset classes, from one request.
+    ///
+    /// Routes through [`Capability::QUOTE`]. Unlike
+    /// [`Tickers`](crate::Tickers) — which is equity-shaped and returns full quote
+    /// summaries — this takes provider-spelled symbols from any market (`"AAPL"`,
+    /// `"X:BTCUSD"`, `"I:SPX"`, `"C:EURUSD"`, `"O:NCLH221014C00005000"`) and
+    /// returns one flattened row each. Polygon is currently the only provider whose
+    /// snapshot endpoint spans markets.
+    ///
+    /// Created via [`Providers::snapshot`](crate::Providers::snapshot).
+    pub struct Snapshot
+    caches: { cache: Vec<MarketSnapshot> }
 }
 
 impl Snapshot {
-    pub(crate) fn with_providers(providers: Arc<ProviderSet>) -> Self {
-        Self {
-            providers,
-            cache: crate::domains::DomainCache::new(crate::utils::CacheMode::default()),
-        }
-    }
-
-    /// Cache responses for `ttl` instead of for the handle's lifetime,
-    /// deduplicating concurrent identical requests.
-    pub fn cache(mut self, ttl: std::time::Duration) -> Self {
-        self.cache = crate::domains::DomainCache::new(crate::utils::CacheMode::Ttl(ttl));
-        self
-    }
-
-    /// Disable caching — every call fetches fresh data.
-    pub fn no_cache(mut self) -> Self {
-        self.cache = crate::domains::DomainCache::new(crate::utils::CacheMode::Off);
-        self
-    }
-
     /// Fetch snapshots for `symbols`, which may span asset classes.
     ///
     /// Cached per symbol list. Symbols the provider could not resolve come back

--- a/src/feeds/mod.rs
+++ b/src/feeds/mod.rs
@@ -34,7 +34,7 @@ use std::time::Duration;
 
 use crate::error::Result;
 
-mod parser;
+pub(crate) mod parser;
 
 /// Cached User-Agent string, computed once from the environment.
 ///

--- a/src/feeds/parser.rs
+++ b/src/feeds/parser.rs
@@ -123,7 +123,7 @@ fn parse_date(raw: &str) -> Option<String> {
         .map(|dt| dt.to_rfc3339())
 }
 
-fn find(haystack: &[u8], from: usize, needle: &[u8]) -> Option<usize> {
+pub(crate) fn find(haystack: &[u8], from: usize, needle: &[u8]) -> Option<usize> {
     if from > haystack.len() {
         return None;
     }

--- a/src/feeds/parser.rs
+++ b/src/feeds/parser.rs
@@ -133,7 +133,7 @@ fn find(haystack: &[u8], from: usize, needle: &[u8]) -> Option<usize> {
         .map(|p| p + from)
 }
 
-fn find_byte(haystack: &[u8], from: usize, byte: u8) -> Option<usize> {
+pub(crate) fn find_byte(haystack: &[u8], from: usize, byte: u8) -> Option<usize> {
     if from > haystack.len() {
         return None;
     }
@@ -143,7 +143,7 @@ fn find_byte(haystack: &[u8], from: usize, byte: u8) -> Option<usize> {
         .map(|p| p + from)
 }
 
-fn trim_ascii(bytes: &[u8]) -> &[u8] {
+pub(crate) fn trim_ascii(bytes: &[u8]) -> &[u8] {
     let start = bytes
         .iter()
         .position(|b| !b.is_ascii_whitespace())
@@ -159,7 +159,7 @@ fn trim_ascii(bytes: &[u8]) -> &[u8] {
 /// Decode the 5 predefined XML entities and numeric character references
 /// (`&#NN;` / `&#xHH;`). Unrecognized or malformed entities are left as a
 /// literal `&` rather than erroring — real-world feeds are inconsistent here.
-fn unescape(raw: &[u8]) -> String {
+pub(crate) fn unescape(raw: &[u8]) -> String {
     let mut out = String::with_capacity(raw.len());
     let mut i = 0;
     loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,20 +238,20 @@ pub use ticker::{ClientHandle, Ticker, TickerBuilder};
 pub use domains::CryptoCoin;
 #[cfg(any(
     feature = "alphavantage",
+    feature = "fmp",
+    feature = "frankfurter",
+    feature = "polygon"
+))]
+pub use domains::ForexPair;
+#[cfg(any(
+    feature = "alphavantage",
     feature = "bls",
     feature = "fiscaldata",
     feature = "fred",
     feature = "polygon",
     feature = "worldbank"
 ))]
-pub use domains::EconomicIndicator;
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "fmp",
-    feature = "frankfurter",
-    feature = "polygon"
-))]
-pub use domains::ForexPair;
+pub use domains::{EconomicCatalog, EconomicIndicator};
 
 // Remaining Capability handles — indices, futures, commodities, filings, discovery
 #[cfg(any(feature = "fmp", feature = "alphavantage"))]
@@ -379,7 +379,9 @@ pub use models::crypto::CryptoQuote;
     feature = "polygon",
     feature = "worldbank"
 ))]
-pub use models::economic::EconomicSeries;
+pub use models::economic::{
+    EconomicCategory, EconomicRelease, EconomicSeries, EconomicSeriesMatch,
+};
 #[cfg(any(
     feature = "alphavantage",
     feature = "fmp",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,6 +263,7 @@ pub use domains::Filings;
 pub use domains::FuturesContract;
 #[cfg(any(feature = "polygon", feature = "fmp"))]
 pub use domains::Index;
+pub use domains::Snapshot;
 #[cfg(any(feature = "fmp", feature = "polygon", feature = "alphavantage"))]
 pub use domains::{Market, MarketCalendar};
 
@@ -350,6 +351,7 @@ pub use models::{
     market::sectors::SectorData,
     options::Options,
     quote::Quote,
+    quote::snapshot::{AssetClass, MarketSnapshot},
     sentiment::{FearAndGreed, FearGreedLabel, SymbolSentiment},
 };
 // Offline VADER sentiment scoring (feature-gated)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,7 +337,8 @@ pub use models::{
     discovery::trending::TrendingQuote,
     filings::{
         CompanyFacts, EdgarSearchResults, EdgarSubmissions, FilingSearchFilters, FilingSearchHit,
-        FilingSection, FilingSectionForm, ProviderFiling, ProviderFilings, RiskFactor,
+        FilingSection, FilingSectionForm, InsiderTrade, InstitutionalHolding, ProviderFiling,
+        ProviderFilings, RiskFactor,
     },
     fundamentals::{
         FinancialRatiosTtm, FinancialStatement, KeyMetricsTtm, PriceTargetConsensus,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,8 +336,8 @@ pub use models::{
     discovery::search::SearchResults,
     discovery::trending::TrendingQuote,
     filings::{
-        CompanyFacts, EdgarSearchResults, EdgarSubmissions, FilingSection, FilingSectionForm,
-        ProviderFiling, ProviderFilings, RiskFactor,
+        CompanyFacts, EdgarSearchResults, EdgarSubmissions, FilingSearchFilters, FilingSearchHit,
+        FilingSection, FilingSectionForm, ProviderFiling, ProviderFilings, RiskFactor,
     },
     fundamentals::{
         FinancialRatiosTtm, FinancialStatement, KeyMetricsTtm, PriceTargetConsensus,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,8 +338,8 @@ pub use models::{
         ProviderFiling, ProviderFilings, RiskFactor,
     },
     fundamentals::{
-        FinancialStatement, PriceTargetConsensus, PriceTargetSummary, RatingConsensus, ShareFloat,
-        ShortInterest, ShortVolume,
+        FinancialRatiosTtm, FinancialStatement, KeyMetricsTtm, PriceTargetConsensus,
+        PriceTargetSummary, RatingConsensus, ShareFloat, ShortInterest, ShortVolume,
     },
     market::currencies::Currency,
     market::exchanges::Exchange,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,6 +263,7 @@ pub use domains::Filings;
 pub use domains::FuturesContract;
 #[cfg(any(feature = "polygon", feature = "fmp"))]
 pub use domains::Index;
+#[cfg(feature = "polygon")]
 pub use domains::Snapshot;
 #[cfg(any(feature = "fmp", feature = "polygon", feature = "alphavantage"))]
 pub use domains::{Market, MarketCalendar};
@@ -353,7 +354,6 @@ pub use models::{
     market::sectors::SectorData,
     options::Options,
     quote::Quote,
-    quote::snapshot::{AssetClass, MarketSnapshot},
     sentiment::{FearAndGreed, FearGreedLabel, SymbolSentiment},
 };
 // Offline VADER sentiment scoring (feature-gated)
@@ -394,6 +394,8 @@ pub use models::forex::ForexQuote;
 pub use models::futures::FuturesQuote;
 #[cfg(any(feature = "polygon", feature = "fmp"))]
 pub use models::indices::{IndexConstituent, IndexConstituentChange, IndexQuote, MajorIndex};
+#[cfg(feature = "polygon")]
+pub use models::quote::snapshot::{AssetClass, MarketSnapshot};
 
 // ============================================================================
 // Nested types - Commonly accessed fields within response types

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,6 +325,7 @@ pub use models::{
     calendar::{CalendarEvent, EventKind},
     chart::Chart,
     chart::spark::Spark,
+    corporate::governance::{EmployeeCount, ExecutiveCompensation},
     corporate::news::News,
     corporate::press_release::PressRelease,
     corporate::recommendation::Recommendation,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,7 +337,10 @@ pub use models::{
         CompanyFacts, EdgarSearchResults, EdgarSubmissions, FilingSection, FilingSectionForm,
         ProviderFiling, ProviderFilings, RiskFactor,
     },
-    fundamentals::{FinancialStatement, ShareFloat, ShortInterest, ShortVolume},
+    fundamentals::{
+        FinancialStatement, PriceTargetConsensus, PriceTargetSummary, RatingConsensus, ShareFloat,
+        ShortInterest, ShortVolume,
+    },
     market::currencies::Currency,
     market::exchanges::Exchange,
     market::hours::MarketHours,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,8 +341,9 @@ pub use models::{
         ProviderFilings, RiskFactor,
     },
     fundamentals::{
-        FinancialRatiosTtm, FinancialStatement, KeyMetricsTtm, PriceTargetConsensus,
-        PriceTargetSummary, RatingConsensus, ShareFloat, ShortInterest, ShortVolume,
+        EtfHolding, EtfProfile, FinancialRatiosTtm, FinancialStatement, KeyMetricsTtm,
+        PriceTargetConsensus, PriceTargetSummary, RatingConsensus, ShareFloat, ShortInterest,
+        ShortVolume,
     },
     market::currencies::Currency,
     market::exchanges::Exchange,

--- a/src/models/corporate/governance.rs
+++ b/src/models/corporate/governance.rs
@@ -1,0 +1,64 @@
+//! Corporate governance models: executive compensation and employee headcount.
+//!
+//! Served through the [`Capability::CORPORATE`](crate::Capability::CORPORATE)
+//! route; FMP is currently the only provider. Both are derived from the
+//! company's own SEC filings (DEF 14A proxy statements and 10-K cover pages
+//! respectively), so figures are annual and lag the filing date.
+
+use serde::{Deserialize, Serialize};
+
+/// One executive's reported compensation for one fiscal year.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ExecutiveCompensation {
+    /// Ticker symbol.
+    pub symbol: Option<String>,
+    /// SEC Central Index Key of the filer.
+    pub cik: Option<String>,
+    /// Company name as filed.
+    pub company_name: Option<String>,
+    /// Executive name and position, as a single filed string.
+    pub name_and_position: Option<String>,
+    /// Fiscal year the compensation covers.
+    pub year: Option<i32>,
+    /// Base salary.
+    pub salary: Option<f64>,
+    /// Cash bonus.
+    pub bonus: Option<f64>,
+    /// Value of stock awards.
+    pub stock_award: Option<f64>,
+    /// Value of option awards.
+    pub option_award: Option<f64>,
+    /// Non-equity incentive plan compensation.
+    pub incentive_plan_compensation: Option<f64>,
+    /// All other compensation.
+    pub other_compensation: Option<f64>,
+    /// Total compensation.
+    pub total: Option<f64>,
+    /// Filing date of the source document (`YYYY-MM-DD`).
+    pub filing_date: Option<String>,
+    /// URL of the source filing.
+    pub url: Option<String>,
+}
+
+/// Employee headcount as reported on one filing.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct EmployeeCount {
+    /// Ticker symbol.
+    pub symbol: Option<String>,
+    /// SEC Central Index Key of the filer.
+    pub cik: Option<String>,
+    /// Company name as filed.
+    pub company_name: Option<String>,
+    /// Number of employees reported.
+    pub employee_count: Option<i64>,
+    /// Period the count is as of (`YYYY-MM-DD`).
+    pub period_of_report: Option<String>,
+    /// Form the count was reported on (e.g. `"10-K"`).
+    pub form_type: Option<String>,
+    /// Filing date (`YYYY-MM-DD`).
+    pub filing_date: Option<String>,
+    /// URL of the source filing.
+    pub source: Option<String>,
+}

--- a/src/models/corporate/mod.rs
+++ b/src/models/corporate/mod.rs
@@ -3,6 +3,8 @@
 //! Company profiles, officers, ownership, insider activity, and related data.
 
 // Sub-capability directories
+/// Executive compensation and employee headcount.
+pub mod governance;
 /// News article models.
 pub mod news;
 

--- a/src/models/economic/catalog.rs
+++ b/src/models/economic/catalog.rs
@@ -1,0 +1,58 @@
+//! Discovery models for the macro-economic series universe.
+//!
+//! Served through the [`Capability::ECONOMIC`](crate::Capability::ECONOMIC)
+//! route; FRED is currently the only provider. These answer "which series
+//! exist" — [`EconomicSeries`](super::EconomicSeries) answers "what does this
+//! series say", and needs an id you already know.
+
+use serde::{Deserialize, Serialize};
+
+/// A series matching a catalog search.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct EconomicSeriesMatch {
+    /// Series identifier (e.g. `"GDPC1"`).
+    pub id: String,
+    /// Human-readable title.
+    pub title: Option<String>,
+    /// Reporting frequency (e.g. `"Quarterly"`).
+    pub frequency: Option<String>,
+    /// Unit of measurement (e.g. `"Billions of Chained 2017 Dollars"`).
+    pub units: Option<String>,
+    /// Seasonal adjustment description.
+    pub seasonal_adjustment: Option<String>,
+    /// Date of the earliest observation (`YYYY-MM-DD`).
+    pub observation_start: Option<String>,
+    /// Date of the latest observation (`YYYY-MM-DD`).
+    pub observation_end: Option<String>,
+    /// Provider popularity score, useful for ranking equally-relevant matches.
+    pub popularity: Option<i64>,
+    /// Provider notes about the series.
+    pub notes: Option<String>,
+}
+
+/// A node in the provider's series category tree.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct EconomicCategory {
+    /// Category identifier.
+    pub id: i64,
+    /// Category name.
+    pub name: Option<String>,
+    /// Parent category identifier; the root category is its own parent.
+    pub parent_id: Option<i64>,
+}
+
+/// A publication that releases economic series on a schedule.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct EconomicRelease {
+    /// Release identifier.
+    pub id: i64,
+    /// Release name (e.g. `"Employment Situation"`).
+    pub name: Option<String>,
+    /// Whether the release is accompanied by a press release.
+    pub press_release: Option<bool>,
+    /// Link to the release on the publisher's site.
+    pub link: Option<String>,
+}

--- a/src/models/economic/mod.rs
+++ b/src/models/economic/mod.rs
@@ -4,6 +4,9 @@
 
 use serde::{Deserialize, Serialize};
 
+mod catalog;
+pub use catalog::{EconomicCategory, EconomicRelease, EconomicSeriesMatch};
+
 /// A provider-agnostic economic data series with metadata.
 ///
 /// Obtain via [`Ticker::economic_series`](crate::Ticker::economic_series). Supported providers:

--- a/src/models/filings/full_text.rs
+++ b/src/models/filings/full_text.rs
@@ -1,0 +1,78 @@
+//! Provider-neutral full-text filing search models.
+//!
+//! Served through the [`Capability::FILINGS`](crate::Capability::FILINGS)
+//! route; EDGAR is currently the only provider. Distinct from
+//! [`EdgarSearchResults`](super::EdgarSearchResults), which mirrors EDGAR's raw
+//! Elasticsearch envelope — this is the flattened shape the routed API returns.
+
+use serde::{Deserialize, Serialize};
+
+/// Which parts of a full-text search to constrain.
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct FilingSearchFilters {
+    /// Restrict to these form types (e.g. `["10-K", "8-K"]`).
+    pub forms: Option<Vec<String>>,
+    /// Earliest filing date, `YYYY-MM-DD`.
+    pub start_date: Option<String>,
+    /// Latest filing date, `YYYY-MM-DD`.
+    pub end_date: Option<String>,
+    /// Restrict to a single filer's CIK (zero-padded or not).
+    pub cik: Option<String>,
+    /// Maximum hits to return. Providers cap this; EDGAR's ceiling is 100.
+    pub limit: Option<u32>,
+}
+
+impl FilingSearchFilters {
+    /// Restrict the search to these form types.
+    pub fn forms<S: Into<String>, I: IntoIterator<Item = S>>(mut self, forms: I) -> Self {
+        self.forms = Some(forms.into_iter().map(Into::into).collect());
+        self
+    }
+
+    /// Restrict the search to filings on or after `date` (`YYYY-MM-DD`).
+    pub fn from(mut self, date: impl Into<String>) -> Self {
+        self.start_date = Some(date.into());
+        self
+    }
+
+    /// Restrict the search to filings on or before `date` (`YYYY-MM-DD`).
+    pub fn to(mut self, date: impl Into<String>) -> Self {
+        self.end_date = Some(date.into());
+        self
+    }
+
+    /// Restrict the search to one filer.
+    pub fn cik(mut self, cik: impl Into<String>) -> Self {
+        self.cik = Some(cik.into());
+        self
+    }
+
+    /// Cap the number of hits returned.
+    pub fn limit(mut self, limit: u32) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+}
+
+/// One filing matching a full-text search.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct FilingSearchHit {
+    /// Accession number of the filing.
+    pub accession_number: Option<String>,
+    /// Form type (e.g. `"10-K"`).
+    pub form: Option<String>,
+    /// Filing date (`YYYY-MM-DD`).
+    pub filed_date: Option<String>,
+    /// Period the filing covers (`YYYY-MM-DD`).
+    pub period_ending: Option<String>,
+    /// Filer display names, as the provider spells them.
+    pub company_names: Vec<String>,
+    /// Filer CIKs.
+    pub ciks: Vec<String>,
+    /// Relevance score assigned by the provider's search index.
+    pub score: Option<f64>,
+    /// Direct URL to the matching document, when it can be derived.
+    pub url: Option<String>,
+}

--- a/src/models/filings/mod.rs
+++ b/src/models/filings/mod.rs
@@ -7,6 +7,7 @@ mod cik;
 mod company_facts;
 pub mod filing_index;
 mod full_text;
+mod ownership;
 mod provider;
 mod search;
 mod sections;
@@ -16,6 +17,7 @@ pub use cik::CikEntry;
 pub use company_facts::{CompanyFacts, FactConcept, FactUnit, FactsByTaxonomy};
 pub use filing_index::EdgarFilingIndex;
 pub use full_text::{FilingSearchFilters, FilingSearchHit};
+pub use ownership::{InsiderTrade, InstitutionalHolding};
 pub use provider::{ProviderFiling, ProviderFilings};
 pub use search::{
     EdgarSearchHit, EdgarSearchHitsContainer, EdgarSearchResults, EdgarSearchSource,

--- a/src/models/filings/mod.rs
+++ b/src/models/filings/mod.rs
@@ -6,6 +6,7 @@
 mod cik;
 mod company_facts;
 pub mod filing_index;
+mod full_text;
 mod provider;
 mod search;
 mod sections;
@@ -14,6 +15,7 @@ mod submissions;
 pub use cik::CikEntry;
 pub use company_facts::{CompanyFacts, FactConcept, FactUnit, FactsByTaxonomy};
 pub use filing_index::EdgarFilingIndex;
+pub use full_text::{FilingSearchFilters, FilingSearchHit};
 pub use provider::{ProviderFiling, ProviderFilings};
 pub use search::{
     EdgarSearchHit, EdgarSearchHitsContainer, EdgarSearchResults, EdgarSearchSource,

--- a/src/models/filings/ownership.rs
+++ b/src/models/filings/ownership.rs
@@ -1,0 +1,86 @@
+//! Ownership models parsed from primary-source SEC filings.
+//!
+//! Served through the [`Capability::FILINGS`](crate::Capability::FILINGS)
+//! route; EDGAR is currently the only provider. Unlike the aggregated holder
+//! summaries on [`Ticker`](crate::Ticker), these come straight from the filed
+//! XML — Forms 3/4/5 for insider activity and 13F-HR information tables for
+//! institutional positions.
+
+use serde::{Deserialize, Serialize};
+
+/// One transaction line from a Form 3, 4, or 5.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct InsiderTrade {
+    /// Issuer's trading symbol, as filed.
+    pub symbol: Option<String>,
+    /// Issuer name, as filed.
+    pub issuer_name: Option<String>,
+    /// Reporting insider's name.
+    pub insider_name: Option<String>,
+    /// Reporting insider's CIK.
+    pub insider_cik: Option<String>,
+    /// Whether the insider is a director of the issuer.
+    pub is_director: bool,
+    /// Whether the insider is an officer of the issuer.
+    pub is_officer: bool,
+    /// Whether the insider holds 10% or more of a class of equity.
+    pub is_ten_percent_owner: bool,
+    /// Officer title, when one was filed.
+    pub officer_title: Option<String>,
+    /// Form the transaction was reported on (`"3"`, `"4"`, `"5"`).
+    pub form_type: Option<String>,
+    /// Accession number of the source filing.
+    pub accession_number: Option<String>,
+    /// URL of the source XML document.
+    pub url: Option<String>,
+    /// Security traded (e.g. `"Common Stock"`).
+    pub security_title: Option<String>,
+    /// Transaction date (`YYYY-MM-DD`).
+    pub transaction_date: Option<String>,
+    /// SEC transaction code (`"P"` purchase, `"S"` sale, `"M"` option exercise…).
+    pub transaction_code: Option<String>,
+    /// `"A"` if shares were acquired, `"D"` if disposed.
+    pub acquired_disposed: Option<String>,
+    /// Number of shares (or derivative units) transacted.
+    pub shares: Option<f64>,
+    /// Price per share, when reported.
+    pub price_per_share: Option<f64>,
+    /// Shares beneficially owned after the transaction.
+    pub shares_owned_after: Option<f64>,
+    /// Whether the line came from the derivative rather than non-derivative table.
+    pub is_derivative: bool,
+}
+
+/// One position from a 13F-HR information table.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct InstitutionalHolding {
+    /// Issuer name, as filed.
+    pub issuer_name: Option<String>,
+    /// Class of security (e.g. `"COM"`).
+    pub title_of_class: Option<String>,
+    /// CUSIP of the security.
+    pub cusip: Option<String>,
+    /// Market value as filed. Filings before 2023 report thousands of dollars;
+    /// later ones report whole dollars. The value is passed through unscaled.
+    pub value: Option<f64>,
+    /// Share or principal amount held.
+    pub shares: Option<f64>,
+    /// Whether `shares` is a share count (`"SH"`) or principal amount (`"PRN"`).
+    pub share_type: Option<String>,
+    /// `"CALL"` or `"PUT"` when the position is an option.
+    pub put_call: Option<String>,
+    /// Investment discretion (`"SOLE"`, `"DFND"`, `"OTR"`).
+    pub investment_discretion: Option<String>,
+    /// Shares over which the filer has sole voting authority.
+    pub voting_sole: Option<f64>,
+    /// Shares over which voting authority is shared.
+    pub voting_shared: Option<f64>,
+    /// Shares over which the filer has no voting authority.
+    pub voting_none: Option<f64>,
+    /// Accession number of the source filing.
+    pub accession_number: Option<String>,
+    /// Period the holdings are reported as of (`YYYY-MM-DD`).
+    pub report_date: Option<String>,
+}

--- a/src/models/fundamentals/consensus.rs
+++ b/src/models/fundamentals/consensus.rs
@@ -1,0 +1,70 @@
+//! Aggregated analyst-consensus models.
+//!
+//! Served through the [`Capability::FUNDAMENTALS`](crate::Capability::FUNDAMENTALS)
+//! route; FMP is currently the only provider. These are provider-side rollups
+//! over the whole analyst panel — distinct from the raw per-analyst grade
+//! actions in [`UpgradeDowngradeHistory`](crate::UpgradeDowngradeHistory).
+
+use serde::{Deserialize, Serialize};
+
+/// Consensus analyst price target for a symbol.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct PriceTargetConsensus {
+    /// Ticker symbol.
+    pub symbol: Option<String>,
+    /// Highest price target across the analyst panel.
+    pub target_high: Option<f64>,
+    /// Lowest price target across the analyst panel.
+    pub target_low: Option<f64>,
+    /// Mean price target.
+    pub target_consensus: Option<f64>,
+    /// Median price target.
+    pub target_median: Option<f64>,
+}
+
+/// Price-target activity over trailing windows: how many targets were published
+/// and their average, per window.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct PriceTargetSummary {
+    /// Ticker symbol.
+    pub symbol: Option<String>,
+    /// Number of price targets published in the last month.
+    pub last_month_count: Option<i64>,
+    /// Average price target published in the last month.
+    pub last_month_avg: Option<f64>,
+    /// Number of price targets published in the last quarter.
+    pub last_quarter_count: Option<i64>,
+    /// Average price target published in the last quarter.
+    pub last_quarter_avg: Option<f64>,
+    /// Number of price targets published in the last year.
+    pub last_year_count: Option<i64>,
+    /// Average price target published in the last year.
+    pub last_year_avg: Option<f64>,
+    /// Number of price targets published all time.
+    pub all_time_count: Option<i64>,
+    /// Average price target published all time.
+    pub all_time_avg: Option<f64>,
+}
+
+/// Consensus rating rollup — the analyst panel's grade distribution plus the
+/// provider's headline recommendation.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct RatingConsensus {
+    /// Ticker symbol.
+    pub symbol: Option<String>,
+    /// Analysts rating the symbol a strong buy.
+    pub strong_buy: Option<i64>,
+    /// Analysts rating the symbol a buy.
+    pub buy: Option<i64>,
+    /// Analysts rating the symbol a hold.
+    pub hold: Option<i64>,
+    /// Analysts rating the symbol a sell.
+    pub sell: Option<i64>,
+    /// Analysts rating the symbol a strong sell.
+    pub strong_sell: Option<i64>,
+    /// Headline consensus label (e.g. `"Buy"`).
+    pub consensus: Option<String>,
+}

--- a/src/models/fundamentals/etf.rs
+++ b/src/models/fundamentals/etf.rs
@@ -1,0 +1,43 @@
+//! ETF profile and holdings models.
+//!
+//! Served through the [`Capability::FUNDAMENTALS`](crate::Capability::FUNDAMENTALS)
+//! route; Alpha Vantage is currently the only provider, and the only wired
+//! source of ETF holdings at all.
+
+use serde::{Deserialize, Serialize};
+
+/// Profile and composition of an exchange-traded fund.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct EtfProfile {
+    /// Fund ticker symbol.
+    pub symbol: Option<String>,
+    /// Fund name.
+    pub name: Option<String>,
+    /// Asset type as reported by the provider.
+    pub asset_type: Option<String>,
+    /// Total net assets.
+    pub net_assets: Option<f64>,
+    /// Net expense ratio, as a fraction (0.0003 = 3 bps).
+    pub net_expense_ratio: Option<f64>,
+    /// Annual portfolio turnover, as a fraction.
+    pub portfolio_turnover: Option<f64>,
+    /// Trailing dividend yield, as a fraction.
+    pub dividend_yield: Option<f64>,
+    /// Inception date (`YYYY-MM-DD`).
+    pub inception_date: Option<String>,
+    /// Portfolio holdings, heaviest first.
+    pub holdings: Vec<EtfHolding>,
+}
+
+/// One position inside an ETF's portfolio.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct EtfHolding {
+    /// Ticker symbol of the held security.
+    pub symbol: Option<String>,
+    /// Security description.
+    pub description: Option<String>,
+    /// Portfolio weight, as a fraction of net assets.
+    pub weight: Option<f64>,
+}

--- a/src/models/fundamentals/mod.rs
+++ b/src/models/fundamentals/mod.rs
@@ -15,6 +15,10 @@ pub use short_activity::{ShareFloat, ShortInterest, ShortVolume};
 mod consensus;
 pub use consensus::{PriceTargetConsensus, PriceTargetSummary, RatingConsensus};
 
+// Trailing-twelve-month snapshots (provider-routed)
+mod ttm;
+pub use ttm::{FinancialRatiosTtm, KeyMetricsTtm};
+
 // quoteSummary modules (canonical home, re-exported from quote/ for backward compat)
 pub(crate) mod balance_sheet_history;
 pub(crate) mod cashflow_statement_history;

--- a/src/models/fundamentals/mod.rs
+++ b/src/models/fundamentals/mod.rs
@@ -11,6 +11,10 @@ pub use response::FinancialStatement;
 mod short_activity;
 pub use short_activity::{ShareFloat, ShortInterest, ShortVolume};
 
+// Aggregated analyst consensus (provider-routed)
+mod consensus;
+pub use consensus::{PriceTargetConsensus, PriceTargetSummary, RatingConsensus};
+
 // quoteSummary modules (canonical home, re-exported from quote/ for backward compat)
 pub(crate) mod balance_sheet_history;
 pub(crate) mod cashflow_statement_history;

--- a/src/models/fundamentals/mod.rs
+++ b/src/models/fundamentals/mod.rs
@@ -19,6 +19,10 @@ pub use consensus::{PriceTargetConsensus, PriceTargetSummary, RatingConsensus};
 mod ttm;
 pub use ttm::{FinancialRatiosTtm, KeyMetricsTtm};
 
+// ETF profile and holdings (provider-routed)
+mod etf;
+pub use etf::{EtfHolding, EtfProfile};
+
 // quoteSummary modules (canonical home, re-exported from quote/ for backward compat)
 pub(crate) mod balance_sheet_history;
 pub(crate) mod cashflow_statement_history;

--- a/src/models/fundamentals/ttm.rs
+++ b/src/models/fundamentals/ttm.rs
@@ -1,0 +1,124 @@
+//! Trailing-twelve-month (TTM) fundamentals snapshots.
+//!
+//! Served through the [`Capability::FUNDAMENTALS`](crate::Capability::FUNDAMENTALS)
+//! route; FMP is currently the only provider. A TTM snapshot is a single
+//! always-current rollup — unlike [`FinancialStatement`](super::FinancialStatement),
+//! it is not indexed by fiscal period, so callers do not need to know whether
+//! the latest filed period is still current.
+
+use serde::{Deserialize, Serialize};
+
+/// Per-share, valuation, and leverage metrics over the trailing twelve months.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct KeyMetricsTtm {
+    /// Ticker symbol.
+    pub symbol: Option<String>,
+    /// Revenue per share.
+    pub revenue_per_share: Option<f64>,
+    /// Net income per share.
+    pub net_income_per_share: Option<f64>,
+    /// Operating cash flow per share.
+    pub operating_cash_flow_per_share: Option<f64>,
+    /// Free cash flow per share.
+    pub free_cash_flow_per_share: Option<f64>,
+    /// Cash per share.
+    pub cash_per_share: Option<f64>,
+    /// Book value per share.
+    pub book_value_per_share: Option<f64>,
+    /// Tangible book value per share.
+    pub tangible_book_value_per_share: Option<f64>,
+    /// Shareholders' equity per share.
+    pub shareholders_equity_per_share: Option<f64>,
+    /// Interest-bearing debt per share.
+    pub interest_debt_per_share: Option<f64>,
+    /// Market capitalization.
+    pub market_cap: Option<f64>,
+    /// Enterprise value.
+    pub enterprise_value: Option<f64>,
+    /// Price-to-earnings ratio.
+    pub pe_ratio: Option<f64>,
+    /// Price-to-book ratio.
+    pub pb_ratio: Option<f64>,
+    /// Enterprise value to sales.
+    pub ev_to_sales: Option<f64>,
+    /// Enterprise value to EBITDA.
+    pub ev_to_ebitda: Option<f64>,
+    /// Enterprise value to operating cash flow.
+    pub ev_to_operating_cash_flow: Option<f64>,
+    /// Enterprise value to free cash flow.
+    pub ev_to_free_cash_flow: Option<f64>,
+    /// Earnings yield.
+    pub earnings_yield: Option<f64>,
+    /// Free cash flow yield.
+    pub free_cash_flow_yield: Option<f64>,
+    /// Debt to equity.
+    pub debt_to_equity: Option<f64>,
+    /// Debt to assets.
+    pub debt_to_assets: Option<f64>,
+    /// Net debt to EBITDA.
+    pub net_debt_to_ebitda: Option<f64>,
+    /// Current ratio.
+    pub current_ratio: Option<f64>,
+    /// Interest coverage.
+    pub interest_coverage: Option<f64>,
+    /// Return on equity.
+    pub return_on_equity: Option<f64>,
+    /// Return on invested capital.
+    pub return_on_invested_capital: Option<f64>,
+    /// Dividend yield (fraction, not percent).
+    pub dividend_yield: Option<f64>,
+    /// Payout ratio.
+    pub payout_ratio: Option<f64>,
+    /// Graham number.
+    pub graham_number: Option<f64>,
+}
+
+/// Liquidity, margin, return, and valuation ratios over the trailing twelve
+/// months.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct FinancialRatiosTtm {
+    /// Ticker symbol.
+    pub symbol: Option<String>,
+    /// Current ratio.
+    pub current_ratio: Option<f64>,
+    /// Quick ratio.
+    pub quick_ratio: Option<f64>,
+    /// Cash ratio.
+    pub cash_ratio: Option<f64>,
+    /// Gross profit margin.
+    pub gross_profit_margin: Option<f64>,
+    /// Operating profit margin.
+    pub operating_profit_margin: Option<f64>,
+    /// Net profit margin.
+    pub net_profit_margin: Option<f64>,
+    /// Return on assets.
+    pub return_on_assets: Option<f64>,
+    /// Return on equity.
+    pub return_on_equity: Option<f64>,
+    /// Return on capital employed.
+    pub return_on_capital_employed: Option<f64>,
+    /// Debt ratio.
+    pub debt_ratio: Option<f64>,
+    /// Debt-to-equity ratio.
+    pub debt_equity_ratio: Option<f64>,
+    /// Interest coverage.
+    pub interest_coverage: Option<f64>,
+    /// Price-to-earnings ratio.
+    pub price_earnings_ratio: Option<f64>,
+    /// Price/earnings-to-growth ratio.
+    pub peg_ratio: Option<f64>,
+    /// Price-to-book ratio.
+    pub price_to_book_ratio: Option<f64>,
+    /// Price-to-sales ratio.
+    pub price_to_sales_ratio: Option<f64>,
+    /// Price-to-free-cash-flow ratio.
+    pub price_to_free_cash_flows_ratio: Option<f64>,
+    /// Enterprise value multiple (EV/EBITDA).
+    pub enterprise_value_multiple: Option<f64>,
+    /// Dividend yield (fraction, not percent).
+    pub dividend_yield: Option<f64>,
+    /// Payout ratio.
+    pub payout_ratio: Option<f64>,
+}

--- a/src/models/fundamentals/ttm.rs
+++ b/src/models/fundamentals/ttm.rs
@@ -5,6 +5,10 @@
 //! always-current rollup — unlike [`FinancialStatement`](super::FinancialStatement),
 //! it is not indexed by fiscal period, so callers do not need to know whether
 //! the latest filed period is still current.
+//!
+//! The `TTM`-suffixed `serde` aliases let the provider's wire shape deserialize
+//! straight into these types instead of through a field-identical DTO; aliases
+//! are deserialize-only, so serialized output stays snake_case.
 
 use serde::{Deserialize, Serialize};
 
@@ -15,62 +19,91 @@ pub struct KeyMetricsTtm {
     /// Ticker symbol.
     pub symbol: Option<String>,
     /// Revenue per share.
+    #[serde(alias = "revenuePerShareTTM")]
     pub revenue_per_share: Option<f64>,
     /// Net income per share.
+    #[serde(alias = "netIncomePerShareTTM")]
     pub net_income_per_share: Option<f64>,
     /// Operating cash flow per share.
+    #[serde(alias = "operatingCashFlowPerShareTTM")]
     pub operating_cash_flow_per_share: Option<f64>,
     /// Free cash flow per share.
+    #[serde(alias = "freeCashFlowPerShareTTM")]
     pub free_cash_flow_per_share: Option<f64>,
     /// Cash per share.
+    #[serde(alias = "cashPerShareTTM")]
     pub cash_per_share: Option<f64>,
     /// Book value per share.
+    #[serde(alias = "bookValuePerShareTTM")]
     pub book_value_per_share: Option<f64>,
     /// Tangible book value per share.
+    #[serde(alias = "tangibleBookValuePerShareTTM")]
     pub tangible_book_value_per_share: Option<f64>,
     /// Shareholders' equity per share.
+    #[serde(alias = "shareholdersEquityPerShareTTM")]
     pub shareholders_equity_per_share: Option<f64>,
     /// Interest-bearing debt per share.
+    #[serde(alias = "interestDebtPerShareTTM")]
     pub interest_debt_per_share: Option<f64>,
     /// Market capitalization.
+    #[serde(alias = "marketCapTTM")]
     pub market_cap: Option<f64>,
     /// Enterprise value.
+    #[serde(alias = "enterpriseValueTTM")]
     pub enterprise_value: Option<f64>,
     /// Price-to-earnings ratio.
+    #[serde(alias = "peRatioTTM")]
     pub pe_ratio: Option<f64>,
     /// Price-to-book ratio.
+    #[serde(alias = "pbRatioTTM")]
     pub pb_ratio: Option<f64>,
     /// Enterprise value to sales.
+    #[serde(alias = "evToSalesTTM")]
     pub ev_to_sales: Option<f64>,
     /// Enterprise value to EBITDA.
+    #[serde(alias = "enterpriseValueOverEBITDATTM")]
     pub ev_to_ebitda: Option<f64>,
     /// Enterprise value to operating cash flow.
+    #[serde(alias = "evToOperatingCashFlowTTM")]
     pub ev_to_operating_cash_flow: Option<f64>,
     /// Enterprise value to free cash flow.
+    #[serde(alias = "evToFreeCashFlowTTM")]
     pub ev_to_free_cash_flow: Option<f64>,
     /// Earnings yield.
+    #[serde(alias = "earningsYieldTTM")]
     pub earnings_yield: Option<f64>,
     /// Free cash flow yield.
+    #[serde(alias = "freeCashFlowYieldTTM")]
     pub free_cash_flow_yield: Option<f64>,
     /// Debt to equity.
+    #[serde(alias = "debtToEquityTTM")]
     pub debt_to_equity: Option<f64>,
     /// Debt to assets.
+    #[serde(alias = "debtToAssetsTTM")]
     pub debt_to_assets: Option<f64>,
     /// Net debt to EBITDA.
+    #[serde(alias = "netDebtToEBITDATTM")]
     pub net_debt_to_ebitda: Option<f64>,
     /// Current ratio.
+    #[serde(alias = "currentRatioTTM")]
     pub current_ratio: Option<f64>,
     /// Interest coverage.
+    #[serde(alias = "interestCoverageTTM")]
     pub interest_coverage: Option<f64>,
     /// Return on equity.
+    #[serde(alias = "roeTTM")]
     pub return_on_equity: Option<f64>,
     /// Return on invested capital.
+    #[serde(alias = "roicTTM")]
     pub return_on_invested_capital: Option<f64>,
     /// Dividend yield (fraction, not percent).
+    #[serde(alias = "dividendYieldTTM")]
     pub dividend_yield: Option<f64>,
     /// Payout ratio.
+    #[serde(alias = "payoutRatioTTM")]
     pub payout_ratio: Option<f64>,
     /// Graham number.
+    #[serde(alias = "grahamNumberTTM")]
     pub graham_number: Option<f64>,
 }
 
@@ -82,43 +115,63 @@ pub struct FinancialRatiosTtm {
     /// Ticker symbol.
     pub symbol: Option<String>,
     /// Current ratio.
+    #[serde(alias = "currentRatioTTM")]
     pub current_ratio: Option<f64>,
     /// Quick ratio.
+    #[serde(alias = "quickRatioTTM")]
     pub quick_ratio: Option<f64>,
     /// Cash ratio.
+    #[serde(alias = "cashRatioTTM")]
     pub cash_ratio: Option<f64>,
     /// Gross profit margin.
+    #[serde(alias = "grossProfitMarginTTM")]
     pub gross_profit_margin: Option<f64>,
     /// Operating profit margin.
+    #[serde(alias = "operatingProfitMarginTTM")]
     pub operating_profit_margin: Option<f64>,
     /// Net profit margin.
+    #[serde(alias = "netProfitMarginTTM")]
     pub net_profit_margin: Option<f64>,
     /// Return on assets.
+    #[serde(alias = "returnOnAssetsTTM")]
     pub return_on_assets: Option<f64>,
     /// Return on equity.
+    #[serde(alias = "returnOnEquityTTM")]
     pub return_on_equity: Option<f64>,
     /// Return on capital employed.
+    #[serde(alias = "returnOnCapitalEmployedTTM")]
     pub return_on_capital_employed: Option<f64>,
     /// Debt ratio.
+    #[serde(alias = "debtRatioTTM")]
     pub debt_ratio: Option<f64>,
     /// Debt-to-equity ratio.
+    #[serde(alias = "debtEquityRatioTTM")]
     pub debt_equity_ratio: Option<f64>,
     /// Interest coverage.
+    #[serde(alias = "interestCoverageTTM")]
     pub interest_coverage: Option<f64>,
     /// Price-to-earnings ratio.
+    #[serde(alias = "priceEarningsRatioTTM")]
     pub price_earnings_ratio: Option<f64>,
     /// Price/earnings-to-growth ratio.
+    #[serde(alias = "pegRatioTTM")]
     pub peg_ratio: Option<f64>,
     /// Price-to-book ratio.
+    #[serde(alias = "priceToBookRatioTTM")]
     pub price_to_book_ratio: Option<f64>,
     /// Price-to-sales ratio.
+    #[serde(alias = "priceToSalesRatioTTM")]
     pub price_to_sales_ratio: Option<f64>,
     /// Price-to-free-cash-flow ratio.
+    #[serde(alias = "priceToFreeCashFlowsRatioTTM")]
     pub price_to_free_cash_flows_ratio: Option<f64>,
     /// Enterprise value multiple (EV/EBITDA).
+    #[serde(alias = "enterpriseValueMultipleTTM")]
     pub enterprise_value_multiple: Option<f64>,
     /// Dividend yield (fraction, not percent).
+    #[serde(alias = "dividendYielTTM", alias = "dividendYieldTTM")]
     pub dividend_yield: Option<f64>,
     /// Payout ratio.
+    #[serde(alias = "payoutRatioTTM")]
     pub payout_ratio: Option<f64>,
 }

--- a/src/models/quote/mod.rs
+++ b/src/models/quote/mod.rs
@@ -11,7 +11,8 @@ pub(crate) mod response;
 pub mod data;
 /// Formatted value wrapper for Yahoo Finance numeric fields.
 pub mod formatted_value;
-/// Cross-market snapshot models (provider-routed).
+/// Cross-market snapshot models (provider-routed; Polygon-only).
+#[cfg(feature = "polygon")]
 pub mod snapshot;
 
 // Re-export only the final flattened Quote struct and FormattedValue (used in Quote's public fields)

--- a/src/models/quote/mod.rs
+++ b/src/models/quote/mod.rs
@@ -11,6 +11,8 @@ pub(crate) mod response;
 pub mod data;
 /// Formatted value wrapper for Yahoo Finance numeric fields.
 pub mod formatted_value;
+/// Cross-market snapshot models (provider-routed).
+pub mod snapshot;
 
 // Re-export only the final flattened Quote struct and FormattedValue (used in Quote's public fields)
 pub use data::Quote;

--- a/src/models/quote/snapshot.rs
+++ b/src/models/quote/snapshot.rs
@@ -1,0 +1,108 @@
+//! Cross-market snapshot model.
+//!
+//! Served through the [`Capability::QUOTE`](crate::Capability::QUOTE) route by
+//! providers whose snapshot endpoint spans asset classes; Polygon is currently
+//! the only one. A single request can mix equities, options contracts, FX
+//! pairs, crypto pairs, and indices — see
+//! [`Providers::snapshot`](crate::Providers::snapshot).
+
+use serde::{Deserialize, Serialize};
+
+/// Which market a snapshot row belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum AssetClass {
+    /// Equities.
+    Stocks,
+    /// Options contracts.
+    Options,
+    /// Currency pairs.
+    Fx,
+    /// Cryptocurrency pairs.
+    Crypto,
+    /// Stock market indices.
+    Indices,
+}
+
+impl AssetClass {
+    /// Lowercase provider-facing name (`"stocks"`, `"fx"`, …).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Stocks => "stocks",
+            Self::Options => "options",
+            Self::Fx => "fx",
+            Self::Crypto => "crypto",
+            Self::Indices => "indices",
+        }
+    }
+}
+
+/// One symbol's current market state, flattened across asset classes.
+///
+/// Providers return a row per requested symbol even when the lookup failed, so
+/// a batch is never silently short: check [`error`](Self::error) before reading
+/// the price fields.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct MarketSnapshot {
+    /// Ticker symbol as the provider spells it (e.g. `"AAPL"`, `"X:BTCUSD"`).
+    pub symbol: Option<String>,
+    /// Human-readable name of the instrument.
+    pub name: Option<String>,
+    /// Market this row belongs to.
+    pub asset_class: Option<AssetClass>,
+    /// Trading status of that market (e.g. `"open"`, `"closed"`).
+    pub market_status: Option<String>,
+    /// Most recent trade price.
+    pub last_price: Option<f64>,
+    /// Best bid.
+    pub bid: Option<f64>,
+    /// Best ask.
+    pub ask: Option<f64>,
+    /// Session open.
+    pub open: Option<f64>,
+    /// Session high.
+    pub high: Option<f64>,
+    /// Session low.
+    pub low: Option<f64>,
+    /// Session close (last price of the current session).
+    pub close: Option<f64>,
+    /// Previous session's close.
+    pub previous_close: Option<f64>,
+    /// Session volume.
+    pub volume: Option<f64>,
+    /// Absolute change over the session.
+    pub change: Option<f64>,
+    /// Percentage change over the session.
+    pub change_percent: Option<f64>,
+    /// Per-symbol error code, if the provider could not resolve this symbol.
+    pub error: Option<String>,
+    /// Human-readable message accompanying [`error`](Self::error).
+    pub message: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn asset_class_round_trips_through_provider_spelling() {
+        for (variant, name) in [
+            (AssetClass::Stocks, "stocks"),
+            (AssetClass::Options, "options"),
+            (AssetClass::Fx, "fx"),
+            (AssetClass::Crypto, "crypto"),
+            (AssetClass::Indices, "indices"),
+        ] {
+            assert_eq!(variant.as_str(), name);
+            let json = serde_json::to_string(&variant).unwrap();
+            assert_eq!(json, format!("\"{name}\""));
+            assert_eq!(
+                serde_json::from_str::<AssetClass>(&json).unwrap(),
+                variant,
+                "{name}"
+            );
+        }
+    }
+}

--- a/src/providers/adapter.rs
+++ b/src/providers/adapter.rs
@@ -43,6 +43,7 @@ pub(crate) trait QuoteProvider: ProviderCore {
     /// Fetch a snapshot for symbols spanning several asset classes in one
     /// request. Rows the provider could not resolve are returned with
     /// `error` set rather than dropped.
+    #[cfg(feature = "polygon")]
     async fn fetch_unified_snapshot(
         &self,
         _symbols: &[&str],
@@ -243,8 +244,13 @@ pub(crate) trait FilingsProvider: ProviderCore {
     }
 
     /// Search filing *text* rather than looking filings up by filer.
+    ///
+    /// `symbol` scopes the search to one filer; the provider resolves it to
+    /// whatever identifier its own index is keyed by (a CIK, for EDGAR).
+    /// `None` searches every filer.
     async fn fetch_filing_search(
         &self,
+        _symbol: Option<&str>,
         _query: &str,
         _filters: &crate::models::filings::FilingSearchFilters,
     ) -> Result<Vec<crate::models::filings::FilingSearchHit>> {

--- a/src/providers/adapter.rs
+++ b/src/providers/adapter.rs
@@ -409,6 +409,40 @@ pub(crate) trait EconomicProvider: ProviderCore {
         &self,
         series_id: &str,
     ) -> Result<crate::models::economic::EconomicSeries>;
+
+    /// Fetch a series as it stood on `date` (`YYYY-MM-DD`) rather than as
+    /// currently revised — the point-in-time view backtests need.
+    async fn fetch_economic_series_as_of(
+        &self,
+        _series_id: &str,
+        _date: &str,
+    ) -> Result<crate::models::economic::EconomicSeries> {
+        Err(self.not_supported(Operation::EconomicSeriesAsOf))
+    }
+
+    /// Search the provider's series catalog by free text.
+    async fn fetch_economic_search(
+        &self,
+        _query: &str,
+        _limit: u32,
+    ) -> Result<Vec<crate::models::economic::EconomicSeriesMatch>> {
+        Err(self.not_supported(Operation::EconomicSearch))
+    }
+
+    /// List the child categories of `parent_id` in the series category tree.
+    async fn fetch_economic_categories(
+        &self,
+        _parent_id: i64,
+    ) -> Result<Vec<crate::models::economic::EconomicCategory>> {
+        Err(self.not_supported(Operation::EconomicCategories))
+    }
+
+    /// List the provider's scheduled data releases.
+    async fn fetch_economic_releases(
+        &self,
+    ) -> Result<Vec<crate::models::economic::EconomicRelease>> {
+        Err(self.not_supported(Operation::EconomicReleases))
+    }
 }
 
 /// [`Capability::FOREX`] — currency-pair quotes.

--- a/src/providers/adapter.rs
+++ b/src/providers/adapter.rs
@@ -131,6 +131,22 @@ pub(crate) trait FundamentalsProvider: ProviderCore {
     ) -> Result<crate::models::fundamentals::RatingConsensus> {
         Err(self.not_supported(Operation::RatingConsensus))
     }
+
+    /// Fetch the trailing-twelve-month key-metrics snapshot.
+    async fn fetch_key_metrics_ttm(
+        &self,
+        _symbol: &str,
+    ) -> Result<crate::models::fundamentals::KeyMetricsTtm> {
+        Err(self.not_supported(Operation::KeyMetricsTtm))
+    }
+
+    /// Fetch the trailing-twelve-month ratios snapshot.
+    async fn fetch_ratios_ttm(
+        &self,
+        _symbol: &str,
+    ) -> Result<crate::models::fundamentals::FinancialRatiosTtm> {
+        Err(self.not_supported(Operation::RatiosTtm))
+    }
 }
 
 /// [`Capability::CORPORATE`] — news, corporate events, similar-symbol

--- a/src/providers/adapter.rs
+++ b/src/providers/adapter.rs
@@ -39,6 +39,16 @@ pub(crate) trait QuoteProvider: ProviderCore {
     async fn fetch_quotes_batch(&self, _: &[&str]) -> Result<Vec<(String, QuoteSummaryResponse)>> {
         Err(self.not_supported(Operation::QuotesBatch))
     }
+
+    /// Fetch a snapshot for symbols spanning several asset classes in one
+    /// request. Rows the provider could not resolve are returned with
+    /// `error` set rather than dropped.
+    async fn fetch_unified_snapshot(
+        &self,
+        _symbols: &[&str],
+    ) -> Result<Vec<crate::models::quote::snapshot::MarketSnapshot>> {
+        Err(self.not_supported(Operation::UnifiedSnapshot))
+    }
 }
 
 /// [`Capability::CHART`] — historical OHLCV candles and sparklines.

--- a/src/providers/adapter.rs
+++ b/src/providers/adapter.rs
@@ -233,6 +233,15 @@ pub(crate) trait FilingsProvider: ProviderCore {
     ) -> Result<Vec<crate::models::filings::RiskFactor>> {
         Err(self.not_supported(Operation::RiskFactors))
     }
+
+    /// Search filing *text* rather than looking filings up by filer.
+    async fn fetch_filing_search(
+        &self,
+        _query: &str,
+        _filters: &crate::models::filings::FilingSearchFilters,
+    ) -> Result<Vec<crate::models::filings::FilingSearchHit>> {
+        Err(self.not_supported(Operation::FilingSearch))
+    }
 }
 
 // ── Capability traits (feature-gated) ───────────────────────────────

--- a/src/providers/adapter.rs
+++ b/src/providers/adapter.rs
@@ -157,6 +157,14 @@ pub(crate) trait FundamentalsProvider: ProviderCore {
     ) -> Result<crate::models::fundamentals::FinancialRatiosTtm> {
         Err(self.not_supported(Operation::RatiosTtm))
     }
+
+    /// Fetch an ETF's profile and portfolio holdings.
+    async fn fetch_etf_profile(
+        &self,
+        _symbol: &str,
+    ) -> Result<crate::models::fundamentals::EtfProfile> {
+        Err(self.not_supported(Operation::EtfProfile))
+    }
 }
 
 /// [`Capability::CORPORATE`] — news, corporate events, similar-symbol
@@ -296,6 +304,18 @@ pub(crate) trait DiscoveryProvider: ProviderCore {
         _filters: &crate::models::discovery::reference::ScreenerFilters,
     ) -> Result<Vec<crate::models::discovery::reference::ScreenerMatch>> {
         Err(self.not_supported(Operation::Screener))
+    }
+
+    /// Fetch the provider's whole listed-security universe.
+    ///
+    /// `active = false` asks for delisted securities instead. Unlike
+    /// [`fetch_symbol_search`](Self::fetch_symbol_search) this is an unfiltered
+    /// dump, so expect thousands of rows in one response.
+    async fn fetch_listing_status(
+        &self,
+        _active: bool,
+    ) -> Result<Vec<crate::models::discovery::reference::SymbolMatch>> {
+        Err(self.not_supported(Operation::ListingStatus))
     }
 }
 

--- a/src/providers/adapter.rs
+++ b/src/providers/adapter.rs
@@ -242,6 +242,23 @@ pub(crate) trait FilingsProvider: ProviderCore {
     ) -> Result<Vec<crate::models::filings::FilingSearchHit>> {
         Err(self.not_supported(Operation::FilingSearch))
     }
+
+    /// Fetch insider transactions reported on Forms 3/4/5, newest filing first.
+    async fn fetch_insider_trades(
+        &self,
+        _symbol: &str,
+        _limit: u32,
+    ) -> Result<Vec<crate::models::filings::InsiderTrade>> {
+        Err(self.not_supported(Operation::InsiderTrades))
+    }
+
+    /// Fetch the latest reported 13F institutional holdings for a filer.
+    async fn fetch_institutional_holdings(
+        &self,
+        _symbol: &str,
+    ) -> Result<Vec<crate::models::filings::InstitutionalHolding>> {
+        Err(self.not_supported(Operation::InstitutionalHoldings))
+    }
 }
 
 // ── Capability traits (feature-gated) ───────────────────────────────

--- a/src/providers/adapter.rs
+++ b/src/providers/adapter.rs
@@ -174,6 +174,22 @@ pub(crate) trait CorporateProvider: ProviderCore {
     ) -> Result<Vec<crate::models::corporate::press_release::PressRelease>> {
         Err(self.not_supported(Operation::PressReleases))
     }
+
+    /// Fetch reported executive compensation, most recent fiscal year first.
+    async fn fetch_executive_compensation(
+        &self,
+        _symbol: &str,
+    ) -> Result<Vec<crate::models::corporate::governance::ExecutiveCompensation>> {
+        Err(self.not_supported(Operation::ExecutiveCompensation))
+    }
+
+    /// Fetch reported employee headcount history, most recent period first.
+    async fn fetch_employee_count(
+        &self,
+        _symbol: &str,
+    ) -> Result<Vec<crate::models::corporate::governance::EmployeeCount>> {
+        Err(self.not_supported(Operation::EmployeeCount))
+    }
 }
 
 /// [`Capability::OPTIONS`] — options chains.

--- a/src/providers/adapter.rs
+++ b/src/providers/adapter.rs
@@ -107,6 +107,30 @@ pub(crate) trait FundamentalsProvider: ProviderCore {
     ) -> Result<crate::models::fundamentals::ShareFloat> {
         Err(self.not_supported(Operation::ShareFloat))
     }
+
+    /// Fetch the aggregated analyst price-target consensus.
+    async fn fetch_price_target_consensus(
+        &self,
+        _symbol: &str,
+    ) -> Result<crate::models::fundamentals::PriceTargetConsensus> {
+        Err(self.not_supported(Operation::PriceTargetConsensus))
+    }
+
+    /// Fetch price-target publication activity over trailing windows.
+    async fn fetch_price_target_summary(
+        &self,
+        _symbol: &str,
+    ) -> Result<crate::models::fundamentals::PriceTargetSummary> {
+        Err(self.not_supported(Operation::PriceTargetSummary))
+    }
+
+    /// Fetch the aggregated analyst rating consensus.
+    async fn fetch_rating_consensus(
+        &self,
+        _symbol: &str,
+    ) -> Result<crate::models::fundamentals::RatingConsensus> {
+        Err(self.not_supported(Operation::RatingConsensus))
+    }
 }
 
 /// [`Capability::CORPORATE`] — news, corporate events, similar-symbol

--- a/src/providers/alphavantage.rs
+++ b/src/providers/alphavantage.rs
@@ -4,9 +4,9 @@
 //! in the adapter functions under `crate::adapters::alphavantage::*`.
 
 use super::{
-    ChartProvider, CommoditiesProvider, CorporateProvider, CryptoProvider, EconomicProvider,
-    ForexProvider, FundamentalsProvider, MarketProvider, OptionsProvider, ProviderAdapter,
-    ProviderCore, QuoteProvider,
+    ChartProvider, CommoditiesProvider, CorporateProvider, CryptoProvider, DiscoveryProvider,
+    EconomicProvider, ForexProvider, FundamentalsProvider, MarketProvider, OptionsProvider,
+    ProviderAdapter, ProviderCore, QuoteProvider,
 };
 use crate::adapters::alphavantage as av;
 use crate::error::Result;
@@ -65,6 +65,39 @@ impl FundamentalsProvider for AlphaVantageProvider {
         frequency: crate::Frequency,
     ) -> Result<crate::models::fundamentals::FinancialStatement> {
         av::fetch_financials_response(symbol, stmt_type, frequency).await
+    }
+
+    async fn fetch_etf_profile(
+        &self,
+        symbol: &str,
+    ) -> Result<crate::models::fundamentals::EtfProfile> {
+        av::fundamentals::etf::fetch_etf_profile_response(symbol).await
+    }
+}
+
+#[async_trait::async_trait]
+impl DiscoveryProvider for AlphaVantageProvider {
+    async fn fetch_symbol_search(
+        &self,
+        query: &str,
+        limit: u32,
+    ) -> Result<Vec<crate::models::discovery::reference::SymbolMatch>> {
+        av::discovery::fetch_symbol_search_response(query, limit).await
+    }
+
+    /// Alpha Vantage has no exchange endpoint; the venue list is derived from
+    /// the active listing universe, so only `name` is populated.
+    async fn fetch_exchanges(
+        &self,
+    ) -> Result<Vec<crate::models::discovery::reference::ExchangeInfo>> {
+        av::discovery::fetch_exchanges_response().await
+    }
+
+    async fn fetch_listing_status(
+        &self,
+        active: bool,
+    ) -> Result<Vec<crate::models::discovery::reference::SymbolMatch>> {
+        av::discovery::fetch_listing_status_response(active).await
     }
 }
 
@@ -187,6 +220,9 @@ impl ProviderAdapter for AlphaVantageProvider {
         Some(self)
     }
     fn as_market(&self) -> Option<&dyn MarketProvider> {
+        Some(self)
+    }
+    fn as_discovery(&self) -> Option<&dyn DiscoveryProvider> {
         Some(self)
     }
 }

--- a/src/providers/coingecko.rs
+++ b/src/providers/coingecko.rs
@@ -1,6 +1,6 @@
 //! CoinGecko provider implementation.
 
-use super::{CryptoProvider, ProviderAdapter, ProviderCore};
+use super::{ChartProvider, CryptoProvider, ProviderAdapter, ProviderCore};
 use crate::error::Result;
 
 pub(crate) struct CoinGeckoProvider;
@@ -23,8 +23,26 @@ impl CryptoProvider for CoinGeckoProvider {
 }
 
 #[async_trait::async_trait]
+impl ChartProvider for CoinGeckoProvider {
+    /// Chart symbols arrive as `"{ID}-{VS}"` from
+    /// [`CryptoCoin::chart`](crate::CryptoCoin::chart); CoinGecko wants the
+    /// coin id and quote currency separately, so the symbol is split back apart.
+    async fn fetch_chart(
+        &self,
+        symbol: &str,
+        interval: crate::Interval,
+        range: crate::TimeRange,
+    ) -> Result<crate::models::chart::Chart> {
+        crate::adapters::coingecko::chart::fetch_chart_response(symbol, interval, range).await
+    }
+}
+
+#[async_trait::async_trait]
 impl ProviderAdapter for CoinGeckoProvider {
     fn as_crypto(&self) -> Option<&dyn CryptoProvider> {
+        Some(self)
+    }
+    fn as_chart(&self) -> Option<&dyn ChartProvider> {
         Some(self)
     }
 }

--- a/src/providers/config.rs
+++ b/src/providers/config.rs
@@ -179,6 +179,18 @@ impl Providers {
         crate::domains::Market::with_providers(Arc::clone(&self.set))
     }
 
+    /// Create an [`EconomicCatalog`](crate::EconomicCatalog) handle backed by
+    /// this provider set.
+    ///
+    /// Routes series search and category/release browsing through
+    /// [`Capability::ECONOMIC`](crate::Capability::ECONOMIC). Unlike
+    /// [`economic`](Self::economic) it takes no series id — it is how you find
+    /// one.
+    #[cfg(any(feature = "fred", feature = "alphavantage", feature = "polygon"))]
+    pub fn economic_catalog(&self) -> crate::domains::EconomicCatalog {
+        crate::domains::EconomicCatalog::with_providers(Arc::clone(&self.set))
+    }
+
     /// Create a [`Snapshot`](crate::Snapshot) handle backed by this provider set.
     ///
     /// Routes cross-market snapshots through

--- a/src/providers/config.rs
+++ b/src/providers/config.rs
@@ -179,6 +179,15 @@ impl Providers {
         crate::domains::Market::with_providers(Arc::clone(&self.set))
     }
 
+    /// Create a [`Snapshot`](crate::Snapshot) handle backed by this provider set.
+    ///
+    /// Routes cross-market snapshots through
+    /// [`Capability::QUOTE`](crate::Capability::QUOTE). Needs a provider whose
+    /// snapshot endpoint spans asset classes — currently Polygon only.
+    pub fn snapshot(&self) -> crate::domains::Snapshot {
+        crate::domains::Snapshot::with_providers(Arc::clone(&self.set))
+    }
+
     /// Create a [`Filings`](crate::Filings) handle backed by this provider set.
     ///
     /// Always available — EDGAR is auto-injected when no other FILINGS provider

--- a/src/providers/config.rs
+++ b/src/providers/config.rs
@@ -195,7 +195,9 @@ impl Providers {
     ///
     /// Routes cross-market snapshots through
     /// [`Capability::QUOTE`](crate::Capability::QUOTE). Needs a provider whose
-    /// snapshot endpoint spans asset classes — currently Polygon only.
+    /// snapshot endpoint spans asset classes — currently Polygon only, which is
+    /// why the handle is gated on that feature.
+    #[cfg(feature = "polygon")]
     pub fn snapshot(&self) -> crate::domains::Snapshot {
         crate::domains::Snapshot::with_providers(Arc::clone(&self.set))
     }

--- a/src/providers/edgar.rs
+++ b/src/providers/edgar.rs
@@ -21,6 +21,15 @@ impl FilingsProvider for EdgarProvider {
     async fn fetch_filings(&self, symbol: &str) -> Result<ProviderFilings> {
         crate::adapters::edgar::fetch_filings_response(symbol).await
     }
+
+    async fn fetch_filing_search(
+        &self,
+        query: &str,
+        filters: &crate::models::filings::FilingSearchFilters,
+    ) -> Result<Vec<crate::models::filings::FilingSearchHit>> {
+        crate::adapters::edgar::filings::full_text::fetch_filing_search_response(query, filters)
+            .await
+    }
 }
 
 #[async_trait::async_trait]

--- a/src/providers/edgar.rs
+++ b/src/providers/edgar.rs
@@ -24,11 +24,14 @@ impl FilingsProvider for EdgarProvider {
 
     async fn fetch_filing_search(
         &self,
+        symbol: Option<&str>,
         query: &str,
         filters: &crate::models::filings::FilingSearchFilters,
     ) -> Result<Vec<crate::models::filings::FilingSearchHit>> {
-        crate::adapters::edgar::filings::full_text::fetch_filing_search_response(query, filters)
-            .await
+        crate::adapters::edgar::filings::full_text::fetch_filing_search_response(
+            symbol, query, filters,
+        )
+        .await
     }
 
     async fn fetch_insider_trades(

--- a/src/providers/edgar.rs
+++ b/src/providers/edgar.rs
@@ -30,6 +30,22 @@ impl FilingsProvider for EdgarProvider {
         crate::adapters::edgar::filings::full_text::fetch_filing_search_response(query, filters)
             .await
     }
+
+    async fn fetch_insider_trades(
+        &self,
+        symbol: &str,
+        limit: u32,
+    ) -> Result<Vec<crate::models::filings::InsiderTrade>> {
+        crate::adapters::edgar::filings::insider::fetch_insider_trades_response(symbol, limit).await
+    }
+
+    async fn fetch_institutional_holdings(
+        &self,
+        symbol: &str,
+    ) -> Result<Vec<crate::models::filings::InstitutionalHolding>> {
+        crate::adapters::edgar::filings::thirteen_f::fetch_institutional_holdings_response(symbol)
+            .await
+    }
 }
 
 #[async_trait::async_trait]

--- a/src/providers/fmp.rs
+++ b/src/providers/fmp.rs
@@ -102,6 +102,29 @@ impl FundamentalsProvider for FmpProvider {
             data,
         ))
     }
+
+    async fn fetch_price_target_consensus(
+        &self,
+        symbol: &str,
+    ) -> Result<crate::models::fundamentals::PriceTargetConsensus> {
+        crate::adapters::fmp::fundamentals::consensus::fetch_price_target_consensus_response(symbol)
+            .await
+    }
+
+    async fn fetch_price_target_summary(
+        &self,
+        symbol: &str,
+    ) -> Result<crate::models::fundamentals::PriceTargetSummary> {
+        crate::adapters::fmp::fundamentals::consensus::fetch_price_target_summary_response(symbol)
+            .await
+    }
+
+    async fn fetch_rating_consensus(
+        &self,
+        symbol: &str,
+    ) -> Result<crate::models::fundamentals::RatingConsensus> {
+        crate::adapters::fmp::fundamentals::consensus::fetch_rating_consensus_response(symbol).await
+    }
 }
 
 #[async_trait::async_trait]

--- a/src/providers/fmp.rs
+++ b/src/providers/fmp.rs
@@ -139,6 +139,13 @@ impl FundamentalsProvider for FmpProvider {
     ) -> Result<crate::models::fundamentals::FinancialRatiosTtm> {
         crate::adapters::fmp::fundamentals::ttm::fetch_ratios_ttm_response(symbol).await
     }
+
+    async fn fetch_share_float(
+        &self,
+        symbol: &str,
+    ) -> Result<crate::models::fundamentals::ShareFloat> {
+        crate::adapters::fmp::fundamentals::float::fetch_share_float_response(symbol).await
+    }
 }
 
 #[async_trait::async_trait]
@@ -168,6 +175,21 @@ impl CorporateProvider for FmpProvider {
         limit: u32,
     ) -> Result<Vec<crate::models::corporate::press_release::PressRelease>> {
         crate::adapters::fmp::corporate::fetch_press_releases_response(symbol, limit).await
+    }
+
+    async fn fetch_executive_compensation(
+        &self,
+        symbol: &str,
+    ) -> Result<Vec<crate::models::corporate::governance::ExecutiveCompensation>> {
+        crate::adapters::fmp::corporate::ownership::fetch_executive_compensation_response(symbol)
+            .await
+    }
+
+    async fn fetch_employee_count(
+        &self,
+        symbol: &str,
+    ) -> Result<Vec<crate::models::corporate::governance::EmployeeCount>> {
+        crate::adapters::fmp::corporate::ownership::fetch_employee_count_response(symbol).await
     }
 }
 

--- a/src/providers/fmp.rs
+++ b/src/providers/fmp.rs
@@ -125,6 +125,20 @@ impl FundamentalsProvider for FmpProvider {
     ) -> Result<crate::models::fundamentals::RatingConsensus> {
         crate::adapters::fmp::fundamentals::consensus::fetch_rating_consensus_response(symbol).await
     }
+
+    async fn fetch_key_metrics_ttm(
+        &self,
+        symbol: &str,
+    ) -> Result<crate::models::fundamentals::KeyMetricsTtm> {
+        crate::adapters::fmp::fundamentals::ttm::fetch_key_metrics_ttm_response(symbol).await
+    }
+
+    async fn fetch_ratios_ttm(
+        &self,
+        symbol: &str,
+    ) -> Result<crate::models::fundamentals::FinancialRatiosTtm> {
+        crate::adapters::fmp::fundamentals::ttm::fetch_ratios_ttm_response(symbol).await
+    }
 }
 
 #[async_trait::async_trait]

--- a/src/providers/fred.rs
+++ b/src/providers/fred.rs
@@ -19,6 +19,35 @@ impl EconomicProvider for FredProvider {
     ) -> Result<crate::models::economic::EconomicSeries> {
         crate::adapters::fred::fetch_economic_series_response(series_id).await
     }
+
+    async fn fetch_economic_series_as_of(
+        &self,
+        series_id: &str,
+        date: &str,
+    ) -> Result<crate::models::economic::EconomicSeries> {
+        crate::adapters::fred::economic::catalog::series_as_of(series_id, date).await
+    }
+
+    async fn fetch_economic_search(
+        &self,
+        query: &str,
+        limit: u32,
+    ) -> Result<Vec<crate::models::economic::EconomicSeriesMatch>> {
+        crate::adapters::fred::economic::catalog::search(query, limit).await
+    }
+
+    async fn fetch_economic_categories(
+        &self,
+        parent_id: i64,
+    ) -> Result<Vec<crate::models::economic::EconomicCategory>> {
+        crate::adapters::fred::economic::catalog::categories(parent_id).await
+    }
+
+    async fn fetch_economic_releases(
+        &self,
+    ) -> Result<Vec<crate::models::economic::EconomicRelease>> {
+        crate::adapters::fred::economic::catalog::releases().await
+    }
 }
 
 #[async_trait::async_trait]

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -502,6 +502,10 @@ pub enum Operation {
     KeyMetricsTtm,
     /// Trailing-twelve-month ratios snapshot.
     RatiosTtm,
+    /// Reported executive compensation.
+    ExecutiveCompensation,
+    /// Reported employee headcount.
+    EmployeeCount,
 }
 
 impl Operation {
@@ -555,6 +559,8 @@ impl Operation {
             Self::RatingConsensus => "rating_consensus",
             Self::KeyMetricsTtm => "key_metrics_ttm",
             Self::RatiosTtm => "ratios_ttm",
+            Self::ExecutiveCompensation => "executive_compensation",
+            Self::EmployeeCount => "employee_count",
         }
     }
 
@@ -572,9 +578,12 @@ impl Operation {
             | Self::RatingConsensus
             | Self::KeyMetricsTtm
             | Self::RatiosTtm => Capability::FUNDAMENTALS,
-            Self::News | Self::Recommendations | Self::Events | Self::PressReleases => {
-                Capability::CORPORATE
-            }
+            Self::News
+            | Self::Recommendations
+            | Self::Events
+            | Self::PressReleases
+            | Self::ExecutiveCompensation
+            | Self::EmployeeCount => Capability::CORPORATE,
             Self::Options => Capability::OPTIONS,
             Self::CryptoQuote => Capability::CRYPTO,
             #[cfg(feature = "defi")]

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -522,6 +522,10 @@ pub enum Operation {
     EconomicCategories,
     /// Scheduled macro data releases.
     EconomicReleases,
+    /// ETF profile and portfolio holdings.
+    EtfProfile,
+    /// The provider's whole listed-security universe.
+    ListingStatus,
 }
 
 impl Operation {
@@ -585,6 +589,8 @@ impl Operation {
             Self::EconomicSearch => "economic_search",
             Self::EconomicCategories => "economic_categories",
             Self::EconomicReleases => "economic_releases",
+            Self::EtfProfile => "etf_profile",
+            Self::ListingStatus => "listing_status",
         }
     }
 
@@ -601,7 +607,8 @@ impl Operation {
             | Self::PriceTargetSummary
             | Self::RatingConsensus
             | Self::KeyMetricsTtm
-            | Self::RatiosTtm => Capability::FUNDAMENTALS,
+            | Self::RatiosTtm
+            | Self::EtfProfile => Capability::FUNDAMENTALS,
             Self::News
             | Self::Recommendations
             | Self::Events
@@ -629,9 +636,11 @@ impl Operation {
             | Self::FilingSearch
             | Self::InsiderTrades
             | Self::InstitutionalHoldings => Capability::FILINGS,
-            Self::SymbolSearch | Self::SymbolDetails | Self::Exchanges | Self::Screener => {
-                Capability::DISCOVERY
-            }
+            Self::SymbolSearch
+            | Self::SymbolDetails
+            | Self::Exchanges
+            | Self::Screener
+            | Self::ListingStatus => Capability::DISCOVERY,
             Self::EarningsCalendar
             | Self::IpoCalendar
             | Self::DividendCalendar

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -510,6 +510,10 @@ pub enum Operation {
     UnifiedSnapshot,
     /// Full-text search over filing content.
     FilingSearch,
+    /// Insider transactions reported on Forms 3/4/5.
+    InsiderTrades,
+    /// Institutional holdings reported on Form 13F-HR.
+    InstitutionalHoldings,
 }
 
 impl Operation {
@@ -567,6 +571,8 @@ impl Operation {
             Self::EmployeeCount => "employee_count",
             Self::UnifiedSnapshot => "unified_snapshot",
             Self::FilingSearch => "filing_search",
+            Self::InsiderTrades => "insider_trades",
+            Self::InstitutionalHoldings => "institutional_holdings",
         }
     }
 
@@ -601,9 +607,12 @@ impl Operation {
             }
             Self::FuturesQuote => Capability::FUTURES,
             Self::CommoditiesQuote => Capability::COMMODITIES,
-            Self::Filings | Self::FilingSections | Self::RiskFactors | Self::FilingSearch => {
-                Capability::FILINGS
-            }
+            Self::Filings
+            | Self::FilingSections
+            | Self::RiskFactors
+            | Self::FilingSearch
+            | Self::InsiderTrades
+            | Self::InstitutionalHoldings => Capability::FILINGS,
             Self::SymbolSearch | Self::SymbolDetails | Self::Exchanges | Self::Screener => {
                 Capability::DISCOVERY
             }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -498,6 +498,10 @@ pub enum Operation {
     PriceTargetSummary,
     /// Aggregated analyst rating consensus.
     RatingConsensus,
+    /// Trailing-twelve-month key-metrics snapshot.
+    KeyMetricsTtm,
+    /// Trailing-twelve-month ratios snapshot.
+    RatiosTtm,
 }
 
 impl Operation {
@@ -549,6 +553,8 @@ impl Operation {
             Self::PriceTargetConsensus => "price_target_consensus",
             Self::PriceTargetSummary => "price_target_summary",
             Self::RatingConsensus => "rating_consensus",
+            Self::KeyMetricsTtm => "key_metrics_ttm",
+            Self::RatiosTtm => "ratios_ttm",
         }
     }
 
@@ -563,7 +569,9 @@ impl Operation {
             | Self::ShareFloat
             | Self::PriceTargetConsensus
             | Self::PriceTargetSummary
-            | Self::RatingConsensus => Capability::FUNDAMENTALS,
+            | Self::RatingConsensus
+            | Self::KeyMetricsTtm
+            | Self::RatiosTtm => Capability::FUNDAMENTALS,
             Self::News | Self::Recommendations | Self::Events | Self::PressReleases => {
                 Capability::CORPORATE
             }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -492,6 +492,12 @@ pub enum Operation {
     /// Historical total value locked in a DeFi protocol.
     #[cfg(feature = "defi")]
     ProtocolTvlHistory,
+    /// Aggregated analyst price-target consensus.
+    PriceTargetConsensus,
+    /// Price-target publication activity over trailing windows.
+    PriceTargetSummary,
+    /// Aggregated analyst rating consensus.
+    RatingConsensus,
 }
 
 impl Operation {
@@ -540,6 +546,9 @@ impl Operation {
             Self::ProtocolTvl => "protocol_tvl",
             #[cfg(feature = "defi")]
             Self::ProtocolTvlHistory => "protocol_tvl_history",
+            Self::PriceTargetConsensus => "price_target_consensus",
+            Self::PriceTargetSummary => "price_target_summary",
+            Self::RatingConsensus => "rating_consensus",
         }
     }
 
@@ -548,9 +557,13 @@ impl Operation {
         match self {
             Self::Quote | Self::QuotesBatch => Capability::QUOTE,
             Self::Chart | Self::ChartRange | Self::Spark => Capability::CHART,
-            Self::Financials | Self::ShortInterest | Self::ShortVolume | Self::ShareFloat => {
-                Capability::FUNDAMENTALS
-            }
+            Self::Financials
+            | Self::ShortInterest
+            | Self::ShortVolume
+            | Self::ShareFloat
+            | Self::PriceTargetConsensus
+            | Self::PriceTargetSummary
+            | Self::RatingConsensus => Capability::FUNDAMENTALS,
             Self::News | Self::Recommendations | Self::Events | Self::PressReleases => {
                 Capability::CORPORATE
             }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -508,6 +508,8 @@ pub enum Operation {
     EmployeeCount,
     /// Cross-market snapshot for symbols spanning several asset classes.
     UnifiedSnapshot,
+    /// Full-text search over filing content.
+    FilingSearch,
 }
 
 impl Operation {
@@ -564,6 +566,7 @@ impl Operation {
             Self::ExecutiveCompensation => "executive_compensation",
             Self::EmployeeCount => "employee_count",
             Self::UnifiedSnapshot => "unified_snapshot",
+            Self::FilingSearch => "filing_search",
         }
     }
 
@@ -598,7 +601,9 @@ impl Operation {
             }
             Self::FuturesQuote => Capability::FUTURES,
             Self::CommoditiesQuote => Capability::COMMODITIES,
-            Self::Filings | Self::FilingSections | Self::RiskFactors => Capability::FILINGS,
+            Self::Filings | Self::FilingSections | Self::RiskFactors | Self::FilingSearch => {
+                Capability::FILINGS
+            }
             Self::SymbolSearch | Self::SymbolDetails | Self::Exchanges | Self::Screener => {
                 Capability::DISCOVERY
             }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -506,6 +506,8 @@ pub enum Operation {
     ExecutiveCompensation,
     /// Reported employee headcount.
     EmployeeCount,
+    /// Cross-market snapshot for symbols spanning several asset classes.
+    UnifiedSnapshot,
 }
 
 impl Operation {
@@ -561,13 +563,14 @@ impl Operation {
             Self::RatiosTtm => "ratios_ttm",
             Self::ExecutiveCompensation => "executive_compensation",
             Self::EmployeeCount => "employee_count",
+            Self::UnifiedSnapshot => "unified_snapshot",
         }
     }
 
     /// The coarser [`Capability`] bit this operation falls under.
     pub fn capability(self) -> Capability {
         match self {
-            Self::Quote | Self::QuotesBatch => Capability::QUOTE,
+            Self::Quote | Self::QuotesBatch | Self::UnifiedSnapshot => Capability::QUOTE,
             Self::Chart | Self::ChartRange | Self::Spark => Capability::CHART,
             Self::Financials
             | Self::ShortInterest

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -514,6 +514,14 @@ pub enum Operation {
     InsiderTrades,
     /// Institutional holdings reported on Form 13F-HR.
     InstitutionalHoldings,
+    /// A macro series as it stood on a past date (vintage/ALFRED view).
+    EconomicSeriesAsOf,
+    /// Free-text search over the macro series catalog.
+    EconomicSearch,
+    /// Macro series category browsing.
+    EconomicCategories,
+    /// Scheduled macro data releases.
+    EconomicReleases,
 }
 
 impl Operation {
@@ -573,6 +581,10 @@ impl Operation {
             Self::FilingSearch => "filing_search",
             Self::InsiderTrades => "insider_trades",
             Self::InstitutionalHoldings => "institutional_holdings",
+            Self::EconomicSeriesAsOf => "economic_series_as_of",
+            Self::EconomicSearch => "economic_search",
+            Self::EconomicCategories => "economic_categories",
+            Self::EconomicReleases => "economic_releases",
         }
     }
 
@@ -600,7 +612,11 @@ impl Operation {
             Self::CryptoQuote => Capability::CRYPTO,
             #[cfg(feature = "defi")]
             Self::ProtocolTvl | Self::ProtocolTvlHistory => Capability::CRYPTO,
-            Self::EconomicSeries => Capability::ECONOMIC,
+            Self::EconomicSeries
+            | Self::EconomicSeriesAsOf
+            | Self::EconomicSearch
+            | Self::EconomicCategories
+            | Self::EconomicReleases => Capability::ECONOMIC,
             Self::ForexQuote => Capability::FOREX,
             Self::IndicesQuote | Self::IndexConstituents | Self::IndexConstituentChanges => {
                 Capability::INDICES

--- a/src/providers/polygon.rs
+++ b/src/providers/polygon.rs
@@ -30,6 +30,13 @@ impl QuoteProvider for PolygonProvider {
     ) -> Result<Vec<(String, QuoteSummaryResponse)>> {
         polygon::fetch_quotes_batch_response(symbols).await
     }
+
+    async fn fetch_unified_snapshot(
+        &self,
+        symbols: &[&str],
+    ) -> Result<Vec<crate::models::quote::snapshot::MarketSnapshot>> {
+        polygon::unified::fetch_unified_snapshot_response(symbols).await
+    }
 }
 
 #[async_trait::async_trait]

--- a/src/ticker/core.rs
+++ b/src/ticker/core.rs
@@ -26,6 +26,7 @@ use crate::models::quote::{
     TopHoldings, UpgradeDowngradeHistory,
 };
 
+use super::macros::ticker_fetch;
 use crate::providers::types::recommendation_from_similar;
 use crate::providers::yahoo::YahooProvider;
 use crate::providers::{
@@ -371,20 +372,7 @@ impl Ticker {
                 return Ok(entry.value.clone());
             }
         }
-        let sym = self.symbol.clone();
-        let data = self
-            .providers
-            .fetch(Capability::CHART, move |p| {
-                let sym = sym.clone();
-                let p = p.clone();
-                async move {
-                    p.as_chart()
-                        .ok_or_else(|| p.not_supported(crate::providers::Operation::Chart))?
-                        .fetch_chart(&sym, interval, range)
-                        .await
-                }
-            })
-            .await?;
+        let data = ticker_fetch!(self, CHART, as_chart, Chart, fetch_chart, interval, range)?;
         let chart = Self::chart_from_provider_data(data, Some(interval), Some(range));
         if self.cache_mode.enabled() {
             let mut cache = self.chart_cache.write().await;
@@ -401,20 +389,16 @@ impl Ticker {
                 reason: format!("end ({end}) must be > start ({start})"),
             });
         }
-        let sym = self.symbol.clone();
-        let data = self
-            .providers
-            .fetch(Capability::CHART, move |p| {
-                let sym = sym.clone();
-                let p = p.clone();
-                async move {
-                    p.as_chart()
-                        .ok_or_else(|| p.not_supported(crate::providers::Operation::ChartRange))?
-                        .fetch_chart_range(&sym, interval, start, end)
-                        .await
-                }
-            })
-            .await?;
+        let data = ticker_fetch!(
+            self,
+            CHART,
+            as_chart,
+            ChartRange,
+            fetch_chart_range,
+            interval,
+            start,
+            end
+        )?;
         Ok(Self::chart_from_provider_data(data, Some(interval), None))
     }
 
@@ -425,20 +409,7 @@ impl Ticker {
                 return Ok(());
             }
         }
-        let sym = self.symbol.clone();
-        let events = self
-            .providers
-            .fetch(Capability::CORPORATE, move |p| {
-                let sym = sym.clone();
-                let p = p.clone();
-                async move {
-                    p.as_corporate()
-                        .ok_or_else(|| p.not_supported(crate::providers::Operation::Events))?
-                        .fetch_events(&sym)
-                        .await
-                }
-            })
-            .await?;
+        let events = ticker_fetch!(self, CORPORATE, as_corporate, Events, fetch_events)?;
         let mut cache = self.events_cache.write().await;
         *cache = Some(CacheEntry::new(events));
         Ok(())
@@ -524,20 +495,7 @@ impl Ticker {
                 return Ok(e.value.clone());
             }
         }
-        let sym = self.symbol.clone();
-        let data = self
-            .providers
-            .fetch(Capability::CORPORATE, move |p| {
-                let sym = sym.clone();
-                let p = p.clone();
-                async move {
-                    p.as_corporate()
-                        .ok_or_else(|| p.not_supported(crate::providers::Operation::News))?
-                        .fetch_news(&sym)
-                        .await
-                }
-            })
-            .await?;
+        let data = ticker_fetch!(self, CORPORATE, as_corporate, News, fetch_news)?;
         let news = data;
         // Score titles before translation — VADER is English-lexicon based.
         #[cfg(feature = "sentiment")]
@@ -588,20 +546,7 @@ impl Ticker {
                 return Ok(e.value.clone());
             }
         }
-        let sym = self.symbol.clone();
-        let opts = self
-            .providers
-            .fetch(Capability::OPTIONS, move |p| {
-                let sym = sym.clone();
-                let p = p.clone();
-                async move {
-                    p.as_options()
-                        .ok_or_else(|| p.not_supported(crate::providers::Operation::Options))?
-                        .fetch_options(&sym, date)
-                        .await
-                }
-            })
-            .await?;
+        let opts = ticker_fetch!(self, OPTIONS, as_options, Options, fetch_options, date)?;
         if self.cache_mode.enabled() {
             let mut c = self.options_cache.write().await;
             self.cache_insert(&mut c, date, opts.clone());
@@ -624,20 +569,15 @@ impl Ticker {
                 return Ok(e.value.clone());
             }
         }
-        let sym = self.symbol.clone();
-        let stmt = self
-            .providers
-            .fetch(Capability::FUNDAMENTALS, move |p| {
-                let sym = sym.clone();
-                let p = p.clone();
-                async move {
-                    p.as_fundamentals()
-                        .ok_or_else(|| p.not_supported(crate::providers::Operation::Financials))?
-                        .fetch_financials(&sym, stmt_type, frequency)
-                        .await
-                }
-            })
-            .await?;
+        let stmt = ticker_fetch!(
+            self,
+            FUNDAMENTALS,
+            as_fundamentals,
+            Financials,
+            fetch_financials,
+            stmt_type,
+            frequency
+        )?;
         if self.cache_mode.enabled() {
             let mut c = self.financials_cache.write().await;
             self.cache_insert(&mut c, key, stmt.clone());
@@ -721,19 +661,7 @@ impl Ticker {
     /// For the full EDGAR submissions response or structured XBRL data, use
     /// [`edgar_submissions`](Self::edgar_submissions) / [`edgar_company_facts`](Self::edgar_company_facts).
     pub async fn filings(&self) -> Result<ProviderFilings> {
-        let symbol = self.symbol.clone();
-        self.providers
-            .fetch(Capability::FILINGS, move |p| {
-                let symbol = symbol.clone();
-                let p = p.clone();
-                async move {
-                    p.as_filings()
-                        .ok_or_else(|| p.not_supported(crate::providers::Operation::Filings))?
-                        .fetch_filings(&symbol)
-                        .await
-                }
-            })
-            .await
+        ticker_fetch!(self, FILINGS, as_filings, Filings, fetch_filings)
     }
 
     /// Fetch short-interest settlement reports via the configured
@@ -742,56 +670,38 @@ impl Ticker {
     /// route to Polygon for the full bi-monthly history:
     /// `.route(Capability::FUNDAMENTALS, [Provider::Polygon, Provider::Yahoo])`.
     pub async fn short_interest(&self) -> Result<Vec<crate::models::fundamentals::ShortInterest>> {
-        let symbol = self.symbol.clone();
-        self.providers
-            .fetch(Capability::FUNDAMENTALS, move |p| {
-                let symbol = symbol.clone();
-                let p = p.clone();
-                async move {
-                    p.as_fundamentals()
-                        .ok_or_else(|| p.not_supported(crate::providers::Operation::ShortInterest))?
-                        .fetch_short_interest(&symbol)
-                        .await
-                }
-            })
-            .await
+        ticker_fetch!(
+            self,
+            FUNDAMENTALS,
+            as_fundamentals,
+            ShortInterest,
+            fetch_short_interest
+        )
     }
 
     /// Fetch daily short-volume data via the configured
     /// [`Capability::FUNDAMENTALS`] provider (currently Polygon only).
     pub async fn short_volume(&self) -> Result<Vec<crate::models::fundamentals::ShortVolume>> {
-        let symbol = self.symbol.clone();
-        self.providers
-            .fetch(Capability::FUNDAMENTALS, move |p| {
-                let symbol = symbol.clone();
-                let p = p.clone();
-                async move {
-                    p.as_fundamentals()
-                        .ok_or_else(|| p.not_supported(crate::providers::Operation::ShortVolume))?
-                        .fetch_short_volume(&symbol)
-                        .await
-                }
-            })
-            .await
+        ticker_fetch!(
+            self,
+            FUNDAMENTALS,
+            as_fundamentals,
+            ShortVolume,
+            fetch_short_volume
+        )
     }
 
     /// Fetch share float and shares outstanding via the configured
     /// [`Capability::FUNDAMENTALS`] provider (Yahoo-derived on the default
     /// route; Polygon serves it too).
     pub async fn share_float(&self) -> Result<crate::models::fundamentals::ShareFloat> {
-        let symbol = self.symbol.clone();
-        self.providers
-            .fetch(Capability::FUNDAMENTALS, move |p| {
-                let symbol = symbol.clone();
-                let p = p.clone();
-                async move {
-                    p.as_fundamentals()
-                        .ok_or_else(|| p.not_supported(crate::providers::Operation::ShareFloat))?
-                        .fetch_share_float(&symbol)
-                        .await
-                }
-            })
-            .await
+        ticker_fetch!(
+            self,
+            FUNDAMENTALS,
+            as_fundamentals,
+            ShareFloat,
+            fetch_share_float
+        )
     }
 
     /// Fetch the company's own press releases via the configured
@@ -801,19 +711,14 @@ impl Ticker {
         &self,
         limit: u32,
     ) -> Result<Vec<crate::models::corporate::press_release::PressRelease>> {
-        let symbol = self.symbol.clone();
-        self.providers
-            .fetch(Capability::CORPORATE, move |p| {
-                let symbol = symbol.clone();
-                let p = p.clone();
-                async move {
-                    p.as_corporate()
-                        .ok_or_else(|| p.not_supported(crate::providers::Operation::PressReleases))?
-                        .fetch_press_releases(&symbol, limit)
-                        .await
-                }
-            })
-            .await
+        ticker_fetch!(
+            self,
+            CORPORATE,
+            as_corporate,
+            PressReleases,
+            fetch_press_releases,
+            limit
+        )
     }
 
     /// Fetch the aggregated analyst price-target consensus (high/low/mean/median)
@@ -823,21 +728,13 @@ impl Ticker {
     pub async fn price_target_consensus(
         &self,
     ) -> Result<crate::models::fundamentals::PriceTargetConsensus> {
-        let symbol = self.symbol.clone();
-        self.providers
-            .fetch(Capability::FUNDAMENTALS, move |p| {
-                let symbol = symbol.clone();
-                let p = p.clone();
-                async move {
-                    p.as_fundamentals()
-                        .ok_or_else(|| {
-                            p.not_supported(crate::providers::Operation::PriceTargetConsensus)
-                        })?
-                        .fetch_price_target_consensus(&symbol)
-                        .await
-                }
-            })
-            .await
+        ticker_fetch!(
+            self,
+            FUNDAMENTALS,
+            as_fundamentals,
+            PriceTargetConsensus,
+            fetch_price_target_consensus
+        )
     }
 
     /// Fetch price-target publication activity over trailing windows (last
@@ -846,21 +743,13 @@ impl Ticker {
     pub async fn price_target_summary(
         &self,
     ) -> Result<crate::models::fundamentals::PriceTargetSummary> {
-        let symbol = self.symbol.clone();
-        self.providers
-            .fetch(Capability::FUNDAMENTALS, move |p| {
-                let symbol = symbol.clone();
-                let p = p.clone();
-                async move {
-                    p.as_fundamentals()
-                        .ok_or_else(|| {
-                            p.not_supported(crate::providers::Operation::PriceTargetSummary)
-                        })?
-                        .fetch_price_target_summary(&symbol)
-                        .await
-                }
-            })
-            .await
+        ticker_fetch!(
+            self,
+            FUNDAMENTALS,
+            as_fundamentals,
+            PriceTargetSummary,
+            fetch_price_target_summary
+        )
     }
 
     /// Fetch the aggregated analyst rating consensus (grade distribution plus a
@@ -868,21 +757,13 @@ impl Ticker {
     /// (currently FMP only). Distinct from
     /// [`recommendations`](Self::recommendations), which returns similar symbols.
     pub async fn rating_consensus(&self) -> Result<crate::models::fundamentals::RatingConsensus> {
-        let symbol = self.symbol.clone();
-        self.providers
-            .fetch(Capability::FUNDAMENTALS, move |p| {
-                let symbol = symbol.clone();
-                let p = p.clone();
-                async move {
-                    p.as_fundamentals()
-                        .ok_or_else(|| {
-                            p.not_supported(crate::providers::Operation::RatingConsensus)
-                        })?
-                        .fetch_rating_consensus(&symbol)
-                        .await
-                }
-            })
-            .await
+        ticker_fetch!(
+            self,
+            FUNDAMENTALS,
+            as_fundamentals,
+            RatingConsensus,
+            fetch_rating_consensus
+        )
     }
 
     /// Fetch the trailing-twelve-month key-metrics snapshot via the configured
@@ -892,37 +773,25 @@ impl Ticker {
     /// to fetch the latest fiscal period and reason about whether it is still
     /// current — see [`financials`](Self::financials) for the period series.
     pub async fn key_metrics_ttm(&self) -> Result<crate::models::fundamentals::KeyMetricsTtm> {
-        let symbol = self.symbol.clone();
-        self.providers
-            .fetch(Capability::FUNDAMENTALS, move |p| {
-                let symbol = symbol.clone();
-                let p = p.clone();
-                async move {
-                    p.as_fundamentals()
-                        .ok_or_else(|| p.not_supported(crate::providers::Operation::KeyMetricsTtm))?
-                        .fetch_key_metrics_ttm(&symbol)
-                        .await
-                }
-            })
-            .await
+        ticker_fetch!(
+            self,
+            FUNDAMENTALS,
+            as_fundamentals,
+            KeyMetricsTtm,
+            fetch_key_metrics_ttm
+        )
     }
 
     /// Fetch the trailing-twelve-month financial-ratios snapshot via the
     /// configured [`Capability::FUNDAMENTALS`] provider (currently FMP only).
     pub async fn ratios_ttm(&self) -> Result<crate::models::fundamentals::FinancialRatiosTtm> {
-        let symbol = self.symbol.clone();
-        self.providers
-            .fetch(Capability::FUNDAMENTALS, move |p| {
-                let symbol = symbol.clone();
-                let p = p.clone();
-                async move {
-                    p.as_fundamentals()
-                        .ok_or_else(|| p.not_supported(crate::providers::Operation::RatiosTtm))?
-                        .fetch_ratios_ttm(&symbol)
-                        .await
-                }
-            })
-            .await
+        ticker_fetch!(
+            self,
+            FUNDAMENTALS,
+            as_fundamentals,
+            RatiosTtm,
+            fetch_ratios_ttm
+        )
     }
 
     /// Fetch reported executive compensation (most recent fiscal year first)
@@ -931,21 +800,13 @@ impl Ticker {
     pub async fn executive_compensation(
         &self,
     ) -> Result<Vec<crate::models::corporate::governance::ExecutiveCompensation>> {
-        let symbol = self.symbol.clone();
-        self.providers
-            .fetch(Capability::CORPORATE, move |p| {
-                let symbol = symbol.clone();
-                let p = p.clone();
-                async move {
-                    p.as_corporate()
-                        .ok_or_else(|| {
-                            p.not_supported(crate::providers::Operation::ExecutiveCompensation)
-                        })?
-                        .fetch_executive_compensation(&symbol)
-                        .await
-                }
-            })
-            .await
+        ticker_fetch!(
+            self,
+            CORPORATE,
+            as_corporate,
+            ExecutiveCompensation,
+            fetch_executive_compensation
+        )
     }
 
     /// Fetch reported employee headcount history (most recent period first) via
@@ -954,19 +815,13 @@ impl Ticker {
     pub async fn employee_count(
         &self,
     ) -> Result<Vec<crate::models::corporate::governance::EmployeeCount>> {
-        let symbol = self.symbol.clone();
-        self.providers
-            .fetch(Capability::CORPORATE, move |p| {
-                let symbol = symbol.clone();
-                let p = p.clone();
-                async move {
-                    p.as_corporate()
-                        .ok_or_else(|| p.not_supported(crate::providers::Operation::EmployeeCount))?
-                        .fetch_employee_count(&symbol)
-                        .await
-                }
-            })
-            .await
+        ticker_fetch!(
+            self,
+            CORPORATE,
+            as_corporate,
+            EmployeeCount,
+            fetch_employee_count
+        )
     }
 
     /// Fetch this fund's profile and portfolio holdings via the configured
@@ -976,19 +831,13 @@ impl Ticker {
     /// Holdings come back heaviest-first. Errors for a symbol that is not a
     /// fund.
     pub async fn etf_profile(&self) -> Result<crate::models::fundamentals::EtfProfile> {
-        let symbol = self.symbol.clone();
-        self.providers
-            .fetch(Capability::FUNDAMENTALS, move |p| {
-                let symbol = symbol.clone();
-                let p = p.clone();
-                async move {
-                    p.as_fundamentals()
-                        .ok_or_else(|| p.not_supported(crate::providers::Operation::EtfProfile))?
-                        .fetch_etf_profile(&symbol)
-                        .await
-                }
-            })
-            .await
+        ticker_fetch!(
+            self,
+            FUNDAMENTALS,
+            as_fundamentals,
+            EtfProfile,
+            fetch_etf_profile
+        )
     }
 
     #[cfg(feature = "indicators")]
@@ -1159,20 +1008,7 @@ impl Ticker {
                 return Ok(cache);
             }
         }
-        let sym = self.symbol.clone();
-        let summary = self
-            .providers
-            .fetch(Capability::QUOTE, move |p| {
-                let sym = sym.clone();
-                let p = p.clone();
-                async move {
-                    p.as_quote()
-                        .ok_or_else(|| p.not_supported(crate::providers::Operation::Quote))?
-                        .fetch_quote(&sym)
-                        .await
-                }
-            })
-            .await?;
+        let summary = ticker_fetch!(self, QUOTE, as_quote, Quote, fetch_quote)?;
         {
             let mut cache = self.quote_cache.write().await;
             *cache = Some(CacheEntry::new(summary));

--- a/src/ticker/core.rs
+++ b/src/ticker/core.rs
@@ -885,6 +885,46 @@ impl Ticker {
             .await
     }
 
+    /// Fetch the trailing-twelve-month key-metrics snapshot via the configured
+    /// [`Capability::FUNDAMENTALS`] provider (currently FMP only).
+    ///
+    /// A TTM snapshot is a single always-current rollup, so callers do not need
+    /// to fetch the latest fiscal period and reason about whether it is still
+    /// current — see [`financials`](Self::financials) for the period series.
+    pub async fn key_metrics_ttm(&self) -> Result<crate::models::fundamentals::KeyMetricsTtm> {
+        let symbol = self.symbol.clone();
+        self.providers
+            .fetch(Capability::FUNDAMENTALS, move |p| {
+                let symbol = symbol.clone();
+                let p = p.clone();
+                async move {
+                    p.as_fundamentals()
+                        .ok_or_else(|| p.not_supported(crate::providers::Operation::KeyMetricsTtm))?
+                        .fetch_key_metrics_ttm(&symbol)
+                        .await
+                }
+            })
+            .await
+    }
+
+    /// Fetch the trailing-twelve-month financial-ratios snapshot via the
+    /// configured [`Capability::FUNDAMENTALS`] provider (currently FMP only).
+    pub async fn ratios_ttm(&self) -> Result<crate::models::fundamentals::FinancialRatiosTtm> {
+        let symbol = self.symbol.clone();
+        self.providers
+            .fetch(Capability::FUNDAMENTALS, move |p| {
+                let symbol = symbol.clone();
+                let p = p.clone();
+                async move {
+                    p.as_fundamentals()
+                        .ok_or_else(|| p.not_supported(crate::providers::Operation::RatiosTtm))?
+                        .fetch_ratios_ttm(&symbol)
+                        .await
+                }
+            })
+            .await
+    }
+
     #[cfg(feature = "indicators")]
     /// Calculate a specific technical indicator over a time range.
     pub async fn indicator(

--- a/src/ticker/core.rs
+++ b/src/ticker/core.rs
@@ -925,6 +925,50 @@ impl Ticker {
             .await
     }
 
+    /// Fetch reported executive compensation (most recent fiscal year first)
+    /// via the configured [`Capability::CORPORATE`] provider (currently FMP
+    /// only). Extracted from DEF 14A proxy statements, so it lags the filing.
+    pub async fn executive_compensation(
+        &self,
+    ) -> Result<Vec<crate::models::corporate::governance::ExecutiveCompensation>> {
+        let symbol = self.symbol.clone();
+        self.providers
+            .fetch(Capability::CORPORATE, move |p| {
+                let symbol = symbol.clone();
+                let p = p.clone();
+                async move {
+                    p.as_corporate()
+                        .ok_or_else(|| {
+                            p.not_supported(crate::providers::Operation::ExecutiveCompensation)
+                        })?
+                        .fetch_executive_compensation(&symbol)
+                        .await
+                }
+            })
+            .await
+    }
+
+    /// Fetch reported employee headcount history (most recent period first) via
+    /// the configured [`Capability::CORPORATE`] provider (currently FMP only).
+    /// Taken from 10-K cover pages, so it is annual.
+    pub async fn employee_count(
+        &self,
+    ) -> Result<Vec<crate::models::corporate::governance::EmployeeCount>> {
+        let symbol = self.symbol.clone();
+        self.providers
+            .fetch(Capability::CORPORATE, move |p| {
+                let symbol = symbol.clone();
+                let p = p.clone();
+                async move {
+                    p.as_corporate()
+                        .ok_or_else(|| p.not_supported(crate::providers::Operation::EmployeeCount))?
+                        .fetch_employee_count(&symbol)
+                        .await
+                }
+            })
+            .await
+    }
+
     #[cfg(feature = "indicators")]
     /// Calculate a specific technical indicator over a time range.
     pub async fn indicator(

--- a/src/ticker/core.rs
+++ b/src/ticker/core.rs
@@ -969,6 +969,28 @@ impl Ticker {
             .await
     }
 
+    /// Fetch this fund's profile and portfolio holdings via the configured
+    /// [`Capability::FUNDAMENTALS`] provider (currently Alpha Vantage only,
+    /// and the only wired source of ETF holdings at all).
+    ///
+    /// Holdings come back heaviest-first. Errors for a symbol that is not a
+    /// fund.
+    pub async fn etf_profile(&self) -> Result<crate::models::fundamentals::EtfProfile> {
+        let symbol = self.symbol.clone();
+        self.providers
+            .fetch(Capability::FUNDAMENTALS, move |p| {
+                let symbol = symbol.clone();
+                let p = p.clone();
+                async move {
+                    p.as_fundamentals()
+                        .ok_or_else(|| p.not_supported(crate::providers::Operation::EtfProfile))?
+                        .fetch_etf_profile(&symbol)
+                        .await
+                }
+            })
+            .await
+    }
+
     #[cfg(feature = "indicators")]
     /// Calculate a specific technical indicator over a time range.
     pub async fn indicator(

--- a/src/ticker/core.rs
+++ b/src/ticker/core.rs
@@ -816,6 +816,75 @@ impl Ticker {
             .await
     }
 
+    /// Fetch the aggregated analyst price-target consensus (high/low/mean/median)
+    /// via the configured [`Capability::FUNDAMENTALS`] provider (currently FMP
+    /// only). Route with
+    /// `.route(Capability::FUNDAMENTALS, [Provider::Fmp, Provider::Yahoo])`.
+    pub async fn price_target_consensus(
+        &self,
+    ) -> Result<crate::models::fundamentals::PriceTargetConsensus> {
+        let symbol = self.symbol.clone();
+        self.providers
+            .fetch(Capability::FUNDAMENTALS, move |p| {
+                let symbol = symbol.clone();
+                let p = p.clone();
+                async move {
+                    p.as_fundamentals()
+                        .ok_or_else(|| {
+                            p.not_supported(crate::providers::Operation::PriceTargetConsensus)
+                        })?
+                        .fetch_price_target_consensus(&symbol)
+                        .await
+                }
+            })
+            .await
+    }
+
+    /// Fetch price-target publication activity over trailing windows (last
+    /// month/quarter/year/all time) via the configured
+    /// [`Capability::FUNDAMENTALS`] provider (currently FMP only).
+    pub async fn price_target_summary(
+        &self,
+    ) -> Result<crate::models::fundamentals::PriceTargetSummary> {
+        let symbol = self.symbol.clone();
+        self.providers
+            .fetch(Capability::FUNDAMENTALS, move |p| {
+                let symbol = symbol.clone();
+                let p = p.clone();
+                async move {
+                    p.as_fundamentals()
+                        .ok_or_else(|| {
+                            p.not_supported(crate::providers::Operation::PriceTargetSummary)
+                        })?
+                        .fetch_price_target_summary(&symbol)
+                        .await
+                }
+            })
+            .await
+    }
+
+    /// Fetch the aggregated analyst rating consensus (grade distribution plus a
+    /// headline label) via the configured [`Capability::FUNDAMENTALS`] provider
+    /// (currently FMP only). Distinct from
+    /// [`recommendations`](Self::recommendations), which returns similar symbols.
+    pub async fn rating_consensus(&self) -> Result<crate::models::fundamentals::RatingConsensus> {
+        let symbol = self.symbol.clone();
+        self.providers
+            .fetch(Capability::FUNDAMENTALS, move |p| {
+                let symbol = symbol.clone();
+                let p = p.clone();
+                async move {
+                    p.as_fundamentals()
+                        .ok_or_else(|| {
+                            p.not_supported(crate::providers::Operation::RatingConsensus)
+                        })?
+                        .fetch_rating_consensus(&symbol)
+                        .await
+                }
+            })
+            .await
+    }
+
     #[cfg(feature = "indicators")]
     /// Calculate a specific technical indicator over a time range.
     pub async fn indicator(

--- a/src/ticker/macros.rs
+++ b/src/ticker/macros.rs
@@ -31,3 +31,31 @@ macro_rules! define_quote_accessors {
 }
 
 pub(crate) use define_quote_accessors;
+
+/// Dispatch a symbol-keyed provider call and await it.
+///
+/// `$acc` is the [`ProviderAdapter`](crate::providers::ProviderAdapter)
+/// capability accessor (e.g. `as_fundamentals`) and `$op` the
+/// [`Operation`](crate::providers::Operation) reported when a routed provider
+/// lacks it. Extra `$arg`s are passed after the symbol and must be `Copy` —
+/// dispatch may call the closure once per routed provider.
+macro_rules! ticker_fetch {
+    ($self:expr, $cap:ident, $acc:ident, $op:ident, $fetch:ident $(, $arg:expr)* $(,)?) => {{
+        let __sym = $self.symbol.clone();
+        $self
+            .providers
+            .fetch(crate::providers::Capability::$cap, move |p| {
+                let __sym = __sym.clone();
+                let p = p.clone();
+                async move {
+                    p.$acc()
+                        .ok_or_else(|| p.not_supported(crate::providers::Operation::$op))?
+                        .$fetch(&__sym $(, $arg)*)
+                        .await
+                }
+            })
+            .await
+    }};
+}
+
+pub(crate) use ticker_fetch;


### PR DESCRIPTION
## Description

Extends the providers we already have with data they expose but the library
didn't reach yet — analyst consensus, TTM metrics, ownership, cross-market
snapshots, insider and 13F filings, FRED's catalog, and Alpha Vantage's ETF
and reference endpoints.

Middle of a 3-PR stack: **#303 → #304 → #305**.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Changes

**FMP**
- `Ticker::price_target_consensus()`, `price_target_summary()`, `rating_consensus()` — the panel-wide rollups, not the per-analyst grade actions already in `UpgradeDowngradeHistory`
- `Ticker::key_metrics_ttm()`, `ratios_ttm()` — trailing-twelve-month snapshots
- `Ticker::executive_compensation()`, `employee_count()`

**Polygon**
- `providers.snapshot().get(&["AAPL", "X:BTCUSD", "I:SPX"])` — a mixed watchlist in one request (max 250 symbols) instead of one request per asset class. Unresolvable symbols come back as rows with `error` set rather than being dropped. New `Snapshot` handle and `MarketSnapshot` / `AssetClass` models

**EDGAR**
- Full-text search now routes through the `FILINGS` capability instead of being a standalone call
- Form 3/4/5 insider trades and 13F institutional holdings

**FRED**
- Series search, category browsing, and ALFRED point-in-time vintages via a new `EconomicCatalog` handle

**CoinGecko**
- Keyless crypto price history (CHART capability)

**Alpha Vantage**
- ETF profile, symbol search, and listing status

The final commit is a cleanup pass: a `ticker_fetch!` macro replaces 20 hand-copied
dispatch closures in `ticker/core.rs` (−250 lines), the FMP TTM and FRED catalog
DTOs are deleted in favour of deserializing straight into the public models, EDGAR
builds one HTTP client per call instead of two or three per filing, and `Snapshot`
is gated on `polygon` like every other feature-dependent handle.

## Breaking Changes

None for existing users. `Snapshot` and `EconomicCatalog` are new, and
`FilingsProvider::fetch_filing_search` gained a `symbol` argument — that trait is
`pub(crate)`, so it isn't part of the public API.

## Testing
- [x] Unit tests added/updated
- [x] All tests pass (`cargo test`)

`cargo test --features full`: 1332 passed, 0 failed. Also checked default features
and `--no-default-features --features fred`, since this PR changes the ECONOMIC
feature gates.

## Documentation
- [x] Code documentation updated (doc comments)
- [x] CHANGELOG.md updated

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy --workspace --all-targets --features full -- -D warnings`)
- [x] Commit messages follow Conventional Commits

## Related Issues

Closes #241
Closes #242
Closes #243
Closes #244
Closes #253
Closes #265
Closes #266
