### PR TITLE
feat: streaming options chain, trades, order-book depth, and price alerts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1912,6 +1912,7 @@ dependencies = [
  "serial_test",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-stream",
  "tokio-test",
  "tokio-tungstenite 0.28.0",
  "tower",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ tracing = "0.1"
 
 # WebSocket streaming support
 tokio-tungstenite = { version = "0.28.0", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
-tokio-stream = { version = "0.1", features = ["sync"] }
+tokio-stream = { version = "0.1", features = ["sync", "time"] }
 prost = "0.14.3"
 base64 = "0.22"
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -42,6 +42,7 @@ redis = { version = "1.2.2", features = ["tokio-comp", "connection-manager"], op
 
 # WebSocket
 tokio-tungstenite = "0.28"
+tokio-stream = { version = "0.1", features = ["sync"] }
 futures-util = "0.3"
 
 # Logging and tracing

--- a/server/asyncapi.yaml
+++ b/server/asyncapi.yaml
@@ -49,11 +49,16 @@ channels:
         oneOf:
           - $ref: '#/components/messages/Subscribe'
           - $ref: '#/components/messages/Unsubscribe'
+          - $ref: '#/components/messages/SetAlerts'
     subscribe:
       operationId: receiveMessage
-      summary: Receive price updates from the server
+      summary: >-
+        Receive price updates from the server, or alert events while an alert
+        rule set is active
       message:
-        $ref: '#/components/messages/PriceUpdate'
+        oneOf:
+          - $ref: '#/components/messages/PriceUpdate'
+          - $ref: '#/components/messages/AlertEvent'
 
   /feeds:
     servers: [feedsProduction, feedsDevelopment]
@@ -110,6 +115,25 @@ components:
             example:
               - AAPL
 
+    SetAlerts:
+      name: alerts
+      title: Set Alerts Message
+      summary: >-
+        Replace the connection's alert rule set. While a non-empty rule set is
+        active the server sends AlertEvent messages instead of raw price
+        updates; send an empty array to revert to raw ticks. Symbols named by
+        rules are subscribed automatically.
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - alerts
+        properties:
+          alerts:
+            type: array
+            items:
+              $ref: '#/components/schemas/AlertRule'
+
     PriceUpdate:
       name: priceUpdate
       title: Price Update
@@ -117,6 +141,14 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/PriceUpdate'
+
+    AlertEvent:
+      name: alertEvent
+      title: Alert Event
+      summary: A price tick that satisfied one of the connection's alert rules
+      contentType: application/json
+      payload:
+        $ref: '#/components/schemas/AlertEvent'
 
     FeedSubscribe:
       name: subscribe
@@ -170,6 +202,66 @@ components:
         $ref: '#/components/schemas/FeedEntry'
 
   schemas:
+    AlertRule:
+      type: object
+      required:
+        - symbol
+        - condition
+        - value
+      properties:
+        symbol:
+          type: string
+          description: Ticker symbol to watch
+          example: AAPL
+        condition:
+          type: string
+          enum:
+            - crossesAbove
+            - crossesBelow
+            - priceAbove
+            - priceBelow
+            - percentChangeAbove
+            - percentChangeBelow
+            - volumeAbove
+          description: >-
+            Predicate to evaluate. Crossing conditions compare against the
+            previous tick and never fire on a symbol's first tick.
+        value:
+          type: number
+          description: Threshold the predicate compares against
+          example: 200.0
+        repeat:
+          type: boolean
+          default: false
+          description: >-
+            Fire every time the condition becomes true again, instead of once
+
+    AlertEvent:
+      type: object
+      properties:
+        symbol:
+          type: string
+        condition:
+          type: object
+          description: >-
+            The condition that fired, as a single-key object — for example
+            `{"crossesAbove": 200.0}`
+        price:
+          type: number
+          format: float
+        previousPrice:
+          type: number
+          format: float
+          nullable: true
+        changePercent:
+          type: number
+          format: float
+        time:
+          type: integer
+          format: int64
+        update:
+          $ref: '#/components/schemas/PriceUpdate'
+
     PriceUpdate:
       type: object
       description: Real-time price update from Yahoo Finance

--- a/server/src/graphql/subscription.rs
+++ b/server/src/graphql/subscription.rs
@@ -8,8 +8,10 @@ use async_graphql::{Context, Error, Result, Subscription};
 use finance_query::feeds::FeedSource;
 use futures_util::{Stream, StreamExt};
 
+use finance_query::streaming::{AlertEvaluator, AlertRule};
+
 use super::types::feeds::GqlFeedEntry;
-use super::types::streaming::GqlPriceUpdate;
+use super::types::streaming::{GqlAlertEvent, GqlAlertRuleInput, GqlPriceUpdate};
 use crate::{AppState, FeedHub, StreamHub};
 
 pub struct SubscriptionRoot;
@@ -51,6 +53,60 @@ impl SubscriptionRoot {
         Ok(GuardedStream {
             _guard: guard,
             inner: Box::pin(filtered),
+        })
+    }
+
+    /// Subscribe to threshold-triggered price alerts.
+    ///
+    /// Same upstream as `priceStream`, but only ticks that satisfy one of the
+    /// supplied rules are sent — the predicate is evaluated here rather than
+    /// pushing every tick to the client. Symbols are derived from the rules
+    /// and ref-counted through the same hub.
+    async fn price_alerts(
+        &self,
+        ctx: &Context<'_>,
+        rules: Vec<GqlAlertRuleInput>,
+    ) -> Result<impl Stream<Item = GqlAlertEvent>> {
+        if rules.is_empty() {
+            return Err(Error::new("at least one alert rule is required"));
+        }
+
+        let state = ctx.data::<AppState>()?;
+        let hub = state.stream_hub.clone();
+
+        let rules: Vec<AlertRule> = rules.into_iter().map(AlertRule::from).collect();
+        let mut evaluator = AlertEvaluator::new(rules);
+        let symbols = evaluator.symbols();
+
+        hub.subscribe_symbols(&symbols)
+            .await
+            .map_err(|e| Error::new(e.to_string()))?;
+
+        let hub_stream = hub
+            .resubscribe()
+            .await
+            .ok_or_else(|| Error::new("Price stream unavailable"))?;
+
+        let guard = SubscriptionGuard {
+            hub: hub.clone(),
+            symbols,
+        };
+
+        let alerts = hub_stream
+            .flat_map(move |update| {
+                futures_util::stream::iter(
+                    evaluator
+                        .evaluate(&update)
+                        .into_iter()
+                        .map(GqlAlertEvent::from)
+                        .collect::<Vec<_>>(),
+                )
+            })
+            .boxed();
+
+        Ok(GuardedAlertStream {
+            _guard: guard,
+            inner: alerts,
         })
     }
 
@@ -128,6 +184,28 @@ impl Unpin for GuardedStream {}
 
 impl Stream for GuardedStream {
     type Item = GqlPriceUpdate;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+    ) -> task::Poll<Option<Self::Item>> {
+        self.inner.as_mut().poll_next(cx)
+    }
+}
+
+/// Wraps an alert-filtered price stream and holds a `SubscriptionGuard` so
+/// symbols are unsubscribed when the stream is dropped.
+struct GuardedAlertStream {
+    _guard: SubscriptionGuard,
+    inner: Pin<Box<dyn Stream<Item = GqlAlertEvent> + Send>>,
+}
+
+// SAFETY: `Pin<Box<T>>` is always `Unpin` (the box pointer can be moved),
+// and `SubscriptionGuard` contains no pinned fields.
+impl Unpin for GuardedAlertStream {}
+
+impl Stream for GuardedAlertStream {
+    type Item = GqlAlertEvent;
 
     fn poll_next(
         mut self: Pin<&mut Self>,

--- a/server/src/graphql/subscription.rs
+++ b/server/src/graphql/subscription.rs
@@ -47,10 +47,10 @@ impl SubscriptionRoot {
         };
 
         let filtered = hub_stream
-            .filter(move |u| std::future::ready(subscribed.contains(&u.id)))
-            .map(GqlPriceUpdate::from);
+            .filter(move |t| std::future::ready(subscribed.contains(&t.update().id)))
+            .map(|t| GqlPriceUpdate::from(t.update().clone()));
 
-        Ok(GuardedStream {
+        Ok(Guarded {
             _guard: guard,
             inner: Box::pin(filtered),
         })
@@ -87,16 +87,20 @@ impl SubscriptionRoot {
             .await
             .ok_or_else(|| Error::new("Price stream unavailable"))?;
 
+        // Pre-filter on the rules' symbols: the hub carries every symbol any
+        // client anywhere subscribed to.
+        let watched: HashSet<String> = symbols.iter().cloned().collect();
         let guard = SubscriptionGuard {
             hub: hub.clone(),
             symbols,
         };
 
         let alerts = hub_stream
-            .flat_map(move |update| {
+            .filter(move |t| std::future::ready(watched.contains(&t.update().id)))
+            .flat_map(move |tick| {
                 futures_util::stream::iter(
                     evaluator
-                        .evaluate(&update)
+                        .evaluate(tick.update())
                         .into_iter()
                         .map(GqlAlertEvent::from)
                         .collect::<Vec<_>>(),
@@ -104,7 +108,7 @@ impl SubscriptionRoot {
             })
             .boxed();
 
-        Ok(GuardedAlertStream {
+        Ok(Guarded {
             _guard: guard,
             inner: alerts,
         })
@@ -148,7 +152,7 @@ impl SubscriptionRoot {
             .filter(move |entry| std::future::ready(subscribed.contains(&entry.source)))
             .map(GqlFeedEntry::from);
 
-        Ok(GuardedFeedStream {
+        Ok(Guarded {
             _guard: guard,
             inner: Box::pin(filtered),
         })
@@ -171,41 +175,19 @@ impl Drop for SubscriptionGuard {
     }
 }
 
-/// Wraps a filtered `PriceStream` and holds a `SubscriptionGuard` so symbols
-/// are unsubscribed when the stream is dropped.
-struct GuardedStream {
-    _guard: SubscriptionGuard,
-    inner: Pin<Box<dyn Stream<Item = GqlPriceUpdate> + Send>>,
+/// A stream that keeps an RAII guard alive for as long as it is polled, so
+/// dropping the subscription releases whatever the guard holds.
+struct Guarded<T, G> {
+    _guard: G,
+    inner: Pin<Box<dyn Stream<Item = T> + Send>>,
 }
 
-// SAFETY: `Pin<Box<T>>` is always `Unpin` (the box pointer can be moved),
-// and `SubscriptionGuard` contains no pinned fields.
-impl Unpin for GuardedStream {}
+// SAFETY: `Pin<Box<T>>` is always `Unpin` (the box pointer can be moved), and
+// the guards stored here contain no pinned fields.
+impl<T, G> Unpin for Guarded<T, G> {}
 
-impl Stream for GuardedStream {
-    type Item = GqlPriceUpdate;
-
-    fn poll_next(
-        mut self: Pin<&mut Self>,
-        cx: &mut task::Context<'_>,
-    ) -> task::Poll<Option<Self::Item>> {
-        self.inner.as_mut().poll_next(cx)
-    }
-}
-
-/// Wraps an alert-filtered price stream and holds a `SubscriptionGuard` so
-/// symbols are unsubscribed when the stream is dropped.
-struct GuardedAlertStream {
-    _guard: SubscriptionGuard,
-    inner: Pin<Box<dyn Stream<Item = GqlAlertEvent> + Send>>,
-}
-
-// SAFETY: `Pin<Box<T>>` is always `Unpin` (the box pointer can be moved),
-// and `SubscriptionGuard` contains no pinned fields.
-impl Unpin for GuardedAlertStream {}
-
-impl Stream for GuardedAlertStream {
-    type Item = GqlAlertEvent;
+impl<T, G> Stream for Guarded<T, G> {
+    type Item = T;
 
     fn poll_next(
         mut self: Pin<&mut Self>,
@@ -228,27 +210,5 @@ impl Drop for FeedSubscriptionGuard {
         tokio::spawn(async move {
             hub.unsubscribe_sources(&sources).await;
         });
-    }
-}
-
-/// Wraps a filtered `NewsStream` and holds a `FeedSubscriptionGuard` so
-/// sources are unsubscribed when the stream is dropped.
-struct GuardedFeedStream {
-    _guard: FeedSubscriptionGuard,
-    inner: Pin<Box<dyn Stream<Item = GqlFeedEntry> + Send>>,
-}
-
-// SAFETY: `Pin<Box<T>>` is always `Unpin` (the box pointer can be moved),
-// and `FeedSubscriptionGuard` contains no pinned fields.
-impl Unpin for GuardedFeedStream {}
-
-impl Stream for GuardedFeedStream {
-    type Item = GqlFeedEntry;
-
-    fn poll_next(
-        mut self: Pin<&mut Self>,
-        cx: &mut task::Context<'_>,
-    ) -> task::Poll<Option<Self::Item>> {
-        self.inner.as_mut().poll_next(cx)
     }
 }

--- a/server/src/graphql/types/streaming.rs
+++ b/server/src/graphql/types/streaming.rs
@@ -1,7 +1,7 @@
 //! GraphQL type for real-time price streaming updates.
 
 use async_graphql::{Enum, InputObject, SimpleObject};
-use finance_query::streaming::{AlertCondition, AlertEvent, AlertRule, PriceUpdate};
+use finance_query::streaming::{AlertConditionKind, AlertEvent, AlertRule, PriceUpdate};
 use serde::Deserialize;
 
 /// A real-time price update from the streaming WebSocket, mirroring `PriceUpdate`.
@@ -85,6 +85,10 @@ impl From<PriceUpdate> for GqlPriceUpdate {
 }
 
 /// Threshold predicate for a price alert subscription.
+///
+/// Mirrors [`AlertConditionKind`] one-for-one; the `From` impls below are
+/// exhaustive both ways, so a new library predicate fails to compile here
+/// instead of silently degrading.
 #[derive(Enum, Copy, Clone, Eq, PartialEq, Debug)]
 #[graphql(rename_items = "SCREAMING_SNAKE_CASE")]
 pub enum GqlAlertConditionKind {
@@ -119,21 +123,37 @@ pub struct GqlAlertRuleInput {
     pub repeat: bool,
 }
 
+impl From<GqlAlertConditionKind> for AlertConditionKind {
+    fn from(kind: GqlAlertConditionKind) -> Self {
+        match kind {
+            GqlAlertConditionKind::CrossesAbove => Self::CrossesAbove,
+            GqlAlertConditionKind::CrossesBelow => Self::CrossesBelow,
+            GqlAlertConditionKind::PriceAbove => Self::PriceAbove,
+            GqlAlertConditionKind::PriceBelow => Self::PriceBelow,
+            GqlAlertConditionKind::PercentChangeAbove => Self::PercentChangeAbove,
+            GqlAlertConditionKind::PercentChangeBelow => Self::PercentChangeBelow,
+            GqlAlertConditionKind::VolumeAbove => Self::VolumeAbove,
+        }
+    }
+}
+
+impl From<AlertConditionKind> for GqlAlertConditionKind {
+    fn from(kind: AlertConditionKind) -> Self {
+        match kind {
+            AlertConditionKind::CrossesAbove => Self::CrossesAbove,
+            AlertConditionKind::CrossesBelow => Self::CrossesBelow,
+            AlertConditionKind::PriceAbove => Self::PriceAbove,
+            AlertConditionKind::PriceBelow => Self::PriceBelow,
+            AlertConditionKind::PercentChangeAbove => Self::PercentChangeAbove,
+            AlertConditionKind::PercentChangeBelow => Self::PercentChangeBelow,
+            AlertConditionKind::VolumeAbove => Self::VolumeAbove,
+        }
+    }
+}
+
 impl From<GqlAlertRuleInput> for AlertRule {
     fn from(input: GqlAlertRuleInput) -> Self {
-        let condition = match input.condition {
-            GqlAlertConditionKind::CrossesAbove => AlertCondition::CrossesAbove(input.value),
-            GqlAlertConditionKind::CrossesBelow => AlertCondition::CrossesBelow(input.value),
-            GqlAlertConditionKind::PriceAbove => AlertCondition::PriceAbove(input.value),
-            GqlAlertConditionKind::PriceBelow => AlertCondition::PriceBelow(input.value),
-            GqlAlertConditionKind::PercentChangeAbove => {
-                AlertCondition::PercentChangeAbove(input.value)
-            }
-            GqlAlertConditionKind::PercentChangeBelow => {
-                AlertCondition::PercentChangeBelow(input.value)
-            }
-            GqlAlertConditionKind::VolumeAbove => AlertCondition::VolumeAbove(input.value as i64),
-        };
+        let condition = AlertConditionKind::from(input.condition).with_value(input.value);
         let rule = AlertRule::new(input.symbol, condition);
         if input.repeat { rule.repeating() } else { rule }
     }
@@ -163,11 +183,10 @@ pub struct GqlAlertEvent {
 
 impl From<AlertEvent> for GqlAlertEvent {
     fn from(event: AlertEvent) -> Self {
-        let (condition, threshold) = split_condition(event.condition);
         Self {
             symbol: event.symbol,
-            condition,
-            threshold,
+            condition: event.condition.kind().into(),
+            threshold: event.condition.threshold(),
             price: event.price,
             previous_price: event.previous_price,
             change_percent: event.change_percent,
@@ -177,26 +196,10 @@ impl From<AlertEvent> for GqlAlertEvent {
     }
 }
 
-/// Flatten the library's data-carrying condition into GraphQL's
-/// enum-plus-scalar shape.
-fn split_condition(condition: AlertCondition) -> (GqlAlertConditionKind, f64) {
-    match condition {
-        AlertCondition::CrossesAbove(v) => (GqlAlertConditionKind::CrossesAbove, v),
-        AlertCondition::CrossesBelow(v) => (GqlAlertConditionKind::CrossesBelow, v),
-        AlertCondition::PriceAbove(v) => (GqlAlertConditionKind::PriceAbove, v),
-        AlertCondition::PriceBelow(v) => (GqlAlertConditionKind::PriceBelow, v),
-        AlertCondition::PercentChangeAbove(v) => (GqlAlertConditionKind::PercentChangeAbove, v),
-        AlertCondition::PercentChangeBelow(v) => (GqlAlertConditionKind::PercentChangeBelow, v),
-        AlertCondition::VolumeAbove(v) => (GqlAlertConditionKind::VolumeAbove, v as f64),
-        // `AlertCondition` is #[non_exhaustive]; new variants degrade to a
-        // price-above alert rather than failing the subscription.
-        _ => (GqlAlertConditionKind::PriceAbove, 0.0),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use finance_query::streaming::AlertCondition;
 
     fn input(condition: GqlAlertConditionKind, value: f64, repeat: bool) -> GqlAlertRuleInput {
         GqlAlertRuleInput {
@@ -224,7 +227,10 @@ mod tests {
         let rule: AlertRule = input(GqlAlertConditionKind::VolumeAbove, 1_000.0, false).into();
         assert_eq!(rule.condition, AlertCondition::VolumeAbove(1_000));
         assert_eq!(
-            split_condition(rule.condition),
+            (
+                GqlAlertConditionKind::from(rule.condition.kind()),
+                rule.condition.threshold()
+            ),
             (GqlAlertConditionKind::VolumeAbove, 1_000.0)
         );
     }

--- a/server/src/graphql/types/streaming.rs
+++ b/server/src/graphql/types/streaming.rs
@@ -1,7 +1,7 @@
 //! GraphQL type for real-time price streaming updates.
 
-use async_graphql::SimpleObject;
-use finance_query::streaming::PriceUpdate;
+use async_graphql::{Enum, InputObject, SimpleObject};
+use finance_query::streaming::{AlertCondition, AlertEvent, AlertRule, PriceUpdate};
 use serde::Deserialize;
 
 /// A real-time price update from the streaming WebSocket, mirroring `PriceUpdate`.
@@ -81,5 +81,151 @@ impl From<PriceUpdate> for GqlPriceUpdate {
             circulating_supply: u.circulating_supply,
             market_cap: u.market_cap,
         }
+    }
+}
+
+/// Threshold predicate for a price alert subscription.
+#[derive(Enum, Copy, Clone, Eq, PartialEq, Debug)]
+#[graphql(rename_items = "SCREAMING_SNAKE_CASE")]
+pub enum GqlAlertConditionKind {
+    /// Price moved from at-or-below `value` to above it.
+    CrossesAbove,
+    /// Price moved from at-or-above `value` to below it.
+    CrossesBelow,
+    /// Price is above `value`.
+    PriceAbove,
+    /// Price is below `value`.
+    PriceBelow,
+    /// Percent change is at or above `value`.
+    PercentChangeAbove,
+    /// Percent change is at or below `value`.
+    PercentChangeBelow,
+    /// Day volume is at or above `value`.
+    VolumeAbove,
+}
+
+/// One alert rule supplied by a subscriber.
+#[derive(InputObject, Clone, Debug)]
+#[graphql(rename_fields = "camelCase")]
+pub struct GqlAlertRuleInput {
+    /// Symbol to watch.
+    pub symbol: String,
+    /// Predicate to evaluate.
+    pub condition: GqlAlertConditionKind,
+    /// Threshold the predicate compares against.
+    pub value: f64,
+    /// Fire every time the condition becomes true again (default: once).
+    #[graphql(default = false)]
+    pub repeat: bool,
+}
+
+impl From<GqlAlertRuleInput> for AlertRule {
+    fn from(input: GqlAlertRuleInput) -> Self {
+        let condition = match input.condition {
+            GqlAlertConditionKind::CrossesAbove => AlertCondition::CrossesAbove(input.value),
+            GqlAlertConditionKind::CrossesBelow => AlertCondition::CrossesBelow(input.value),
+            GqlAlertConditionKind::PriceAbove => AlertCondition::PriceAbove(input.value),
+            GqlAlertConditionKind::PriceBelow => AlertCondition::PriceBelow(input.value),
+            GqlAlertConditionKind::PercentChangeAbove => {
+                AlertCondition::PercentChangeAbove(input.value)
+            }
+            GqlAlertConditionKind::PercentChangeBelow => {
+                AlertCondition::PercentChangeBelow(input.value)
+            }
+            GqlAlertConditionKind::VolumeAbove => AlertCondition::VolumeAbove(input.value as i64),
+        };
+        let rule = AlertRule::new(input.symbol, condition);
+        if input.repeat { rule.repeating() } else { rule }
+    }
+}
+
+/// A fired price alert.
+#[derive(SimpleObject, Debug, Clone)]
+#[graphql(rename_fields = "camelCase")]
+pub struct GqlAlertEvent {
+    /// Symbol that triggered.
+    pub symbol: String,
+    /// Which predicate fired.
+    pub condition: GqlAlertConditionKind,
+    /// Threshold the predicate compared against.
+    pub threshold: f64,
+    /// Price on the triggering tick.
+    pub price: f32,
+    /// Last price seen before this tick.
+    pub previous_price: Option<f32>,
+    /// Percent change carried by the triggering tick.
+    pub change_percent: f32,
+    /// Tick timestamp (milliseconds).
+    pub time: i64,
+    /// The full triggering tick.
+    pub update: GqlPriceUpdate,
+}
+
+impl From<AlertEvent> for GqlAlertEvent {
+    fn from(event: AlertEvent) -> Self {
+        let (condition, threshold) = split_condition(event.condition);
+        Self {
+            symbol: event.symbol,
+            condition,
+            threshold,
+            price: event.price,
+            previous_price: event.previous_price,
+            change_percent: event.change_percent,
+            time: event.time,
+            update: GqlPriceUpdate::from(event.update),
+        }
+    }
+}
+
+/// Flatten the library's data-carrying condition into GraphQL's
+/// enum-plus-scalar shape.
+fn split_condition(condition: AlertCondition) -> (GqlAlertConditionKind, f64) {
+    match condition {
+        AlertCondition::CrossesAbove(v) => (GqlAlertConditionKind::CrossesAbove, v),
+        AlertCondition::CrossesBelow(v) => (GqlAlertConditionKind::CrossesBelow, v),
+        AlertCondition::PriceAbove(v) => (GqlAlertConditionKind::PriceAbove, v),
+        AlertCondition::PriceBelow(v) => (GqlAlertConditionKind::PriceBelow, v),
+        AlertCondition::PercentChangeAbove(v) => (GqlAlertConditionKind::PercentChangeAbove, v),
+        AlertCondition::PercentChangeBelow(v) => (GqlAlertConditionKind::PercentChangeBelow, v),
+        AlertCondition::VolumeAbove(v) => (GqlAlertConditionKind::VolumeAbove, v as f64),
+        // `AlertCondition` is #[non_exhaustive]; new variants degrade to a
+        // price-above alert rather than failing the subscription.
+        _ => (GqlAlertConditionKind::PriceAbove, 0.0),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn input(condition: GqlAlertConditionKind, value: f64, repeat: bool) -> GqlAlertRuleInput {
+        GqlAlertRuleInput {
+            symbol: "AAPL".into(),
+            condition,
+            value,
+            repeat,
+        }
+    }
+
+    #[test]
+    fn rule_input_maps_onto_library_conditions() {
+        let rule: AlertRule = input(GqlAlertConditionKind::CrossesAbove, 150.0, false).into();
+        assert_eq!(rule.symbol, "AAPL");
+        assert_eq!(rule.condition, AlertCondition::CrossesAbove(150.0));
+        assert!(!rule.repeat);
+
+        let repeating: AlertRule = input(GqlAlertConditionKind::PriceBelow, 10.0, true).into();
+        assert!(repeating.repeat);
+        assert_eq!(repeating.condition, AlertCondition::PriceBelow(10.0));
+    }
+
+    #[test]
+    fn volume_thresholds_round_trip_through_the_float_input() {
+        let rule: AlertRule = input(GqlAlertConditionKind::VolumeAbove, 1_000.0, false).into();
+        assert_eq!(rule.condition, AlertCondition::VolumeAbove(1_000));
+        assert_eq!(
+            split_condition(rule.condition),
+            (GqlAlertConditionKind::VolumeAbove, 1_000.0)
+        );
     }
 }

--- a/server/src/handlers/stream.rs
+++ b/server/src/handlers/stream.rs
@@ -42,13 +42,21 @@ use axum::{
     },
     response::IntoResponse,
 };
-use finance_query::streaming::{AlertCondition, AlertEvaluator, AlertRule};
-use finance_query_server::{AppState, metrics};
+use finance_query::FinanceError;
+use finance_query::streaming::{AlertConditionKind, AlertEvaluator, AlertEvent, AlertRule};
+use finance_query_server::{AppState, SharedTick, StreamHub, TickStream, metrics};
+use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
 use serde::Deserialize;
 use std::collections::HashSet;
-use std::sync::Arc;
+use std::fmt::Display;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, RwLock};
+use tokio::sync::mpsc;
 use tracing::{error, info, warn};
+
+/// Outbound control-message channel depth.
+const OUTBOUND_CAPACITY: usize = 32;
 
 /// Stream command from client
 #[derive(Debug, Deserialize)]
@@ -72,17 +80,11 @@ struct WsAlertRule {
 
 impl WsAlertRule {
     fn parse(&self) -> Result<AlertRule, String> {
-        let condition = match self.condition.as_str() {
-            "crossesAbove" => AlertCondition::CrossesAbove(self.value),
-            "crossesBelow" => AlertCondition::CrossesBelow(self.value),
-            "priceAbove" => AlertCondition::PriceAbove(self.value),
-            "priceBelow" => AlertCondition::PriceBelow(self.value),
-            "percentChangeAbove" => AlertCondition::PercentChangeAbove(self.value),
-            "percentChangeBelow" => AlertCondition::PercentChangeBelow(self.value),
-            "volumeAbove" => AlertCondition::VolumeAbove(self.value as i64),
-            other => return Err(format!("unknown alert condition: {other}")),
-        };
-        let rule = AlertRule::new(self.symbol.clone(), condition);
+        let kind: AlertConditionKind = self
+            .condition
+            .parse()
+            .map_err(|e: FinanceError| e.to_string())?;
+        let rule = AlertRule::new(self.symbol.clone(), kind.with_value(self.value));
         Ok(if self.repeat { rule.repeating() } else { rule })
     }
 }
@@ -90,6 +92,109 @@ impl WsAlertRule {
 /// Turn wire rules into library rules, reporting the first bad condition.
 fn parse_rules(rules: &[WsAlertRule]) -> Result<Vec<AlertRule>, String> {
     rules.iter().map(WsAlertRule::parse).collect()
+}
+
+/// One `{"error": ...}` frame.
+fn error_msg(e: impl Display) -> Message {
+    Message::Text(
+        serde_json::json!({ "error": e.to_string() })
+            .to_string()
+            .into(),
+    )
+}
+
+/// Per-connection state shared by this client's send and receive tasks.
+///
+/// The locks are `std`, not `tokio`: no guard is ever held across an `await`,
+/// so an async lock would add waker bookkeeping to the per-tick delivery path
+/// for nothing.
+struct ClientState {
+    subscriptions: RwLock<HashSet<String>>,
+    evaluator: Mutex<Option<AlertEvaluator>>,
+    /// Mirrors `evaluator.is_some()` so delivery skips the lock entirely for
+    /// the common case of a client with no rules.
+    has_rules: AtomicBool,
+}
+
+impl ClientState {
+    fn new(symbols: &[String], rules: Option<Vec<AlertRule>>) -> Self {
+        Self {
+            subscriptions: RwLock::new(symbols.iter().cloned().collect()),
+            has_rules: AtomicBool::new(rules.is_some()),
+            evaluator: Mutex::new(rules.map(AlertEvaluator::new)),
+        }
+    }
+
+    fn wants(&self, symbol: &str) -> bool {
+        self.subscriptions
+            .read()
+            .expect("subscription lock poisoned")
+            .contains(symbol)
+    }
+
+    fn len(&self) -> usize {
+        self.subscriptions
+            .read()
+            .expect("subscription lock poisoned")
+            .len()
+    }
+
+    fn snapshot(&self) -> Vec<String> {
+        self.subscriptions
+            .read()
+            .expect("subscription lock poisoned")
+            .iter()
+            .cloned()
+            .collect()
+    }
+
+    /// Add `symbols`, returning only those not already subscribed.
+    fn add(&self, symbols: Vec<String>) -> Vec<String> {
+        let mut subs = self
+            .subscriptions
+            .write()
+            .expect("subscription lock poisoned");
+        symbols
+            .into_iter()
+            .filter(|s| subs.insert(s.clone()))
+            .collect()
+    }
+
+    /// Remove `symbols`, returning only those that were actually subscribed.
+    fn remove(&self, symbols: Vec<String>) -> Vec<String> {
+        let mut subs = self
+            .subscriptions
+            .write()
+            .expect("subscription lock poisoned");
+        symbols.into_iter().filter(|s| subs.remove(s)).collect()
+    }
+
+    fn extend(&self, symbols: Vec<String>) {
+        self.subscriptions
+            .write()
+            .expect("subscription lock poisoned")
+            .extend(symbols);
+    }
+
+    /// Install a rule set; an empty one reverts the socket to raw ticks.
+    fn set_rules(&self, rules: Vec<AlertRule>) {
+        let mut guard = self.evaluator.lock().expect("evaluator lock poisoned");
+        *guard = (!rules.is_empty()).then(|| AlertEvaluator::new(rules));
+        // Flagged under the lock, so a reader that sees `true` finds the rules.
+        self.has_rules.store(guard.is_some(), Ordering::Release);
+    }
+
+    /// Alerts this tick fired, or `None` when the client wants raw ticks.
+    fn evaluate(&self, tick: &SharedTick) -> Option<Vec<AlertEvent>> {
+        if !self.has_rules.load(Ordering::Acquire) {
+            return None;
+        }
+        self.evaluator
+            .lock()
+            .expect("evaluator lock poisoned")
+            .as_mut()
+            .map(|e| e.evaluate(tick.update()))
+    }
 }
 
 /// RAII guard to decrement WebSocket connection count on drop
@@ -116,257 +221,221 @@ async fn handle_stream_socket(state: AppState, mut socket: WebSocket) {
     let _guard = ConnectionGuard; // Ensures connection count is decremented on exit
     info!("New streaming WebSocket connection");
 
-    // Wait for the initial subscribe/alerts message
-    let (symbols, initial_rules) = match wait_for_subscription(&mut socket).await {
-        Some(start) => {
-            metrics::WEBSOCKET_MESSAGES_RECEIVED.inc();
-            start
-        }
-        None => {
-            warn!("WebSocket closed before subscription");
-            return;
-        }
+    let Some((symbols, initial_rules)) = wait_for_subscription(&mut socket).await else {
+        warn!("WebSocket closed before subscription");
+        return;
     };
-
-    let evaluator = Arc::new(tokio::sync::Mutex::new(
-        initial_rules.map(AlertEvaluator::new),
-    ));
-
+    metrics::WEBSOCKET_MESSAGES_RECEIVED.inc();
     info!("Starting stream for symbols: {:?}", symbols);
     metrics::WEBSOCKET_SYMBOLS_SUBSCRIBED.set(symbols.len() as f64);
 
-    // Ref-counted subscribe (shared upstream stream).
-    if let Err(e) = state.stream_hub.subscribe_symbols(&symbols).await {
-        error!("Failed to create shared price stream: {}", e);
-        let _ = socket
-            .send(Message::Text(
-                serde_json::json!({"error": e.to_string()})
-                    .to_string()
-                    .into(),
-            ))
-            .await;
+    let Some(hub_stream) = open_hub_stream(&state, &symbols, &mut socket).await else {
         return;
-    }
-
-    let mut hub_stream = match state.stream_hub.resubscribe().await {
-        Some(s) => s,
-        None => {
-            let _ = socket
-                .send(Message::Text(
-                    serde_json::json!({"error": "stream unavailable"})
-                        .to_string()
-                        .into(),
-                ))
-                .await;
-            return;
-        }
     };
 
-    let subscriptions = Arc::new(tokio::sync::RwLock::new(
-        symbols.iter().cloned().collect::<HashSet<String>>(),
+    let client = Arc::new(ClientState::new(&symbols, initial_rules));
+    let (out_tx, out_rx) = mpsc::channel::<Message>(OUTBOUND_CAPACITY);
+    let (sender, receiver) = socket.split();
+
+    let mut send_task = tokio::spawn(run_send_task(
+        sender,
+        hub_stream,
+        out_rx,
+        Arc::clone(&client),
     ));
-
-    let (out_tx, mut out_rx) = tokio::sync::mpsc::channel::<Message>(32);
-
-    // Split socket for concurrent read/write
-    let (mut sender, mut receiver) = socket.split();
-
-    // Spawn task to forward filtered price updates + outbound messages to client
-    let subscriptions_for_send = Arc::clone(&subscriptions);
-    let evaluator_for_send = Arc::clone(&evaluator);
-    let mut send_task = tokio::spawn(async move {
-        use futures_util::stream::StreamExt;
-        loop {
-            tokio::select! {
-                msg = out_rx.recv() => {
-                    match msg {
-                        Some(msg) => {
-                            if sender.send(msg).await.is_err() {
-                                break;
-                            }
-                        }
-                        None => {
-                            // Control channel closed.
-                            break;
-                        }
-                    }
-                }
-
-                maybe_price = hub_stream.next() => {
-                    match maybe_price {
-                        Some(price) => {
-                            let should_send = {
-                                let subs = subscriptions_for_send.read().await;
-                                subs.contains(&price.id)
-                            };
-                            if !should_send {
-                                continue;
-                            }
-
-                            // Evaluate under the lock, send outside it.
-                            let alerts = {
-                                let mut guard = evaluator_for_send.lock().await;
-                                guard.as_mut().map(|e| e.evaluate(&price))
-                            };
-
-                            let payloads: Vec<String> = match alerts {
-                                Some(events) => events
-                                    .iter()
-                                    .map(|e| serde_json::to_string(e).unwrap_or_default())
-                                    .collect(),
-                                None => vec![serde_json::to_string(&price).unwrap_or_default()],
-                            };
-
-                            for payload in payloads {
-                                if sender.send(Message::Text(payload.into())).await.is_err() {
-                                    return;
-                                }
-                                metrics::WEBSOCKET_MESSAGES_SENT.inc();
-                            }
-                        }
-                        None => break,
-                    }
-                }
-            }
-        }
-    });
-
-    // Handle incoming messages (subscribe/unsubscribe)
-    let subscriptions_for_recv = Arc::clone(&subscriptions);
-    let evaluator_for_recv = Arc::clone(&evaluator);
-    let stream_hub = state.stream_hub.clone();
-    let mut recv_task = tokio::spawn(async move {
-        while let Some(Ok(msg)) = receiver.next().await {
-            match msg {
-                Message::Text(text) => {
-                    if let Ok(cmd) = serde_json::from_str::<StreamCommand>(&text) {
-                        metrics::WEBSOCKET_MESSAGES_RECEIVED.inc();
-                        info!("Received stream command: {:?}", cmd);
-
-                        if let Some(symbols) = cmd.subscribe {
-                            let mut newly_added: Vec<String> = Vec::new();
-                            {
-                                let mut subs = subscriptions_for_recv.write().await;
-                                for s in symbols {
-                                    if subs.insert(s.clone()) {
-                                        newly_added.push(s);
-                                    }
-                                }
-                            }
-
-                            if !newly_added.is_empty() {
-                                if let Err(e) = stream_hub.subscribe_symbols(&newly_added).await {
-                                    error!("Failed to subscribe symbols: {}", e);
-                                    {
-                                        let mut subs = subscriptions_for_recv.write().await;
-                                        for s in &newly_added {
-                                            subs.remove(s);
-                                        }
-                                    }
-                                    let _ = out_tx
-                                        .send(Message::Text(
-                                            serde_json::json!({"error": e.to_string()})
-                                                .to_string()
-                                                .into(),
-                                        ))
-                                        .await;
-                                } else {
-                                    // Update symbol count on successful subscription
-                                    let count = {
-                                        let subs = subscriptions_for_recv.read().await;
-                                        subs.len()
-                                    };
-                                    metrics::WEBSOCKET_SYMBOLS_SUBSCRIBED.set(count as f64);
-                                }
-                            }
-                        }
-
-                        if let Some(rules) = cmd.alerts {
-                            match parse_rules(&rules) {
-                                Ok(parsed) => {
-                                    let extra: Vec<String> = parsed
-                                        .iter()
-                                        .map(|r| r.symbol.clone())
-                                        .filter(|s| !s.is_empty())
-                                        .collect();
-                                    if !extra.is_empty()
-                                        && let Err(e) = stream_hub.subscribe_symbols(&extra).await
-                                    {
-                                        error!("Failed to subscribe alert symbols: {}", e);
-                                    } else {
-                                        let mut subs = subscriptions_for_recv.write().await;
-                                        subs.extend(extra);
-                                    }
-                                    // An empty rule set reverts to raw ticks.
-                                    let mut guard = evaluator_for_recv.lock().await;
-                                    *guard =
-                                        (!parsed.is_empty()).then(|| AlertEvaluator::new(parsed));
-                                }
-                                Err(message) => {
-                                    let _ = out_tx
-                                        .send(Message::Text(
-                                            serde_json::json!({"error": message})
-                                                .to_string()
-                                                .into(),
-                                        ))
-                                        .await;
-                                }
-                            }
-                        }
-
-                        if let Some(symbols) = cmd.unsubscribe {
-                            let mut removed: Vec<String> = Vec::new();
-                            {
-                                let mut subs = subscriptions_for_recv.write().await;
-                                for s in symbols {
-                                    if subs.remove(&s) {
-                                        removed.push(s);
-                                    }
-                                }
-                            }
-
-                            if !removed.is_empty() {
-                                stream_hub.unsubscribe_symbols(&removed).await;
-                                // Update symbol count after unsubscription
-                                let count = {
-                                    let subs = subscriptions_for_recv.read().await;
-                                    subs.len()
-                                };
-                                metrics::WEBSOCKET_SYMBOLS_SUBSCRIBED.set(count as f64);
-                            }
-                        }
-                    }
-                }
-                Message::Close(_) => {
-                    info!("WebSocket closed by client");
-                    break;
-                }
-                _ => {}
-            }
-        }
-    });
+    let mut recv_task = tokio::spawn(run_recv_task(
+        receiver,
+        Arc::clone(&client),
+        state.stream_hub.clone(),
+        out_tx,
+    ));
 
     // Wait for either task to complete, then ensure per-client resources are torn down.
     tokio::select! {
         _ = &mut send_task => info!("Send task completed"),
         _ = &mut recv_task => info!("Receive task completed"),
     }
-
-    // Ensure tasks stop promptly.
     send_task.abort();
     recv_task.abort();
 
     // Release this client's active subscriptions from the global hub.
-    let symbols_to_release: Vec<String> = {
-        let subs = subscriptions.read().await;
-        subs.iter().cloned().collect()
-    };
     state
         .stream_hub
-        .unsubscribe_symbols(&symbols_to_release)
+        .unsubscribe_symbols(&client.snapshot())
         .await;
-
     info!("WebSocket stream connection closed");
+}
+
+/// Ref-counted subscribe plus a receiver on the shared hub, reporting failure
+/// to the client rather than closing silently.
+async fn open_hub_stream(
+    state: &AppState,
+    symbols: &[String],
+    socket: &mut WebSocket,
+) -> Option<TickStream> {
+    if let Err(e) = state.stream_hub.subscribe_symbols(symbols).await {
+        error!("Failed to create shared price stream: {}", e);
+        let _ = socket.send(error_msg(e)).await;
+        return None;
+    }
+    match state.stream_hub.resubscribe().await {
+        Some(stream) => Some(stream),
+        None => {
+            let _ = socket.send(error_msg("stream unavailable")).await;
+            None
+        }
+    }
+}
+
+/// Forward filtered price updates and outbound control messages to the client.
+async fn run_send_task(
+    mut sender: SplitSink<WebSocket, Message>,
+    mut hub_stream: TickStream,
+    mut out_rx: mpsc::Receiver<Message>,
+    client: Arc<ClientState>,
+) {
+    loop {
+        tokio::select! {
+            msg = out_rx.recv() => {
+                // Control channel closed.
+                let Some(msg) = msg else { break };
+                if sender.send(msg).await.is_err() {
+                    break;
+                }
+            }
+
+            maybe_tick = hub_stream.next() => {
+                let Some(tick) = maybe_tick else { break };
+                if !client.wants(&tick.update().id) {
+                    continue;
+                }
+                if !deliver(&mut sender, &client, &tick).await {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+/// Send one tick (or the alerts it fired); `false` once the socket is gone.
+///
+/// Raw ticks reuse the hub's shared JSON — alert payloads are per-client by
+/// nature, but rare enough that serializing them here costs nothing.
+async fn deliver(
+    sender: &mut SplitSink<WebSocket, Message>,
+    client: &ClientState,
+    tick: &SharedTick,
+) -> bool {
+    let payloads: Vec<Arc<str>> = match client.evaluate(tick) {
+        Some(events) => events
+            .iter()
+            .map(|e| Arc::from(serde_json::to_string(e).unwrap_or_default()))
+            .collect(),
+        None => vec![tick.json()],
+    };
+
+    for payload in payloads {
+        if sender
+            .send(Message::Text(payload.as_ref().into()))
+            .await
+            .is_err()
+        {
+            return false;
+        }
+        metrics::WEBSOCKET_MESSAGES_SENT.inc();
+    }
+    true
+}
+
+/// Handle incoming subscribe/unsubscribe/alerts commands.
+async fn run_recv_task(
+    mut receiver: SplitStream<WebSocket>,
+    client: Arc<ClientState>,
+    hub: StreamHub,
+    out_tx: mpsc::Sender<Message>,
+) {
+    while let Some(Ok(msg)) = receiver.next().await {
+        if matches!(msg, Message::Close(_)) {
+            info!("WebSocket closed by client");
+            break;
+        }
+        let Message::Text(text) = msg else {
+            continue;
+        };
+        let Ok(cmd) = serde_json::from_str::<StreamCommand>(&text) else {
+            continue;
+        };
+        metrics::WEBSOCKET_MESSAGES_RECEIVED.inc();
+        info!("Received stream command: {:?}", cmd);
+
+        if let Some(symbols) = cmd.subscribe {
+            apply_subscribe(symbols, &client, &hub, &out_tx).await;
+        }
+        if let Some(rules) = cmd.alerts {
+            apply_alerts(&rules, &client, &hub, &out_tx).await;
+        }
+        if let Some(symbols) = cmd.unsubscribe {
+            apply_unsubscribe(symbols, &client, &hub).await;
+        }
+    }
+}
+
+async fn apply_subscribe(
+    symbols: Vec<String>,
+    client: &ClientState,
+    hub: &StreamHub,
+    out_tx: &mpsc::Sender<Message>,
+) {
+    let added = client.add(symbols);
+    if added.is_empty() {
+        return;
+    }
+    if let Err(e) = hub.subscribe_symbols(&added).await {
+        error!("Failed to subscribe symbols: {}", e);
+        client.remove(added);
+        let _ = out_tx.send(error_msg(e)).await;
+        return;
+    }
+    metrics::WEBSOCKET_SYMBOLS_SUBSCRIBED.set(client.len() as f64);
+}
+
+async fn apply_alerts(
+    rules: &[WsAlertRule],
+    client: &ClientState,
+    hub: &StreamHub,
+    out_tx: &mpsc::Sender<Message>,
+) {
+    let parsed = match parse_rules(rules) {
+        Ok(parsed) => parsed,
+        Err(message) => {
+            let _ = out_tx.send(error_msg(message)).await;
+            return;
+        }
+    };
+
+    // Alert symbols need their own upstream subscription — a client may alert
+    // on a symbol it never asked for ticks on.
+    let extra: Vec<String> = parsed
+        .iter()
+        .map(|r| r.symbol.clone())
+        .filter(|s| !s.is_empty())
+        .collect();
+    if !extra.is_empty() {
+        match hub.subscribe_symbols(&extra).await {
+            Ok(()) => client.extend(extra),
+            Err(e) => error!("Failed to subscribe alert symbols: {}", e),
+        }
+    }
+    client.set_rules(parsed);
+}
+
+async fn apply_unsubscribe(symbols: Vec<String>, client: &ClientState, hub: &StreamHub) {
+    let removed = client.remove(symbols);
+    if removed.is_empty() {
+        return;
+    }
+    hub.unsubscribe_symbols(&removed).await;
+    metrics::WEBSOCKET_SYMBOLS_SUBSCRIBED.set(client.len() as f64);
 }
 
 /// Wait for the first message carrying symbols and/or alert rules.
@@ -388,11 +457,7 @@ async fn wait_for_subscription(
         let rules = match cmd.alerts.as_deref().map(parse_rules) {
             Some(Ok(parsed)) if !parsed.is_empty() => Some(parsed),
             Some(Err(message)) => {
-                let _ = socket
-                    .send(Message::Text(
-                        serde_json::json!({"error": message}).to_string().into(),
-                    ))
-                    .await;
+                let _ = socket.send(error_msg(message)).await;
                 continue;
             }
             _ => None,
@@ -417,6 +482,7 @@ async fn wait_for_subscription(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use finance_query::streaming::AlertCondition;
 
     fn command(json: &str) -> StreamCommand {
         serde_json::from_str(json).expect("command should deserialize")

--- a/server/src/handlers/stream.rs
+++ b/server/src/handlers/stream.rs
@@ -12,6 +12,16 @@
 //! {"unsubscribe": ["AAPL"]}
 //! ```
 //!
+//! **Subscribe to threshold alerts instead of every tick:**
+//! ```json
+//! {"alerts": [{"symbol": "AAPL", "condition": "crossesAbove", "value": 200.0}]}
+//! ```
+//! Conditions: `crossesAbove`, `crossesBelow`, `priceAbove`, `priceBelow`,
+//! `percentChangeAbove`, `percentChangeBelow`, `volumeAbove`. Add
+//! `"repeat": true` to re-fire whenever the condition becomes true again.
+//! While a rule set is active the socket emits `AlertEvent` objects rather
+//! than raw ticks; send `{"alerts": []}` to go back to raw ticks.
+//!
 //! **Receive price updates:**
 //! ```json
 //! {
@@ -32,6 +42,7 @@ use axum::{
     },
     response::IntoResponse,
 };
+use finance_query::streaming::{AlertCondition, AlertEvaluator, AlertRule};
 use finance_query_server::{AppState, metrics};
 use futures_util::{SinkExt, StreamExt};
 use serde::Deserialize;
@@ -45,6 +56,40 @@ use tracing::{error, info, warn};
 struct StreamCommand {
     subscribe: Option<Vec<String>>,
     unsubscribe: Option<Vec<String>>,
+    alerts: Option<Vec<WsAlertRule>>,
+}
+
+/// One alert rule as sent over the wire.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WsAlertRule {
+    symbol: String,
+    condition: String,
+    value: f64,
+    #[serde(default)]
+    repeat: bool,
+}
+
+impl WsAlertRule {
+    fn parse(&self) -> Result<AlertRule, String> {
+        let condition = match self.condition.as_str() {
+            "crossesAbove" => AlertCondition::CrossesAbove(self.value),
+            "crossesBelow" => AlertCondition::CrossesBelow(self.value),
+            "priceAbove" => AlertCondition::PriceAbove(self.value),
+            "priceBelow" => AlertCondition::PriceBelow(self.value),
+            "percentChangeAbove" => AlertCondition::PercentChangeAbove(self.value),
+            "percentChangeBelow" => AlertCondition::PercentChangeBelow(self.value),
+            "volumeAbove" => AlertCondition::VolumeAbove(self.value as i64),
+            other => return Err(format!("unknown alert condition: {other}")),
+        };
+        let rule = AlertRule::new(self.symbol.clone(), condition);
+        Ok(if self.repeat { rule.repeating() } else { rule })
+    }
+}
+
+/// Turn wire rules into library rules, reporting the first bad condition.
+fn parse_rules(rules: &[WsAlertRule]) -> Result<Vec<AlertRule>, String> {
+    rules.iter().map(WsAlertRule::parse).collect()
 }
 
 /// RAII guard to decrement WebSocket connection count on drop
@@ -71,17 +116,21 @@ async fn handle_stream_socket(state: AppState, mut socket: WebSocket) {
     let _guard = ConnectionGuard; // Ensures connection count is decremented on exit
     info!("New streaming WebSocket connection");
 
-    // Wait for initial subscription message
-    let symbols = match wait_for_subscription(&mut socket).await {
-        Some(symbols) => {
+    // Wait for the initial subscribe/alerts message
+    let (symbols, initial_rules) = match wait_for_subscription(&mut socket).await {
+        Some(start) => {
             metrics::WEBSOCKET_MESSAGES_RECEIVED.inc();
-            symbols
+            start
         }
         None => {
             warn!("WebSocket closed before subscription");
             return;
         }
     };
+
+    let evaluator = Arc::new(tokio::sync::Mutex::new(
+        initial_rules.map(AlertEvaluator::new),
+    ));
 
     info!("Starting stream for symbols: {:?}", symbols);
     metrics::WEBSOCKET_SYMBOLS_SUBSCRIBED.set(symbols.len() as f64);
@@ -124,6 +173,7 @@ async fn handle_stream_socket(state: AppState, mut socket: WebSocket) {
 
     // Spawn task to forward filtered price updates + outbound messages to client
     let subscriptions_for_send = Arc::clone(&subscriptions);
+    let evaluator_for_send = Arc::clone(&evaluator);
     let mut send_task = tokio::spawn(async move {
         use futures_util::stream::StreamExt;
         loop {
@@ -149,11 +199,27 @@ async fn handle_stream_socket(state: AppState, mut socket: WebSocket) {
                                 let subs = subscriptions_for_send.read().await;
                                 subs.contains(&price.id)
                             };
+                            if !should_send {
+                                continue;
+                            }
 
-                            if should_send {
-                                let json = serde_json::to_string(&price).unwrap_or_default();
-                                if sender.send(Message::Text(json.into())).await.is_err() {
-                                    break;
+                            // Evaluate under the lock, send outside it.
+                            let alerts = {
+                                let mut guard = evaluator_for_send.lock().await;
+                                guard.as_mut().map(|e| e.evaluate(&price))
+                            };
+
+                            let payloads: Vec<String> = match alerts {
+                                Some(events) => events
+                                    .iter()
+                                    .map(|e| serde_json::to_string(e).unwrap_or_default())
+                                    .collect(),
+                                None => vec![serde_json::to_string(&price).unwrap_or_default()],
+                            };
+
+                            for payload in payloads {
+                                if sender.send(Message::Text(payload.into())).await.is_err() {
+                                    return;
                                 }
                                 metrics::WEBSOCKET_MESSAGES_SENT.inc();
                             }
@@ -167,6 +233,7 @@ async fn handle_stream_socket(state: AppState, mut socket: WebSocket) {
 
     // Handle incoming messages (subscribe/unsubscribe)
     let subscriptions_for_recv = Arc::clone(&subscriptions);
+    let evaluator_for_recv = Arc::clone(&evaluator);
     let stream_hub = state.stream_hub.clone();
     let mut recv_task = tokio::spawn(async move {
         while let Some(Ok(msg)) = receiver.next().await {
@@ -210,6 +277,39 @@ async fn handle_stream_socket(state: AppState, mut socket: WebSocket) {
                                         subs.len()
                                     };
                                     metrics::WEBSOCKET_SYMBOLS_SUBSCRIBED.set(count as f64);
+                                }
+                            }
+                        }
+
+                        if let Some(rules) = cmd.alerts {
+                            match parse_rules(&rules) {
+                                Ok(parsed) => {
+                                    let extra: Vec<String> = parsed
+                                        .iter()
+                                        .map(|r| r.symbol.clone())
+                                        .filter(|s| !s.is_empty())
+                                        .collect();
+                                    if !extra.is_empty()
+                                        && let Err(e) = stream_hub.subscribe_symbols(&extra).await
+                                    {
+                                        error!("Failed to subscribe alert symbols: {}", e);
+                                    } else {
+                                        let mut subs = subscriptions_for_recv.write().await;
+                                        subs.extend(extra);
+                                    }
+                                    // An empty rule set reverts to raw ticks.
+                                    let mut guard = evaluator_for_recv.lock().await;
+                                    *guard =
+                                        (!parsed.is_empty()).then(|| AlertEvaluator::new(parsed));
+                                }
+                                Err(message) => {
+                                    let _ = out_tx
+                                        .send(Message::Text(
+                                            serde_json::json!({"error": message})
+                                                .to_string()
+                                                .into(),
+                                        ))
+                                        .await;
                                 }
                             }
                         }
@@ -269,15 +369,107 @@ async fn handle_stream_socket(state: AppState, mut socket: WebSocket) {
     info!("WebSocket stream connection closed");
 }
 
-/// Wait for initial subscription message
-async fn wait_for_subscription(socket: &mut WebSocket) -> Option<Vec<String>> {
+/// Wait for the first message carrying symbols and/or alert rules.
+///
+/// Returns the symbols to subscribe (the union of `subscribe` and the rules'
+/// own symbols, so a client need not list alert symbols twice) plus the
+/// parsed rules, if any.
+async fn wait_for_subscription(
+    socket: &mut WebSocket,
+) -> Option<(Vec<String>, Option<Vec<AlertRule>>)> {
     while let Some(Ok(msg)) = socket.next().await {
-        if let Message::Text(text) = msg
-            && let Ok(cmd) = serde_json::from_str::<StreamCommand>(&text)
-            && let Some(symbols) = cmd.subscribe
-        {
-            return Some(symbols);
+        let Message::Text(text) = msg else {
+            continue;
+        };
+        let Ok(cmd) = serde_json::from_str::<StreamCommand>(&text) else {
+            continue;
+        };
+
+        let rules = match cmd.alerts.as_deref().map(parse_rules) {
+            Some(Ok(parsed)) if !parsed.is_empty() => Some(parsed),
+            Some(Err(message)) => {
+                let _ = socket
+                    .send(Message::Text(
+                        serde_json::json!({"error": message}).to_string().into(),
+                    ))
+                    .await;
+                continue;
+            }
+            _ => None,
+        };
+
+        let mut symbols = cmd.subscribe.unwrap_or_default();
+        if let Some(rules) = rules.as_ref() {
+            for rule in rules {
+                if !symbols.contains(&rule.symbol) {
+                    symbols.push(rule.symbol.clone());
+                }
+            }
+        }
+
+        if !symbols.is_empty() {
+            return Some((symbols, rules));
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn command(json: &str) -> StreamCommand {
+        serde_json::from_str(json).expect("command should deserialize")
+    }
+
+    #[test]
+    fn alert_commands_parse_into_library_rules() {
+        let cmd = command(
+            r#"{"alerts":[{"symbol":"AAPL","condition":"crossesAbove","value":200.0},
+                          {"symbol":"NVDA","condition":"volumeAbove","value":1000,"repeat":true}]}"#,
+        );
+        let rules = parse_rules(&cmd.alerts.unwrap()).expect("rules should parse");
+
+        assert_eq!(rules.len(), 2);
+        assert_eq!(rules[0].condition, AlertCondition::CrossesAbove(200.0));
+        assert!(!rules[0].repeat);
+        assert_eq!(rules[1].condition, AlertCondition::VolumeAbove(1000));
+        assert!(rules[1].repeat);
+    }
+
+    #[test]
+    fn an_unknown_condition_is_reported_not_ignored() {
+        let cmd = command(r#"{"alerts":[{"symbol":"AAPL","condition":"wat","value":1.0}]}"#);
+        let err = parse_rules(&cmd.alerts.unwrap()).expect_err("should reject");
+        assert!(err.contains("wat"), "error should name the bad condition");
+    }
+
+    #[test]
+    fn plain_subscribe_commands_carry_no_alerts() {
+        let cmd = command(r#"{"subscribe":["AAPL"]}"#);
+        assert!(cmd.alerts.is_none());
+        assert_eq!(cmd.subscribe.unwrap(), vec!["AAPL"]);
+    }
+
+    #[test]
+    fn alert_rules_drive_an_evaluator_end_to_end() {
+        let cmd =
+            command(r#"{"alerts":[{"symbol":"AAPL","condition":"crossesAbove","value":150}]}"#);
+        let rules = parse_rules(&cmd.alerts.unwrap()).unwrap();
+        let mut evaluator = AlertEvaluator::new(rules);
+
+        let below = finance_query::streaming::PriceUpdate {
+            id: "AAPL".into(),
+            price: 149.0,
+            ..Default::default()
+        };
+        let above = finance_query::streaming::PriceUpdate {
+            id: "AAPL".into(),
+            price: 151.0,
+            ..Default::default()
+        };
+
+        assert!(evaluator.evaluate(&below).is_empty());
+        assert_eq!(evaluator.evaluate(&above).len(), 1);
+    }
 }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -10,15 +10,80 @@ pub mod services;
 
 use finance_query::FinanceError;
 use finance_query::feeds::FeedSource;
-use finance_query::streaming::{NewsStream, PriceStream};
+use finance_query::streaming::{NewsStream, PriceStream, PriceUpdate};
+use futures_util::{Stream, StreamExt};
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::pin::Pin;
+use std::sync::{Arc, OnceLock};
+use std::task::{Context, Poll};
+use tokio::sync::broadcast;
+use tokio_stream::wrappers::BroadcastStream;
+
+/// Fan-out channel depth, matching the library's own price-stream capacity.
+const FANOUT_CAPACITY: usize = 1024;
 
 #[derive(Clone)]
 pub struct AppState {
     pub cache: cache::Cache,
     pub stream_hub: StreamHub,
     pub feed_hub: FeedHub,
+}
+
+/// One price tick plus its wire JSON, shared by every connected client.
+///
+/// Serializing per client rebuilt identical JSON once per client per tick; the
+/// first consumer that needs the wire form now builds it for all of them, and
+/// consumers that never need it (GraphQL) pay nothing.
+pub struct SharedTick {
+    update: PriceUpdate,
+    json: OnceLock<Arc<str>>,
+}
+
+impl SharedTick {
+    fn new(update: PriceUpdate) -> Self {
+        Self {
+            update,
+            json: OnceLock::new(),
+        }
+    }
+
+    /// The decoded tick.
+    pub fn update(&self) -> &PriceUpdate {
+        &self.update
+    }
+
+    /// The tick's JSON encoding, built once and shared.
+    pub fn json(&self) -> Arc<str> {
+        self.json
+            .get_or_init(|| {
+                serde_json::to_string(&self.update)
+                    .unwrap_or_default()
+                    .into()
+            })
+            .clone()
+    }
+}
+
+/// A per-client receiver over the hub's shared tick fan-out.
+pub struct TickStream {
+    inner: BroadcastStream<Arc<SharedTick>>,
+}
+
+impl Stream for TickStream {
+    type Item = Arc<SharedTick>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        loop {
+            match Pin::new(&mut this.inner).poll_next(cx) {
+                Poll::Ready(Some(Ok(tick))) => return Poll::Ready(Some(tick)),
+                // A lag means this client missed ticks, not that the feed ended.
+                Poll::Ready(Some(Err(_))) => continue,
+                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    }
 }
 
 /// Process-wide hub that maintains a single upstream Yahoo Finance stream.
@@ -33,7 +98,17 @@ pub struct StreamHub {
 #[derive(Default)]
 struct StreamHubInner {
     upstream: Option<PriceStream>,
+    /// Re-broadcast of `upstream` carrying shareable ticks.
+    fanout: Option<broadcast::Sender<Arc<SharedTick>>>,
+    pump: Option<tokio::task::JoinHandle<()>>,
     symbol_ref_counts: HashMap<String, usize>,
+}
+
+/// Read the upstream stream once and hand every client the same tick.
+async fn pump_ticks(mut upstream: PriceStream, fanout: broadcast::Sender<Arc<SharedTick>>) {
+    while let Some(update) = upstream.next().await {
+        let _ = fanout.send(Arc::new(SharedTick::new(update)));
+    }
 }
 
 impl StreamHub {
@@ -42,9 +117,11 @@ impl StreamHub {
         Self::default()
     }
 
-    pub async fn resubscribe(&self) -> Option<PriceStream> {
+    pub async fn resubscribe(&self) -> Option<TickStream> {
         let inner = self.inner.lock().await;
-        inner.upstream.as_ref().map(|s| s.resubscribe())
+        inner.fanout.as_ref().map(|fanout| TickStream {
+            inner: BroadcastStream::new(fanout.subscribe()),
+        })
     }
 
     pub async fn subscribe_symbols(&self, symbols: &[String]) -> Result<(), FinanceError> {
@@ -75,6 +152,12 @@ impl StreamHub {
         // Create upstream stream if this is the first active subscription.
         if inner.upstream.is_none() {
             let stream = PriceStream::subscribe(unique.iter().map(|s| s.as_str())).await?;
+            let (fanout, _) = broadcast::channel(FANOUT_CAPACITY);
+            inner.pump = Some(tokio::spawn(pump_ticks(
+                stream.resubscribe(),
+                fanout.clone(),
+            )));
+            inner.fanout = Some(fanout);
             inner.upstream = Some(stream);
             return Ok(());
         }
@@ -131,10 +214,14 @@ impl StreamHub {
         }
 
         // If nothing is subscribed anywhere, close upstream to stop background tasks.
-        if inner.symbol_ref_counts.is_empty()
-            && let Some(upstream) = inner.upstream.take()
-        {
-            upstream.close().await;
+        if inner.symbol_ref_counts.is_empty() {
+            if let Some(pump) = inner.pump.take() {
+                pump.abort();
+            }
+            inner.fanout = None;
+            if let Some(upstream) = inner.upstream.take() {
+                upstream.close().await;
+            }
         }
     }
 }

--- a/src/adapters/fred/client.rs
+++ b/src/adapters/fred/client.rs
@@ -126,10 +126,25 @@ impl FredClient {
 
     /// Fetch all observations for a FRED series by ID (e.g., `"FEDFUNDS"`, `"CPIAUCSL"`).
     pub async fn series(&self, series_id: &str) -> Result<MacroSeries> {
+        self.observations(series_id, "").await
+    }
+
+    /// Fetch only the most recent observation for a series.
+    ///
+    /// Pollers reading one value would otherwise download the whole history.
+    pub async fn latest_observation(&self, series_id: &str) -> Result<Option<MacroObservation>> {
+        let series = self
+            .observations(series_id, "&sort_order=desc&limit=1")
+            .await?;
+        Ok(series.observations.into_iter().next())
+    }
+
+    /// Query `series/observations`, appending `extra` query parameters.
+    async fn observations(&self, series_id: &str, extra: &str) -> Result<MacroSeries> {
         self.limiter.acquire().await;
 
         let url = format!(
-            "{}/series/observations?series_id={series_id}&api_key={}&file_type=json",
+            "{}/series/observations?series_id={series_id}&api_key={}&file_type=json{extra}",
             self.base_url, self.api_key
         );
 

--- a/src/adapters/fred/mod.rs
+++ b/src/adapters/fred/mod.rs
@@ -119,6 +119,25 @@ pub(crate) fn build_client() -> Result<client::FredClient> {
         .build_with_limiter(Arc::clone(&s.limiter))
 }
 
+/// Fetch only the most recent observation of a FRED series.
+///
+/// Used by the economic stream's poll loop, where downloading a series'
+/// full observation history to read one value is pure waste.
+pub(crate) async fn latest_observation(
+    series_id: &str,
+) -> Result<Option<crate::models::economic::MacroObservation>> {
+    let s = FRED_SINGLETON
+        .get()
+        .ok_or_else(|| FinanceError::InvalidParameter {
+            param: "fred".to_string(),
+            reason: "FRED not initialized. Call fred::init(api_key) first.".to_string(),
+        })?;
+    let c = FredClientBuilder::new(&s.api_key)
+        .timeout(s.timeout)
+        .build_with_limiter(Arc::clone(&s.limiter))?;
+    c.latest_observation(series_id).await
+}
+
 /// Fetch upcoming scheduled economic-data release dates (CPI, NFP, GDP, FOMC, …).
 ///
 /// Returns releases scheduled from today onward, sorted ascending.

--- a/src/adapters/polygon/mod.rs
+++ b/src/adapters/polygon/mod.rs
@@ -44,9 +44,8 @@ mod crypto; // CRYPTO
 mod forex; // FOREX
 mod futures; // FUTURES
 mod indices; // INDICES
-mod options; // OPTIONS
+pub(crate) mod options; // OPTIONS
 
-#[allow(dead_code)] // unrouted: PriceStream is Yahoo-backed; Polygon streaming lands with #247/#250
 pub(crate) mod websocket;
 
 use crate::adapters::singleton::{provider_build_client, provider_singleton_state};

--- a/src/adapters/polygon/websocket.rs
+++ b/src/adapters/polygon/websocket.rs
@@ -64,8 +64,10 @@ impl ClusterDTO {
 pub struct StreamTrade {
     /// Event type (e.g., `"T"`).
     pub ev: Option<String>,
-    /// Symbol.
+    /// Symbol. Absent on the crypto cluster, which sends `pair` instead.
     pub sym: Option<String>,
+    /// Currency pair (crypto cluster, e.g. `"BTC-USD"`).
+    pub pair: Option<String>,
     /// Price.
     pub p: Option<f64>,
     /// Size.
@@ -76,6 +78,15 @@ pub struct StreamTrade {
     pub c: Option<Vec<i32>>,
     /// Timestamp (milliseconds).
     pub t: Option<i64>,
+    /// Trade ID (crypto cluster).
+    pub i: Option<String>,
+}
+
+impl StreamTrade {
+    /// Symbol under whichever key this cluster uses.
+    pub fn symbol(&self) -> Option<&str> {
+        self.sym.as_deref().or(self.pair.as_deref())
+    }
 }
 
 /// A real-time quote message.
@@ -84,8 +95,10 @@ pub struct StreamTrade {
 pub struct StreamQuote {
     /// Event type (e.g., `"Q"`).
     pub ev: Option<String>,
-    /// Symbol.
+    /// Symbol. Absent on the crypto cluster, which sends `pair` instead.
     pub sym: Option<String>,
+    /// Currency pair (crypto cluster, e.g. `"BTC-USD"`).
+    pub pair: Option<String>,
     /// Bid price.
     pub bp: Option<f64>,
     /// Bid size.
@@ -105,14 +118,23 @@ pub struct StreamQuote {
     pub t: Option<i64>,
 }
 
+impl StreamQuote {
+    /// Symbol under whichever key this cluster uses.
+    pub fn symbol(&self) -> Option<&str> {
+        self.sym.as_deref().or(self.pair.as_deref())
+    }
+}
+
 /// A real-time aggregate bar message.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct StreamAggregate {
     /// Event type (e.g., `"A"` per-second, `"AM"` per-minute).
     pub ev: Option<String>,
-    /// Symbol.
+    /// Symbol. Absent on the crypto/forex clusters, which send `pair` instead.
     pub sym: Option<String>,
+    /// Currency pair (crypto/forex clusters, e.g. `"BTC-USD"`, `"USD/EUR"`).
+    pub pair: Option<String>,
     /// Open.
     pub o: Option<f64>,
     /// High.
@@ -131,6 +153,55 @@ pub struct StreamAggregate {
     pub e: Option<i64>,
     /// Number of trades.
     pub z: Option<u64>,
+}
+
+impl StreamAggregate {
+    /// Symbol under whichever key this cluster uses.
+    pub fn symbol(&self) -> Option<&str> {
+        self.sym.as_deref().or(self.pair.as_deref())
+    }
+}
+
+/// A real-time forex quote message (`forex` cluster, event `"C"`).
+///
+/// The forex cluster uses single-letter keys that collide with the stock
+/// quote shape (`a`/`b` rather than `ap`/`bp`), so it needs its own type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct StreamForexQuote {
+    /// Event type (`"C"`).
+    pub ev: Option<String>,
+    /// Currency pair (e.g., `"USD/EUR"`).
+    pub p: Option<String>,
+    /// Ask price.
+    pub a: Option<f64>,
+    /// Bid price.
+    pub b: Option<f64>,
+    /// Exchange ID.
+    pub x: Option<i32>,
+    /// Timestamp (milliseconds).
+    pub t: Option<i64>,
+}
+
+/// One side of an order book: `[price, size]` pairs.
+pub type BookSide = Vec<[f64; 2]>;
+
+/// A real-time level-2 order book snapshot (`crypto` cluster, event `"XL2"`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct StreamLevel2 {
+    /// Event type (`"XL2"`).
+    pub ev: Option<String>,
+    /// Currency pair (e.g., `"BTC-USD"`).
+    pub pair: Option<String>,
+    /// Bid levels, `[price, size]`, best first.
+    pub b: Option<BookSide>,
+    /// Ask levels, `[price, size]`, best first.
+    pub a: Option<BookSide>,
+    /// Exchange ID.
+    pub x: Option<i32>,
+    /// Timestamp (milliseconds).
+    pub t: Option<i64>,
 }
 
 /// A real-time index value message (`indices` cluster).
@@ -157,6 +228,10 @@ pub enum PolygonMessage {
     Quote(StreamQuote),
     /// Aggregate bar (per-second or per-minute).
     Aggregate(StreamAggregate),
+    /// Forex quote (`forex` cluster).
+    ForexQuote(StreamForexQuote),
+    /// Level-2 order book (`crypto` cluster).
+    Level2(StreamLevel2),
     /// Index value (`indices` cluster).
     IndexValue(StreamIndexValue),
     /// Status/control message (auth, subscription confirmations).
@@ -240,7 +315,8 @@ impl PolygonStreamBuilder {
 
         Ok(PolygonStream {
             read: Box::pin(read),
-            _write: write,
+            write,
+            pending: std::collections::VecDeque::new(),
         })
     }
 }
@@ -255,16 +331,54 @@ pub struct PolygonStream {
                 + Send,
         >,
     >,
-    _write: std::sync::Arc<
-        tokio::sync::Mutex<
-            futures::stream::SplitSink<
-                tokio_tungstenite::WebSocketStream<
-                    tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
-                >,
-                Message,
+    write: SharedSink,
+    // One frame carries many events; hold the tail so none are dropped.
+    pending: std::collections::VecDeque<PolygonMessage>,
+}
+
+type SharedSink = std::sync::Arc<
+    tokio::sync::Mutex<
+        futures::stream::SplitSink<
+            tokio_tungstenite::WebSocketStream<
+                tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
             >,
+            Message,
         >,
     >,
+>;
+
+/// Send half of a [`PolygonStream`], detachable so a session can change its
+/// subscriptions while the read half is borrowed by a `select!` arm.
+#[derive(Clone)]
+pub struct PolygonSender {
+    write: SharedSink,
+}
+
+impl PolygonSender {
+    /// Subscribe to additional channels on the live connection.
+    pub async fn subscribe_channels(&self, channels: &[String]) -> Result<()> {
+        self.send_action("subscribe", channels).await
+    }
+
+    /// Unsubscribe from channels on the live connection.
+    pub async fn unsubscribe_channels(&self, channels: &[String]) -> Result<()> {
+        self.send_action("unsubscribe", channels).await
+    }
+
+    async fn send_action(&self, action: &str, channels: &[String]) -> Result<()> {
+        use futures::SinkExt;
+
+        if channels.is_empty() {
+            return Ok(());
+        }
+        let msg = serde_json::json!({ "action": action, "params": channels.join(",") });
+        self.write
+            .lock()
+            .await
+            .send(Message::Text(msg.to_string().into()))
+            .await
+            .map_err(|e| FinanceError::ApiError(format!("Polygon WebSocket {action} error: {e}")))
+    }
 }
 
 impl PolygonStream {
@@ -278,6 +392,13 @@ impl PolygonStream {
             subscriptions: Vec::new(),
         })
     }
+
+    /// Detach the send half so subscriptions can change mid-session.
+    pub fn sender(&self) -> PolygonSender {
+        PolygonSender {
+            write: std::sync::Arc::clone(&self.write),
+        }
+    }
 }
 
 impl Stream for PolygonStream {
@@ -285,9 +406,12 @@ impl Stream for PolygonStream {
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         loop {
+            if let Some(msg) = self.pending.pop_front() {
+                return Poll::Ready(Some(msg));
+            }
             match self.read.as_mut().poll_next(cx) {
                 Poll::Ready(Some(Ok(Message::Text(text)))) => {
-                    return Poll::Ready(Some(parse_message(&text)));
+                    self.pending.extend(parse_messages(&text));
                 }
                 Poll::Ready(Some(Ok(Message::Close(_)))) | Poll::Ready(None) => {
                     return Poll::Ready(None);
@@ -300,56 +424,70 @@ impl Stream for PolygonStream {
     }
 }
 
-fn parse_message(text: &str) -> PolygonMessage {
-    // Polygon sends arrays of events
+/// Parse every event in one Polygon frame.
+///
+/// Frames carry an array of events; tick-by-tick consumers need all of them,
+/// so nothing is collapsed to a single message here.
+pub(crate) fn parse_messages(text: &str) -> Vec<PolygonMessage> {
     let events: Vec<serde_json::Value> = match serde_json::from_str(text) {
         Ok(v) => v,
-        Err(_) => return PolygonMessage::Unknown(text.to_string()),
+        Err(_) => return vec![PolygonMessage::Unknown(text.to_string())],
     };
 
-    // Return the first meaningful event
+    let mut out = Vec::with_capacity(events.len());
     for event in events {
-        let ev = event.get("ev").and_then(|v| v.as_str()).unwrap_or("");
-        match ev {
-            "T" | "XT" => {
-                if let Ok(trade) = serde_json::from_value(event) {
-                    return PolygonMessage::Trade(trade);
-                }
-            }
-            "Q" | "XQ" => {
-                if let Ok(quote) = serde_json::from_value(event) {
-                    return PolygonMessage::Quote(quote);
-                }
-            }
-            "A" | "AM" | "XA" | "XAM" => {
-                if let Ok(agg) = serde_json::from_value(event) {
-                    return PolygonMessage::Aggregate(agg);
-                }
-            }
-            "V" => {
-                if let Ok(value) = serde_json::from_value(event) {
-                    return PolygonMessage::IndexValue(value);
-                }
-            }
-            "status" => {
-                return PolygonMessage::Status(event);
-            }
-            _ => {}
+        let ev = event
+            .get("ev")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let parsed = match ev.as_str() {
+            "T" | "XT" => serde_json::from_value(event)
+                .ok()
+                .map(PolygonMessage::Trade),
+            "Q" | "XQ" => serde_json::from_value(event)
+                .ok()
+                .map(PolygonMessage::Quote),
+            "A" | "AM" | "XA" | "XAM" | "CA" | "CAS" => serde_json::from_value(event)
+                .ok()
+                .map(PolygonMessage::Aggregate),
+            "C" => serde_json::from_value(event)
+                .ok()
+                .map(PolygonMessage::ForexQuote),
+            "XL2" => serde_json::from_value(event)
+                .ok()
+                .map(PolygonMessage::Level2),
+            "V" => serde_json::from_value(event)
+                .ok()
+                .map(PolygonMessage::IndexValue),
+            "status" => Some(PolygonMessage::Status(event)),
+            _ => None,
+        };
+        if let Some(msg) = parsed {
+            out.push(msg);
         }
     }
 
-    PolygonMessage::Unknown(text.to_string())
+    if out.is_empty() {
+        out.push(PolygonMessage::Unknown(text.to_string()));
+    }
+    out
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// First parsed event of a frame — most cases here send a single event.
+    fn first(text: &str) -> PolygonMessage {
+        parse_messages(text).into_iter().next().expect("no events")
+    }
+
     #[test]
     fn test_parse_trade_message() {
         let msg =
             r#"[{"ev":"T","sym":"AAPL","p":186.19,"s":100,"x":4,"c":[12,37],"t":1705363200000}]"#;
-        match parse_message(msg) {
+        match first(msg) {
             PolygonMessage::Trade(t) => {
                 assert_eq!(t.sym.as_deref(), Some("AAPL"));
                 assert!((t.p.unwrap() - 186.19).abs() < 0.01);
@@ -362,7 +500,7 @@ mod tests {
     #[test]
     fn test_parse_quote_message() {
         let msg = r#"[{"ev":"Q","sym":"AAPL","bp":186.18,"bs":2,"ap":186.25,"as":3,"bx":19,"ax":11,"t":1705363200000}]"#;
-        match parse_message(msg) {
+        match first(msg) {
             PolygonMessage::Quote(q) => {
                 assert_eq!(q.sym.as_deref(), Some("AAPL"));
                 assert!((q.bp.unwrap() - 186.18).abs() < 0.01);
@@ -375,7 +513,7 @@ mod tests {
     #[test]
     fn test_parse_aggregate_message() {
         let msg = r#"[{"ev":"AM","sym":"AAPL","o":186.0,"h":186.25,"l":185.90,"c":186.19,"v":1500000,"vw":186.05,"s":1705363200000,"e":1705363260000,"z":823}]"#;
-        match parse_message(msg) {
+        match first(msg) {
             PolygonMessage::Aggregate(a) => {
                 assert_eq!(a.sym.as_deref(), Some("AAPL"));
                 assert!((a.c.unwrap() - 186.19).abs() < 0.01);
@@ -388,7 +526,7 @@ mod tests {
     #[test]
     fn test_parse_index_value_message() {
         let msg = r#"[{"ev":"V","val":3988.5,"T":"I:SPX","t":1678220098130}]"#;
-        match parse_message(msg) {
+        match first(msg) {
             PolygonMessage::IndexValue(v) => {
                 assert_eq!(v.ev.as_deref(), Some("V"));
                 assert_eq!(v.ticker.as_deref(), Some("I:SPX"));
@@ -402,13 +540,13 @@ mod tests {
     #[test]
     fn test_index_value_not_dropped_as_unknown() {
         let msg = r#"[{"ev":"V","val":3988.5,"T":"I:SPX","t":1678220098130}]"#;
-        assert!(!matches!(parse_message(msg), PolygonMessage::Unknown(_)));
+        assert!(!matches!(first(msg), PolygonMessage::Unknown(_)));
     }
 
     #[test]
     fn test_parse_status_message() {
         let msg = r#"[{"ev":"status","status":"auth_success","message":"authenticated"}]"#;
-        match parse_message(msg) {
+        match first(msg) {
             PolygonMessage::Status(v) => {
                 assert_eq!(v.get("status").unwrap().as_str().unwrap(), "auth_success");
             }
@@ -419,7 +557,7 @@ mod tests {
     #[test]
     fn test_parse_unknown_message() {
         let msg = "not json at all";
-        assert!(matches!(parse_message(msg), PolygonMessage::Unknown(_)));
+        assert!(matches!(first(msg), PolygonMessage::Unknown(_)));
     }
 
     #[test]

--- a/src/adapters/polygon/websocket.rs
+++ b/src/adapters/polygon/websocket.rs
@@ -436,12 +436,8 @@ pub(crate) fn parse_messages(text: &str) -> Vec<PolygonMessage> {
 
     let mut out = Vec::with_capacity(events.len());
     for event in events {
-        let ev = event
-            .get("ev")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
-        let parsed = match ev.as_str() {
+        let ev = event.get("ev").and_then(|v| v.as_str()).unwrap_or("");
+        let parsed = match ev {
             "T" | "XT" => serde_json::from_value(event)
                 .ok()
                 .map(PolygonMessage::Trade),

--- a/src/adapters/polygon/websocket.rs
+++ b/src/adapters/polygon/websocket.rs
@@ -231,6 +231,7 @@ pub enum PolygonMessage {
     /// Forex quote (`forex` cluster).
     ForexQuote(StreamForexQuote),
     /// Level-2 order book (`crypto` cluster).
+    #[allow(dead_code)] // read by the depth-of-book source (#250)
     Level2(StreamLevel2),
     /// Index value (`indices` cluster).
     IndexValue(StreamIndexValue),

--- a/src/adapters/polygon/websocket.rs
+++ b/src/adapters/polygon/websocket.rs
@@ -231,7 +231,6 @@ pub enum PolygonMessage {
     /// Forex quote (`forex` cluster).
     ForexQuote(StreamForexQuote),
     /// Level-2 order book (`crypto` cluster).
-    #[allow(dead_code)] // read by the depth-of-book source (#250)
     Level2(StreamLevel2),
     /// Index value (`indices` cluster).
     IndexValue(StreamIndexValue),

--- a/src/streaming/alerts.rs
+++ b/src/streaming/alerts.rs
@@ -1,0 +1,384 @@
+//! Threshold-triggered alerting over a price subscription.
+//!
+//! Consumers that only care about specific crossings would otherwise receive
+//! every tick and filter client-side. [`AlertEvaluator`] moves that predicate
+//! next to the stream; [`AlertStream`] wraps it as a `Stream` adapter so it
+//! composes with any `Stream<Item = PriceUpdate>` (including a server-side
+//! shared hub stream) rather than being welded to one transport.
+
+use std::collections::{HashMap, VecDeque};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures::stream::Stream;
+use serde::{Deserialize, Serialize};
+
+use super::pricing::PriceUpdate;
+
+/// A predicate over incoming price ticks.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub enum AlertCondition {
+    /// Price moved from at-or-below the threshold to above it.
+    CrossesAbove(f64),
+    /// Price moved from at-or-above the threshold to below it.
+    CrossesBelow(f64),
+    /// Price is above the threshold (fires on the first matching tick).
+    PriceAbove(f64),
+    /// Price is below the threshold (fires on the first matching tick).
+    PriceBelow(f64),
+    /// Percent change from the previous close is at or above the threshold.
+    PercentChangeAbove(f64),
+    /// Percent change from the previous close is at or below the threshold.
+    PercentChangeBelow(f64),
+    /// Day volume is at or above the threshold.
+    VolumeAbove(i64),
+}
+
+impl AlertCondition {
+    /// Whether the condition holds for this tick.
+    ///
+    /// `previous` is the last price seen for the symbol; crossing conditions
+    /// need it and never fire on the first tick of a symbol.
+    fn holds(&self, update: &PriceUpdate, previous: Option<f32>) -> bool {
+        let price = update.price as f64;
+        match *self {
+            Self::CrossesAbove(t) => previous.is_some_and(|p| (p as f64) <= t) && price > t,
+            Self::CrossesBelow(t) => previous.is_some_and(|p| (p as f64) >= t) && price < t,
+            Self::PriceAbove(t) => price > t,
+            Self::PriceBelow(t) => price < t,
+            Self::PercentChangeAbove(t) => update.change_percent as f64 >= t,
+            Self::PercentChangeBelow(t) => update.change_percent as f64 <= t,
+            Self::VolumeAbove(t) => update.day_volume >= t,
+        }
+    }
+}
+
+/// A symbol paired with the condition that should trigger an alert.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct AlertRule {
+    /// Symbol this rule watches (matched against `PriceUpdate::id`).
+    pub symbol: String,
+    /// Predicate to evaluate.
+    pub condition: AlertCondition,
+    /// Fire repeatedly (re-arming whenever the condition stops holding)
+    /// instead of once.
+    pub repeat: bool,
+}
+
+impl AlertRule {
+    /// A one-shot rule: fires the first time the condition holds.
+    pub fn new(symbol: impl Into<String>, condition: AlertCondition) -> Self {
+        Self {
+            symbol: symbol.into(),
+            condition,
+            repeat: false,
+        }
+    }
+
+    /// Fire every time the condition becomes true again.
+    pub fn repeating(mut self) -> Self {
+        self.repeat = true;
+        self
+    }
+}
+
+/// A fired alert, carrying the tick that triggered it.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct AlertEvent {
+    /// Symbol that triggered.
+    pub symbol: String,
+    /// Condition that fired.
+    pub condition: AlertCondition,
+    /// Price on the triggering tick.
+    pub price: f32,
+    /// Last price seen before this tick, if any.
+    pub previous_price: Option<f32>,
+    /// Percent change carried by the triggering tick.
+    pub change_percent: f32,
+    /// Tick timestamp (milliseconds).
+    pub time: i64,
+    /// The full triggering tick.
+    pub update: PriceUpdate,
+}
+
+/// Per-rule firing state.
+struct RuleState {
+    rule: AlertRule,
+    /// `false` after firing; a repeating rule re-arms when the condition
+    /// stops holding, a one-shot rule never does.
+    armed: bool,
+}
+
+/// Evaluates [`AlertRule`]s against a price feed, tracking the per-symbol
+/// history that crossing conditions need.
+///
+/// Exposed so consumers that already own a price stream (the server's shared
+/// hub, for instance) can apply alerts without re-wrapping the stream.
+pub struct AlertEvaluator {
+    rules: Vec<RuleState>,
+    last_price: HashMap<String, f32>,
+}
+
+impl AlertEvaluator {
+    /// Build an evaluator from a rule set.
+    pub fn new(rules: impl IntoIterator<Item = AlertRule>) -> Self {
+        Self {
+            rules: rules
+                .into_iter()
+                .map(|rule| RuleState { rule, armed: true })
+                .collect(),
+            last_price: HashMap::new(),
+        }
+    }
+
+    /// Distinct symbols referenced by the rule set, in first-seen order.
+    pub fn symbols(&self) -> Vec<String> {
+        let mut symbols: Vec<String> = Vec::new();
+        for state in &self.rules {
+            if !symbols.contains(&state.rule.symbol) {
+                symbols.push(state.rule.symbol.clone());
+            }
+        }
+        symbols
+    }
+
+    /// `true` once every rule has fired and none can fire again.
+    pub fn is_exhausted(&self) -> bool {
+        self.rules
+            .iter()
+            .all(|state| !state.armed && !state.rule.repeat)
+    }
+
+    /// Feed one tick, returning the alerts it triggered.
+    pub fn evaluate(&mut self, update: &PriceUpdate) -> Vec<AlertEvent> {
+        let previous = self.last_price.get(&update.id).copied();
+        let mut fired = Vec::new();
+
+        for state in self.rules.iter_mut() {
+            if state.rule.symbol != update.id {
+                continue;
+            }
+            let holds = state.rule.condition.holds(update, previous);
+            if holds && state.armed {
+                state.armed = false;
+                fired.push(AlertEvent {
+                    symbol: update.id.clone(),
+                    condition: state.rule.condition,
+                    price: update.price,
+                    previous_price: previous,
+                    change_percent: update.change_percent,
+                    time: update.time,
+                    update: update.clone(),
+                });
+            } else if !holds && state.rule.repeat {
+                state.armed = true;
+            }
+        }
+
+        // Heartbeats and other priceless ticks must not poison the crossing
+        // history with a zero.
+        if update.price != 0.0 {
+            self.last_price.insert(update.id.clone(), update.price);
+        }
+        fired
+    }
+}
+
+/// A `Stream<Item = AlertEvent>` over any price stream.
+pub struct AlertStream<S> {
+    inner: S,
+    evaluator: AlertEvaluator,
+    pending: VecDeque<AlertEvent>,
+}
+
+impl<S> AlertStream<S> {
+    /// Wrap `inner`, evaluating `rules` against every tick it yields.
+    pub fn new(inner: S, rules: impl IntoIterator<Item = AlertRule>) -> Self {
+        Self {
+            inner,
+            evaluator: AlertEvaluator::new(rules),
+            pending: VecDeque::new(),
+        }
+    }
+}
+
+impl<S> Stream for AlertStream<S>
+where
+    S: Stream<Item = PriceUpdate> + Unpin,
+{
+    type Item = AlertEvent;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        loop {
+            if let Some(event) = this.pending.pop_front() {
+                return Poll::Ready(Some(event));
+            }
+            match Pin::new(&mut this.inner).poll_next(cx) {
+                Poll::Ready(Some(update)) => this.pending.extend(this.evaluator.evaluate(&update)),
+                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    }
+}
+
+/// Adds [`alerts`](AlertExt::alerts) to every price stream.
+///
+/// # Example
+///
+/// ```no_run
+/// use finance_query::streaming::{AlertCondition, AlertExt, AlertRule, PriceStream};
+/// use futures::StreamExt;
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut alerts = PriceStream::subscribe(["AAPL"])
+///     .await?
+///     .alerts([AlertRule::new("AAPL", AlertCondition::CrossesAbove(200.0))]);
+///
+/// while let Some(alert) = alerts.next().await {
+///     println!("{} crossed at {}", alert.symbol, alert.price);
+/// }
+/// # Ok(())
+/// # }
+/// ```
+pub trait AlertExt: Stream<Item = PriceUpdate> + Sized + Unpin {
+    /// Yield only the ticks that trigger one of `rules`.
+    fn alerts(self, rules: impl IntoIterator<Item = AlertRule>) -> AlertStream<Self> {
+        AlertStream::new(self, rules)
+    }
+}
+
+impl<S> AlertExt for S where S: Stream<Item = PriceUpdate> + Sized + Unpin {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+
+    fn tick(symbol: &str, price: f32) -> PriceUpdate {
+        PriceUpdate {
+            id: symbol.to_string(),
+            price,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn crossing_needs_a_previous_price() {
+        let mut evaluator =
+            AlertEvaluator::new([AlertRule::new("AAPL", AlertCondition::CrossesAbove(150.0))]);
+
+        // First tick is already above the threshold but has no history.
+        assert!(evaluator.evaluate(&tick("AAPL", 155.0)).is_empty());
+    }
+
+    #[test]
+    fn crossing_fires_once_on_the_upward_move() {
+        let mut evaluator =
+            AlertEvaluator::new([AlertRule::new("AAPL", AlertCondition::CrossesAbove(150.0))]);
+
+        assert!(evaluator.evaluate(&tick("AAPL", 149.0)).is_empty());
+        let fired = evaluator.evaluate(&tick("AAPL", 151.0));
+        assert_eq!(fired.len(), 1);
+        assert_eq!(fired[0].previous_price, Some(149.0));
+
+        // One-shot: no repeat while it stays above, and none on a re-cross.
+        assert!(evaluator.evaluate(&tick("AAPL", 152.0)).is_empty());
+        assert!(evaluator.evaluate(&tick("AAPL", 148.0)).is_empty());
+        assert!(evaluator.evaluate(&tick("AAPL", 153.0)).is_empty());
+        assert!(evaluator.is_exhausted());
+    }
+
+    #[test]
+    fn repeating_rules_rearm_when_the_condition_clears() {
+        let mut evaluator =
+            AlertEvaluator::new([
+                AlertRule::new("AAPL", AlertCondition::CrossesAbove(150.0)).repeating()
+            ]);
+
+        evaluator.evaluate(&tick("AAPL", 149.0));
+        assert_eq!(evaluator.evaluate(&tick("AAPL", 151.0)).len(), 1);
+        assert!(evaluator.evaluate(&tick("AAPL", 152.0)).is_empty());
+        // Falls back below (clearing the condition), then crosses again.
+        assert!(evaluator.evaluate(&tick("AAPL", 148.0)).is_empty());
+        assert_eq!(evaluator.evaluate(&tick("AAPL", 151.0)).len(), 1);
+        assert!(!evaluator.is_exhausted());
+    }
+
+    #[test]
+    fn crossing_below_is_symmetric() {
+        let mut evaluator =
+            AlertEvaluator::new([AlertRule::new("AAPL", AlertCondition::CrossesBelow(100.0))]);
+        evaluator.evaluate(&tick("AAPL", 101.0));
+        assert_eq!(evaluator.evaluate(&tick("AAPL", 99.0)).len(), 1);
+    }
+
+    #[test]
+    fn level_and_metric_conditions_fire_without_history() {
+        let mut level =
+            AlertEvaluator::new([AlertRule::new("AAPL", AlertCondition::PriceAbove(10.0))]);
+        assert_eq!(level.evaluate(&tick("AAPL", 11.0)).len(), 1);
+
+        let mut pct = AlertEvaluator::new([AlertRule::new(
+            "AAPL",
+            AlertCondition::PercentChangeAbove(5.0),
+        )]);
+        let mut update = tick("AAPL", 11.0);
+        update.change_percent = 6.0;
+        assert_eq!(pct.evaluate(&update).len(), 1);
+
+        let mut vol =
+            AlertEvaluator::new([AlertRule::new("AAPL", AlertCondition::VolumeAbove(1_000))]);
+        let mut update = tick("AAPL", 11.0);
+        update.day_volume = 1_500;
+        assert_eq!(vol.evaluate(&update).len(), 1);
+    }
+
+    #[test]
+    fn rules_only_see_their_own_symbol() {
+        let mut evaluator = AlertEvaluator::new([
+            AlertRule::new("AAPL", AlertCondition::PriceAbove(10.0)),
+            AlertRule::new("NVDA", AlertCondition::PriceAbove(10.0)),
+        ]);
+        let fired = evaluator.evaluate(&tick("NVDA", 20.0));
+        assert_eq!(fired.len(), 1);
+        assert_eq!(fired[0].symbol, "NVDA");
+        assert_eq!(evaluator.symbols(), vec!["AAPL", "NVDA"]);
+    }
+
+    #[test]
+    fn priceless_ticks_do_not_become_crossing_history() {
+        let mut evaluator =
+            AlertEvaluator::new([AlertRule::new("AAPL", AlertCondition::CrossesAbove(150.0))]);
+        evaluator.evaluate(&tick("AAPL", 149.0));
+        // A heartbeat-style tick with no price must not reset the baseline.
+        evaluator.evaluate(&tick("AAPL", 0.0));
+        assert_eq!(evaluator.evaluate(&tick("AAPL", 151.0)).len(), 1);
+    }
+
+    #[tokio::test]
+    async fn stream_adapter_yields_only_triggering_ticks() {
+        let updates = futures::stream::iter(vec![
+            tick("AAPL", 149.0),
+            tick("AAPL", 149.5),
+            tick("AAPL", 151.0),
+            tick("AAPL", 152.0),
+        ]);
+
+        let alerts: Vec<AlertEvent> = updates
+            .alerts([AlertRule::new("AAPL", AlertCondition::CrossesAbove(150.0))])
+            .collect()
+            .await;
+
+        assert_eq!(alerts.len(), 1);
+        assert_eq!(alerts[0].price, 151.0);
+        assert_eq!(alerts[0].update.id, "AAPL");
+    }
+}

--- a/src/streaming/alerts.rs
+++ b/src/streaming/alerts.rs
@@ -6,14 +6,16 @@
 //! composes with any `Stream<Item = PriceUpdate>` (including a server-side
 //! shared hub stream) rather than being welded to one transport.
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::pin::Pin;
+use std::str::FromStr;
 use std::task::{Context, Poll};
 
 use futures::stream::Stream;
 use serde::{Deserialize, Serialize};
 
 use super::pricing::PriceUpdate;
+use crate::error::FinanceError;
 
 /// A predicate over incoming price ticks.
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
@@ -36,7 +38,111 @@ pub enum AlertCondition {
     VolumeAbove(i64),
 }
 
+/// Which predicate an [`AlertCondition`] applies, without its threshold.
+///
+/// Deliberately **exhaustive** (no `#[non_exhaustive]`): transports that
+/// project a condition onto a flat `kind` + `value` pair must fail to compile
+/// when a predicate is added, rather than silently degrading it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum AlertConditionKind {
+    /// See [`AlertCondition::CrossesAbove`].
+    CrossesAbove,
+    /// See [`AlertCondition::CrossesBelow`].
+    CrossesBelow,
+    /// See [`AlertCondition::PriceAbove`].
+    PriceAbove,
+    /// See [`AlertCondition::PriceBelow`].
+    PriceBelow,
+    /// See [`AlertCondition::PercentChangeAbove`].
+    PercentChangeAbove,
+    /// See [`AlertCondition::PercentChangeBelow`].
+    PercentChangeBelow,
+    /// See [`AlertCondition::VolumeAbove`].
+    VolumeAbove,
+}
+
+impl AlertConditionKind {
+    /// Pair this predicate with a threshold to get a usable condition.
+    pub fn with_value(self, value: f64) -> AlertCondition {
+        match self {
+            Self::CrossesAbove => AlertCondition::CrossesAbove(value),
+            Self::CrossesBelow => AlertCondition::CrossesBelow(value),
+            Self::PriceAbove => AlertCondition::PriceAbove(value),
+            Self::PriceBelow => AlertCondition::PriceBelow(value),
+            Self::PercentChangeAbove => AlertCondition::PercentChangeAbove(value),
+            Self::PercentChangeBelow => AlertCondition::PercentChangeBelow(value),
+            Self::VolumeAbove => AlertCondition::VolumeAbove(value as i64),
+        }
+    }
+
+    /// Wire name of this predicate (`"crossesAbove"`, …).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::CrossesAbove => "crossesAbove",
+            Self::CrossesBelow => "crossesBelow",
+            Self::PriceAbove => "priceAbove",
+            Self::PriceBelow => "priceBelow",
+            Self::PercentChangeAbove => "percentChangeAbove",
+            Self::PercentChangeBelow => "percentChangeBelow",
+            Self::VolumeAbove => "volumeAbove",
+        }
+    }
+}
+
+impl std::fmt::Display for AlertConditionKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for AlertConditionKind {
+    type Err = FinanceError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "crossesAbove" => Ok(Self::CrossesAbove),
+            "crossesBelow" => Ok(Self::CrossesBelow),
+            "priceAbove" => Ok(Self::PriceAbove),
+            "priceBelow" => Ok(Self::PriceBelow),
+            "percentChangeAbove" => Ok(Self::PercentChangeAbove),
+            "percentChangeBelow" => Ok(Self::PercentChangeBelow),
+            "volumeAbove" => Ok(Self::VolumeAbove),
+            other => Err(FinanceError::InvalidParameter {
+                param: "condition".to_string(),
+                reason: format!("unknown alert condition: {other}"),
+            }),
+        }
+    }
+}
+
 impl AlertCondition {
+    /// Which predicate this condition applies.
+    pub fn kind(&self) -> AlertConditionKind {
+        match *self {
+            Self::CrossesAbove(_) => AlertConditionKind::CrossesAbove,
+            Self::CrossesBelow(_) => AlertConditionKind::CrossesBelow,
+            Self::PriceAbove(_) => AlertConditionKind::PriceAbove,
+            Self::PriceBelow(_) => AlertConditionKind::PriceBelow,
+            Self::PercentChangeAbove(_) => AlertConditionKind::PercentChangeAbove,
+            Self::PercentChangeBelow(_) => AlertConditionKind::PercentChangeBelow,
+            Self::VolumeAbove(_) => AlertConditionKind::VolumeAbove,
+        }
+    }
+
+    /// Threshold this condition compares against.
+    pub fn threshold(&self) -> f64 {
+        match *self {
+            Self::CrossesAbove(t)
+            | Self::CrossesBelow(t)
+            | Self::PriceAbove(t)
+            | Self::PriceBelow(t)
+            | Self::PercentChangeAbove(t)
+            | Self::PercentChangeBelow(t) => t,
+            Self::VolumeAbove(t) => t as f64,
+        }
+    }
+
     /// Whether the condition holds for this tick.
     ///
     /// `previous` is the last price seen for the symbol; crossing conditions
@@ -122,17 +228,22 @@ struct RuleState {
 /// hub, for instance) can apply alerts without re-wrapping the stream.
 pub struct AlertEvaluator {
     rules: Vec<RuleState>,
+    /// Symbols any rule watches — a shared feed carries far more than these,
+    /// and untracked ids must not accumulate history.
+    watched: HashSet<String>,
     last_price: HashMap<String, f32>,
 }
 
 impl AlertEvaluator {
     /// Build an evaluator from a rule set.
     pub fn new(rules: impl IntoIterator<Item = AlertRule>) -> Self {
+        let rules: Vec<RuleState> = rules
+            .into_iter()
+            .map(|rule| RuleState { rule, armed: true })
+            .collect();
         Self {
-            rules: rules
-                .into_iter()
-                .map(|rule| RuleState { rule, armed: true })
-                .collect(),
+            watched: rules.iter().map(|s| s.rule.symbol.clone()).collect(),
+            rules,
             last_price: HashMap::new(),
         }
     }
@@ -157,6 +268,9 @@ impl AlertEvaluator {
 
     /// Feed one tick, returning the alerts it triggered.
     pub fn evaluate(&mut self, update: &PriceUpdate) -> Vec<AlertEvent> {
+        if !self.watched.contains(&update.id) {
+            return Vec::new();
+        }
         let previous = self.last_price.get(&update.id).copied();
         let mut fired = Vec::new();
 
@@ -184,7 +298,12 @@ impl AlertEvaluator {
         // Heartbeats and other priceless ticks must not poison the crossing
         // history with a zero.
         if update.price != 0.0 {
-            self.last_price.insert(update.id.clone(), update.price);
+            match self.last_price.get_mut(&update.id) {
+                Some(last) => *last = update.price,
+                None => {
+                    self.last_price.insert(update.id.clone(), update.price);
+                }
+            }
         }
         fired
     }
@@ -361,6 +480,50 @@ mod tests {
         // A heartbeat-style tick with no price must not reset the baseline.
         evaluator.evaluate(&tick("AAPL", 0.0));
         assert_eq!(evaluator.evaluate(&tick("AAPL", 151.0)).len(), 1);
+    }
+
+    #[test]
+    fn unwatched_symbols_leave_no_trace() {
+        let mut evaluator =
+            AlertEvaluator::new([AlertRule::new("AAPL", AlertCondition::CrossesAbove(150.0))]);
+        // A shared hub carries every symbol any client subscribed to.
+        assert!(evaluator.evaluate(&tick("TSLA", 400.0)).is_empty());
+        assert!(!evaluator.last_price.contains_key("TSLA"));
+    }
+
+    #[test]
+    fn conditions_project_onto_kind_and_threshold() {
+        for condition in [
+            AlertCondition::CrossesAbove(1.5),
+            AlertCondition::CrossesBelow(1.5),
+            AlertCondition::PriceAbove(1.5),
+            AlertCondition::PriceBelow(1.5),
+            AlertCondition::PercentChangeAbove(1.5),
+            AlertCondition::PercentChangeBelow(1.5),
+        ] {
+            let round_tripped = condition.kind().with_value(condition.threshold());
+            assert_eq!(round_tripped, condition);
+        }
+
+        let volume = AlertCondition::VolumeAbove(1_000);
+        assert_eq!(volume.kind(), AlertConditionKind::VolumeAbove);
+        assert_eq!(volume.kind().with_value(volume.threshold()), volume);
+    }
+
+    #[test]
+    fn condition_kinds_round_trip_through_their_wire_names() {
+        for kind in [
+            AlertConditionKind::CrossesAbove,
+            AlertConditionKind::CrossesBelow,
+            AlertConditionKind::PriceAbove,
+            AlertConditionKind::PriceBelow,
+            AlertConditionKind::PercentChangeAbove,
+            AlertConditionKind::PercentChangeBelow,
+            AlertConditionKind::VolumeAbove,
+        ] {
+            assert_eq!(kind.as_str().parse::<AlertConditionKind>().unwrap(), kind);
+        }
+        assert!("wat".parse::<AlertConditionKind>().is_err());
     }
 
     #[tokio::test]

--- a/src/streaming/batch.rs
+++ b/src/streaming/batch.rs
@@ -1,0 +1,208 @@
+//! Batched delivery for any streaming subscription.
+//!
+//! A consumer watching N symbols normally receives N separate messages per
+//! tick. [`Batched`] coalesces whatever arrived inside a time window into one
+//! `Vec`, cutting per-message overhead for wide watchlists. It is a plain
+//! `Stream` adapter, so it composes with every handle in this module instead
+//! of being a per-stream delivery mode.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use futures::stream::Stream;
+use tokio::time::{Instant, Sleep, sleep_until};
+
+/// Default cap on items per batch when none is given.
+const DEFAULT_MAX_BATCH: usize = 512;
+
+/// A stream that yields `Vec<T>` batches collected over a time window.
+///
+/// A batch is emitted when the window since the batch's first item elapses, or
+/// as soon as `max_items` is reached — whichever comes first. Empty batches are
+/// never emitted, and any partial batch is flushed when the source ends.
+pub struct Batched<S>
+where
+    S: Stream,
+{
+    inner: S,
+    window: Duration,
+    max_items: usize,
+    buffer: Vec<S::Item>,
+    deadline: Option<Pin<Box<Sleep>>>,
+    exhausted: bool,
+}
+
+impl<S> Batched<S>
+where
+    S: Stream + Unpin,
+{
+    /// Batch `inner` over `window`, emitting early once `max_items` accumulate.
+    pub fn new(inner: S, window: Duration, max_items: usize) -> Self {
+        Self {
+            inner,
+            window,
+            max_items: max_items.max(1),
+            buffer: Vec::new(),
+            deadline: None,
+            exhausted: false,
+        }
+    }
+
+    fn take_batch(&mut self) -> Vec<S::Item> {
+        self.deadline = None;
+        std::mem::take(&mut self.buffer)
+    }
+}
+
+impl<S> Stream for Batched<S>
+where
+    S: Stream + Unpin,
+    S::Item: Unpin,
+{
+    type Item = Vec<S::Item>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+
+        loop {
+            if this.exhausted {
+                return if this.buffer.is_empty() {
+                    Poll::Ready(None)
+                } else {
+                    Poll::Ready(Some(this.take_batch()))
+                };
+            }
+
+            match Pin::new(&mut this.inner).poll_next(cx) {
+                Poll::Ready(Some(item)) => {
+                    this.buffer.push(item);
+                    if this.deadline.is_none() {
+                        this.deadline = Some(Box::pin(sleep_until(Instant::now() + this.window)));
+                    }
+                    if this.buffer.len() >= this.max_items {
+                        return Poll::Ready(Some(this.take_batch()));
+                    }
+                }
+                Poll::Ready(None) => this.exhausted = true,
+                Poll::Pending => break,
+            }
+        }
+
+        // Source is idle: emit once the current batch's window expires.
+        if let Some(deadline) = this.deadline.as_mut()
+            && deadline.as_mut().poll(cx).is_ready()
+        {
+            return Poll::Ready(Some(this.take_batch()));
+        }
+
+        Poll::Pending
+    }
+}
+
+/// Adds [`batched`](StreamBatchExt::batched) to every `Stream`.
+///
+/// # Example
+///
+/// ```no_run
+/// use finance_query::streaming::{PriceStream, StreamBatchExt};
+/// use futures::StreamExt;
+/// use std::time::Duration;
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut batches = PriceStream::subscribe(["AAPL", "NVDA", "TSLA"])
+///     .await?
+///     .batched(Duration::from_millis(250));
+///
+/// while let Some(batch) = batches.next().await {
+///     println!("{} updates in this window", batch.len());
+/// }
+/// # Ok(())
+/// # }
+/// ```
+pub trait StreamBatchExt: Stream + Sized + Unpin {
+    /// Coalesce items arriving within `window` into one `Vec` (max 512 items).
+    fn batched(self, window: Duration) -> Batched<Self> {
+        Batched::new(self, window, DEFAULT_MAX_BATCH)
+    }
+
+    /// Same as [`batched`](Self::batched) with an explicit per-batch cap.
+    fn batched_with_capacity(self, window: Duration, max_items: usize) -> Batched<Self> {
+        Batched::new(self, window, max_items)
+    }
+}
+
+impl<S> StreamBatchExt for S where S: Stream + Sized + Unpin {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+    use tokio::sync::mpsc;
+    use tokio_stream::wrappers::ReceiverStream;
+
+    #[tokio::test]
+    async fn window_coalesces_items_into_one_batch() {
+        let (tx, rx) = mpsc::channel(16);
+        let mut batched = ReceiverStream::new(rx).batched(Duration::from_millis(60));
+
+        for i in 0..5 {
+            tx.send(i).await.unwrap();
+        }
+
+        let batch = tokio::time::timeout(Duration::from_secs(2), batched.next())
+            .await
+            .expect("timed out")
+            .expect("stream ended");
+        assert_eq!(batch, vec![0, 1, 2, 3, 4]);
+        drop(tx);
+    }
+
+    #[tokio::test]
+    async fn max_items_flushes_before_the_window_elapses() {
+        let (tx, rx) = mpsc::channel(16);
+        let mut batched = ReceiverStream::new(rx).batched_with_capacity(Duration::from_secs(30), 2);
+
+        for i in 0..4 {
+            tx.send(i).await.unwrap();
+        }
+
+        // Would block for 30s if the size cap were not honored.
+        let batch = tokio::time::timeout(Duration::from_secs(2), batched.next())
+            .await
+            .expect("timed out")
+            .expect("stream ended");
+        assert_eq!(batch, vec![0, 1]);
+        drop(tx);
+    }
+
+    #[tokio::test]
+    async fn partial_batch_is_flushed_when_the_source_ends() {
+        let (tx, rx) = mpsc::channel(16);
+        let mut batched = ReceiverStream::new(rx).batched(Duration::from_secs(30));
+        tx.send(7).await.unwrap();
+        drop(tx);
+
+        let batch = tokio::time::timeout(Duration::from_secs(2), batched.next())
+            .await
+            .expect("timed out")
+            .expect("stream ended");
+        assert_eq!(batch, vec![7]);
+
+        let end = tokio::time::timeout(Duration::from_secs(2), batched.next())
+            .await
+            .expect("timed out");
+        assert!(end.is_none());
+    }
+
+    #[tokio::test]
+    async fn empty_batches_are_never_emitted() {
+        let (tx, rx) = mpsc::channel::<u8>(1);
+        let mut batched = ReceiverStream::new(rx).batched(Duration::from_millis(20));
+
+        let idle = tokio::time::timeout(Duration::from_millis(150), batched.next()).await;
+        assert!(idle.is_err(), "idle source must not emit empty batches");
+        drop(tx);
+    }
+}

--- a/src/streaming/batch.rs
+++ b/src/streaming/batch.rs
@@ -6,13 +6,12 @@
 //! `Stream` adapter, so it composes with every handle in this module instead
 //! of being a per-stream delivery mode.
 
-use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
 use futures::stream::Stream;
-use tokio::time::{Instant, Sleep, sleep_until};
+use tokio_stream::adapters::ChunksTimeout;
 
 /// Default cap on items per batch when none is given.
 const DEFAULT_MAX_BATCH: usize = 512;
@@ -22,82 +21,41 @@ const DEFAULT_MAX_BATCH: usize = 512;
 /// A batch is emitted when the window since the batch's first item elapses, or
 /// as soon as `max_items` is reached — whichever comes first. Empty batches are
 /// never emitted, and any partial batch is flushed when the source ends.
+///
+/// Boxed rather than a plain newtype so the handle stays `Unpin` — callers
+/// `.next()` it directly, without pinning it first.
 pub struct Batched<S>
 where
     S: Stream,
 {
-    inner: S,
-    window: Duration,
-    max_items: usize,
-    buffer: Vec<S::Item>,
-    deadline: Option<Pin<Box<Sleep>>>,
-    exhausted: bool,
+    inner: Pin<Box<ChunksTimeout<S>>>,
 }
 
 impl<S> Batched<S>
 where
-    S: Stream + Unpin,
+    S: Stream,
 {
     /// Batch `inner` over `window`, emitting early once `max_items` accumulate.
     pub fn new(inner: S, window: Duration, max_items: usize) -> Self {
-        Self {
-            inner,
-            window,
-            max_items: max_items.max(1),
-            buffer: Vec::new(),
-            deadline: None,
-            exhausted: false,
-        }
-    }
+        // Scoped: a module-level import would collide with `futures::StreamExt`.
+        use tokio_stream::StreamExt as _;
 
-    fn take_batch(&mut self) -> Vec<S::Item> {
-        self.deadline = None;
-        std::mem::take(&mut self.buffer)
+        Self {
+            // `chunks_timeout` panics on a zero cap; a zero-sized batch is
+            // meaningless, so clamp rather than propagate the panic.
+            inner: Box::pin(inner.chunks_timeout(max_items.max(1), window)),
+        }
     }
 }
 
 impl<S> Stream for Batched<S>
 where
-    S: Stream + Unpin,
-    S::Item: Unpin,
+    S: Stream,
 {
     type Item = Vec<S::Item>;
 
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let this = self.get_mut();
-
-        loop {
-            if this.exhausted {
-                return if this.buffer.is_empty() {
-                    Poll::Ready(None)
-                } else {
-                    Poll::Ready(Some(this.take_batch()))
-                };
-            }
-
-            match Pin::new(&mut this.inner).poll_next(cx) {
-                Poll::Ready(Some(item)) => {
-                    this.buffer.push(item);
-                    if this.deadline.is_none() {
-                        this.deadline = Some(Box::pin(sleep_until(Instant::now() + this.window)));
-                    }
-                    if this.buffer.len() >= this.max_items {
-                        return Poll::Ready(Some(this.take_batch()));
-                    }
-                }
-                Poll::Ready(None) => this.exhausted = true,
-                Poll::Pending => break,
-            }
-        }
-
-        // Source is idle: emit once the current batch's window expires.
-        if let Some(deadline) = this.deadline.as_mut()
-            && deadline.as_mut().poll(cx).is_ready()
-        {
-            return Poll::Ready(Some(this.take_batch()));
-        }
-
-        Poll::Pending
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.inner.as_mut().poll_next(cx)
     }
 }
 

--- a/src/streaming/book.rs
+++ b/src/streaming/book.rs
@@ -1,0 +1,259 @@
+//! Order-book (level 2) depth streaming.
+//!
+//! Top-of-book bid/ask is all [`PriceUpdate`](super::PriceUpdate) can carry;
+//! this stream pushes the full ladder of price levels per side.
+
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use futures::stream::Stream;
+use serde::{Deserialize, Serialize};
+
+use super::client::StreamResult;
+use super::handle::SourceStream;
+use super::polygon::PolygonBookSource;
+
+/// Reconnection backoff, matching [`PriceStream`](super::PriceStream).
+const RECONNECT_BACKOFF_SECS: u64 = 3;
+
+/// Channel capacity — book updates are large but less frequent than prints.
+const CHANNEL_CAPACITY: usize = 1024;
+
+/// One price level of an order book.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct BookLevel {
+    /// Level price.
+    pub price: f64,
+    /// Total size resting at this price.
+    pub size: f64,
+}
+
+/// A depth-of-book update: both sides, best level first.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct OrderBookUpdate {
+    /// Symbol or pair this book belongs to.
+    pub symbol: String,
+    /// Bid levels, highest price first.
+    pub bids: Vec<BookLevel>,
+    /// Ask levels, lowest price first.
+    pub asks: Vec<BookLevel>,
+    /// Exchange identifier, where the venue reports one.
+    pub exchange: Option<i32>,
+    /// Update timestamp (milliseconds).
+    pub time: i64,
+}
+
+impl OrderBookUpdate {
+    /// Best (highest) bid level.
+    pub fn best_bid(&self) -> Option<BookLevel> {
+        self.bids.first().copied()
+    }
+
+    /// Best (lowest) ask level.
+    pub fn best_ask(&self) -> Option<BookLevel> {
+        self.asks.first().copied()
+    }
+
+    /// Difference between best ask and best bid.
+    pub fn spread(&self) -> Option<f64> {
+        Some(self.best_ask()?.price - self.best_bid()?.price)
+    }
+
+    /// Midpoint of the top of book.
+    pub fn mid(&self) -> Option<f64> {
+        Some((self.best_ask()?.price + self.best_bid()?.price) / 2.0)
+    }
+
+    /// Total size resting on each side, as `(bid_depth, ask_depth)`.
+    pub fn depth(&self) -> (f64, f64) {
+        (
+            self.bids.iter().map(|l| l.size).sum(),
+            self.asks.iter().map(|l| l.size).sum(),
+        )
+    }
+}
+
+/// A subscription to level-2 order-book depth.
+///
+/// Backed by Polygon's crypto level-2 feed (`XL2`) — the one cluster that
+/// publishes depth — so pairs are crypto pairs (`"BTC-USD"`). Requires the
+/// `polygon` feature and [`polygon::init`](crate::polygon::init).
+///
+/// # Example
+///
+/// ```no_run
+/// use finance_query::streaming::DepthStream;
+/// use futures::StreamExt;
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut books = DepthStream::subscribe(["BTC-USD"]).await?;
+///
+/// while let Some(book) = books.next().await {
+///     println!("{} spread {:?}", book.symbol, book.spread());
+/// }
+/// # Ok(())
+/// # }
+/// ```
+pub struct DepthStream {
+    inner: SourceStream<OrderBookUpdate>,
+}
+
+impl DepthStream {
+    /// Subscribe to depth updates for the given crypto pairs.
+    pub async fn subscribe<S, I>(pairs: I) -> StreamResult<Self>
+    where
+        S: Into<String>,
+        I: IntoIterator<Item = S>,
+    {
+        DepthStreamBuilder::new().pairs(pairs).build().await
+    }
+
+    /// Create an independent receiver sharing this subscription's connection.
+    pub fn resubscribe(&self) -> Self {
+        DepthStream {
+            inner: self.inner.resubscribe(),
+        }
+    }
+
+    /// Add pairs to the subscription.
+    pub async fn add_pairs<S, I>(&self, pairs: I)
+    where
+        S: Into<String>,
+        I: IntoIterator<Item = S>,
+    {
+        self.inner.add(pairs).await;
+    }
+
+    /// Remove pairs from the subscription.
+    pub async fn remove_pairs<S, I>(&self, pairs: I)
+    where
+        S: Into<String>,
+        I: IntoIterator<Item = S>,
+    {
+        self.inner.remove(pairs).await;
+    }
+
+    /// Close the stream and disconnect.
+    pub async fn close(&self) {
+        self.inner.close().await;
+    }
+}
+
+impl Stream for DepthStream {
+    type Item = OrderBookUpdate;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.inner).poll_next(cx)
+    }
+}
+
+/// Builder for a [`DepthStream`].
+pub struct DepthStreamBuilder {
+    pairs: Vec<String>,
+    retry_delay: Duration,
+}
+
+impl DepthStreamBuilder {
+    /// Create a builder with no pairs.
+    pub fn new() -> Self {
+        Self {
+            pairs: Vec::new(),
+            retry_delay: Duration::from_secs(RECONNECT_BACKOFF_SECS),
+        }
+    }
+
+    /// Add crypto pairs to subscribe to.
+    pub fn pairs<S, I>(mut self, pairs: I) -> Self
+    where
+        S: Into<String>,
+        I: IntoIterator<Item = S>,
+    {
+        self.pairs.extend(pairs.into_iter().map(Into::into));
+        self
+    }
+
+    /// Set the delay between reconnection attempts (default: 3s).
+    pub fn retry(mut self, delay: Duration) -> Self {
+        self.retry_delay = delay;
+        self
+    }
+
+    /// Build and start the stream.
+    pub async fn build(self) -> StreamResult<DepthStream> {
+        Ok(DepthStream {
+            inner: SourceStream::start(
+                Arc::new(PolygonBookSource),
+                self.pairs,
+                self.retry_delay,
+                CHANNEL_CAPACITY,
+            ),
+        })
+    }
+}
+
+impl Default for DepthStreamBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn book() -> OrderBookUpdate {
+        OrderBookUpdate {
+            symbol: "BTC-USD".into(),
+            bids: vec![
+                BookLevel {
+                    price: 100.0,
+                    size: 2.0,
+                },
+                BookLevel {
+                    price: 99.0,
+                    size: 3.0,
+                },
+            ],
+            asks: vec![
+                BookLevel {
+                    price: 101.0,
+                    size: 1.0,
+                },
+                BookLevel {
+                    price: 102.0,
+                    size: 4.0,
+                },
+            ],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn top_of_book_helpers_use_the_first_level() {
+        let book = book();
+        assert_eq!(book.best_bid().unwrap().price, 100.0);
+        assert_eq!(book.best_ask().unwrap().price, 101.0);
+        assert!((book.spread().unwrap() - 1.0).abs() < 1e-9);
+        assert!((book.mid().unwrap() - 100.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn depth_sums_each_side() {
+        let (bid_depth, ask_depth) = book().depth();
+        assert!((bid_depth - 5.0).abs() < 1e-9);
+        assert!((ask_depth - 5.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn an_empty_side_has_no_spread() {
+        let empty = OrderBookUpdate::default();
+        assert!(empty.spread().is_none());
+        assert!(empty.mid().is_none());
+    }
+}

--- a/src/streaming/book.rs
+++ b/src/streaming/book.rs
@@ -3,20 +3,14 @@
 //! Top-of-book bid/ask is all [`PriceUpdate`](super::PriceUpdate) can carry;
 //! this stream pushes the full ladder of price levels per side.
 
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context, Poll};
 use std::time::Duration;
 
-use futures::stream::Stream;
 use serde::{Deserialize, Serialize};
 
 use super::client::StreamResult;
-use super::handle::SourceStream;
+use super::handle::{RECONNECT_BACKOFF, SourceStream, stream_builder, stream_handle};
 use super::polygon::PolygonBookSource;
-
-/// Reconnection backoff, matching [`PriceStream`](super::PriceStream).
-const RECONNECT_BACKOFF_SECS: u64 = 3;
 
 /// Channel capacity — book updates are large but less frequent than prints.
 const CHANNEL_CAPACITY: usize = 1024;
@@ -79,29 +73,31 @@ impl OrderBookUpdate {
     }
 }
 
-/// A subscription to level-2 order-book depth.
-///
-/// Backed by Polygon's crypto level-2 feed (`XL2`) — the one cluster that
-/// publishes depth — so pairs are crypto pairs (`"BTC-USD"`). Requires the
-/// `polygon` feature and [`polygon::init`](crate::polygon::init).
-///
-/// # Example
-///
-/// ```no_run
-/// use finance_query::streaming::DepthStream;
-/// use futures::StreamExt;
-///
-/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// let mut books = DepthStream::subscribe(["BTC-USD"]).await?;
-///
-/// while let Some(book) = books.next().await {
-///     println!("{} spread {:?}", book.symbol, book.spread());
-/// }
-/// # Ok(())
-/// # }
-/// ```
-pub struct DepthStream {
-    inner: SourceStream<OrderBookUpdate>,
+stream_handle! {
+    /// A subscription to level-2 order-book depth.
+    ///
+    /// Backed by Polygon's crypto level-2 feed (`XL2`) — the one cluster that
+    /// publishes depth — so pairs are crypto pairs (`"BTC-USD"`). Requires the
+    /// `polygon` feature and [`polygon::init`](crate::polygon::init).
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use finance_query::streaming::DepthStream;
+    /// use futures::StreamExt;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut books = DepthStream::subscribe(["BTC-USD"]).await?;
+    ///
+    /// while let Some(book) = books.next().await {
+    ///     println!("{} spread {:?}", book.symbol, book.spread());
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    DepthStream(OrderBookUpdate);
+    add: add_pairs = "Add pairs to the subscription.",
+    remove: remove_pairs = "Remove pairs from the subscription.",
 }
 
 impl DepthStream {
@@ -112,44 +108,6 @@ impl DepthStream {
         I: IntoIterator<Item = S>,
     {
         DepthStreamBuilder::new().pairs(pairs).build().await
-    }
-
-    /// Create an independent receiver sharing this subscription's connection.
-    pub fn resubscribe(&self) -> Self {
-        DepthStream {
-            inner: self.inner.resubscribe(),
-        }
-    }
-
-    /// Add pairs to the subscription.
-    pub async fn add_pairs<S, I>(&self, pairs: I)
-    where
-        S: Into<String>,
-        I: IntoIterator<Item = S>,
-    {
-        self.inner.add(pairs).await;
-    }
-
-    /// Remove pairs from the subscription.
-    pub async fn remove_pairs<S, I>(&self, pairs: I)
-    where
-        S: Into<String>,
-        I: IntoIterator<Item = S>,
-    {
-        self.inner.remove(pairs).await;
-    }
-
-    /// Close the stream and disconnect.
-    pub async fn close(&self) {
-        self.inner.close().await;
-    }
-}
-
-impl Stream for DepthStream {
-    type Item = OrderBookUpdate;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        Pin::new(&mut self.inner).poll_next(cx)
     }
 }
 
@@ -164,24 +122,8 @@ impl DepthStreamBuilder {
     pub fn new() -> Self {
         Self {
             pairs: Vec::new(),
-            retry_delay: Duration::from_secs(RECONNECT_BACKOFF_SECS),
+            retry_delay: RECONNECT_BACKOFF,
         }
-    }
-
-    /// Add crypto pairs to subscribe to.
-    pub fn pairs<S, I>(mut self, pairs: I) -> Self
-    where
-        S: Into<String>,
-        I: IntoIterator<Item = S>,
-    {
-        self.pairs.extend(pairs.into_iter().map(Into::into));
-        self
-    }
-
-    /// Set the delay between reconnection attempts (default: 3s).
-    pub fn retry(mut self, delay: Duration) -> Self {
-        self.retry_delay = delay;
-        self
     }
 
     /// Build and start the stream.
@@ -197,11 +139,10 @@ impl DepthStreamBuilder {
     }
 }
 
-impl Default for DepthStreamBuilder {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+stream_builder!(
+    DepthStreamBuilder,
+    pairs = "Add crypto pairs to subscribe to."
+);
 
 #[cfg(test)]
 mod tests {

--- a/src/streaming/client.rs
+++ b/src/streaming/client.rs
@@ -11,9 +11,9 @@ use std::time::Duration;
 
 use futures::stream::Stream;
 
+use super::handle::SourceStream;
 use super::pricing::PriceUpdate;
-use super::source::{StreamCommand, StreamSource, run_stream_loop};
-use super::subscription::Subscription;
+use super::source::StreamSource;
 use super::yahoo::YahooStreamSource;
 use crate::error::FinanceError;
 
@@ -85,7 +85,7 @@ const CHANNEL_CAPACITY: usize = 1024;
 /// # }
 /// ```
 pub struct PriceStream {
-    inner: Subscription<PriceUpdate, StreamCommand>,
+    inner: SourceStream<PriceUpdate>,
 }
 
 impl PriceStream {
@@ -123,7 +123,7 @@ impl PriceStream {
     /// Yahoo is the default ([`subscribe`](Self::subscribe)); this is the
     /// generic entry point shared with [`PriceStreamBuilder`].
     pub(crate) async fn subscribe_with_source<S, I>(
-        source: Arc<dyn StreamSource>,
+        source: Arc<dyn StreamSource<PriceUpdate>>,
         symbols: I,
         retry_delay: Duration,
     ) -> StreamResult<Self>
@@ -133,22 +133,9 @@ impl PriceStream {
     {
         let initial_symbols: Vec<String> = symbols.into_iter().map(Into::into).collect();
 
-        let inner = Subscription::start(
-            CHANNEL_CAPACITY,
-            32,
-            move |broadcast_tx, command_rx| async move {
-                let _ = run_stream_loop(
-                    source,
-                    initial_symbols,
-                    broadcast_tx,
-                    command_rx,
-                    retry_delay,
-                )
-                .await;
-            },
-        );
-
-        Ok(PriceStream { inner })
+        Ok(PriceStream {
+            inner: SourceStream::start(source, initial_symbols, retry_delay, CHANNEL_CAPACITY),
+        })
     }
 
     /// Create a new receiver for this stream.
@@ -178,8 +165,7 @@ impl PriceStream {
         S: Into<String>,
         I: IntoIterator<Item = S>,
     {
-        let symbols: Vec<String> = symbols.into_iter().map(Into::into).collect();
-        self.inner.send(StreamCommand::Subscribe(symbols)).await;
+        self.inner.add(symbols).await;
     }
 
     /// Remove symbols from the subscription.
@@ -200,13 +186,12 @@ impl PriceStream {
         S: Into<String>,
         I: IntoIterator<Item = S>,
     {
-        let symbols: Vec<String> = symbols.into_iter().map(Into::into).collect();
-        self.inner.send(StreamCommand::Unsubscribe(symbols)).await;
+        self.inner.remove(symbols).await;
     }
 
     /// Close the stream and disconnect from the WebSocket.
     pub async fn close(&self) {
-        self.inner.send(StreamCommand::Close).await;
+        self.inner.close().await;
     }
 }
 
@@ -218,10 +203,27 @@ impl Stream for PriceStream {
     }
 }
 
+/// Which upstream backend a [`PriceStream`] connects to.
+///
+/// Yahoo multiplexes every asset class onto one connection; Polygon runs a
+/// separate cluster per asset class, so its variant carries the class to use.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub enum PriceSource {
+    /// Yahoo Finance WebSocket — keyless, all asset classes (default).
+    #[default]
+    Yahoo,
+    /// Polygon.io real-time cluster for one asset class. Requires
+    /// [`polygon::init`](crate::polygon::init).
+    #[cfg(feature = "polygon")]
+    Polygon(crate::streaming::AssetClass),
+}
+
 /// Builder for creating price streams with custom configuration
 pub struct PriceStreamBuilder {
     symbols: Vec<String>,
     retry_delay: Duration,
+    source: PriceSource,
 }
 
 impl PriceStreamBuilder {
@@ -230,7 +232,30 @@ impl PriceStreamBuilder {
         Self {
             symbols: Vec::new(),
             retry_delay: Duration::from_secs(RECONNECT_BACKOFF_SECS),
+            source: PriceSource::Yahoo,
         }
+    }
+
+    /// Choose the upstream backend (default: [`PriceSource::Yahoo`]).
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # #[cfg(feature = "polygon")]
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// use finance_query::streaming::{AssetClass, PriceSource, PriceStreamBuilder};
+    ///
+    /// let stream = PriceStreamBuilder::new()
+    ///     .symbols(["BTC-USD"])
+    ///     .source(PriceSource::Polygon(AssetClass::Crypto))
+    ///     .build()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn source(mut self, source: PriceSource) -> Self {
+        self.source = source;
+        self
     }
 
     /// Add symbols to subscribe to
@@ -249,14 +274,14 @@ impl PriceStreamBuilder {
         self
     }
 
-    /// Build and start the price stream (Yahoo-backed).
+    /// Build and start the price stream using the configured source.
     pub async fn build(self) -> StreamResult<PriceStream> {
-        PriceStream::subscribe_with_source(
-            Arc::new(YahooStreamSource),
-            self.symbols,
-            self.retry_delay,
-        )
-        .await
+        let source: Arc<dyn StreamSource<PriceUpdate>> = match self.source {
+            PriceSource::Yahoo => Arc::new(YahooStreamSource),
+            #[cfg(feature = "polygon")]
+            PriceSource::Polygon(class) => Arc::new(super::polygon::PolygonPriceSource::new(class)),
+        };
+        PriceStream::subscribe_with_source(source, self.symbols, self.retry_delay).await
     }
 }
 

--- a/src/streaming/economic.rs
+++ b/src/streaming/economic.rs
@@ -2,20 +2,20 @@
 //!
 //! Macro data has no push transport — series are revised on a publication
 //! calendar — so this is a poll loop that emits a purpose-built
-//! [`EconomicRelease`] only when a series' latest observation actually
+//! [`SeriesUpdate`] only when a series' latest observation actually
 //! changes, rather than pushing an unrelated price-tick shape.
 
 use std::collections::HashMap;
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::sync::Arc;
 use std::time::Duration;
 
-use futures::stream::Stream;
+use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{broadcast, mpsc};
 use tracing::warn;
 
-use super::subscription::Subscription;
+use super::handle::{SourceStream, stream_handle};
+use super::source::StreamCommand;
 
 /// Default interval between polls of all subscribed series.
 const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(900);
@@ -23,11 +23,15 @@ const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(900);
 /// Channel capacity — macro releases are rare compared to price ticks.
 const CHANNEL_CAPACITY: usize = 128;
 
+/// Concurrent FRED polls per tick — the adapter's own limiter still paces
+/// them, this only stops one slow series from serialising the rest.
+const POLL_CONCURRENCY: usize = 8;
+
 /// A newly published (or revised) observation for an economic series.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
-pub struct EconomicRelease {
+pub struct SeriesUpdate {
     /// Series identifier (e.g. `"FEDFUNDS"`, `"CPIAUCSL"`).
     pub series_id: String,
     /// Observation date as `YYYY-MM-DD`.
@@ -43,13 +47,6 @@ pub struct EconomicRelease {
     pub observed_at: i64,
 }
 
-/// Commands accepted by a running economic poll loop.
-enum EconomicCommand {
-    AddSeries(Vec<String>),
-    RemoveSeries(Vec<String>),
-    Close,
-}
-
 /// Fetches the latest observation for a series.
 ///
 /// A trait rather than a direct FRED call so the poll loop can be exercised
@@ -59,30 +56,32 @@ pub(crate) trait ReleaseSource: Send + Sync + 'static {
     async fn latest(&self, series_id: &str) -> Option<(String, Option<f64>)>;
 }
 
-/// A continuous subscription to economic-series releases.
-///
-/// Polls each subscribed series on an interval (15 minutes by default) and
-/// yields an [`EconomicRelease`] only when the latest observation is new or
-/// revised. Requires the `fred` feature and
-/// [`fred::init`](crate::fred::init).
-///
-/// # Example
-///
-/// ```no_run
-/// use finance_query::streaming::EconomicStream;
-/// use futures::StreamExt;
-///
-/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// let mut stream = EconomicStream::subscribe(["FEDFUNDS", "CPIAUCSL"]).await;
-///
-/// while let Some(release) = stream.next().await {
-///     println!("{} = {:?} ({})", release.series_id, release.value, release.date);
-/// }
-/// # Ok(())
-/// # }
-/// ```
-pub struct EconomicStream {
-    inner: Subscription<EconomicRelease, EconomicCommand>,
+stream_handle! {
+    /// A continuous subscription to economic-series releases.
+    ///
+    /// Polls each subscribed series on an interval (15 minutes by default) and
+    /// yields a [`SeriesUpdate`] only when the latest observation is new or
+    /// revised. Requires the `fred` feature and
+    /// [`fred::init`](crate::fred::init).
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use finance_query::streaming::EconomicStream;
+    /// use futures::StreamExt;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut stream = EconomicStream::subscribe(["FEDFUNDS", "CPIAUCSL"]).await;
+    ///
+    /// while let Some(release) = stream.next().await {
+    ///     println!("{} = {:?} ({})", release.series_id, release.value, release.date);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    EconomicStream(SeriesUpdate);
+    add: add_series = "Add series to the subscription.",
+    remove: remove_series = "Remove series from the subscription.",
 }
 
 impl EconomicStream {
@@ -96,54 +95,15 @@ impl EconomicStream {
     }
 
     pub(crate) fn start(
-        source: std::sync::Arc<dyn ReleaseSource>,
+        source: Arc<dyn ReleaseSource>,
         series: Vec<String>,
         poll_interval: Duration,
     ) -> Self {
-        let inner = Subscription::start(CHANNEL_CAPACITY, 32, move |broadcast_tx, command_rx| {
-            run_economic_loop(source, series, poll_interval, broadcast_tx, command_rx)
-        });
-        EconomicStream { inner }
-    }
-
-    /// Create an independent receiver sharing this subscription's poll loop.
-    pub fn resubscribe(&self) -> Self {
         EconomicStream {
-            inner: self.inner.resubscribe(),
+            inner: SourceStream::spawn(CHANNEL_CAPACITY, move |broadcast_tx, command_rx| {
+                run_economic_loop(source, series, poll_interval, broadcast_tx, command_rx)
+            }),
         }
-    }
-
-    /// Add series to the subscription.
-    pub async fn add_series<S, I>(&self, series: I)
-    where
-        S: Into<String>,
-        I: IntoIterator<Item = S>,
-    {
-        let series = series.into_iter().map(Into::into).collect();
-        self.inner.send(EconomicCommand::AddSeries(series)).await;
-    }
-
-    /// Remove series from the subscription.
-    pub async fn remove_series<S, I>(&self, series: I)
-    where
-        S: Into<String>,
-        I: IntoIterator<Item = S>,
-    {
-        let series = series.into_iter().map(Into::into).collect();
-        self.inner.send(EconomicCommand::RemoveSeries(series)).await;
-    }
-
-    /// Stop polling and close the stream.
-    pub async fn close(&self) {
-        self.inner.send(EconomicCommand::Close).await;
-    }
-}
-
-impl Stream for EconomicStream {
-    type Item = EconomicRelease;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        Pin::new(&mut self.inner).poll_next(cx)
     }
 }
 
@@ -181,7 +141,7 @@ impl EconomicStreamBuilder {
     /// Start the stream.
     pub async fn build(self) -> EconomicStream {
         EconomicStream::start(
-            std::sync::Arc::new(DefaultReleaseSource),
+            Arc::new(DefaultReleaseSource),
             self.series,
             self.poll_interval,
         )
@@ -194,29 +154,21 @@ impl Default for EconomicStreamBuilder {
     }
 }
 
-/// FRED-backed release source (no-op without the `fred` feature).
+/// FRED-backed release source.
 struct DefaultReleaseSource;
 
 #[async_trait::async_trait]
 impl ReleaseSource for DefaultReleaseSource {
-    #[cfg(feature = "fred")]
     async fn latest(&self, series_id: &str) -> Option<(String, Option<f64>)> {
-        match crate::adapters::fred::series(series_id).await {
-            Ok(series) => series
-                .observations
-                .last()
-                .map(|o| (o.date.clone(), o.value)),
+        // Only the newest observation matters here; the full series is decades
+        // of rows to discard.
+        match crate::adapters::fred::latest_observation(series_id).await {
+            Ok(observation) => observation.map(|o| (o.date, o.value)),
             Err(e) => {
                 warn!("economic stream poll failed for {series_id}: {e}");
                 None
             }
         }
-    }
-
-    #[cfg(not(feature = "fred"))]
-    async fn latest(&self, series_id: &str) -> Option<(String, Option<f64>)> {
-        warn!("economic stream needs the `fred` feature; ignoring {series_id}");
-        None
     }
 }
 
@@ -227,12 +179,39 @@ struct LastSeen {
     value: Option<f64>,
 }
 
+/// Poll one series, carrying its id through so results can be reordered.
+async fn poll_one(
+    source: Arc<dyn ReleaseSource>,
+    id: String,
+) -> (String, Option<(String, Option<f64>)>) {
+    let observation = source.latest(&id).await;
+    (id, observation)
+}
+
+/// Poll every subscribed series concurrently.
+///
+/// A serial loop would hold the poll arm for N round-trips, during which the
+/// loop cannot service subscribe/unsubscribe commands.
+async fn poll_all(
+    source: &Arc<dyn ReleaseSource>,
+    series: &[String],
+) -> Vec<(String, Option<(String, Option<f64>)>)> {
+    let mut polls = Vec::with_capacity(series.len());
+    for id in series {
+        polls.push(poll_one(Arc::clone(source), id.clone()));
+    }
+    futures::stream::iter(polls)
+        .buffer_unordered(POLL_CONCURRENCY)
+        .collect()
+        .await
+}
+
 async fn run_economic_loop(
-    source: std::sync::Arc<dyn ReleaseSource>,
+    source: Arc<dyn ReleaseSource>,
     initial_series: Vec<String>,
     poll_interval: Duration,
-    broadcast_tx: broadcast::Sender<EconomicRelease>,
-    mut command_rx: mpsc::Receiver<EconomicCommand>,
+    broadcast_tx: broadcast::Sender<SeriesUpdate>,
+    mut command_rx: mpsc::Receiver<StreamCommand>,
 ) {
     let mut series: Vec<String> = initial_series;
     let mut seen: HashMap<String, LastSeen> = HashMap::new();
@@ -243,12 +222,12 @@ async fn run_economic_loop(
     loop {
         tokio::select! {
             _ = ticker.tick() => {
-                for id in &series {
-                    let Some((date, value)) = source.latest(id).await else {
+                for (id, observation) in poll_all(&source, &series).await {
+                    let Some((date, value)) = observation else {
                         continue;
                     };
-                    let release = classify(id, &date, value, seen.get(id));
-                    seen.insert(id.clone(), LastSeen { date, value });
+                    let release = classify(&id, &date, value, seen.get(&id));
+                    seen.insert(id, LastSeen { date, value });
                     if let Some(release) = release {
                         let _ = broadcast_tx.send(release);
                     }
@@ -256,20 +235,20 @@ async fn run_economic_loop(
             }
             cmd = command_rx.recv() => {
                 match cmd {
-                    Some(EconomicCommand::AddSeries(added)) => {
+                    Some(StreamCommand::Subscribe(added)) => {
                         for id in added {
                             if !series.contains(&id) {
                                 series.push(id);
                             }
                         }
                     }
-                    Some(EconomicCommand::RemoveSeries(removed)) => {
+                    Some(StreamCommand::Unsubscribe(removed)) => {
                         series.retain(|id| !removed.contains(id));
                         for id in removed {
                             seen.remove(&id);
                         }
                     }
-                    Some(EconomicCommand::Close) | None => break,
+                    Some(StreamCommand::Close) | None => break,
                 }
             }
         }
@@ -285,13 +264,13 @@ fn classify(
     date: &str,
     value: Option<f64>,
     previous: Option<&LastSeen>,
-) -> Option<EconomicRelease> {
+) -> Option<SeriesUpdate> {
     let previous = previous?;
     let revision = previous.date == date;
     if revision && previous.value == value {
         return None;
     }
-    Some(EconomicRelease {
+    Some(SeriesUpdate {
         series_id: series_id.to_string(),
         date: date.to_string(),
         value,
@@ -304,8 +283,6 @@ fn classify(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use futures::StreamExt;
-    use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     /// Canned source: returns a scripted observation per poll, no network.

--- a/src/streaming/economic.rs
+++ b/src/streaming/economic.rs
@@ -1,0 +1,399 @@
+//! Economic-release streaming.
+//!
+//! Macro data has no push transport — series are revised on a publication
+//! calendar — so this is a poll loop that emits a purpose-built
+//! [`EconomicRelease`] only when a series' latest observation actually
+//! changes, rather than pushing an unrelated price-tick shape.
+
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use futures::stream::Stream;
+use serde::{Deserialize, Serialize};
+use tokio::sync::{broadcast, mpsc};
+use tracing::warn;
+
+use super::subscription::Subscription;
+
+/// Default interval between polls of all subscribed series.
+const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(900);
+
+/// Channel capacity — macro releases are rare compared to price ticks.
+const CHANNEL_CAPACITY: usize = 128;
+
+/// A newly published (or revised) observation for an economic series.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct EconomicRelease {
+    /// Series identifier (e.g. `"FEDFUNDS"`, `"CPIAUCSL"`).
+    pub series_id: String,
+    /// Observation date as `YYYY-MM-DD`.
+    pub date: String,
+    /// Newly published value, or `None` when the source reports a gap.
+    pub value: Option<f64>,
+    /// Value this release replaced: the prior observation, or the prior value
+    /// for the same date when the release is a revision.
+    pub previous_value: Option<f64>,
+    /// `true` when the same observation date was re-published with a new value.
+    pub revision: bool,
+    /// Unix timestamp (seconds) at which this release was observed.
+    pub observed_at: i64,
+}
+
+/// Commands accepted by a running economic poll loop.
+enum EconomicCommand {
+    AddSeries(Vec<String>),
+    RemoveSeries(Vec<String>),
+    Close,
+}
+
+/// Fetches the latest observation for a series.
+///
+/// A trait rather than a direct FRED call so the poll loop can be exercised
+/// without a socket.
+#[async_trait::async_trait]
+pub(crate) trait ReleaseSource: Send + Sync + 'static {
+    async fn latest(&self, series_id: &str) -> Option<(String, Option<f64>)>;
+}
+
+/// A continuous subscription to economic-series releases.
+///
+/// Polls each subscribed series on an interval (15 minutes by default) and
+/// yields an [`EconomicRelease`] only when the latest observation is new or
+/// revised. Requires the `fred` feature and
+/// [`fred::init`](crate::fred::init).
+///
+/// # Example
+///
+/// ```no_run
+/// use finance_query::streaming::EconomicStream;
+/// use futures::StreamExt;
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut stream = EconomicStream::subscribe(["FEDFUNDS", "CPIAUCSL"]).await;
+///
+/// while let Some(release) = stream.next().await {
+///     println!("{} = {:?} ({})", release.series_id, release.value, release.date);
+/// }
+/// # Ok(())
+/// # }
+/// ```
+pub struct EconomicStream {
+    inner: Subscription<EconomicRelease, EconomicCommand>,
+}
+
+impl EconomicStream {
+    /// Subscribe to the given series, polling every 15 minutes.
+    pub async fn subscribe<S, I>(series: I) -> Self
+    where
+        S: Into<String>,
+        I: IntoIterator<Item = S>,
+    {
+        EconomicStreamBuilder::new().series(series).build().await
+    }
+
+    pub(crate) fn start(
+        source: std::sync::Arc<dyn ReleaseSource>,
+        series: Vec<String>,
+        poll_interval: Duration,
+    ) -> Self {
+        let inner = Subscription::start(CHANNEL_CAPACITY, 32, move |broadcast_tx, command_rx| {
+            run_economic_loop(source, series, poll_interval, broadcast_tx, command_rx)
+        });
+        EconomicStream { inner }
+    }
+
+    /// Create an independent receiver sharing this subscription's poll loop.
+    pub fn resubscribe(&self) -> Self {
+        EconomicStream {
+            inner: self.inner.resubscribe(),
+        }
+    }
+
+    /// Add series to the subscription.
+    pub async fn add_series<S, I>(&self, series: I)
+    where
+        S: Into<String>,
+        I: IntoIterator<Item = S>,
+    {
+        let series = series.into_iter().map(Into::into).collect();
+        self.inner.send(EconomicCommand::AddSeries(series)).await;
+    }
+
+    /// Remove series from the subscription.
+    pub async fn remove_series<S, I>(&self, series: I)
+    where
+        S: Into<String>,
+        I: IntoIterator<Item = S>,
+    {
+        let series = series.into_iter().map(Into::into).collect();
+        self.inner.send(EconomicCommand::RemoveSeries(series)).await;
+    }
+
+    /// Stop polling and close the stream.
+    pub async fn close(&self) {
+        self.inner.send(EconomicCommand::Close).await;
+    }
+}
+
+impl Stream for EconomicStream {
+    type Item = EconomicRelease;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.inner).poll_next(cx)
+    }
+}
+
+/// Builder for an [`EconomicStream`] with a custom poll interval.
+pub struct EconomicStreamBuilder {
+    series: Vec<String>,
+    poll_interval: Duration,
+}
+
+impl EconomicStreamBuilder {
+    /// Create a builder with no series and the default 15-minute interval.
+    pub fn new() -> Self {
+        Self {
+            series: Vec::new(),
+            poll_interval: DEFAULT_POLL_INTERVAL,
+        }
+    }
+
+    /// Add series identifiers to poll.
+    pub fn series<S, I>(mut self, series: I) -> Self
+    where
+        S: Into<String>,
+        I: IntoIterator<Item = S>,
+    {
+        self.series.extend(series.into_iter().map(Into::into));
+        self
+    }
+
+    /// Set the interval between polls (default: 15 minutes).
+    pub fn poll_interval(mut self, interval: Duration) -> Self {
+        self.poll_interval = interval;
+        self
+    }
+
+    /// Start the stream.
+    pub async fn build(self) -> EconomicStream {
+        EconomicStream::start(
+            std::sync::Arc::new(DefaultReleaseSource),
+            self.series,
+            self.poll_interval,
+        )
+    }
+}
+
+impl Default for EconomicStreamBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// FRED-backed release source (no-op without the `fred` feature).
+struct DefaultReleaseSource;
+
+#[async_trait::async_trait]
+impl ReleaseSource for DefaultReleaseSource {
+    #[cfg(feature = "fred")]
+    async fn latest(&self, series_id: &str) -> Option<(String, Option<f64>)> {
+        match crate::adapters::fred::series(series_id).await {
+            Ok(series) => series
+                .observations
+                .last()
+                .map(|o| (o.date.clone(), o.value)),
+            Err(e) => {
+                warn!("economic stream poll failed for {series_id}: {e}");
+                None
+            }
+        }
+    }
+
+    #[cfg(not(feature = "fred"))]
+    async fn latest(&self, series_id: &str) -> Option<(String, Option<f64>)> {
+        warn!("economic stream needs the `fred` feature; ignoring {series_id}");
+        None
+    }
+}
+
+/// Last observation seen per series, used to detect new vs. revised releases.
+#[derive(Clone)]
+struct LastSeen {
+    date: String,
+    value: Option<f64>,
+}
+
+async fn run_economic_loop(
+    source: std::sync::Arc<dyn ReleaseSource>,
+    initial_series: Vec<String>,
+    poll_interval: Duration,
+    broadcast_tx: broadcast::Sender<EconomicRelease>,
+    mut command_rx: mpsc::Receiver<EconomicCommand>,
+) {
+    let mut series: Vec<String> = initial_series;
+    let mut seen: HashMap<String, LastSeen> = HashMap::new();
+
+    let mut ticker = tokio::time::interval(poll_interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    loop {
+        tokio::select! {
+            _ = ticker.tick() => {
+                for id in &series {
+                    let Some((date, value)) = source.latest(id).await else {
+                        continue;
+                    };
+                    let release = classify(id, &date, value, seen.get(id));
+                    seen.insert(id.clone(), LastSeen { date, value });
+                    if let Some(release) = release {
+                        let _ = broadcast_tx.send(release);
+                    }
+                }
+            }
+            cmd = command_rx.recv() => {
+                match cmd {
+                    Some(EconomicCommand::AddSeries(added)) => {
+                        for id in added {
+                            if !series.contains(&id) {
+                                series.push(id);
+                            }
+                        }
+                    }
+                    Some(EconomicCommand::RemoveSeries(removed)) => {
+                        series.retain(|id| !removed.contains(id));
+                        for id in removed {
+                            seen.remove(&id);
+                        }
+                    }
+                    Some(EconomicCommand::Close) | None => break,
+                }
+            }
+        }
+    }
+}
+
+/// Decide whether an observation is worth emitting.
+///
+/// The first poll of a series only records a baseline — emitting there would
+/// report every subscribe as a fresh release.
+fn classify(
+    series_id: &str,
+    date: &str,
+    value: Option<f64>,
+    previous: Option<&LastSeen>,
+) -> Option<EconomicRelease> {
+    let previous = previous?;
+    let revision = previous.date == date;
+    if revision && previous.value == value {
+        return None;
+    }
+    Some(EconomicRelease {
+        series_id: series_id.to_string(),
+        date: date.to_string(),
+        value,
+        previous_value: previous.value,
+        revision,
+        observed_at: chrono::Utc::now().timestamp(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Canned source: returns a scripted observation per poll, no network.
+    struct ScriptedSource {
+        observations: Vec<(String, Option<f64>)>,
+        calls: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl ReleaseSource for ScriptedSource {
+        async fn latest(&self, _series_id: &str) -> Option<(String, Option<f64>)> {
+            let idx = self.calls.fetch_add(1, Ordering::SeqCst);
+            self.observations.get(idx).cloned()
+        }
+    }
+
+    #[test]
+    fn first_observation_only_sets_a_baseline() {
+        assert!(classify("FEDFUNDS", "2026-01-01", Some(5.0), None).is_none());
+    }
+
+    #[test]
+    fn unchanged_observation_is_not_a_release() {
+        let last = LastSeen {
+            date: "2026-01-01".into(),
+            value: Some(5.0),
+        };
+        assert!(classify("FEDFUNDS", "2026-01-01", Some(5.0), Some(&last)).is_none());
+    }
+
+    #[test]
+    fn same_date_with_a_new_value_is_a_revision() {
+        let last = LastSeen {
+            date: "2026-01-01".into(),
+            value: Some(5.0),
+        };
+        let release = classify("FEDFUNDS", "2026-01-01", Some(5.25), Some(&last)).unwrap();
+        assert!(release.revision);
+        assert_eq!(release.previous_value, Some(5.0));
+        assert_eq!(release.value, Some(5.25));
+    }
+
+    #[test]
+    fn a_new_date_is_a_fresh_release() {
+        let last = LastSeen {
+            date: "2026-01-01".into(),
+            value: Some(5.0),
+        };
+        let release = classify("FEDFUNDS", "2026-02-01", Some(5.5), Some(&last)).unwrap();
+        assert!(!release.revision);
+        assert_eq!(release.date, "2026-02-01");
+    }
+
+    #[tokio::test]
+    async fn poll_loop_emits_only_changed_observations() {
+        let source = Arc::new(ScriptedSource {
+            observations: vec![
+                ("2026-01-01".into(), Some(5.0)),
+                ("2026-01-01".into(), Some(5.0)),
+                ("2026-02-01".into(), Some(5.5)),
+            ],
+            calls: AtomicUsize::new(0),
+        });
+
+        let mut stream = EconomicStream::start(
+            source,
+            vec!["FEDFUNDS".to_string()],
+            Duration::from_millis(10),
+        );
+
+        let release = tokio::time::timeout(Duration::from_secs(5), stream.next())
+            .await
+            .expect("timed out")
+            .expect("stream ended");
+        assert_eq!(release.date, "2026-02-01");
+        assert_eq!(release.previous_value, Some(5.0));
+        stream.close().await;
+    }
+
+    #[tokio::test]
+    async fn close_ends_the_stream() {
+        let source = Arc::new(ScriptedSource {
+            observations: Vec::new(),
+            calls: AtomicUsize::new(0),
+        });
+        let mut stream = EconomicStream::start(source, Vec::new(), Duration::from_millis(10));
+        stream.close().await;
+        let ended = tokio::time::timeout(Duration::from_secs(2), stream.next()).await;
+        assert!(matches!(ended, Ok(None)));
+    }
+}

--- a/src/streaming/handle.rs
+++ b/src/streaming/handle.rs
@@ -1,0 +1,93 @@
+//! Shared plumbing behind every public stream handle.
+//!
+//! Wraps the generic broadcast [`Subscription`] plus the reconnect loop into
+//! one reusable, item-generic handle so `PriceStream`, `TradeStream`,
+//! `DepthStream` and `OptionsChainStream` are thin newtypes over the same
+//! machinery rather than four copies of it.
+
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use futures::stream::Stream;
+
+use super::source::{StreamCommand, StreamSource, run_stream_loop};
+use super::subscription::Subscription;
+
+/// Command-channel depth: control messages are rare compared to data.
+const COMMAND_CAPACITY: usize = 32;
+
+/// A `Stream<Item = T>` fed by a [`StreamSource`] with automatic reconnection.
+pub(crate) struct SourceStream<T>
+where
+    T: Clone + Send + 'static,
+{
+    inner: Subscription<T, StreamCommand>,
+}
+
+impl<T> SourceStream<T>
+where
+    T: Clone + Send + 'static,
+{
+    /// Spawn the source's reconnect loop and return a handle to its output.
+    pub(crate) fn start(
+        source: Arc<dyn StreamSource<T>>,
+        symbols: Vec<String>,
+        retry_delay: Duration,
+        capacity: usize,
+    ) -> Self {
+        let inner = Subscription::start(
+            capacity,
+            COMMAND_CAPACITY,
+            move |broadcast_tx, command_rx| async move {
+                let _ =
+                    run_stream_loop(source, symbols, broadcast_tx, command_rx, retry_delay).await;
+            },
+        );
+        SourceStream { inner }
+    }
+
+    /// Create an independent receiver sharing the same background task.
+    pub(crate) fn resubscribe(&self) -> Self {
+        SourceStream {
+            inner: self.inner.resubscribe(),
+        }
+    }
+
+    /// Add symbols to the live subscription.
+    pub(crate) async fn add<S, I>(&self, symbols: I)
+    where
+        S: Into<String>,
+        I: IntoIterator<Item = S>,
+    {
+        let symbols: Vec<String> = symbols.into_iter().map(Into::into).collect();
+        self.inner.send(StreamCommand::Subscribe(symbols)).await;
+    }
+
+    /// Remove symbols from the live subscription.
+    pub(crate) async fn remove<S, I>(&self, symbols: I)
+    where
+        S: Into<String>,
+        I: IntoIterator<Item = S>,
+    {
+        let symbols: Vec<String> = symbols.into_iter().map(Into::into).collect();
+        self.inner.send(StreamCommand::Unsubscribe(symbols)).await;
+    }
+
+    /// Close the session and stop reconnecting.
+    pub(crate) async fn close(&self) {
+        self.inner.send(StreamCommand::Close).await;
+    }
+}
+
+impl<T> Stream for SourceStream<T>
+where
+    T: Clone + Send + 'static,
+{
+    type Item = T;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.inner).poll_next(cx)
+    }
+}

--- a/src/streaming/handle.rs
+++ b/src/streaming/handle.rs
@@ -2,21 +2,30 @@
 //!
 //! Wraps the generic broadcast [`Subscription`] plus the reconnect loop into
 //! one reusable, item-generic handle so `PriceStream`, `TradeStream`,
-//! `DepthStream` and `OptionsChainStream` are thin newtypes over the same
-//! machinery rather than four copies of it.
+//! `DepthStream`, `OptionsChainStream` and `EconomicStream` are thin newtypes
+//! over the same machinery rather than five copies of it. The
+//! [`stream_handle!`] and [`stream_builder!`] macros emit the delegating
+//! methods, `Stream` impl and builder boilerplate those newtypes would
+//! otherwise repeat verbatim.
 
+use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
 use futures::stream::Stream;
+use tokio::sync::{broadcast, mpsc};
 
 use super::source::{StreamCommand, StreamSource, run_stream_loop};
 use super::subscription::Subscription;
 
 /// Command-channel depth: control messages are rare compared to data.
 const COMMAND_CAPACITY: usize = 32;
+
+/// Delay between reconnection attempts, shared by every socket-backed handle.
+#[cfg(feature = "polygon")]
+pub(crate) const RECONNECT_BACKOFF: Duration = Duration::from_secs(3);
 
 /// A `Stream<Item = T>` fed by a [`StreamSource`] with automatic reconnection.
 pub(crate) struct SourceStream<T>
@@ -37,15 +46,23 @@ where
         retry_delay: Duration,
         capacity: usize,
     ) -> Self {
-        let inner = Subscription::start(
-            capacity,
-            COMMAND_CAPACITY,
-            move |broadcast_tx, command_rx| async move {
-                let _ =
-                    run_stream_loop(source, symbols, broadcast_tx, command_rx, retry_delay).await;
-            },
-        );
-        SourceStream { inner }
+        Self::spawn(capacity, move |broadcast_tx, command_rx| async move {
+            let _ = run_stream_loop(source, symbols, broadcast_tx, command_rx, retry_delay).await;
+        })
+    }
+
+    /// Spawn an arbitrary background loop behind the same handle API.
+    ///
+    /// For producers with no socket to reconnect (a poll loop, say) that still
+    /// want subscribe/unsubscribe/close and shared receivers.
+    pub(crate) fn spawn<F, Fut>(capacity: usize, run: F) -> Self
+    where
+        F: FnOnce(broadcast::Sender<T>, mpsc::Receiver<StreamCommand>) -> Fut,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        SourceStream {
+            inner: Subscription::start(capacity, COMMAND_CAPACITY, run),
+        }
     }
 
     /// Create an independent receiver sharing the same background task.
@@ -91,3 +108,106 @@ where
         Pin::new(&mut self.inner).poll_next(cx)
     }
 }
+
+/// Emit a public stream handle over [`SourceStream`].
+///
+/// The handles differ only in item type and in the noun their add/remove
+/// methods use, so everything else — the newtype, `resubscribe`, `close` and
+/// the `Stream` impl — is generated here instead of copied per file.
+#[cfg(any(feature = "polygon", feature = "fred"))]
+macro_rules! stream_handle {
+    (
+        $(#[$attr:meta])*
+        $name:ident($item:ty);
+        add: $add:ident = $add_doc:literal,
+        remove: $remove:ident = $remove_doc:literal,
+    ) => {
+        $(#[$attr])*
+        pub struct $name {
+            inner: $crate::streaming::handle::SourceStream<$item>,
+        }
+
+        impl $name {
+            /// Create an independent receiver sharing this subscription's
+            /// background task.
+            pub fn resubscribe(&self) -> Self {
+                Self {
+                    inner: self.inner.resubscribe(),
+                }
+            }
+
+            #[doc = $add_doc]
+            pub async fn $add<S, I>(&self, symbols: I)
+            where
+                S: Into<String>,
+                I: IntoIterator<Item = S>,
+            {
+                self.inner.add(symbols).await;
+            }
+
+            #[doc = $remove_doc]
+            pub async fn $remove<S, I>(&self, symbols: I)
+            where
+                S: Into<String>,
+                I: IntoIterator<Item = S>,
+            {
+                self.inner.remove(symbols).await;
+            }
+
+            /// Close the stream and stop its background task.
+            pub async fn close(&self) {
+                self.inner.close().await;
+            }
+        }
+
+        impl ::futures::stream::Stream for $name {
+            type Item = $item;
+
+            fn poll_next(
+                mut self: ::std::pin::Pin<&mut Self>,
+                cx: &mut ::std::task::Context<'_>,
+            ) -> ::std::task::Poll<Option<Self::Item>> {
+                ::futures::stream::Stream::poll_next(
+                    ::std::pin::Pin::new(&mut self.inner),
+                    cx,
+                )
+            }
+        }
+    };
+}
+
+/// Emit the symbol-accumulating setter, `retry` and `Default` for a builder
+/// whose fields are `$field: Vec<String>` and `retry_delay: Duration`.
+#[cfg(feature = "polygon")]
+macro_rules! stream_builder {
+    ($builder:ident, $field:ident = $doc:literal) => {
+        impl $builder {
+            #[doc = $doc]
+            pub fn $field<S, I>(mut self, symbols: I) -> Self
+            where
+                S: Into<String>,
+                I: IntoIterator<Item = S>,
+            {
+                self.$field.extend(symbols.into_iter().map(Into::into));
+                self
+            }
+
+            /// Set the delay between reconnection attempts (default: 3s).
+            pub fn retry(mut self, delay: ::std::time::Duration) -> Self {
+                self.retry_delay = delay;
+                self
+            }
+        }
+
+        impl Default for $builder {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+    };
+}
+
+#[cfg(feature = "polygon")]
+pub(crate) use stream_builder;
+#[cfg(any(feature = "polygon", feature = "fred"))]
+pub(crate) use stream_handle;

--- a/src/streaming/mod.rs
+++ b/src/streaming/mod.rs
@@ -39,13 +39,22 @@
 //! # }
 //! ```
 
+mod batch;
 mod client;
+mod economic;
+mod handle;
 mod news;
+#[cfg(feature = "polygon")]
+mod polygon;
 mod pricing;
 mod source;
 mod subscription;
 mod yahoo;
 
-pub use client::{PriceStream, PriceStreamBuilder, StreamError, StreamResult};
+pub use batch::{Batched, StreamBatchExt};
+pub use client::{PriceSource, PriceStream, PriceStreamBuilder, StreamError, StreamResult};
+pub use economic::{EconomicRelease, EconomicStream, EconomicStreamBuilder};
 pub use news::{NewsStream, NewsStreamBuilder};
+#[cfg(feature = "polygon")]
+pub use polygon::AssetClass;
 pub use pricing::{MarketHoursType, OptionType, PriceUpdate, QuoteType};

--- a/src/streaming/mod.rs
+++ b/src/streaming/mod.rs
@@ -44,6 +44,7 @@ mod batch;
 #[cfg(feature = "polygon")]
 mod book;
 mod client;
+#[cfg(feature = "fred")]
 mod economic;
 mod handle;
 mod news;
@@ -58,12 +59,16 @@ mod subscription;
 mod trades;
 mod yahoo;
 
-pub use alerts::{AlertCondition, AlertEvaluator, AlertEvent, AlertExt, AlertRule, AlertStream};
+pub use alerts::{
+    AlertCondition, AlertConditionKind, AlertEvaluator, AlertEvent, AlertExt, AlertRule,
+    AlertStream,
+};
 pub use batch::{Batched, StreamBatchExt};
 #[cfg(feature = "polygon")]
 pub use book::{BookLevel, DepthStream, DepthStreamBuilder, OrderBookUpdate};
 pub use client::{PriceSource, PriceStream, PriceStreamBuilder, StreamError, StreamResult};
-pub use economic::{EconomicRelease, EconomicStream, EconomicStreamBuilder};
+#[cfg(feature = "fred")]
+pub use economic::{EconomicStream, EconomicStreamBuilder, SeriesUpdate};
 pub use news::{NewsStream, NewsStreamBuilder};
 #[cfg(feature = "polygon")]
 pub use options::{Greeks, OptionContractUpdate, OptionsChainStream, OptionsChainStreamBuilder};

--- a/src/streaming/mod.rs
+++ b/src/streaming/mod.rs
@@ -39,6 +39,7 @@
 //! # }
 //! ```
 
+mod alerts;
 mod batch;
 #[cfg(feature = "polygon")]
 mod book;
@@ -57,6 +58,7 @@ mod subscription;
 mod trades;
 mod yahoo;
 
+pub use alerts::{AlertCondition, AlertEvaluator, AlertEvent, AlertExt, AlertRule, AlertStream};
 pub use batch::{Batched, StreamBatchExt};
 #[cfg(feature = "polygon")]
 pub use book::{BookLevel, DepthStream, DepthStreamBuilder, OrderBookUpdate};

--- a/src/streaming/mod.rs
+++ b/src/streaming/mod.rs
@@ -40,6 +40,8 @@
 //! ```
 
 mod batch;
+#[cfg(feature = "polygon")]
+mod book;
 mod client;
 mod economic;
 mod handle;
@@ -51,9 +53,13 @@ mod polygon;
 mod pricing;
 mod source;
 mod subscription;
+#[cfg(feature = "polygon")]
+mod trades;
 mod yahoo;
 
 pub use batch::{Batched, StreamBatchExt};
+#[cfg(feature = "polygon")]
+pub use book::{BookLevel, DepthStream, DepthStreamBuilder, OrderBookUpdate};
 pub use client::{PriceSource, PriceStream, PriceStreamBuilder, StreamError, StreamResult};
 pub use economic::{EconomicRelease, EconomicStream, EconomicStreamBuilder};
 pub use news::{NewsStream, NewsStreamBuilder};
@@ -62,3 +68,5 @@ pub use options::{Greeks, OptionContractUpdate, OptionsChainStream, OptionsChain
 #[cfg(feature = "polygon")]
 pub use polygon::AssetClass;
 pub use pricing::{MarketHoursType, OptionType, PriceUpdate, QuoteType};
+#[cfg(feature = "polygon")]
+pub use trades::{TradeStream, TradeStreamBuilder, TradeTick};

--- a/src/streaming/mod.rs
+++ b/src/streaming/mod.rs
@@ -45,6 +45,8 @@ mod economic;
 mod handle;
 mod news;
 #[cfg(feature = "polygon")]
+mod options;
+#[cfg(feature = "polygon")]
 mod polygon;
 mod pricing;
 mod source;
@@ -55,6 +57,8 @@ pub use batch::{Batched, StreamBatchExt};
 pub use client::{PriceSource, PriceStream, PriceStreamBuilder, StreamError, StreamResult};
 pub use economic::{EconomicRelease, EconomicStream, EconomicStreamBuilder};
 pub use news::{NewsStream, NewsStreamBuilder};
+#[cfg(feature = "polygon")]
+pub use options::{Greeks, OptionContractUpdate, OptionsChainStream, OptionsChainStreamBuilder};
 #[cfg(feature = "polygon")]
 pub use polygon::AssetClass;
 pub use pricing::{MarketHoursType, OptionType, PriceUpdate, QuoteType};

--- a/src/streaming/options.rs
+++ b/src/streaming/options.rs
@@ -4,21 +4,15 @@
 //! many contracts per underlying, each with its own quote, open interest and
 //! greeks — a shape a single-symbol price tick cannot carry.
 
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context, Poll};
 use std::time::Duration;
 
-use futures::stream::Stream;
 use serde::{Deserialize, Serialize};
 
 use super::client::StreamResult;
-use super::handle::SourceStream;
+use super::handle::{RECONNECT_BACKOFF, SourceStream, stream_builder, stream_handle};
 use super::polygon::PolygonOptionsSource;
 use super::pricing::OptionType;
-
-/// Reconnection backoff, matching [`PriceStream`](super::PriceStream).
-const RECONNECT_BACKOFF_SECS: u64 = 3;
 
 /// Channel capacity — a wide chain fans out many contracts per tick.
 const CHANNEL_CAPACITY: usize = 2048;
@@ -145,29 +139,31 @@ pub(crate) fn parse_contract_symbol(symbol: &str) -> Option<ContractParts> {
     })
 }
 
-/// A live subscription to one or more options chains.
-///
-/// Subscribe by underlying (`"AAPL"`) to follow the whole chain, or by full
-/// OCC symbol (`"O:AAPL250117C00150000"`) to follow single contracts.
-/// Requires the `polygon` feature and [`polygon::init`](crate::polygon::init).
-///
-/// # Example
-///
-/// ```no_run
-/// use finance_query::streaming::OptionsChainStream;
-/// use futures::StreamExt;
-///
-/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// let mut stream = OptionsChainStream::subscribe(["AAPL"]).await?;
-///
-/// while let Some(contract) = stream.next().await {
-///     println!("{} {:?}/{:?}", contract.contract_symbol, contract.bid, contract.ask);
-/// }
-/// # Ok(())
-/// # }
-/// ```
-pub struct OptionsChainStream {
-    inner: SourceStream<OptionContractUpdate>,
+stream_handle! {
+    /// A live subscription to one or more options chains.
+    ///
+    /// Subscribe by underlying (`"AAPL"`) to follow the whole chain, or by full
+    /// OCC symbol (`"O:AAPL250117C00150000"`) to follow single contracts.
+    /// Requires the `polygon` feature and [`polygon::init`](crate::polygon::init).
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use finance_query::streaming::OptionsChainStream;
+    /// use futures::StreamExt;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut stream = OptionsChainStream::subscribe(["AAPL"]).await?;
+    ///
+    /// while let Some(contract) = stream.next().await {
+    ///     println!("{} {:?}/{:?}", contract.contract_symbol, contract.bid, contract.ask);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    OptionsChainStream(OptionContractUpdate);
+    add: add = "Add underlyings or contracts to the subscription.",
+    remove: remove = "Remove underlyings or contracts from the subscription.",
 }
 
 impl OptionsChainStream {
@@ -181,44 +177,6 @@ impl OptionsChainStream {
             .underlyings(underlyings)
             .build()
             .await
-    }
-
-    /// Create an independent receiver sharing this subscription's connection.
-    pub fn resubscribe(&self) -> Self {
-        OptionsChainStream {
-            inner: self.inner.resubscribe(),
-        }
-    }
-
-    /// Add underlyings or contracts to the subscription.
-    pub async fn add<S, I>(&self, symbols: I)
-    where
-        S: Into<String>,
-        I: IntoIterator<Item = S>,
-    {
-        self.inner.add(symbols).await;
-    }
-
-    /// Remove underlyings or contracts from the subscription.
-    pub async fn remove<S, I>(&self, symbols: I)
-    where
-        S: Into<String>,
-        I: IntoIterator<Item = S>,
-    {
-        self.inner.remove(symbols).await;
-    }
-
-    /// Close the stream and disconnect.
-    pub async fn close(&self) {
-        self.inner.close().await;
-    }
-}
-
-impl Stream for OptionsChainStream {
-    type Item = OptionContractUpdate;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        Pin::new(&mut self.inner).poll_next(cx)
     }
 }
 
@@ -234,25 +192,9 @@ impl OptionsChainStreamBuilder {
     pub fn new() -> Self {
         Self {
             underlyings: Vec::new(),
-            retry_delay: Duration::from_secs(RECONNECT_BACKOFF_SECS),
+            retry_delay: RECONNECT_BACKOFF,
             greeks_refresh: Some(DEFAULT_GREEKS_REFRESH),
         }
-    }
-
-    /// Add underlyings (or full OCC contract symbols) to follow.
-    pub fn underlyings<S, I>(mut self, symbols: I) -> Self
-    where
-        S: Into<String>,
-        I: IntoIterator<Item = S>,
-    {
-        self.underlyings.extend(symbols.into_iter().map(Into::into));
-        self
-    }
-
-    /// Set the delay between reconnection attempts (default: 3s).
-    pub fn retry(mut self, delay: Duration) -> Self {
-        self.retry_delay = delay;
-        self
     }
 
     /// Interval between greeks/open-interest snapshot refreshes.
@@ -278,11 +220,10 @@ impl OptionsChainStreamBuilder {
     }
 }
 
-impl Default for OptionsChainStreamBuilder {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+stream_builder!(
+    OptionsChainStreamBuilder,
+    underlyings = "Add underlyings (or full OCC contract symbols) to follow."
+);
 
 #[cfg(test)]
 mod tests {

--- a/src/streaming/options.rs
+++ b/src/streaming/options.rs
@@ -1,0 +1,346 @@
+//! Live options-chain streaming.
+//!
+//! A dedicated stream type rather than a reuse of [`PriceUpdate`]: a chain is
+//! many contracts per underlying, each with its own quote, open interest and
+//! greeks — a shape a single-symbol price tick cannot carry.
+
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use futures::stream::Stream;
+use serde::{Deserialize, Serialize};
+
+use super::client::StreamResult;
+use super::handle::SourceStream;
+use super::polygon::PolygonOptionsSource;
+use super::pricing::OptionType;
+
+/// Reconnection backoff, matching [`PriceStream`](super::PriceStream).
+const RECONNECT_BACKOFF_SECS: u64 = 3;
+
+/// Channel capacity — a wide chain fans out many contracts per tick.
+const CHANNEL_CAPACITY: usize = 2048;
+
+/// Default interval between greeks/open-interest snapshot refreshes.
+const DEFAULT_GREEKS_REFRESH: Duration = Duration::from_secs(60);
+
+/// Option greeks for a contract.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct Greeks {
+    /// Rate of change of price with respect to the underlying.
+    pub delta: Option<f64>,
+    /// Rate of change of delta with respect to the underlying.
+    pub gamma: Option<f64>,
+    /// Rate of change of price with respect to time.
+    pub theta: Option<f64>,
+    /// Rate of change of price with respect to volatility.
+    pub vega: Option<f64>,
+}
+
+impl Greeks {
+    /// `true` when no greek was populated.
+    pub fn is_empty(&self) -> bool {
+        self.delta.is_none() && self.gamma.is_none() && self.theta.is_none() && self.vega.is_none()
+    }
+}
+
+/// A live update for one options contract.
+///
+/// Quote and trade fields arrive from the real-time WebSocket; `greeks`,
+/// `implied_volatility` and `open_interest` come from the periodic chain
+/// snapshot (see [`OptionsChainStreamBuilder::greeks_refresh`]) because the
+/// real-time feed does not carry them.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct OptionContractUpdate {
+    /// OCC contract symbol (e.g. `"O:AAPL250117C00150000"`).
+    pub contract_symbol: String,
+    /// Underlying symbol parsed from the contract (e.g. `"AAPL"`).
+    pub underlying: String,
+    /// Expiration date as a Unix timestamp (seconds).
+    pub expiration: Option<i64>,
+    /// Strike price.
+    pub strike: Option<f64>,
+    /// Call or put.
+    pub option_type: Option<OptionType>,
+    /// Best bid.
+    pub bid: Option<f64>,
+    /// Best bid size.
+    pub bid_size: Option<f64>,
+    /// Best ask.
+    pub ask: Option<f64>,
+    /// Best ask size.
+    pub ask_size: Option<f64>,
+    /// Last traded price.
+    pub last_price: Option<f64>,
+    /// Last traded size.
+    pub last_size: Option<f64>,
+    /// Day volume, when the snapshot supplies it.
+    pub volume: Option<i64>,
+    /// Open interest, from the snapshot refresh.
+    pub open_interest: Option<i64>,
+    /// Implied volatility, from the snapshot refresh.
+    pub implied_volatility: Option<f64>,
+    /// Greeks, from the snapshot refresh.
+    pub greeks: Option<Greeks>,
+    /// Event timestamp (milliseconds).
+    pub time: i64,
+}
+
+/// Contract metadata decoded from an OCC symbol.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct ContractParts {
+    pub(crate) underlying: String,
+    pub(crate) expiration: i64,
+    pub(crate) option_type: OptionType,
+    pub(crate) strike: f64,
+}
+
+/// Decode an OCC-style contract symbol (`O:AAPL250117C00150000`).
+///
+/// Returns `None` for anything that does not match the layout, so a malformed
+/// upstream ticker is skipped rather than mislabeled.
+pub(crate) fn parse_contract_symbol(symbol: &str) -> Option<ContractParts> {
+    let body = symbol.strip_prefix("O:").unwrap_or(symbol);
+    // Trailing fixed-width fields: 6 date + 1 type + 8 strike.
+    if body.len() < 16 {
+        return None;
+    }
+    let split = body.len() - 15;
+    let (underlying, rest) = body.split_at(split);
+    if underlying.is_empty() || !underlying.chars().all(|c| c.is_ascii_alphanumeric()) {
+        return None;
+    }
+
+    let (date, rest) = rest.split_at(6);
+    let (kind, strike) = rest.split_at(1);
+    if !date.chars().all(|c| c.is_ascii_digit()) || !strike.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+
+    let option_type = match kind {
+        "C" => OptionType::Call,
+        "P" => OptionType::Put,
+        _ => return None,
+    };
+
+    let year = 2000 + date[0..2].parse::<i32>().ok()?;
+    let month = date[2..4].parse::<u32>().ok()?;
+    let day = date[4..6].parse::<u32>().ok()?;
+    let expiration = chrono::NaiveDate::from_ymd_opt(year, month, day)?
+        .and_hms_opt(0, 0, 0)?
+        .and_utc()
+        .timestamp();
+
+    Some(ContractParts {
+        underlying: underlying.to_string(),
+        expiration,
+        option_type,
+        strike: strike.parse::<f64>().ok()? / 1000.0,
+    })
+}
+
+/// A live subscription to one or more options chains.
+///
+/// Subscribe by underlying (`"AAPL"`) to follow the whole chain, or by full
+/// OCC symbol (`"O:AAPL250117C00150000"`) to follow single contracts.
+/// Requires the `polygon` feature and [`polygon::init`](crate::polygon::init).
+///
+/// # Example
+///
+/// ```no_run
+/// use finance_query::streaming::OptionsChainStream;
+/// use futures::StreamExt;
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut stream = OptionsChainStream::subscribe(["AAPL"]).await?;
+///
+/// while let Some(contract) = stream.next().await {
+///     println!("{} {:?}/{:?}", contract.contract_symbol, contract.bid, contract.ask);
+/// }
+/// # Ok(())
+/// # }
+/// ```
+pub struct OptionsChainStream {
+    inner: SourceStream<OptionContractUpdate>,
+}
+
+impl OptionsChainStream {
+    /// Subscribe to the chains of the given underlyings.
+    pub async fn subscribe<S, I>(underlyings: I) -> StreamResult<Self>
+    where
+        S: Into<String>,
+        I: IntoIterator<Item = S>,
+    {
+        OptionsChainStreamBuilder::new()
+            .underlyings(underlyings)
+            .build()
+            .await
+    }
+
+    /// Create an independent receiver sharing this subscription's connection.
+    pub fn resubscribe(&self) -> Self {
+        OptionsChainStream {
+            inner: self.inner.resubscribe(),
+        }
+    }
+
+    /// Add underlyings or contracts to the subscription.
+    pub async fn add<S, I>(&self, symbols: I)
+    where
+        S: Into<String>,
+        I: IntoIterator<Item = S>,
+    {
+        self.inner.add(symbols).await;
+    }
+
+    /// Remove underlyings or contracts from the subscription.
+    pub async fn remove<S, I>(&self, symbols: I)
+    where
+        S: Into<String>,
+        I: IntoIterator<Item = S>,
+    {
+        self.inner.remove(symbols).await;
+    }
+
+    /// Close the stream and disconnect.
+    pub async fn close(&self) {
+        self.inner.close().await;
+    }
+}
+
+impl Stream for OptionsChainStream {
+    type Item = OptionContractUpdate;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.inner).poll_next(cx)
+    }
+}
+
+/// Builder for an [`OptionsChainStream`].
+pub struct OptionsChainStreamBuilder {
+    underlyings: Vec<String>,
+    retry_delay: Duration,
+    greeks_refresh: Option<Duration>,
+}
+
+impl OptionsChainStreamBuilder {
+    /// Create a builder with no symbols and default timings.
+    pub fn new() -> Self {
+        Self {
+            underlyings: Vec::new(),
+            retry_delay: Duration::from_secs(RECONNECT_BACKOFF_SECS),
+            greeks_refresh: Some(DEFAULT_GREEKS_REFRESH),
+        }
+    }
+
+    /// Add underlyings (or full OCC contract symbols) to follow.
+    pub fn underlyings<S, I>(mut self, symbols: I) -> Self
+    where
+        S: Into<String>,
+        I: IntoIterator<Item = S>,
+    {
+        self.underlyings.extend(symbols.into_iter().map(Into::into));
+        self
+    }
+
+    /// Set the delay between reconnection attempts (default: 3s).
+    pub fn retry(mut self, delay: Duration) -> Self {
+        self.retry_delay = delay;
+        self
+    }
+
+    /// Interval between greeks/open-interest snapshot refreshes.
+    ///
+    /// `None` disables them, leaving only WebSocket bid/ask/last (one REST
+    /// call per underlying per interval otherwise). Default: 60s.
+    pub fn greeks_refresh(mut self, interval: Option<Duration>) -> Self {
+        self.greeks_refresh = interval;
+        self
+    }
+
+    /// Build and start the stream.
+    pub async fn build(self) -> StreamResult<OptionsChainStream> {
+        let source = Arc::new(PolygonOptionsSource::new(self.greeks_refresh));
+        Ok(OptionsChainStream {
+            inner: SourceStream::start(
+                source,
+                self.underlyings,
+                self.retry_delay,
+                CHANNEL_CAPACITY,
+            ),
+        })
+    }
+}
+
+impl Default for OptionsChainStreamBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_a_call_contract_symbol() {
+        let parts = parse_contract_symbol("O:AAPL250117C00150000").expect("should parse");
+        assert_eq!(parts.underlying, "AAPL");
+        assert_eq!(parts.option_type, OptionType::Call);
+        assert!((parts.strike - 150.0).abs() < 1e-9);
+        // 2025-01-17T00:00:00Z
+        assert_eq!(parts.expiration, 1737072000);
+    }
+
+    #[test]
+    fn parses_a_put_and_a_fractional_strike() {
+        let parts = parse_contract_symbol("O:SPY261218P00512500").expect("should parse");
+        assert_eq!(parts.underlying, "SPY");
+        assert_eq!(parts.option_type, OptionType::Put);
+        assert!((parts.strike - 512.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn parses_without_the_o_prefix() {
+        assert_eq!(
+            parse_contract_symbol("AAPL250117C00150000")
+                .unwrap()
+                .underlying,
+            "AAPL"
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_symbols() {
+        for bad in [
+            "O:AAPL",
+            "AAPL250117X00150000",
+            "O:AAPL2501I7C00150000",
+            "",
+            "O:250117C00150000",
+        ] {
+            assert!(
+                parse_contract_symbol(bad).is_none(),
+                "expected {bad} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn greeks_report_emptiness() {
+        assert!(Greeks::default().is_empty());
+        assert!(
+            !Greeks {
+                delta: Some(0.5),
+                ..Default::default()
+            }
+            .is_empty()
+        );
+    }
+}

--- a/src/streaming/polygon/book.rs
+++ b/src/streaming/polygon/book.rs
@@ -1,0 +1,123 @@
+//! Polygon-backed level-2 depth source (crypto `XL2`).
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use tokio::sync::{RwLock, broadcast, mpsc};
+
+use crate::adapters::polygon::websocket::PolygonMessage;
+use crate::streaming::book::{BookLevel, OrderBookUpdate};
+use crate::streaming::client::StreamResult;
+use crate::streaming::source::{StreamCommand, StreamSource};
+
+use super::{AssetClass, run_polygon_session};
+
+/// Depth-of-book channel — only the crypto cluster publishes level 2.
+const BOOK_CHANNEL: &str = "XL2";
+
+/// Order-book source backed by Polygon's crypto level-2 feed.
+pub(crate) struct PolygonBookSource;
+
+#[async_trait::async_trait]
+impl StreamSource<OrderBookUpdate> for PolygonBookSource {
+    fn id(&self) -> &'static str {
+        "polygon-book"
+    }
+
+    async fn run_session(
+        &self,
+        subscriptions: &Arc<RwLock<HashSet<String>>>,
+        broadcast_tx: &broadcast::Sender<OrderBookUpdate>,
+        command_rx: &mut mpsc::Receiver<StreamCommand>,
+    ) -> StreamResult<()> {
+        run_polygon_session(
+            AssetClass::Crypto,
+            &[BOOK_CHANNEL],
+            subscriptions,
+            broadcast_tx,
+            command_rx,
+            |msg| to_book(msg).into_iter().collect(),
+        )
+        .await
+    }
+}
+
+/// Map a wire level-2 event onto the public book shape.
+///
+/// Sides are sorted defensively (bids high→low, asks low→high) so the
+/// top-of-book helpers hold regardless of upstream ordering.
+pub(crate) fn to_book(msg: PolygonMessage) -> Option<OrderBookUpdate> {
+    let PolygonMessage::Level2(book) = msg else {
+        return None;
+    };
+
+    let mut bids = levels(book.b.as_deref());
+    let mut asks = levels(book.a.as_deref());
+    bids.sort_by(|a, b| b.price.total_cmp(&a.price));
+    asks.sort_by(|a, b| a.price.total_cmp(&b.price));
+
+    Some(OrderBookUpdate {
+        symbol: book.pair.clone()?,
+        bids,
+        asks,
+        exchange: book.x,
+        time: book.t.unwrap_or_default(),
+    })
+}
+
+fn levels(side: Option<&[[f64; 2]]>) -> Vec<BookLevel> {
+    side.unwrap_or_default()
+        .iter()
+        .map(|[price, size]| BookLevel {
+            price: *price,
+            size: *size,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapters::polygon::websocket::parse_messages;
+
+    const FRAME: &str = r#"[{"ev":"XL2","pair":"BTC-USD","x":1,"t":1705363200000,
+        "b":[[99.0,3.0],[100.0,2.0]],
+        "a":[[102.0,4.0],[101.0,1.0]]}]"#;
+
+    #[test]
+    fn level2_frames_become_sorted_books() {
+        let book = parse_messages(FRAME)
+            .into_iter()
+            .find_map(to_book)
+            .expect("book dropped");
+
+        assert_eq!(book.symbol, "BTC-USD");
+        assert_eq!(book.exchange, Some(1));
+        assert_eq!(book.bids.len(), 2);
+        assert_eq!(book.best_bid().unwrap().price, 100.0);
+        assert_eq!(book.best_ask().unwrap().price, 101.0);
+        assert!((book.spread().unwrap() - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn a_one_sided_book_still_parses() {
+        let frame = r#"[{"ev":"XL2","pair":"ETH-USD","b":[[10.0,1.0]],"t":5}]"#;
+        let book = parse_messages(frame)
+            .into_iter()
+            .find_map(to_book)
+            .expect("book dropped");
+        assert!(book.asks.is_empty());
+        assert!(book.spread().is_none());
+    }
+
+    #[test]
+    fn non_book_events_are_ignored() {
+        let frame = r#"[{"ev":"XT","pair":"BTC-USD","p":1.0,"t":1}]"#;
+        assert!(
+            parse_messages(frame)
+                .into_iter()
+                .find_map(to_book)
+                .is_none()
+        );
+    }
+}

--- a/src/streaming/polygon/book.rs
+++ b/src/streaming/polygon/book.rs
@@ -10,7 +10,7 @@ use crate::streaming::book::{BookLevel, OrderBookUpdate};
 use crate::streaming::client::StreamResult;
 use crate::streaming::source::{StreamCommand, StreamSource};
 
-use super::{AssetClass, run_polygon_session};
+use super::{AssetClass, Decode, run_polygon_session};
 
 /// Depth-of-book channel — only the crypto cluster publishes level 2.
 const BOOK_CHANNEL: &str = "XL2";
@@ -36,7 +36,7 @@ impl StreamSource<OrderBookUpdate> for PolygonBookSource {
             subscriptions,
             broadcast_tx,
             command_rx,
-            |msg| to_book(msg).into_iter().collect(),
+            Decode(|msg| to_book(msg).into_iter().collect()),
         )
         .await
     }

--- a/src/streaming/polygon/mod.rs
+++ b/src/streaming/polygon/mod.rs
@@ -1,0 +1,208 @@
+//! Polygon.io-backed streaming sources.
+//!
+//! Polygon runs one WebSocket cluster per asset class, so each class gets a
+//! purpose-built source instead of riding a single generic feed. Everything
+//! here reuses the existing [`PolygonStream`] adapter — the only Polygon
+//! WebSocket client in the crate.
+
+mod price;
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use futures::StreamExt;
+use tokio::sync::{RwLock, broadcast, mpsc};
+use tracing::{debug, info, warn};
+
+use crate::adapters::polygon::websocket::{ClusterDTO, PolygonMessage, PolygonStream};
+
+use super::client::{StreamError, StreamResult};
+use super::source::{StreamCommand, apply_command};
+
+pub(crate) use price::PolygonPriceSource;
+
+/// Asset class of a Polygon real-time cluster.
+///
+/// Each variant is a separate upstream connection with its own channel
+/// vocabulary and symbol format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub enum AssetClass {
+    /// US equities and ETFs (`AAPL`).
+    #[default]
+    Stocks,
+    /// Options contracts in OCC format (`O:AAPL250117C00150000`).
+    Options,
+    /// Currency pairs (`EUR/USD`).
+    Forex,
+    /// Crypto pairs (`BTC-USD`).
+    Crypto,
+    /// Futures contracts (`ESZ4`).
+    Futures,
+    /// Index values (`I:SPX`).
+    Indices,
+}
+
+impl AssetClass {
+    pub(crate) fn cluster(self) -> ClusterDTO {
+        match self {
+            Self::Stocks => ClusterDTO::Stocks,
+            Self::Options => ClusterDTO::Options,
+            Self::Forex => ClusterDTO::Forex,
+            Self::Crypto => ClusterDTO::Crypto,
+            Self::Futures => ClusterDTO::Futures,
+            Self::Indices => ClusterDTO::Indices,
+        }
+    }
+
+    /// Channels carrying price-forming events for this class.
+    pub(crate) fn price_channels(self) -> &'static [&'static str] {
+        match self {
+            Self::Stocks | Self::Options | Self::Futures => &["T", "Q"],
+            Self::Forex => &["C", "CA"],
+            Self::Crypto => &["XT", "XQ"],
+            Self::Indices => &["V"],
+        }
+    }
+
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Stocks => "polygon-stocks",
+            Self::Options => "polygon-options",
+            Self::Forex => "polygon-forex",
+            Self::Crypto => "polygon-crypto",
+            Self::Futures => "polygon-futures",
+            Self::Indices => "polygon-indices",
+        }
+    }
+
+    /// Put a user-supplied symbol into the cluster's wire format.
+    pub(crate) fn wire_symbol(self, symbol: &str) -> String {
+        let symbol = symbol.trim();
+        match self {
+            Self::Indices if !symbol.starts_with("I:") => format!("I:{}", symbol.to_uppercase()),
+            Self::Options if !symbol.starts_with("O:") => format!("O:{}", symbol.to_uppercase()),
+            _ => symbol.to_uppercase(),
+        }
+    }
+}
+
+/// Expand `symbols` into `prefix.symbol` channel names.
+pub(crate) fn channels_for(
+    class: AssetClass,
+    prefixes: &[&str],
+    symbols: impl IntoIterator<Item = String>,
+) -> Vec<String> {
+    let symbols: Vec<String> = symbols
+        .into_iter()
+        .map(|s| class.wire_symbol(&s))
+        .filter(|s| !s.is_empty())
+        .collect();
+    prefixes
+        .iter()
+        .flat_map(|p| symbols.iter().map(move |s| format!("{p}.{s}")))
+        .collect()
+}
+
+/// Run one connected Polygon session, mapping wire events to `T` via `map`.
+///
+/// `map` is `FnMut` so sources can carry per-session state (e.g. merging a
+/// quote and a trade into one snapshot) without a second broadcast hop.
+pub(crate) async fn run_polygon_session<T, M>(
+    class: AssetClass,
+    prefixes: &[&str],
+    subscriptions: &Arc<RwLock<HashSet<String>>>,
+    broadcast_tx: &broadcast::Sender<T>,
+    command_rx: &mut mpsc::Receiver<StreamCommand>,
+    mut map: M,
+) -> StreamResult<()>
+where
+    T: Clone + Send + 'static,
+    M: FnMut(PolygonMessage) -> Vec<T> + Send,
+{
+    let initial: Vec<String> = subscriptions.read().await.iter().cloned().collect();
+    let channels = channels_for(class, prefixes, initial);
+    let channel_refs: Vec<&str> = channels.iter().map(String::as_str).collect();
+
+    let mut stream = PolygonStream::from_singleton()
+        .map_err(|e| StreamError::ConnectionFailed(e.to_string()))?
+        .cluster(class.cluster())
+        .subscribe(&channel_refs)
+        .build()
+        .await
+        .map_err(|e| StreamError::ConnectionFailed(e.to_string()))?;
+
+    let sender = stream.sender();
+    info!("Connected to Polygon {} cluster", class.label());
+
+    loop {
+        tokio::select! {
+            Some(msg) = stream.next() => {
+                match msg {
+                    PolygonMessage::Status(status) => debug!("polygon status: {status}"),
+                    PolygonMessage::Unknown(raw) => warn!("unparsed polygon frame: {raw}"),
+                    msg => {
+                        for item in map(msg) {
+                            let _ = broadcast_tx.send(item);
+                        }
+                    }
+                }
+            }
+
+            Some(cmd) = command_rx.recv() => {
+                let Some(changed) = apply_command(&cmd, subscriptions).await else {
+                    return Ok(());
+                };
+                if changed.is_empty() {
+                    continue;
+                }
+                let channels = channels_for(class, prefixes, changed);
+                let result = match cmd {
+                    StreamCommand::Subscribe(_) => sender.subscribe_channels(&channels).await,
+                    _ => sender.unsubscribe_channels(&channels).await,
+                };
+                if let Err(e) = result {
+                    return Err(StreamError::WebSocketError(e.to_string()));
+                }
+            }
+
+            else => break,
+        }
+    }
+
+    // Upstream ended without a Close command — reconnect.
+    Err(StreamError::WebSocketError(format!(
+        "{} connection closed",
+        class.label()
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wire_symbol_applies_cluster_prefixes() {
+        assert_eq!(AssetClass::Indices.wire_symbol("spx"), "I:SPX");
+        assert_eq!(AssetClass::Indices.wire_symbol("I:SPX"), "I:SPX");
+        assert_eq!(AssetClass::Stocks.wire_symbol("aapl"), "AAPL");
+        assert_eq!(AssetClass::Crypto.wire_symbol("btc-usd"), "BTC-USD");
+        assert_eq!(
+            AssetClass::Options.wire_symbol("AAPL250117C00150000"),
+            "O:AAPL250117C00150000"
+        );
+    }
+
+    #[test]
+    fn channels_expand_across_prefixes_and_symbols() {
+        let channels = channels_for(
+            AssetClass::Crypto,
+            &["XT", "XQ"],
+            ["btc-usd".to_string(), "eth-usd".to_string()],
+        );
+        assert_eq!(
+            channels,
+            vec!["XT.BTC-USD", "XT.ETH-USD", "XQ.BTC-USD", "XQ.ETH-USD"]
+        );
+    }
+}

--- a/src/streaming/polygon/mod.rs
+++ b/src/streaming/polygon/mod.rs
@@ -5,8 +5,10 @@
 //! here reuses the existing [`PolygonStream`] adapter — the only Polygon
 //! WebSocket client in the crate.
 
+mod book;
 mod options;
 mod price;
+mod trades;
 
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -20,8 +22,10 @@ use crate::adapters::polygon::websocket::{ClusterDTO, PolygonMessage, PolygonStr
 use super::client::{StreamError, StreamResult};
 use super::source::{StreamCommand, apply_command};
 
+pub(crate) use book::PolygonBookSource;
 pub(crate) use options::PolygonOptionsSource;
 pub(crate) use price::PolygonPriceSource;
+pub(crate) use trades::PolygonTradeSource;
 
 /// Asset class of a Polygon real-time cluster.
 ///
@@ -64,6 +68,16 @@ impl AssetClass {
             Self::Forex => &["C", "CA"],
             Self::Crypto => &["XT", "XQ"],
             Self::Indices => &["V"],
+        }
+    }
+
+    /// Channel carrying individual trade prints, where the class has one.
+    pub(crate) fn trade_channel(self) -> Option<&'static str> {
+        match self {
+            Self::Stocks | Self::Options | Self::Futures => Some("T"),
+            Self::Crypto => Some("XT"),
+            // Forex and indices publish no per-trade prints.
+            Self::Forex | Self::Indices => None,
         }
     }
 

--- a/src/streaming/polygon/mod.rs
+++ b/src/streaming/polygon/mod.rs
@@ -10,7 +10,7 @@ mod options;
 mod price;
 mod trades;
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use futures::StreamExt;
@@ -130,21 +130,63 @@ pub(crate) fn channels_for(
         .collect()
 }
 
-/// Run one connected Polygon session, mapping wire events to `T` via `map`.
+/// Decodes wire events into `T`, and drops any per-symbol state on unsubscribe.
 ///
-/// `map` is `FnMut` so sources can carry per-session state (e.g. merging a
-/// quote and a trade into one snapshot) without a second broadcast hop.
-pub(crate) async fn run_polygon_session<T, M>(
+/// Stateful because sources merge several event types into one snapshot per
+/// symbol; that state must not outlive the subscription that created it.
+pub(crate) trait SessionHandler<T>: Send {
+    /// Decode one wire event.
+    fn on_event(&mut self, msg: PolygonMessage) -> Vec<T>;
+
+    /// Forget state for symbols that just left the subscription set.
+    fn on_unsubscribe(&mut self, _removed: &[String]) {}
+}
+
+/// Adapts a stateless decode function to [`SessionHandler`].
+pub(crate) struct Decode<F>(pub(crate) F);
+
+impl<T, F> SessionHandler<T> for Decode<F>
+where
+    F: FnMut(PolygonMessage) -> Vec<T> + Send,
+{
+    fn on_event(&mut self, msg: PolygonMessage) -> Vec<T> {
+        (self.0)(msg)
+    }
+}
+
+/// `true` when a wire symbol — possibly an `O:AAPL*` wildcard — covers `key`.
+fn covers(pattern: &str, key: &str) -> bool {
+    match pattern.strip_suffix('*') {
+        Some(prefix) => key.starts_with(prefix),
+        None => key == pattern,
+    }
+}
+
+/// Drop per-symbol state for symbols that just left the subscription set.
+///
+/// Keys are wire symbols, so user input is normalised the same way the
+/// subscription was; an options wildcard prunes the whole chain it created.
+pub(crate) fn prune_symbols<V>(
+    state: &mut HashMap<String, V>,
+    class: AssetClass,
+    removed: &[String],
+) {
+    let patterns: Vec<String> = removed.iter().map(|s| class.wire_symbol(s)).collect();
+    state.retain(|key, _| !patterns.iter().any(|p| covers(p, key)));
+}
+
+/// Run one connected Polygon session, decoding wire events via `handler`.
+pub(crate) async fn run_polygon_session<T, H>(
     class: AssetClass,
     prefixes: &[&str],
     subscriptions: &Arc<RwLock<HashSet<String>>>,
     broadcast_tx: &broadcast::Sender<T>,
     command_rx: &mut mpsc::Receiver<StreamCommand>,
-    mut map: M,
+    mut handler: H,
 ) -> StreamResult<()>
 where
     T: Clone + Send + 'static,
-    M: FnMut(PolygonMessage) -> Vec<T> + Send,
+    H: SessionHandler<T>,
 {
     let initial: Vec<String> = subscriptions.read().await.iter().cloned().collect();
     let channels = channels_for(class, prefixes, initial);
@@ -168,7 +210,7 @@ where
                     PolygonMessage::Status(status) => debug!("polygon status: {status}"),
                     PolygonMessage::Unknown(raw) => warn!("unparsed polygon frame: {raw}"),
                     msg => {
-                        for item in map(msg) {
+                        for item in handler.on_event(msg) {
                             let _ = broadcast_tx.send(item);
                         }
                     }
@@ -182,10 +224,15 @@ where
                 if changed.is_empty() {
                     continue;
                 }
+                let subscribing = matches!(cmd, StreamCommand::Subscribe(_));
+                if !subscribing {
+                    handler.on_unsubscribe(&changed);
+                }
                 let channels = channels_for(class, prefixes, changed);
-                let result = match cmd {
-                    StreamCommand::Subscribe(_) => sender.subscribe_channels(&channels).await,
-                    _ => sender.unsubscribe_channels(&channels).await,
+                let result = if subscribing {
+                    sender.subscribe_channels(&channels).await
+                } else {
+                    sender.unsubscribe_channels(&channels).await
                 };
                 if let Err(e) = result {
                     return Err(StreamError::WebSocketError(e.to_string()));
@@ -219,6 +266,26 @@ mod tests {
         );
         assert_eq!(AssetClass::Options.wire_symbol("aapl"), "O:AAPL*");
         assert_eq!(AssetClass::Options.wire_symbol("O:AAPL*"), "O:AAPL*");
+    }
+
+    #[test]
+    fn pruning_drops_exact_and_wildcard_matches() {
+        let mut state: HashMap<String, u8> = HashMap::from([
+            ("O:AAPL250117C00150000".to_string(), 1),
+            ("O:AAPL250117P00150000".to_string(), 2),
+            ("O:SPY250117C00500000".to_string(), 3),
+        ]);
+
+        // A bare underlying was subscribed as the `O:AAPL*` wildcard, so it
+        // must take the whole chain with it.
+        prune_symbols(&mut state, AssetClass::Options, &["AAPL".to_string()]);
+        assert_eq!(state.len(), 1);
+        assert!(state.contains_key("O:SPY250117C00500000"));
+
+        let mut equities: HashMap<String, u8> =
+            HashMap::from([("AAPL".to_string(), 1), ("NVDA".to_string(), 2)]);
+        prune_symbols(&mut equities, AssetClass::Stocks, &["aapl".to_string()]);
+        assert_eq!(equities.keys().collect::<Vec<_>>(), vec!["NVDA"]);
     }
 
     #[test]

--- a/src/streaming/polygon/mod.rs
+++ b/src/streaming/polygon/mod.rs
@@ -5,6 +5,7 @@
 //! here reuses the existing [`PolygonStream`] adapter — the only Polygon
 //! WebSocket client in the crate.
 
+mod options;
 mod price;
 
 use std::collections::HashSet;
@@ -19,6 +20,7 @@ use crate::adapters::polygon::websocket::{ClusterDTO, PolygonMessage, PolygonStr
 use super::client::{StreamError, StreamResult};
 use super::source::{StreamCommand, apply_command};
 
+pub(crate) use options::PolygonOptionsSource;
 pub(crate) use price::PolygonPriceSource;
 
 /// Asset class of a Polygon real-time cluster.
@@ -77,12 +79,22 @@ impl AssetClass {
     }
 
     /// Put a user-supplied symbol into the cluster's wire format.
+    ///
+    /// A bare options underlying (no digits) becomes an `O:AAPL*` wildcard so
+    /// the whole chain is followed; a full OCC symbol stays exact.
     pub(crate) fn wire_symbol(self, symbol: &str) -> String {
-        let symbol = symbol.trim();
+        let symbol = symbol.trim().to_uppercase();
         match self {
-            Self::Indices if !symbol.starts_with("I:") => format!("I:{}", symbol.to_uppercase()),
-            Self::Options if !symbol.starts_with("O:") => format!("O:{}", symbol.to_uppercase()),
-            _ => symbol.to_uppercase(),
+            Self::Indices if !symbol.starts_with("I:") => format!("I:{symbol}"),
+            Self::Options => {
+                let body = symbol.strip_prefix("O:").unwrap_or(&symbol);
+                if body.chars().any(|c| c.is_ascii_digit()) {
+                    format!("O:{body}")
+                } else {
+                    format!("O:{}*", body.trim_end_matches('*'))
+                }
+            }
+            _ => symbol,
         }
     }
 }
@@ -191,6 +203,8 @@ mod tests {
             AssetClass::Options.wire_symbol("AAPL250117C00150000"),
             "O:AAPL250117C00150000"
         );
+        assert_eq!(AssetClass::Options.wire_symbol("aapl"), "O:AAPL*");
+        assert_eq!(AssetClass::Options.wire_symbol("O:AAPL*"), "O:AAPL*");
     }
 
     #[test]

--- a/src/streaming/polygon/options.rs
+++ b/src/streaming/polygon/options.rs
@@ -8,6 +8,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
+use futures::StreamExt;
 use tokio::sync::{RwLock, broadcast, mpsc};
 use tracing::warn;
 
@@ -19,7 +20,11 @@ use crate::streaming::options::{
 };
 use crate::streaming::source::{StreamCommand, StreamSource};
 
-use super::{AssetClass, run_polygon_session};
+use super::{AssetClass, SessionHandler, prune_symbols, run_polygon_session};
+
+/// Concurrent chain snapshots per refresh tick — Polygon's own rate limiter
+/// still paces the requests.
+const SNAPSHOT_CONCURRENCY: usize = 8;
 
 /// Live options-chain source backed by Polygon's options cluster.
 pub(crate) struct PolygonOptionsSource {
@@ -52,14 +57,13 @@ impl StreamSource<OptionContractUpdate> for PolygonOptionsSource {
             ))
         });
 
-        let mut merger = ContractMerger::default();
         let result = run_polygon_session(
             AssetClass::Options,
             AssetClass::Options.price_channels(),
             subscriptions,
             broadcast_tx,
             command_rx,
-            move |msg| merger.apply(msg).into_iter().collect(),
+            ContractMerger::default(),
         )
         .await;
 
@@ -77,6 +81,18 @@ pub(crate) struct ContractMerger {
     contracts: HashMap<String, OptionContractUpdate>,
 }
 
+impl SessionHandler<OptionContractUpdate> for ContractMerger {
+    fn on_event(&mut self, msg: PolygonMessage) -> Vec<OptionContractUpdate> {
+        self.apply(msg).into_iter().collect()
+    }
+
+    /// A wildcard subscription accumulates one entry per contract in the
+    /// chain — thousands per underlying if never pruned.
+    fn on_unsubscribe(&mut self, removed: &[String]) {
+        prune_symbols(&mut self.contracts, AssetClass::Options, removed);
+    }
+}
+
 impl ContractMerger {
     fn entry(&mut self, symbol: &str) -> Option<&mut OptionContractUpdate> {
         if !self.contracts.contains_key(symbol) {
@@ -91,8 +107,7 @@ impl ContractMerger {
     pub(crate) fn apply(&mut self, msg: PolygonMessage) -> Option<OptionContractUpdate> {
         match msg {
             PolygonMessage::Trade(trade) => {
-                let symbol = trade.symbol()?.to_string();
-                let contract = self.entry(&symbol)?;
+                let contract = self.entry(trade.symbol()?)?;
                 contract.last_price = trade.p.or(contract.last_price);
                 contract.last_size = trade.s.or(contract.last_size);
                 if let Some(t) = trade.t {
@@ -101,8 +116,7 @@ impl ContractMerger {
                 Some(contract.clone())
             }
             PolygonMessage::Quote(quote) => {
-                let symbol = quote.symbol()?.to_string();
-                let contract = self.entry(&symbol)?;
+                let contract = self.entry(quote.symbol()?)?;
                 contract.bid = quote.bp.or(contract.bid);
                 contract.ask = quote.ap.or(contract.ask);
                 contract.bid_size = quote.bs.or(contract.bid_size);
@@ -158,21 +172,31 @@ async fn refresh_snapshots(
         // Snapshot the set first — never hold the lock across the HTTP call.
         let subscribed: Vec<String> = subscriptions.read().await.iter().cloned().collect();
 
-        for underlying in underlyings(subscribed) {
-            match options_chain_snapshot(&underlying, &[("limit", "250")]).await {
-                Ok(page) => {
-                    for update in page
-                        .results
-                        .unwrap_or_default()
-                        .iter()
-                        .filter_map(snapshot_to_update)
-                    {
-                        let _ = broadcast_tx.send(update);
+        // Independent HTTP calls — serialising them would make one refresh
+        // tick take as long as the sum of every underlying's round-trip.
+        let sender = &broadcast_tx;
+        futures::stream::iter(underlyings(subscribed))
+            .map(|underlying| async move {
+                let page = options_chain_snapshot(&underlying, &[("limit", "250")]).await;
+                (underlying, page)
+            })
+            .buffer_unordered(SNAPSHOT_CONCURRENCY)
+            .for_each(|(underlying, page)| async move {
+                match page {
+                    Ok(page) => {
+                        for update in page
+                            .results
+                            .unwrap_or_default()
+                            .iter()
+                            .filter_map(snapshot_to_update)
+                        {
+                            let _ = sender.send(update);
+                        }
                     }
+                    Err(e) => warn!("options snapshot refresh failed for {underlying}: {e}"),
                 }
-                Err(e) => warn!("options snapshot refresh failed for {underlying}: {e}"),
-            }
-        }
+            })
+            .await;
     }
 }
 
@@ -292,6 +316,24 @@ mod tests {
         }))
         .expect("fixture should deserialize");
         assert!(snapshot_to_update(&dto).unwrap().greeks.is_none());
+    }
+
+    #[test]
+    fn unsubscribing_an_underlying_evicts_its_whole_chain() {
+        let mut merger = ContractMerger::default();
+        merger.apply(event(
+            r#"[{"ev":"T","sym":"O:AAPL250117C00150000","p":3.3,"t":1}]"#,
+        ));
+        merger.apply(event(
+            r#"[{"ev":"T","sym":"O:SPY261218P00512500","p":1.1,"t":2}]"#,
+        ));
+        assert_eq!(merger.contracts.len(), 2);
+
+        merger.on_unsubscribe(&["AAPL".to_string()]);
+        assert_eq!(
+            merger.contracts.keys().collect::<Vec<_>>(),
+            vec!["O:SPY261218P00512500"]
+        );
     }
 
     #[test]

--- a/src/streaming/polygon/options.rs
+++ b/src/streaming/polygon/options.rs
@@ -1,0 +1,307 @@
+//! Polygon-backed options-chain source.
+//!
+//! The real-time options cluster carries quotes and trades only, so greeks,
+//! implied volatility and open interest are folded in from a periodic chain
+//! snapshot on the REST side.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::{RwLock, broadcast, mpsc};
+use tracing::warn;
+
+use crate::adapters::polygon::options::snapshots::options_chain_snapshot;
+use crate::adapters::polygon::websocket::PolygonMessage;
+use crate::streaming::client::StreamResult;
+use crate::streaming::options::{
+    ContractParts, Greeks, OptionContractUpdate, parse_contract_symbol,
+};
+use crate::streaming::source::{StreamCommand, StreamSource};
+
+use super::{AssetClass, run_polygon_session};
+
+/// Live options-chain source backed by Polygon's options cluster.
+pub(crate) struct PolygonOptionsSource {
+    greeks_refresh: Option<Duration>,
+}
+
+impl PolygonOptionsSource {
+    pub(crate) fn new(greeks_refresh: Option<Duration>) -> Self {
+        Self { greeks_refresh }
+    }
+}
+
+#[async_trait::async_trait]
+impl StreamSource<OptionContractUpdate> for PolygonOptionsSource {
+    fn id(&self) -> &'static str {
+        "polygon-options"
+    }
+
+    async fn run_session(
+        &self,
+        subscriptions: &Arc<RwLock<HashSet<String>>>,
+        broadcast_tx: &broadcast::Sender<OptionContractUpdate>,
+        command_rx: &mut mpsc::Receiver<StreamCommand>,
+    ) -> StreamResult<()> {
+        let refresh = self.greeks_refresh.map(|interval| {
+            tokio::spawn(refresh_snapshots(
+                interval,
+                Arc::clone(subscriptions),
+                broadcast_tx.clone(),
+            ))
+        });
+
+        let mut merger = ContractMerger::default();
+        let result = run_polygon_session(
+            AssetClass::Options,
+            AssetClass::Options.price_channels(),
+            subscriptions,
+            broadcast_tx,
+            command_rx,
+            move |msg| merger.apply(msg).into_iter().collect(),
+        )
+        .await;
+
+        if let Some(handle) = refresh {
+            handle.abort();
+        }
+        result
+    }
+}
+
+/// Keeps the last known state per contract so a quote-only event still
+/// publishes the contract's most recent trade (and vice versa).
+#[derive(Default)]
+pub(crate) struct ContractMerger {
+    contracts: HashMap<String, OptionContractUpdate>,
+}
+
+impl ContractMerger {
+    fn entry(&mut self, symbol: &str) -> Option<&mut OptionContractUpdate> {
+        if !self.contracts.contains_key(symbol) {
+            let parts = parse_contract_symbol(symbol)?;
+            self.contracts
+                .insert(symbol.to_string(), new_contract(symbol, &parts));
+        }
+        self.contracts.get_mut(symbol)
+    }
+
+    /// Merge one wire event into the contract's snapshot.
+    pub(crate) fn apply(&mut self, msg: PolygonMessage) -> Option<OptionContractUpdate> {
+        match msg {
+            PolygonMessage::Trade(trade) => {
+                let symbol = trade.symbol()?.to_string();
+                let contract = self.entry(&symbol)?;
+                contract.last_price = trade.p.or(contract.last_price);
+                contract.last_size = trade.s.or(contract.last_size);
+                if let Some(t) = trade.t {
+                    contract.time = t;
+                }
+                Some(contract.clone())
+            }
+            PolygonMessage::Quote(quote) => {
+                let symbol = quote.symbol()?.to_string();
+                let contract = self.entry(&symbol)?;
+                contract.bid = quote.bp.or(contract.bid);
+                contract.ask = quote.ap.or(contract.ask);
+                contract.bid_size = quote.bs.or(contract.bid_size);
+                contract.ask_size = quote.ask_size.or(contract.ask_size);
+                if let Some(t) = quote.t {
+                    contract.time = t;
+                }
+                Some(contract.clone())
+            }
+            _ => None,
+        }
+    }
+}
+
+fn new_contract(symbol: &str, parts: &ContractParts) -> OptionContractUpdate {
+    OptionContractUpdate {
+        contract_symbol: symbol.to_string(),
+        underlying: parts.underlying.clone(),
+        expiration: Some(parts.expiration),
+        strike: Some(parts.strike),
+        option_type: Some(parts.option_type),
+        ..Default::default()
+    }
+}
+
+/// Underlyings to snapshot, derived from the live subscription set.
+fn underlyings(symbols: impl IntoIterator<Item = String>) -> Vec<String> {
+    let mut seen: Vec<String> = Vec::new();
+    for symbol in symbols {
+        let trimmed = symbol.trim_start_matches("O:").trim_end_matches('*');
+        let root = parse_contract_symbol(&symbol)
+            .map(|p| p.underlying)
+            .unwrap_or_else(|| trimmed.to_uppercase());
+        if !root.is_empty() && !seen.contains(&root) {
+            seen.push(root);
+        }
+    }
+    seen
+}
+
+/// Periodically fold greeks/IV/open interest from the REST chain snapshot
+/// into the same broadcast channel the WebSocket feeds.
+async fn refresh_snapshots(
+    interval: Duration,
+    subscriptions: Arc<RwLock<HashSet<String>>>,
+    broadcast_tx: broadcast::Sender<OptionContractUpdate>,
+) {
+    let mut ticker = tokio::time::interval(interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    loop {
+        ticker.tick().await;
+        // Snapshot the set first — never hold the lock across the HTTP call.
+        let subscribed: Vec<String> = subscriptions.read().await.iter().cloned().collect();
+
+        for underlying in underlyings(subscribed) {
+            match options_chain_snapshot(&underlying, &[("limit", "250")]).await {
+                Ok(page) => {
+                    for update in page
+                        .results
+                        .unwrap_or_default()
+                        .iter()
+                        .filter_map(snapshot_to_update)
+                    {
+                        let _ = broadcast_tx.send(update);
+                    }
+                }
+                Err(e) => warn!("options snapshot refresh failed for {underlying}: {e}"),
+            }
+        }
+    }
+}
+
+/// Map a REST chain snapshot entry onto the live update shape.
+pub(crate) fn snapshot_to_update(
+    snapshot: &crate::adapters::polygon::options::snapshots::OptionsSnapshotDTO,
+) -> Option<OptionContractUpdate> {
+    let details = snapshot.details.as_ref()?;
+    let symbol = details.ticker.clone()?;
+    let parts = parse_contract_symbol(&symbol)?;
+
+    let quote = snapshot.last_quote.as_ref();
+    let trade = snapshot.last_trade.as_ref();
+    let greeks = snapshot.greeks.as_ref().map(|g| Greeks {
+        delta: g.delta,
+        gamma: g.gamma,
+        theta: g.theta,
+        vega: g.vega,
+    });
+
+    Some(OptionContractUpdate {
+        contract_symbol: symbol,
+        underlying: parts.underlying,
+        expiration: Some(parts.expiration),
+        strike: details.strike_price.or(Some(parts.strike)),
+        option_type: Some(parts.option_type),
+        bid: quote.and_then(|q| q.bid),
+        bid_size: quote.and_then(|q| q.bid_size),
+        ask: quote.and_then(|q| q.ask),
+        ask_size: quote.and_then(|q| q.ask_size),
+        last_price: trade.and_then(|t| t.price),
+        last_size: trade.and_then(|t| t.size),
+        volume: snapshot
+            .day
+            .as_ref()
+            .and_then(|d| d.volume)
+            .map(|v| v as i64),
+        open_interest: snapshot.open_interest.map(|oi| oi as i64),
+        implied_volatility: snapshot.implied_volatility,
+        greeks: greeks.filter(|g| !g.is_empty()),
+        time: quote
+            .and_then(|q| q.last_updated)
+            .or_else(|| trade.and_then(|t| t.sip_timestamp))
+            .unwrap_or_default(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapters::polygon::options::snapshots::OptionsSnapshotDTO;
+    use crate::adapters::polygon::websocket::parse_messages;
+    use crate::streaming::pricing::OptionType;
+
+    fn event(frame: &str) -> PolygonMessage {
+        parse_messages(frame).remove(0)
+    }
+
+    #[test]
+    fn quote_and_trade_merge_into_one_contract() {
+        let mut merger = ContractMerger::default();
+        merger.apply(event(
+            r#"[{"ev":"Q","sym":"O:AAPL250117C00150000","bp":3.2,"bs":10,"ap":3.4,"as":12,"t":1}]"#,
+        ));
+        let update = merger
+            .apply(event(
+                r#"[{"ev":"T","sym":"O:AAPL250117C00150000","p":3.3,"s":5,"t":2}]"#,
+            ))
+            .expect("trade dropped");
+
+        assert_eq!(update.underlying, "AAPL");
+        assert_eq!(update.option_type, Some(OptionType::Call));
+        assert_eq!(update.strike, Some(150.0));
+        assert_eq!(update.bid, Some(3.2));
+        assert_eq!(update.ask, Some(3.4));
+        assert_eq!(update.last_price, Some(3.3));
+        assert_eq!(update.time, 2);
+    }
+
+    #[test]
+    fn unparsable_contract_symbols_are_skipped() {
+        let mut merger = ContractMerger::default();
+        assert!(
+            merger
+                .apply(event(
+                    r#"[{"ev":"T","sym":"NOT-A-CONTRACT","p":1.0,"t":1}]"#
+                ))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn snapshot_supplies_greeks_and_open_interest() {
+        let dto: OptionsSnapshotDTO = serde_json::from_value(serde_json::json!({
+            "details": {"ticker": "O:AAPL250117C00150000", "strike_price": 150.0,
+                        "contract_type": "call", "expiration_date": "2025-01-17"},
+            "greeks": {"delta": 0.55, "gamma": 0.02, "theta": -0.03, "vega": 0.11},
+            "implied_volatility": 0.28,
+            "open_interest": 4200,
+            "day": {"v": 1500.0},
+            "last_quote": {"bid": 3.2, "ask": 3.4, "last_updated": 99}
+        }))
+        .expect("fixture should deserialize");
+
+        let update = snapshot_to_update(&dto).expect("snapshot dropped");
+        assert_eq!(update.open_interest, Some(4200));
+        assert_eq!(update.implied_volatility, Some(0.28));
+        assert_eq!(update.greeks.unwrap().delta, Some(0.55));
+        assert_eq!(update.volume, Some(1500));
+        assert_eq!(update.time, 99);
+    }
+
+    #[test]
+    fn snapshot_without_greeks_leaves_the_field_unset() {
+        let dto: OptionsSnapshotDTO = serde_json::from_value(serde_json::json!({
+            "details": {"ticker": "O:AAPL250117C00150000"}
+        }))
+        .expect("fixture should deserialize");
+        assert!(snapshot_to_update(&dto).unwrap().greeks.is_none());
+    }
+
+    #[test]
+    fn underlyings_dedupe_across_wildcards_and_contracts() {
+        let roots = underlyings(vec![
+            "O:AAPL*".to_string(),
+            "AAPL".to_string(),
+            "O:AAPL250117C00150000".to_string(),
+            "O:SPY*".to_string(),
+        ]);
+        assert_eq!(roots, vec!["AAPL", "SPY"]);
+    }
+}

--- a/src/streaming/polygon/price.rs
+++ b/src/streaming/polygon/price.rs
@@ -1,0 +1,298 @@
+//! Polygon-backed [`PriceUpdate`] sources, one per asset class.
+//!
+//! Trades, quotes and aggregates arrive as separate events; the merger keeps
+//! the last snapshot per symbol so subscribers always see a complete tick
+//! rather than a partial one.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use tokio::sync::{RwLock, broadcast, mpsc};
+
+use crate::adapters::polygon::websocket::PolygonMessage;
+use crate::streaming::client::StreamResult;
+use crate::streaming::pricing::{MarketHoursType, PriceUpdate, QuoteType};
+use crate::streaming::source::{StreamCommand, StreamSource};
+
+use super::{AssetClass, run_polygon_session};
+
+/// Real-time price source backed by one Polygon cluster.
+pub(crate) struct PolygonPriceSource {
+    class: AssetClass,
+}
+
+impl PolygonPriceSource {
+    pub(crate) fn new(class: AssetClass) -> Self {
+        Self { class }
+    }
+}
+
+#[async_trait::async_trait]
+impl StreamSource<PriceUpdate> for PolygonPriceSource {
+    fn id(&self) -> &'static str {
+        self.class.label()
+    }
+
+    async fn run_session(
+        &self,
+        subscriptions: &Arc<RwLock<HashSet<String>>>,
+        broadcast_tx: &broadcast::Sender<PriceUpdate>,
+        command_rx: &mut mpsc::Receiver<StreamCommand>,
+    ) -> StreamResult<()> {
+        let mut merger = PriceMerger::new(self.class);
+        run_polygon_session(
+            self.class,
+            self.class.price_channels(),
+            subscriptions,
+            broadcast_tx,
+            command_rx,
+            move |msg| merger.apply(msg).into_iter().collect(),
+        )
+        .await
+    }
+}
+
+/// Folds per-event Polygon messages into one snapshot per symbol.
+pub(crate) struct PriceMerger {
+    quote_type: QuoteType,
+    snapshots: HashMap<String, PriceUpdate>,
+}
+
+impl PriceMerger {
+    pub(crate) fn new(class: AssetClass) -> Self {
+        Self {
+            quote_type: match class {
+                AssetClass::Stocks => QuoteType::Equity,
+                AssetClass::Options => QuoteType::Option,
+                AssetClass::Forex => QuoteType::Currency,
+                AssetClass::Crypto => QuoteType::Cryptocurrency,
+                AssetClass::Futures => QuoteType::Future,
+                AssetClass::Indices => QuoteType::Index,
+            },
+            snapshots: HashMap::new(),
+        }
+    }
+
+    fn entry(&mut self, symbol: &str) -> &mut PriceUpdate {
+        let quote_type = self.quote_type;
+        self.snapshots.entry(symbol.to_string()).or_insert_with(|| {
+            let mut update = PriceUpdate {
+                id: symbol.to_string(),
+                quote_type,
+                market_hours: MarketHoursType::RegularMarket,
+                ..Default::default()
+            };
+            update.currency = default_currency(symbol).to_string();
+            update
+        })
+    }
+
+    /// Merge one event, returning the updated snapshot when it carried a price.
+    pub(crate) fn apply(&mut self, msg: PolygonMessage) -> Option<PriceUpdate> {
+        match msg {
+            PolygonMessage::Trade(trade) => {
+                let symbol = trade.symbol()?.to_string();
+                let snapshot = self.entry(&symbol);
+                if let Some(p) = trade.p {
+                    snapshot.price = p as f32;
+                }
+                if let Some(s) = trade.s {
+                    snapshot.last_size = s as i64;
+                }
+                if let Some(x) = trade.x {
+                    snapshot.exchange = x.to_string();
+                }
+                if let Some(t) = trade.t {
+                    snapshot.time = t;
+                }
+                Some(snapshot.clone())
+            }
+            PolygonMessage::Quote(quote) => {
+                let symbol = quote.symbol()?.to_string();
+                let snapshot = self.entry(&symbol);
+                if let Some(bp) = quote.bp {
+                    snapshot.bid = bp as f32;
+                }
+                if let Some(ap) = quote.ap {
+                    snapshot.ask = ap as f32;
+                }
+                if let Some(bs) = quote.bs {
+                    snapshot.bid_size = bs as i64;
+                }
+                if let Some(a_s) = quote.ask_size {
+                    snapshot.ask_size = a_s as i64;
+                }
+                if let Some(t) = quote.t {
+                    snapshot.time = t;
+                }
+                // Quote-only symbols would otherwise never report a price.
+                if snapshot.price == 0.0 && snapshot.bid > 0.0 && snapshot.ask > 0.0 {
+                    snapshot.price = (snapshot.bid + snapshot.ask) / 2.0;
+                }
+                Some(snapshot.clone())
+            }
+            PolygonMessage::ForexQuote(quote) => {
+                let symbol = quote.p.clone()?;
+                let snapshot = self.entry(&symbol);
+                if let Some(b) = quote.b {
+                    snapshot.bid = b as f32;
+                }
+                if let Some(a) = quote.a {
+                    snapshot.ask = a as f32;
+                }
+                if let Some(t) = quote.t {
+                    snapshot.time = t;
+                }
+                if snapshot.bid > 0.0 && snapshot.ask > 0.0 {
+                    snapshot.price = (snapshot.bid + snapshot.ask) / 2.0;
+                }
+                Some(snapshot.clone())
+            }
+            PolygonMessage::Aggregate(agg) => {
+                let symbol = agg.symbol()?.to_string();
+                let snapshot = self.entry(&symbol);
+                if let Some(c) = agg.c {
+                    snapshot.price = c as f32;
+                }
+                if let Some(o) = agg.o {
+                    snapshot.open_price = o as f32;
+                }
+                if let Some(h) = agg.h {
+                    snapshot.day_high = snapshot.day_high.max(h as f32);
+                }
+                if let Some(l) = agg.l {
+                    snapshot.day_low = if snapshot.day_low == 0.0 {
+                        l as f32
+                    } else {
+                        snapshot.day_low.min(l as f32)
+                    };
+                }
+                if let Some(v) = agg.v {
+                    snapshot.day_volume = v as i64;
+                }
+                if let Some(e) = agg.e {
+                    snapshot.time = e;
+                }
+                recompute_change(snapshot);
+                Some(snapshot.clone())
+            }
+            PolygonMessage::IndexValue(index) => {
+                let symbol = index.ticker.clone()?;
+                let snapshot = self.entry(&symbol);
+                if let Some(val) = index.val {
+                    snapshot.price = val as f32;
+                }
+                if let Some(t) = index.t {
+                    snapshot.time = t;
+                }
+                Some(snapshot.clone())
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Intraday change against the session open — Polygon's real-time feed carries
+/// no previous close, so that field stays zero.
+fn recompute_change(snapshot: &mut PriceUpdate) {
+    if snapshot.open_price > 0.0 && snapshot.price > 0.0 {
+        snapshot.change = snapshot.price - snapshot.open_price;
+        snapshot.change_percent = snapshot.change / snapshot.open_price * 100.0;
+    }
+}
+
+/// Quote currency for pair-shaped symbols (`BTC-USD`, `EUR/USD`).
+fn default_currency(symbol: &str) -> &str {
+    symbol
+        .rsplit(['-', '/'])
+        .next()
+        .filter(|q| q.len() == 3 && *q != symbol)
+        .unwrap_or("USD")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapters::polygon::websocket::parse_messages;
+
+    fn events(frame: &str) -> Vec<PolygonMessage> {
+        parse_messages(frame)
+    }
+
+    #[test]
+    fn trade_then_quote_merge_into_one_snapshot() {
+        let mut merger = PriceMerger::new(AssetClass::Stocks);
+        let frame = r#"[{"ev":"T","sym":"AAPL","p":186.19,"s":100,"x":4,"t":1705363200000},
+                        {"ev":"Q","sym":"AAPL","bp":186.18,"bs":2,"ap":186.25,"as":3,"t":1705363200001}]"#;
+
+        let mut last = None;
+        for msg in events(frame) {
+            last = merger.apply(msg);
+        }
+
+        let snapshot = last.expect("no snapshot emitted");
+        assert_eq!(snapshot.id, "AAPL");
+        assert!((snapshot.price - 186.19).abs() < 0.01, "trade price kept");
+        assert!((snapshot.bid - 186.18).abs() < 0.01);
+        assert!((snapshot.ask - 186.25).abs() < 0.01);
+        assert_eq!(snapshot.quote_type, QuoteType::Equity);
+        assert_eq!(snapshot.time, 1705363200001);
+    }
+
+    #[test]
+    fn crypto_events_key_off_pair() {
+        let mut merger = PriceMerger::new(AssetClass::Crypto);
+        let frame = r#"[{"ev":"XT","pair":"BTC-USD","p":65000.5,"s":0.25,"t":1705363200000}]"#;
+        let snapshot = merger
+            .apply(events(frame).remove(0))
+            .expect("crypto trade dropped");
+        assert_eq!(snapshot.id, "BTC-USD");
+        assert_eq!(snapshot.quote_type, QuoteType::Cryptocurrency);
+        assert_eq!(snapshot.currency, "USD");
+    }
+
+    #[test]
+    fn forex_quote_produces_a_midpoint_price() {
+        let mut merger = PriceMerger::new(AssetClass::Forex);
+        let frame = r#"[{"ev":"C","p":"EUR/USD","a":1.0902,"b":1.0898,"x":48,"t":1705363200000}]"#;
+        let snapshot = merger
+            .apply(events(frame).remove(0))
+            .expect("forex quote dropped");
+        assert_eq!(snapshot.id, "EUR/USD");
+        assert!((snapshot.price - 1.09).abs() < 0.001);
+        assert_eq!(snapshot.quote_type, QuoteType::Currency);
+    }
+
+    #[test]
+    fn aggregate_fills_ohlcv_and_intraday_change() {
+        let mut merger = PriceMerger::new(AssetClass::Stocks);
+        let frame = r#"[{"ev":"AM","sym":"AAPL","o":100.0,"h":110.0,"l":95.0,"c":105.0,"v":1500,"s":1,"e":2}]"#;
+        let snapshot = merger
+            .apply(events(frame).remove(0))
+            .expect("aggregate dropped");
+        assert_eq!(snapshot.day_volume, 1500);
+        assert!((snapshot.day_high - 110.0).abs() < 0.01);
+        assert!((snapshot.day_low - 95.0).abs() < 0.01);
+        assert!((snapshot.change - 5.0).abs() < 0.01);
+        assert!((snapshot.change_percent - 5.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn index_values_map_to_price() {
+        let mut merger = PriceMerger::new(AssetClass::Indices);
+        let frame = r#"[{"ev":"V","val":3988.5,"T":"I:SPX","t":1678220098130}]"#;
+        let snapshot = merger
+            .apply(events(frame).remove(0))
+            .expect("index value dropped");
+        assert_eq!(snapshot.id, "I:SPX");
+        assert!((snapshot.price - 3988.5).abs() < 0.01);
+        assert_eq!(snapshot.quote_type, QuoteType::Index);
+    }
+
+    #[test]
+    fn status_frames_produce_no_snapshot() {
+        let mut merger = PriceMerger::new(AssetClass::Stocks);
+        let frame = r#"[{"ev":"status","status":"auth_success"}]"#;
+        assert!(merger.apply(events(frame).remove(0)).is_none());
+    }
+}

--- a/src/streaming/polygon/price.rs
+++ b/src/streaming/polygon/price.rs
@@ -14,7 +14,7 @@ use crate::streaming::client::StreamResult;
 use crate::streaming::pricing::{MarketHoursType, PriceUpdate, QuoteType};
 use crate::streaming::source::{StreamCommand, StreamSource};
 
-use super::{AssetClass, run_polygon_session};
+use super::{AssetClass, SessionHandler, prune_symbols, run_polygon_session};
 
 /// Real-time price source backed by one Polygon cluster.
 pub(crate) struct PolygonPriceSource {
@@ -39,14 +39,13 @@ impl StreamSource<PriceUpdate> for PolygonPriceSource {
         broadcast_tx: &broadcast::Sender<PriceUpdate>,
         command_rx: &mut mpsc::Receiver<StreamCommand>,
     ) -> StreamResult<()> {
-        let mut merger = PriceMerger::new(self.class);
         run_polygon_session(
             self.class,
             self.class.price_channels(),
             subscriptions,
             broadcast_tx,
             command_rx,
-            move |msg| merger.apply(msg).into_iter().collect(),
+            PriceMerger::new(self.class),
         )
         .await
     }
@@ -54,13 +53,25 @@ impl StreamSource<PriceUpdate> for PolygonPriceSource {
 
 /// Folds per-event Polygon messages into one snapshot per symbol.
 pub(crate) struct PriceMerger {
+    class: AssetClass,
     quote_type: QuoteType,
     snapshots: HashMap<String, PriceUpdate>,
+}
+
+impl SessionHandler<PriceUpdate> for PriceMerger {
+    fn on_event(&mut self, msg: PolygonMessage) -> Vec<PriceUpdate> {
+        self.apply(msg).into_iter().collect()
+    }
+
+    fn on_unsubscribe(&mut self, removed: &[String]) {
+        prune_symbols(&mut self.snapshots, self.class, removed);
+    }
 }
 
 impl PriceMerger {
     pub(crate) fn new(class: AssetClass) -> Self {
         Self {
+            class,
             quote_type: match class {
                 AssetClass::Stocks => QuoteType::Equity,
                 AssetClass::Options => QuoteType::Option,
@@ -73,26 +84,29 @@ impl PriceMerger {
         }
     }
 
+    /// Snapshot for `symbol`, created on first sight.
+    ///
+    /// Keyed by `&str` so a cache hit costs no allocation; borrowck needs the
+    /// second lookup to hand back the mutable borrow.
     fn entry(&mut self, symbol: &str) -> &mut PriceUpdate {
-        let quote_type = self.quote_type;
-        self.snapshots.entry(symbol.to_string()).or_insert_with(|| {
+        if !self.snapshots.contains_key(symbol) {
             let mut update = PriceUpdate {
                 id: symbol.to_string(),
-                quote_type,
+                quote_type: self.quote_type,
                 market_hours: MarketHoursType::RegularMarket,
                 ..Default::default()
             };
             update.currency = default_currency(symbol).to_string();
-            update
-        })
+            self.snapshots.insert(symbol.to_string(), update);
+        }
+        self.snapshots.get_mut(symbol).expect("inserted above")
     }
 
     /// Merge one event, returning the updated snapshot when it carried a price.
     pub(crate) fn apply(&mut self, msg: PolygonMessage) -> Option<PriceUpdate> {
         match msg {
             PolygonMessage::Trade(trade) => {
-                let symbol = trade.symbol()?.to_string();
-                let snapshot = self.entry(&symbol);
+                let snapshot = self.entry(trade.symbol()?);
                 if let Some(p) = trade.p {
                     snapshot.price = p as f32;
                 }
@@ -108,8 +122,7 @@ impl PriceMerger {
                 Some(snapshot.clone())
             }
             PolygonMessage::Quote(quote) => {
-                let symbol = quote.symbol()?.to_string();
-                let snapshot = self.entry(&symbol);
+                let snapshot = self.entry(quote.symbol()?);
                 if let Some(bp) = quote.bp {
                     snapshot.bid = bp as f32;
                 }
@@ -132,8 +145,7 @@ impl PriceMerger {
                 Some(snapshot.clone())
             }
             PolygonMessage::ForexQuote(quote) => {
-                let symbol = quote.p.clone()?;
-                let snapshot = self.entry(&symbol);
+                let snapshot = self.entry(quote.p.as_deref()?);
                 if let Some(b) = quote.b {
                     snapshot.bid = b as f32;
                 }
@@ -149,8 +161,7 @@ impl PriceMerger {
                 Some(snapshot.clone())
             }
             PolygonMessage::Aggregate(agg) => {
-                let symbol = agg.symbol()?.to_string();
-                let snapshot = self.entry(&symbol);
+                let snapshot = self.entry(agg.symbol()?);
                 if let Some(c) = agg.c {
                     snapshot.price = c as f32;
                 }
@@ -177,8 +188,7 @@ impl PriceMerger {
                 Some(snapshot.clone())
             }
             PolygonMessage::IndexValue(index) => {
-                let symbol = index.ticker.clone()?;
-                let snapshot = self.entry(&symbol);
+                let snapshot = self.entry(index.ticker.as_deref()?);
                 if let Some(val) = index.val {
                     snapshot.price = val as f32;
                 }
@@ -287,6 +297,20 @@ mod tests {
         assert_eq!(snapshot.id, "I:SPX");
         assert!((snapshot.price - 3988.5).abs() < 0.01);
         assert_eq!(snapshot.quote_type, QuoteType::Index);
+    }
+
+    #[test]
+    fn unsubscribing_evicts_the_symbol_snapshot() {
+        let mut merger = PriceMerger::new(AssetClass::Stocks);
+        let frame = r#"[{"ev":"T","sym":"AAPL","p":186.19,"t":1},
+                        {"ev":"T","sym":"NVDA","p":95.0,"t":2}]"#;
+        for msg in events(frame) {
+            merger.apply(msg);
+        }
+        assert_eq!(merger.snapshots.len(), 2);
+
+        merger.on_unsubscribe(&["aapl".to_string()]);
+        assert_eq!(merger.snapshots.keys().collect::<Vec<_>>(), vec!["NVDA"]);
     }
 
     #[test]

--- a/src/streaming/polygon/trades.rs
+++ b/src/streaming/polygon/trades.rs
@@ -1,0 +1,120 @@
+//! Polygon-backed tick-by-tick trade source.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use tokio::sync::{RwLock, broadcast, mpsc};
+
+use crate::adapters::polygon::websocket::PolygonMessage;
+use crate::streaming::client::{StreamError, StreamResult};
+use crate::streaming::source::{StreamCommand, StreamSource};
+use crate::streaming::trades::TradeTick;
+
+use super::{AssetClass, run_polygon_session};
+
+/// Trade-print source for one Polygon cluster.
+pub(crate) struct PolygonTradeSource {
+    class: AssetClass,
+    channel: &'static str,
+}
+
+impl PolygonTradeSource {
+    /// Fails fast for asset classes that publish no per-trade prints.
+    pub(crate) fn new(class: AssetClass) -> StreamResult<Self> {
+        let channel = class.trade_channel().ok_or_else(|| {
+            StreamError::ConnectionFailed(format!("{} publishes no trade prints", class.label()))
+        })?;
+        Ok(Self { class, channel })
+    }
+}
+
+#[async_trait::async_trait]
+impl StreamSource<TradeTick> for PolygonTradeSource {
+    fn id(&self) -> &'static str {
+        self.class.label()
+    }
+
+    async fn run_session(
+        &self,
+        subscriptions: &Arc<RwLock<HashSet<String>>>,
+        broadcast_tx: &broadcast::Sender<TradeTick>,
+        command_rx: &mut mpsc::Receiver<StreamCommand>,
+    ) -> StreamResult<()> {
+        run_polygon_session(
+            self.class,
+            &[self.channel],
+            subscriptions,
+            broadcast_tx,
+            command_rx,
+            |msg| to_tick(msg).into_iter().collect(),
+        )
+        .await
+    }
+}
+
+/// Map a wire trade event onto the public tick shape.
+pub(crate) fn to_tick(msg: PolygonMessage) -> Option<TradeTick> {
+    let PolygonMessage::Trade(trade) = msg else {
+        return None;
+    };
+    Some(TradeTick {
+        symbol: trade.symbol()?.to_string(),
+        price: trade.p?,
+        size: trade.s.unwrap_or_default(),
+        exchange: trade.x,
+        conditions: trade.c.clone().unwrap_or_default(),
+        trade_id: trade.i.clone(),
+        time: trade.t.unwrap_or_default(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapters::polygon::websocket::parse_messages;
+
+    #[test]
+    fn every_print_in_a_frame_becomes_a_tick() {
+        let frame = r#"[{"ev":"T","sym":"AAPL","p":186.19,"s":100,"x":4,"c":[12,37],"t":1},
+                        {"ev":"T","sym":"AAPL","p":186.20,"s":50,"x":4,"t":2},
+                        {"ev":"T","sym":"AAPL","p":186.21,"s":25,"x":11,"t":3}]"#;
+        let ticks: Vec<TradeTick> = parse_messages(frame)
+            .into_iter()
+            .filter_map(to_tick)
+            .collect();
+
+        assert_eq!(ticks.len(), 3, "no print may be coalesced away");
+        assert_eq!(ticks[0].conditions, vec![12, 37]);
+        assert_eq!(ticks[1].size, 50.0);
+        assert_eq!(ticks[2].exchange, Some(11));
+        assert!((ticks[0].notional() - 18619.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn crypto_prints_carry_pair_and_trade_id() {
+        let frame = r#"[{"ev":"XT","pair":"BTC-USD","p":65000.5,"s":0.25,"i":"t-1","t":9}]"#;
+        let tick = parse_messages(frame)
+            .into_iter()
+            .find_map(to_tick)
+            .expect("crypto print dropped");
+        assert_eq!(tick.symbol, "BTC-USD");
+        assert_eq!(tick.trade_id.as_deref(), Some("t-1"));
+    }
+
+    #[test]
+    fn non_trade_events_are_ignored() {
+        let frame = r#"[{"ev":"Q","sym":"AAPL","bp":1.0,"ap":1.1,"t":1}]"#;
+        assert!(
+            parse_messages(frame)
+                .into_iter()
+                .find_map(to_tick)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn classes_without_a_trade_feed_fail_construction() {
+        assert!(PolygonTradeSource::new(AssetClass::Forex).is_err());
+        assert!(PolygonTradeSource::new(AssetClass::Stocks).is_ok());
+    }
+}

--- a/src/streaming/polygon/trades.rs
+++ b/src/streaming/polygon/trades.rs
@@ -10,7 +10,7 @@ use crate::streaming::client::{StreamError, StreamResult};
 use crate::streaming::source::{StreamCommand, StreamSource};
 use crate::streaming::trades::TradeTick;
 
-use super::{AssetClass, run_polygon_session};
+use super::{AssetClass, Decode, run_polygon_session};
 
 /// Trade-print source for one Polygon cluster.
 pub(crate) struct PolygonTradeSource {
@@ -46,7 +46,7 @@ impl StreamSource<TradeTick> for PolygonTradeSource {
             subscriptions,
             broadcast_tx,
             command_rx,
-            |msg| to_tick(msg).into_iter().collect(),
+            Decode(|msg| to_tick(msg).into_iter().collect()),
         )
         .await
     }
@@ -57,13 +57,14 @@ pub(crate) fn to_tick(msg: PolygonMessage) -> Option<TradeTick> {
     let PolygonMessage::Trade(trade) = msg else {
         return None;
     };
+    let symbol = trade.symbol()?.to_string();
     Some(TradeTick {
-        symbol: trade.symbol()?.to_string(),
+        symbol,
         price: trade.p?,
         size: trade.s.unwrap_or_default(),
         exchange: trade.x,
-        conditions: trade.c.clone().unwrap_or_default(),
-        trade_id: trade.i.clone(),
+        conditions: trade.c.unwrap_or_default(),
+        trade_id: trade.i,
         time: trade.t.unwrap_or_default(),
     })
 }

--- a/src/streaming/pricing.rs
+++ b/src/streaming/pricing.rs
@@ -303,7 +303,7 @@ impl PricingData {
 ///
 /// This is the user-facing struct with properly typed enum fields
 /// that serialize to readable strings like `"EQUITY"` or `"CRYPTOCURRENCY"`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[allow(missing_docs)]
 pub struct PriceUpdate {

--- a/src/streaming/source.rs
+++ b/src/streaming/source.rs
@@ -2,9 +2,9 @@
 //!
 //! Separates the provider-specific transport + wire protocol (connect,
 //! subscribe, decode) from the generic machinery — reconnection, the
-//! subscription set, and the public [`PriceStream`](super::PriceStream) API.
-//! Yahoo is the reference implementation in [`super::yahoo`]; additional
-//! backends (e.g. Polygon) implement the same trait.
+//! subscription set, and the public stream handles. The trait is generic over
+//! the item type so price ticks, trade prints, order books and options
+//! contracts all reuse one reconnect loop.
 
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -14,7 +14,6 @@ use tokio::sync::{RwLock, broadcast, mpsc};
 use tracing::{error, info};
 
 use super::client::StreamResult;
-use super::pricing::PriceUpdate;
 
 /// Commands sent to a running streaming session.
 pub(crate) enum StreamCommand {
@@ -26,13 +25,16 @@ pub(crate) enum StreamCommand {
     Close,
 }
 
-/// A real-time price source backing a [`PriceStream`](super::PriceStream).
+/// A real-time source backing one of the public stream handles.
 ///
-/// Implementations own the transport and wire protocol and push decoded
-/// [`PriceUpdate`]s onto `broadcast_tx`. Reconnection and the public stream
-/// API are provided generically by [`run_stream_loop`].
+/// Implementations own the transport and wire protocol and push decoded items
+/// of type `T` onto `broadcast_tx`. Reconnection and the public stream API are
+/// provided generically by [`run_stream_loop`].
 #[async_trait::async_trait]
-pub(crate) trait StreamSource: Send + Sync + 'static {
+pub(crate) trait StreamSource<T>: Send + Sync + 'static
+where
+    T: Clone + Send + 'static,
+{
     /// Short identifier for logging (e.g. `"yahoo"`).
     fn id(&self) -> &'static str;
 
@@ -46,19 +48,25 @@ pub(crate) trait StreamSource: Send + Sync + 'static {
     async fn run_session(
         &self,
         subscriptions: &Arc<RwLock<HashSet<String>>>,
-        broadcast_tx: &broadcast::Sender<PriceUpdate>,
+        broadcast_tx: &broadcast::Sender<T>,
         command_rx: &mut mpsc::Receiver<StreamCommand>,
     ) -> StreamResult<()>;
 }
 
 /// Drive a [`StreamSource`] with automatic reconnection until it shuts down.
-pub(crate) async fn run_stream_loop(
-    source: Arc<dyn StreamSource>,
+///
+/// `retry_delay` is supplied by the caller rather than hard-coded so a smarter
+/// policy (see issue #276) can be swapped in without touching sources.
+pub(crate) async fn run_stream_loop<T>(
+    source: Arc<dyn StreamSource<T>>,
     initial_symbols: Vec<String>,
-    broadcast_tx: broadcast::Sender<PriceUpdate>,
+    broadcast_tx: broadcast::Sender<T>,
     mut command_rx: mpsc::Receiver<StreamCommand>,
     retry_delay: Duration,
-) -> StreamResult<()> {
+) -> StreamResult<()>
+where
+    T: Clone + Send + 'static,
+{
     let subscriptions = Arc::new(RwLock::new(HashSet::<String>::from_iter(initial_symbols)));
 
     loop {
@@ -85,11 +93,44 @@ pub(crate) async fn run_stream_loop(
     Ok(())
 }
 
+/// Apply a [`StreamCommand`] to the shared subscription set.
+///
+/// Returns the symbols that actually changed state, so sources only send
+/// wire-level (un)subscribes for real deltas. `Close` returns `None`.
+pub(crate) async fn apply_command(
+    command: &StreamCommand,
+    subscriptions: &Arc<RwLock<HashSet<String>>>,
+) -> Option<Vec<String>> {
+    match command {
+        StreamCommand::Subscribe(symbols) => {
+            let mut subs = subscriptions.write().await;
+            Some(
+                symbols
+                    .iter()
+                    .filter(|s| subs.insert((*s).clone()))
+                    .cloned()
+                    .collect(),
+            )
+        }
+        StreamCommand::Unsubscribe(symbols) => {
+            let mut subs = subscriptions.write().await;
+            Some(
+                symbols
+                    .iter()
+                    .filter(|s| subs.remove(*s))
+                    .cloned()
+                    .collect(),
+            )
+        }
+        StreamCommand::Close => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::streaming::client::PriceStream;
-    use crate::streaming::pricing::PricingData;
+    use crate::streaming::pricing::{PriceUpdate, PricingData};
     use futures::StreamExt;
 
     /// A network-free source that emits one synthetic update per subscribed
@@ -97,7 +138,7 @@ mod tests {
     struct MockSource;
 
     #[async_trait::async_trait]
-    impl StreamSource for MockSource {
+    impl StreamSource<PriceUpdate> for MockSource {
         fn id(&self) -> &'static str {
             "mock"
         }
@@ -144,5 +185,26 @@ mod tests {
         assert_eq!(update.id, "AAPL");
         assert_eq!(update.price, 42.0);
         stream.close().await;
+    }
+
+    #[tokio::test]
+    async fn apply_command_reports_only_real_deltas() {
+        let subs = Arc::new(RwLock::new(HashSet::from(["AAPL".to_string()])));
+
+        let added = apply_command(
+            &StreamCommand::Subscribe(vec!["AAPL".into(), "NVDA".into()]),
+            &subs,
+        )
+        .await;
+        assert_eq!(added, Some(vec!["NVDA".to_string()]));
+
+        let removed = apply_command(
+            &StreamCommand::Unsubscribe(vec!["NVDA".into(), "TSLA".into()]),
+            &subs,
+        )
+        .await;
+        assert_eq!(removed, Some(vec!["NVDA".to_string()]));
+
+        assert!(apply_command(&StreamCommand::Close, &subs).await.is_none());
     }
 }

--- a/src/streaming/trades.rs
+++ b/src/streaming/trades.rs
@@ -4,20 +4,14 @@
 //! tick; this stream pushes every individual print, which is what
 //! execution-quality and microstructure work needs.
 
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context, Poll};
 use std::time::Duration;
 
-use futures::stream::Stream;
 use serde::{Deserialize, Serialize};
 
 use super::client::StreamResult;
-use super::handle::SourceStream;
+use super::handle::{RECONNECT_BACKOFF, SourceStream, stream_builder, stream_handle};
 use super::polygon::{AssetClass, PolygonTradeSource};
-
-/// Reconnection backoff, matching [`PriceStream`](super::PriceStream).
-const RECONNECT_BACKOFF_SECS: u64 = 3;
 
 /// Channel capacity — trade prints are the highest-volume feed here.
 const CHANNEL_CAPACITY: usize = 4096;
@@ -50,29 +44,31 @@ impl TradeTick {
     }
 }
 
-/// A subscription to every trade print for the given symbols.
-///
-/// Requires the `polygon` feature and [`polygon::init`](crate::polygon::init).
-/// This is a companion to [`PriceStream`](super::PriceStream), not a
-/// replacement — most consumers want the coalesced tick.
-///
-/// # Example
-///
-/// ```no_run
-/// use finance_query::streaming::TradeStream;
-/// use futures::StreamExt;
-///
-/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// let mut trades = TradeStream::subscribe(["AAPL"]).await?;
-///
-/// while let Some(trade) = trades.next().await {
-///     println!("{} {} @ {}", trade.symbol, trade.size, trade.price);
-/// }
-/// # Ok(())
-/// # }
-/// ```
-pub struct TradeStream {
-    inner: SourceStream<TradeTick>,
+stream_handle! {
+    /// A subscription to every trade print for the given symbols.
+    ///
+    /// Requires the `polygon` feature and [`polygon::init`](crate::polygon::init).
+    /// This is a companion to [`PriceStream`](super::PriceStream), not a
+    /// replacement — most consumers want the coalesced tick.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use finance_query::streaming::TradeStream;
+    /// use futures::StreamExt;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut trades = TradeStream::subscribe(["AAPL"]).await?;
+    ///
+    /// while let Some(trade) = trades.next().await {
+    ///     println!("{} {} @ {}", trade.symbol, trade.size, trade.price);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    TradeStream(TradeTick);
+    add: add_symbols = "Add symbols to the subscription.",
+    remove: remove_symbols = "Remove symbols from the subscription.",
 }
 
 impl TradeStream {
@@ -83,44 +79,6 @@ impl TradeStream {
         I: IntoIterator<Item = S>,
     {
         TradeStreamBuilder::new().symbols(symbols).build().await
-    }
-
-    /// Create an independent receiver sharing this subscription's connection.
-    pub fn resubscribe(&self) -> Self {
-        TradeStream {
-            inner: self.inner.resubscribe(),
-        }
-    }
-
-    /// Add symbols to the subscription.
-    pub async fn add_symbols<S, I>(&self, symbols: I)
-    where
-        S: Into<String>,
-        I: IntoIterator<Item = S>,
-    {
-        self.inner.add(symbols).await;
-    }
-
-    /// Remove symbols from the subscription.
-    pub async fn remove_symbols<S, I>(&self, symbols: I)
-    where
-        S: Into<String>,
-        I: IntoIterator<Item = S>,
-    {
-        self.inner.remove(symbols).await;
-    }
-
-    /// Close the stream and disconnect.
-    pub async fn close(&self) {
-        self.inner.close().await;
-    }
-}
-
-impl Stream for TradeStream {
-    type Item = TradeTick;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        Pin::new(&mut self.inner).poll_next(cx)
     }
 }
 
@@ -137,18 +95,8 @@ impl TradeStreamBuilder {
         Self {
             symbols: Vec::new(),
             asset_class: AssetClass::Stocks,
-            retry_delay: Duration::from_secs(RECONNECT_BACKOFF_SECS),
+            retry_delay: RECONNECT_BACKOFF,
         }
-    }
-
-    /// Add symbols to subscribe to.
-    pub fn symbols<S, I>(mut self, symbols: I) -> Self
-    where
-        S: Into<String>,
-        I: IntoIterator<Item = S>,
-    {
-        self.symbols.extend(symbols.into_iter().map(Into::into));
-        self
     }
 
     /// Choose the asset class (default: [`AssetClass::Stocks`]).
@@ -157,12 +105,6 @@ impl TradeStreamBuilder {
     /// rejected at [`build`](Self::build).
     pub fn asset_class(mut self, class: AssetClass) -> Self {
         self.asset_class = class;
-        self
-    }
-
-    /// Set the delay between reconnection attempts (default: 3s).
-    pub fn retry(mut self, delay: Duration) -> Self {
-        self.retry_delay = delay;
         self
     }
 
@@ -180,11 +122,7 @@ impl TradeStreamBuilder {
     }
 }
 
-impl Default for TradeStreamBuilder {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+stream_builder!(TradeStreamBuilder, symbols = "Add symbols to subscribe to.");
 
 #[cfg(test)]
 mod tests {

--- a/src/streaming/trades.rs
+++ b/src/streaming/trades.rs
@@ -1,0 +1,216 @@
+//! Tick-by-tick trade streaming.
+//!
+//! [`PriceStream`](super::PriceStream) coalesces activity into a last-price
+//! tick; this stream pushes every individual print, which is what
+//! execution-quality and microstructure work needs.
+
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use futures::stream::Stream;
+use serde::{Deserialize, Serialize};
+
+use super::client::StreamResult;
+use super::handle::SourceStream;
+use super::polygon::{AssetClass, PolygonTradeSource};
+
+/// Reconnection backoff, matching [`PriceStream`](super::PriceStream).
+const RECONNECT_BACKOFF_SECS: u64 = 3;
+
+/// Channel capacity — trade prints are the highest-volume feed here.
+const CHANNEL_CAPACITY: usize = 4096;
+
+/// A single executed trade.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct TradeTick {
+    /// Symbol or pair the trade executed on.
+    pub symbol: String,
+    /// Execution price.
+    pub price: f64,
+    /// Executed size (shares, contracts, or base-asset units).
+    pub size: f64,
+    /// Exchange identifier, where the venue reports one.
+    pub exchange: Option<i32>,
+    /// Trade condition codes.
+    pub conditions: Vec<i32>,
+    /// Provider trade identifier, where one is supplied.
+    pub trade_id: Option<String>,
+    /// Execution timestamp (milliseconds).
+    pub time: i64,
+}
+
+impl TradeTick {
+    /// Notional value of the print (`price * size`).
+    pub fn notional(&self) -> f64 {
+        self.price * self.size
+    }
+}
+
+/// A subscription to every trade print for the given symbols.
+///
+/// Requires the `polygon` feature and [`polygon::init`](crate::polygon::init).
+/// This is a companion to [`PriceStream`](super::PriceStream), not a
+/// replacement — most consumers want the coalesced tick.
+///
+/// # Example
+///
+/// ```no_run
+/// use finance_query::streaming::TradeStream;
+/// use futures::StreamExt;
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut trades = TradeStream::subscribe(["AAPL"]).await?;
+///
+/// while let Some(trade) = trades.next().await {
+///     println!("{} {} @ {}", trade.symbol, trade.size, trade.price);
+/// }
+/// # Ok(())
+/// # }
+/// ```
+pub struct TradeStream {
+    inner: SourceStream<TradeTick>,
+}
+
+impl TradeStream {
+    /// Subscribe to US equity trade prints for the given symbols.
+    pub async fn subscribe<S, I>(symbols: I) -> StreamResult<Self>
+    where
+        S: Into<String>,
+        I: IntoIterator<Item = S>,
+    {
+        TradeStreamBuilder::new().symbols(symbols).build().await
+    }
+
+    /// Create an independent receiver sharing this subscription's connection.
+    pub fn resubscribe(&self) -> Self {
+        TradeStream {
+            inner: self.inner.resubscribe(),
+        }
+    }
+
+    /// Add symbols to the subscription.
+    pub async fn add_symbols<S, I>(&self, symbols: I)
+    where
+        S: Into<String>,
+        I: IntoIterator<Item = S>,
+    {
+        self.inner.add(symbols).await;
+    }
+
+    /// Remove symbols from the subscription.
+    pub async fn remove_symbols<S, I>(&self, symbols: I)
+    where
+        S: Into<String>,
+        I: IntoIterator<Item = S>,
+    {
+        self.inner.remove(symbols).await;
+    }
+
+    /// Close the stream and disconnect.
+    pub async fn close(&self) {
+        self.inner.close().await;
+    }
+}
+
+impl Stream for TradeStream {
+    type Item = TradeTick;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.inner).poll_next(cx)
+    }
+}
+
+/// Builder for a [`TradeStream`].
+pub struct TradeStreamBuilder {
+    symbols: Vec<String>,
+    asset_class: AssetClass,
+    retry_delay: Duration,
+}
+
+impl TradeStreamBuilder {
+    /// Create a builder defaulting to US equities.
+    pub fn new() -> Self {
+        Self {
+            symbols: Vec::new(),
+            asset_class: AssetClass::Stocks,
+            retry_delay: Duration::from_secs(RECONNECT_BACKOFF_SECS),
+        }
+    }
+
+    /// Add symbols to subscribe to.
+    pub fn symbols<S, I>(mut self, symbols: I) -> Self
+    where
+        S: Into<String>,
+        I: IntoIterator<Item = S>,
+    {
+        self.symbols.extend(symbols.into_iter().map(Into::into));
+        self
+    }
+
+    /// Choose the asset class (default: [`AssetClass::Stocks`]).
+    ///
+    /// Forex and indices publish no per-trade prints; those classes are
+    /// rejected at [`build`](Self::build).
+    pub fn asset_class(mut self, class: AssetClass) -> Self {
+        self.asset_class = class;
+        self
+    }
+
+    /// Set the delay between reconnection attempts (default: 3s).
+    pub fn retry(mut self, delay: Duration) -> Self {
+        self.retry_delay = delay;
+        self
+    }
+
+    /// Build and start the stream.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StreamError::ConnectionFailed`](super::StreamError::ConnectionFailed)
+    /// when the chosen asset class has no trade feed.
+    pub async fn build(self) -> StreamResult<TradeStream> {
+        let source = Arc::new(PolygonTradeSource::new(self.asset_class)?);
+        Ok(TradeStream {
+            inner: SourceStream::start(source, self.symbols, self.retry_delay, CHANNEL_CAPACITY),
+        })
+    }
+}
+
+impl Default for TradeStreamBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn classes_without_trade_prints_are_rejected() {
+        for class in [AssetClass::Forex, AssetClass::Indices] {
+            assert!(
+                TradeStreamBuilder::new()
+                    .symbols(["X"])
+                    .asset_class(class)
+                    .build()
+                    .await
+                    .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn notional_multiplies_price_by_size() {
+        let tick = TradeTick {
+            price: 10.0,
+            size: 25.0,
+            ..Default::default()
+        };
+        assert!((tick.notional() - 250.0).abs() < 1e-9);
+    }
+}

--- a/src/streaming/yahoo.rs
+++ b/src/streaming/yahoo.rs
@@ -17,7 +17,7 @@ use tracing::{debug, error, info, warn};
 
 use super::client::{StreamError, StreamResult};
 use super::pricing::{PriceUpdate, PricingData, PricingDecodeError};
-use super::source::{StreamCommand, StreamSource};
+use super::source::{StreamCommand, StreamSource, apply_command};
 
 /// Yahoo Finance WebSocket URL.
 const YAHOO_WS_URL: &str = "wss://streamer.finance.yahoo.com/?version=2";
@@ -29,7 +29,7 @@ const HEARTBEAT_INTERVAL_SECS: u64 = 15;
 pub(crate) struct YahooStreamSource;
 
 #[async_trait::async_trait]
-impl StreamSource for YahooStreamSource {
+impl StreamSource<PriceUpdate> for YahooStreamSource {
     fn id(&self) -> &'static str {
         "yahoo"
     }
@@ -138,45 +138,20 @@ async fn connect_and_stream(
 
             // Handle commands (subscribe/unsubscribe)
             Some(cmd) = command_rx.recv() => {
-                match cmd {
-                    StreamCommand::Subscribe(symbols) => {
-                        let mut newly_added = Vec::new();
-                        {
-                            let mut subs = subscriptions.write().await;
-                            for s in &symbols {
-                                if subs.insert(s.clone()) {
-                                    newly_added.push(s.clone());
-                                }
-                            }
-                        }
-                        if !newly_added.is_empty() {
-                            let msg = serde_json::json!({ "subscribe": newly_added });
-                            let _ = write.send(Message::Text(msg.to_string().into())).await;
-                            info!("Added subscriptions: {:?}", newly_added);
-                        }
-                    }
-                    StreamCommand::Unsubscribe(symbols) => {
-                        let mut actually_removed = Vec::new();
-                        {
-                            let mut subs = subscriptions.write().await;
-                            for s in &symbols {
-                                if subs.remove(s) {
-                                    actually_removed.push(s.clone());
-                                }
-                            }
-                        }
-                        if !actually_removed.is_empty() {
-                            let msg = serde_json::json!({ "unsubscribe": actually_removed });
-                            let _ = write.send(Message::Text(msg.to_string().into())).await;
-                            info!("Removed subscriptions: {:?}", actually_removed);
-                        }
-                    }
-                    StreamCommand::Close => {
-                        info!("Received close command");
-                        let _ = write.send(Message::Close(None)).await;
-                        return Ok(());
-                    }
+                let Some(changed) = apply_command(&cmd, subscriptions).await else {
+                    info!("Received close command");
+                    let _ = write.send(Message::Close(None)).await;
+                    return Ok(());
+                };
+                if changed.is_empty() {
+                    continue;
                 }
+                let msg = match cmd {
+                    StreamCommand::Subscribe(_) => serde_json::json!({ "subscribe": changed }),
+                    _ => serde_json::json!({ "unsubscribe": changed }),
+                };
+                let _ = write.send(Message::Text(msg.to_string().into())).await;
+                info!("Subscription change applied: {:?}", changed);
             }
 
             else => break,


### PR DESCRIPTION
## Description

Adds four new things you can subscribe to — options chains, trades, order-book
depth, and price alerts — and reworks the streaming internals so each one is a
thin handle over shared machinery instead of its own copy.

Top of a 3-PR stack: **#303 → #304 → #305**.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Performance improvement

## Changes

**New subscriptions**
- `OptionsChainStream` — live options chain with bid/ask and greeks
- `TradeStream` — tick-by-tick prints
- `DepthStream` — order-book depth
- `AlertStream` / `AlertEvaluator` — threshold-triggered alerts (price above/below, change above/below, volume), exposed over both WebSocket and GraphQL
- Asset-class-aware stream sources (stocks, options, forex, crypto, indices, futures) and batched delivery

**Server**
- WebSocket and GraphQL subscriptions for the above
- A tick is now serialized to JSON once at the hub and shared across clients, instead of once per client per tick
- The delivery path no longer takes async locks — a client with no alert rules takes no lock at all
- `handle_stream_socket` was a 255-line function nested 7 deep; it's now split into `run_send_task` / `run_recv_task` / `deliver` / `apply_subscribe` / `apply_alerts` / `apply_unsubscribe`, all under 50 lines

**Internals**
- `stream_handle!` / `stream_builder!` macros replace ~360 lines of duplicated handle and builder boilerplate across four stream types
- `EconomicCommand` deleted; economic streams now use the shared `StreamCommand` and ride `SourceStream` like the others
- One generic `Guarded<T, G>` replaces three identical GraphQL stream newtypes
- `Batched` now delegates to `tokio_stream`'s `chunks_timeout` instead of hand-rolling the same poll state machine

**Fixes to wasted work on the tick path**
- Merger snapshot maps are pruned on unsubscribe — previously they grew for the process lifetime, badly so for options where one underlying expands to a whole chain
- `AlertEvaluator` only tracks symbols a rule references, instead of every symbol any client anywhere subscribed to
- Options greeks refresh and economic polls now fan out concurrently instead of one round-trip at a time
- FRED polls fetch one observation (`sort_order=desc&limit=1`) instead of the full series history
- Removed per-event string allocations in the Polygon wire decode and price merger

## Breaking Changes

`streaming::EconomicRelease` is renamed to `SeriesUpdate`. It was added earlier in
this same unreleased cycle and never shipped, and #304 introduces a different
public `EconomicRelease` (a scheduled FRED release) — two different concepts under
one name.

`mod economic` in `streaming` is now gated on the `fred` feature. Without `fred`
it previously built fine and then silently never yielded anything.

## Testing
- [x] Unit tests added/updated
- [x] All tests pass (`cargo test`)

`cargo test --workspace --features full`: 1473 passed, 0 failed. Default-feature
build checked too, since this PR changes feature gating.

## Documentation
- [x] Code documentation updated (doc comments)
- [x] CHANGELOG.md updated

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy --workspace --all-targets --features full -- -D warnings`)
- [x] Commit messages follow Conventional Commits

## Related Issues

Closes #247
Closes #248
Closes #249
Closes #250
