### PR TITLE
test: add unit coverage for MCP tool helper functions

### DIFF
--- a/finance-query-mcp/src/tools/analysis.rs
+++ b/finance-query-mcp/src/tools/analysis.rs
@@ -30,6 +30,44 @@ fn holder_paginated_field(gql_field: &str) -> Option<&'static str> {
     }
 }
 
+/// Build the `<gqlField> { ... }` selection for `get_holders`: delegates to
+/// the paginated-composite builder when the holder type has a paginated
+/// nested list, otherwise falls back to the plain type-spec builder.
+#[allow(clippy::too_many_arguments)]
+fn build_holders_selection(
+    field_list: Option<&[String]>,
+    valid_fields: &[&str],
+    default_fields: &[&str],
+    composite_fields: &[(&str, &str)],
+    paginated_field: Option<&str>,
+    limit: u32,
+    cursor: Option<&str>,
+) -> String {
+    match paginated_field {
+        Some(pf) => {
+            let item_selection = composite_fields
+                .iter()
+                .find(|(name, _)| *name == pf)
+                .map(|(_, sel)| *sel)
+                .unwrap_or("{ }");
+            let fields_csv = field_list.map(|fs| fs.join(","));
+            build_paginated_composite_selection(
+                fields_csv.as_deref(),
+                valid_fields,
+                default_fields,
+                composite_fields,
+                pf,
+                item_selection,
+                Some(limit),
+                cursor,
+            )
+        }
+        None => {
+            build_type_spec_selection(field_list, valid_fields, default_fields, composite_fields)
+        }
+    }
+}
+
 pub async fn get_holders(
     schema: &FinanceSchema,
     symbol: String,
@@ -47,32 +85,15 @@ pub async fn get_holders(
 
     let field_list = parse_fields(fields);
     let paginated_field = holder_paginated_field(gql_field);
-    let selection = match paginated_field {
-        Some(pf) => {
-            let item_selection = composite_fields
-                .iter()
-                .find(|(name, _)| *name == pf)
-                .map(|(_, sel)| *sel)
-                .unwrap_or("{ }");
-            let fields_csv = field_list.as_ref().map(|fs| fs.join(","));
-            build_paginated_composite_selection(
-                fields_csv.as_deref(),
-                valid_fields,
-                default_fields,
-                composite_fields,
-                pf,
-                item_selection,
-                Some(limit.unwrap_or(DEFAULT_MCP_PAGE_SIZE)),
-                cursor.as_deref(),
-            )
-        }
-        None => build_type_spec_selection(
-            field_list.as_deref(),
-            valid_fields,
-            default_fields,
-            composite_fields,
-        ),
-    };
+    let selection = build_holders_selection(
+        field_list.as_deref(),
+        valid_fields,
+        default_fields,
+        composite_fields,
+        paginated_field,
+        limit.unwrap_or(DEFAULT_MCP_PAGE_SIZE),
+        cursor.as_deref(),
+    );
 
     let query = format!(
         "query GetHolders($symbol: String!) {{ ticker(symbol: $symbol) {{ {gql_field} {selection} }} }}"
@@ -130,4 +151,205 @@ pub async fn get_analysis(
     Ok(CallToolResult::success(vec![rmcp::model::Content::text(
         serde_json::to_string(&data).map_err(ser_err)?,
     )]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn holder_type_to_field_maps_every_known_value() {
+        assert_eq!(holder_type_to_field("major"), Some("majorHolders"));
+        assert_eq!(
+            holder_type_to_field("institutional"),
+            Some("institutionalHolders")
+        );
+        assert_eq!(
+            holder_type_to_field("mutualfund"),
+            Some("mutualFundHolders")
+        );
+        assert_eq!(
+            holder_type_to_field("insidertransactions"),
+            Some("insiderTransactions")
+        );
+        assert_eq!(
+            holder_type_to_field("insiderpurchases"),
+            Some("insiderPurchases")
+        );
+        assert_eq!(holder_type_to_field("insiderroster"), Some("insiderRoster"));
+    }
+
+    #[test]
+    fn holder_type_to_field_normalizes_hyphens_and_case() {
+        assert_eq!(
+            holder_type_to_field("insider-transactions"),
+            Some("insiderTransactions")
+        );
+        assert_eq!(
+            holder_type_to_field("Insider-Purchases"),
+            Some("insiderPurchases")
+        );
+        assert_eq!(
+            holder_type_to_field("MUTUAL-FUND"),
+            Some("mutualFundHolders")
+        );
+        assert_eq!(holder_type_to_field("Major"), Some("majorHolders"));
+    }
+
+    #[test]
+    fn holder_type_to_field_rejects_unknown_and_empty_input() {
+        assert_eq!(holder_type_to_field("bogus"), None);
+        assert_eq!(holder_type_to_field(""), None);
+        assert_eq!(holder_type_to_field("-"), None);
+    }
+
+    #[test]
+    fn holder_paginated_field_maps_paginated_holder_types() {
+        assert_eq!(
+            holder_paginated_field("institutionalHolders"),
+            Some("ownershipList")
+        );
+        assert_eq!(
+            holder_paginated_field("mutualFundHolders"),
+            Some("ownershipList")
+        );
+        assert_eq!(
+            holder_paginated_field("insiderTransactions"),
+            Some("transactions")
+        );
+        assert_eq!(holder_paginated_field("insiderRoster"), Some("holders"));
+    }
+
+    #[test]
+    fn holder_paginated_field_returns_none_for_unpaginated_or_unknown_types() {
+        assert_eq!(holder_paginated_field("majorHolders"), None);
+        assert_eq!(holder_paginated_field("insiderPurchases"), None);
+        assert_eq!(holder_paginated_field("bogusField"), None);
+        assert_eq!(holder_paginated_field(""), None);
+    }
+
+    #[test]
+    fn analysis_type_to_field_maps_every_known_value() {
+        assert_eq!(
+            analysis_type_to_field("recommendations"),
+            Some("recommendationTrend")
+        );
+        assert_eq!(
+            analysis_type_to_field("upgradesdowngrades"),
+            Some("gradingHistory")
+        );
+        assert_eq!(
+            analysis_type_to_field("earningsestimate"),
+            Some("earningsEstimate")
+        );
+        assert_eq!(
+            analysis_type_to_field("earningshistory"),
+            Some("earningsHistory")
+        );
+    }
+
+    #[test]
+    fn analysis_type_to_field_normalizes_hyphens_and_case() {
+        assert_eq!(
+            analysis_type_to_field("upgrades-downgrades"),
+            Some("gradingHistory")
+        );
+        assert_eq!(
+            analysis_type_to_field("Earnings-Estimate"),
+            Some("earningsEstimate")
+        );
+        assert_eq!(
+            analysis_type_to_field("EARNINGS-HISTORY"),
+            Some("earningsHistory")
+        );
+    }
+
+    #[test]
+    fn analysis_type_to_field_rejects_unknown_and_empty_input() {
+        assert_eq!(analysis_type_to_field("bogus"), None);
+        assert_eq!(analysis_type_to_field(""), None);
+    }
+
+    #[test]
+    fn build_holders_selection_uses_type_spec_builder_when_not_paginated() {
+        let (_, valid_fields, default_fields, composite_fields) = HOLDER_TYPE_SPECS
+            .iter()
+            .find(|(n, ..)| *n == "majorHolders")
+            .unwrap();
+        let selection = build_holders_selection(
+            None,
+            valid_fields,
+            default_fields,
+            composite_fields,
+            None,
+            25,
+            None,
+        );
+
+        for f in *default_fields {
+            assert!(selection.contains(f));
+        }
+        assert!(!selection.contains("first:"));
+    }
+
+    #[test]
+    fn build_holders_selection_builds_paginated_connection_when_holder_type_is_paginated() {
+        let (_, valid_fields, default_fields, composite_fields) = HOLDER_TYPE_SPECS
+            .iter()
+            .find(|(n, ..)| *n == "institutionalHolders")
+            .unwrap();
+        let selection = build_holders_selection(
+            None,
+            valid_fields,
+            default_fields,
+            composite_fields,
+            Some("ownershipList"),
+            10,
+            None,
+        );
+
+        assert!(selection.contains("ownershipList"));
+        assert!(selection.contains("first: 10"));
+        assert!(selection.contains("edges"));
+        assert!(selection.contains("pageInfo"));
+    }
+
+    #[test]
+    fn build_holders_selection_includes_cursor_when_present() {
+        let (_, valid_fields, default_fields, composite_fields) = HOLDER_TYPE_SPECS
+            .iter()
+            .find(|(n, ..)| *n == "insiderTransactions")
+            .unwrap();
+        let selection = build_holders_selection(
+            None,
+            valid_fields,
+            default_fields,
+            composite_fields,
+            Some("transactions"),
+            25,
+            Some("abc123"),
+        );
+
+        assert!(selection.contains("after: \"abc123\""));
+    }
+
+    #[test]
+    fn build_holders_selection_respects_explicit_field_list() {
+        let (_, valid_fields, default_fields, composite_fields) = HOLDER_TYPE_SPECS
+            .iter()
+            .find(|(n, ..)| *n == "majorHolders")
+            .unwrap();
+        let requested = vec!["institutionsCount".to_string()];
+        let selection = build_holders_selection(
+            Some(&requested),
+            valid_fields,
+            default_fields,
+            composite_fields,
+            None,
+            25,
+            None,
+        );
+
+        assert_eq!(selection, "{ institutionsCount }");
+    }
 }

--- a/finance-query-mcp/src/tools/calendar.rs
+++ b/finance-query-mcp/src/tools/calendar.rs
@@ -64,3 +64,72 @@ pub async fn get_calendar(
         serde_json::to_string(&data).map_err(ser_err)?,
     )]))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fields(names: &[&str]) -> Vec<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn build_calendar_selection_defaults_to_all_fields_including_event_union() {
+        let selection = build_calendar_selection(None);
+
+        assert!(selection.contains("timestamp"));
+        assert!(selection.contains("date"));
+        assert!(selection.contains("symbol"));
+        assert!(selection.contains("event"));
+        assert!(selection.contains("__typename"));
+        assert!(selection.contains("GqlEarningsEvent"));
+    }
+
+    #[test]
+    fn build_calendar_selection_falls_back_to_all_fields_when_list_is_empty() {
+        let empty = fields(&[]);
+        let selection = build_calendar_selection(Some(&empty));
+
+        assert!(selection.contains("event"));
+        assert!(selection.contains("__typename"));
+    }
+
+    #[test]
+    fn build_calendar_selection_without_event_returns_flat_selection() {
+        let requested = fields(&["timestamp", "symbol"]);
+        let selection = build_calendar_selection(Some(&requested));
+
+        assert_eq!(selection, "{ timestamp symbol }");
+        assert!(!selection.contains("event"));
+        assert!(!selection.contains("__typename"));
+    }
+
+    #[test]
+    fn build_calendar_selection_with_event_expands_union_and_omits_unrequested_scalars() {
+        let requested = fields(&["symbol", "event"]);
+        let selection = build_calendar_selection(Some(&requested));
+
+        assert!(selection.contains("symbol"));
+        assert!(selection.contains("event"));
+        assert!(selection.contains("__typename"));
+        assert!(!selection.contains("timestamp"));
+        assert!(!selection.contains("date "));
+    }
+
+    #[test]
+    fn build_calendar_selection_drops_unknown_field_names() {
+        let requested = fields(&["bogusField"]);
+        let selection = build_calendar_selection(Some(&requested));
+
+        assert_eq!(selection, "{ }");
+    }
+
+    #[test]
+    fn build_calendar_selection_is_injection_safe_against_unmatched_strings() {
+        let requested = fields(&["\") { __schema", "event } evil"]);
+        let selection = build_calendar_selection(Some(&requested));
+
+        assert_eq!(selection, "{ }");
+        assert!(!selection.contains("__schema"));
+    }
+}

--- a/finance-query-mcp/src/tools/chart.rs
+++ b/finance-query-mcp/src/tools/chart.rs
@@ -86,6 +86,15 @@ fn build_chart_selection(
     sel
 }
 
+/// Split a comma-separated symbols param into a trimmed, non-empty list.
+fn split_symbols(symbols: &str) -> Vec<String> {
+    symbols
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
 /// Accepts one or more comma-separated symbols: a single symbol returns the
 /// flat chart shape (and honors `start`/`end`), multiple symbols return the
 /// batch `{charts, errors}` shape (`start`/`end` are ignored for batch — the
@@ -102,11 +111,7 @@ pub async fn get_chart(
     limit: Option<u32>,
     cursor: Option<String>,
 ) -> Result<CallToolResult, McpError> {
-    let syms: Vec<String> = symbols
-        .split(',')
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .collect();
+    let syms = split_symbols(&symbols);
     if syms.len() == 1 {
         get_one_chart(
             schema,
@@ -122,6 +127,36 @@ pub async fn get_chart(
         .await
     } else {
         get_many_charts(schema, syms, interval, range, fields).await
+    }
+}
+
+/// Build the single-symbol `chart(...)` query text: absolute `start`/`end`
+/// timestamps take priority over `interval`/`range` (mirrors the original
+/// inline branching in `get_one_chart` exactly, including the "now" fallback
+/// for a missing `end`).
+fn build_chart_query(
+    selection: &str,
+    interval: Option<&str>,
+    range: Option<&str>,
+    start: Option<i64>,
+    end: Option<i64>,
+) -> String {
+    if let Some(start) = start {
+        let end = end.unwrap_or_else(|| {
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs() as i64
+        });
+        format!(
+            "query GetChart($symbol: String!) {{ ticker(symbol: $symbol) {{ chart(start: {start}, end: {end}) {selection} }} }}"
+        )
+    } else {
+        let gql_interval = interval_to_gql(interval.unwrap_or("1d"));
+        let gql_range = range_to_gql(range.unwrap_or("1mo"));
+        format!(
+            "query GetChart($symbol: String!) {{ ticker(symbol: $symbol) {{ chart(interval: {gql_interval}, range: {gql_range}) {selection} }} }}"
+        )
     }
 }
 
@@ -153,29 +188,15 @@ async fn get_one_chart(
     );
 
     // Build query based on whether start date is set.
-    let (query, variables) = if let Some(start) = start {
-        let end = end.unwrap_or_else(|| {
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs() as i64
-        });
-        let q = format!(
-            "query GetChart($symbol: String!) {{ ticker(symbol: $symbol) {{ chart(start: {start}, end: {end}) {selection} }} }}"
-        );
-        let mut vars = async_graphql::Variables::default();
-        vars.insert(async_graphql::Name::new("symbol"), symbol.into());
-        (q, vars)
-    } else {
-        let gql_interval = interval_to_gql(interval.as_deref().unwrap_or("1d"));
-        let gql_range = range_to_gql(range.as_deref().unwrap_or("1mo"));
-        let q = format!(
-            "query GetChart($symbol: String!) {{ ticker(symbol: $symbol) {{ chart(interval: {gql_interval}, range: {gql_range}) {selection} }} }}"
-        );
-        let mut vars = async_graphql::Variables::default();
-        vars.insert(async_graphql::Name::new("symbol"), symbol.into());
-        (q, vars)
-    };
+    let query = build_chart_query(
+        &selection,
+        interval.as_deref(),
+        range.as_deref(),
+        start,
+        end,
+    );
+    let mut variables = async_graphql::Variables::default();
+    variables.insert(async_graphql::Name::new("symbol"), symbol.into());
 
     let json = execute_query(schema, &query, variables).await?;
 
@@ -185,6 +206,20 @@ async fn get_one_chart(
     Ok(CallToolResult::success(vec![rmcp::model::Content::text(
         text,
     )]))
+}
+
+/// Build the outer `{ symbol [chart <chart_sel>] }` selection for a batch
+/// charts response, omitting the nested `chart` block entirely when not
+/// requested.
+fn build_batch_chart_selection(want_chart: bool, chart_sel: &str) -> String {
+    let mut selection = String::from("{ symbol ");
+    if want_chart {
+        selection.push_str("chart ");
+        selection.push_str(chart_sel);
+        selection.push(' ');
+    }
+    selection.push('}');
+    selection
 }
 
 async fn get_many_charts(
@@ -214,13 +249,7 @@ async fn get_many_charts(
         String::new()
     };
 
-    let mut selection = String::from("{ symbol ");
-    if want_chart {
-        selection.push_str("chart ");
-        selection.push_str(&chart_sel);
-        selection.push(' ');
-    }
-    selection.push('}');
+    let selection = build_batch_chart_selection(want_chart, &chart_sel);
 
     let query = format!(
         "query {{ charts(symbols: [{}], interval: {gql_interval}, range: {gql_range}) {{ charts {selection} errors {{ symbol message }} }} }}",
@@ -244,21 +273,11 @@ async fn get_many_charts(
     )]))
 }
 
-pub async fn get_spark(
-    schema: &FinanceSchema,
-    symbols: String,
-    interval: Option<String>,
-    range: Option<String>,
-    fields: Option<String>,
-) -> Result<CallToolResult, McpError> {
-    let gql_interval = interval_to_gql(interval.as_deref().unwrap_or("1d"));
-    let gql_range = range_to_gql(range.as_deref().unwrap_or("1mo"));
-
-    let syms: Vec<String> = symbols.split(',').map(|s| s.trim().to_string()).collect();
-    let syms_literal = gql_string_list_literal(&syms);
-
-    let field_list = parse_fields(fields);
-    let chosen: Vec<&str> = match field_list.as_deref() {
+/// Build the `spark(...)` selection: `meta` (when requested) is expanded
+/// with its own nested sub-selection, every other chosen field is emitted
+/// bare.
+fn build_spark_selection(fields: Option<&[String]>) -> String {
+    let chosen: Vec<&str> = match fields {
         Some(fs) if !fs.is_empty() => fs
             .iter()
             .map(|f| f.trim())
@@ -284,6 +303,24 @@ pub async fn get_spark(
         selection.push(' ');
     }
     selection.push('}');
+    selection
+}
+
+pub async fn get_spark(
+    schema: &FinanceSchema,
+    symbols: String,
+    interval: Option<String>,
+    range: Option<String>,
+    fields: Option<String>,
+) -> Result<CallToolResult, McpError> {
+    let gql_interval = interval_to_gql(interval.as_deref().unwrap_or("1d"));
+    let gql_range = range_to_gql(range.as_deref().unwrap_or("1mo"));
+
+    let syms: Vec<String> = symbols.split(',').map(|s| s.trim().to_string()).collect();
+    let syms_literal = gql_string_list_literal(&syms);
+
+    let field_list = parse_fields(fields);
+    let selection = build_spark_selection(field_list.as_deref());
 
     let query = format!(
         "query {{ spark(symbols: [{syms_literal}], interval: {gql_interval}, range: {gql_range}) {{ sparks {selection} errors {{ symbol message }} }} }}"
@@ -294,4 +331,157 @@ pub async fn get_spark(
     Ok(CallToolResult::success(vec![rmcp::model::Content::text(
         serde_json::to_string(&data).map_err(ser_err)?,
     )]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fields(names: &[&str]) -> Vec<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn build_chart_selection_defaults_include_meta_and_candles() {
+        let selection = build_chart_selection(None, Some(10), None);
+
+        assert!(selection.contains("symbol"));
+        assert!(selection.contains("meta"));
+        assert!(selection.contains("candles"));
+        assert!(selection.contains("first: 10"));
+    }
+
+    #[test]
+    fn build_chart_selection_flat_when_neither_meta_nor_candles_requested() {
+        let requested = fields(&["symbol", "interval"]);
+        let selection = build_chart_selection(Some(&requested), None, None);
+
+        assert_eq!(selection, "{ symbol interval }");
+        assert!(!selection.contains("candles"));
+    }
+
+    #[test]
+    fn build_chart_selection_omits_candles_args_when_limit_and_cursor_absent() {
+        let requested = fields(&["candles"]);
+        let selection = build_chart_selection(Some(&requested), None, None);
+
+        assert!(selection.contains("candles"));
+        assert!(!selection.contains("first:"));
+        assert!(!selection.contains("after:"));
+    }
+
+    #[test]
+    fn build_chart_selection_includes_cursor_arg_when_present() {
+        let requested = fields(&["candles"]);
+        let selection = build_chart_selection(Some(&requested), Some(5), Some("cur123"));
+
+        assert!(selection.contains("first: 5"));
+        assert!(selection.contains("after: \"cur123\""));
+    }
+
+    #[test]
+    fn build_chart_selection_drops_unknown_fields() {
+        let requested = fields(&["bogusField"]);
+        let selection = build_chart_selection(Some(&requested), None, None);
+
+        assert_eq!(selection, "{ }");
+    }
+
+    #[test]
+    fn split_symbols_trims_and_filters_empty_entries() {
+        assert_eq!(split_symbols("AAPL"), vec!["AAPL".to_string()]);
+        assert_eq!(
+            split_symbols("AAPL, MSFT ,GOOG"),
+            vec!["AAPL".to_string(), "MSFT".to_string(), "GOOG".to_string()]
+        );
+        assert_eq!(
+            split_symbols("AAPL,,MSFT,"),
+            vec!["AAPL".to_string(), "MSFT".to_string()]
+        );
+    }
+
+    #[test]
+    fn split_symbols_returns_empty_vec_for_blank_input() {
+        assert_eq!(split_symbols(""), Vec::<String>::new());
+        assert_eq!(split_symbols("   "), Vec::<String>::new());
+        assert_eq!(split_symbols(","), Vec::<String>::new());
+    }
+
+    #[test]
+    fn build_chart_query_with_start_only_defaults_end_to_now() {
+        let query = build_chart_query("{ symbol }", None, None, Some(100), None);
+
+        assert!(query.contains("start: 100"));
+        assert!(query.contains("end:"));
+        assert!(!query.contains("interval:"));
+    }
+
+    #[test]
+    fn build_chart_query_with_start_and_end_uses_both_explicitly() {
+        let query = build_chart_query("{ symbol }", None, None, Some(100), Some(200));
+
+        assert!(query.contains("start: 100"));
+        assert!(query.contains("end: 200"));
+    }
+
+    #[test]
+    fn build_chart_query_without_start_uses_interval_and_range() {
+        let query = build_chart_query("{ symbol }", Some("1h"), Some("5d"), None, None);
+
+        assert!(query.contains("interval: ONE_HOUR"));
+        assert!(query.contains("range: FIVE_DAYS"));
+        assert!(!query.contains("start:"));
+    }
+
+    #[test]
+    fn build_chart_query_without_start_defaults_interval_and_range() {
+        let query = build_chart_query("{ symbol }", None, None, None, None);
+
+        assert!(query.contains("interval: ONE_DAY"));
+        assert!(query.contains("range: ONE_MONTH"));
+    }
+
+    #[test]
+    fn build_batch_chart_selection_includes_chart_block_when_requested() {
+        let selection = build_batch_chart_selection(true, "{ candles { edges { } } }");
+
+        assert!(selection.contains("symbol"));
+        assert!(selection.contains("chart"));
+        assert!(selection.contains("candles"));
+    }
+
+    #[test]
+    fn build_batch_chart_selection_omits_chart_block_when_not_requested() {
+        let selection = build_batch_chart_selection(false, "{ candles { } }");
+
+        assert_eq!(selection, "{ symbol }");
+        assert!(!selection.contains("chart"));
+    }
+
+    #[test]
+    fn build_spark_selection_defaults_omit_meta() {
+        let selection = build_spark_selection(None);
+
+        assert!(selection.contains("symbol"));
+        assert!(selection.contains("closes"));
+        assert!(!selection.contains("meta"));
+    }
+
+    #[test]
+    fn build_spark_selection_expands_meta_when_requested() {
+        let requested = fields(&["symbol", "meta"]);
+        let selection = build_spark_selection(Some(&requested));
+
+        assert!(selection.contains("symbol"));
+        assert!(selection.contains("meta"));
+        assert!(selection.contains("currency"));
+    }
+
+    #[test]
+    fn build_spark_selection_drops_unknown_fields() {
+        let requested = fields(&["bogusField"]);
+        let selection = build_spark_selection(Some(&requested));
+
+        assert_eq!(selection, "{ }");
+    }
 }

--- a/finance-query-mcp/src/tools/crypto.rs
+++ b/finance-query-mcp/src/tools/crypto.rs
@@ -8,6 +8,15 @@ use crate::tools::gql::{
     wrap_connection,
 };
 
+/// Build the `first`/`after` connection args for the `cryptoCoins` query.
+fn build_conn_args(limit: Option<u32>, cursor: Option<&str>) -> String {
+    let mut args = vec![format!("first: {}", limit.unwrap_or(DEFAULT_MCP_PAGE_SIZE))];
+    if let Some(c) = cursor {
+        args.push(format!("after: \"{}\"", escape_gql_string(c)));
+    }
+    args.join(", ")
+}
+
 pub async fn get_crypto_coins(
     schema: &FinanceSchema,
     count: Option<u32>,
@@ -25,11 +34,7 @@ pub async fn get_crypto_coins(
         GQL_COIN_VALID_FIELDS,
     );
     let selection = build_connection_selection(&inner_selection);
-    let mut conn_args = vec![format!("first: {}", limit.unwrap_or(DEFAULT_MCP_PAGE_SIZE))];
-    if let Some(c) = cursor.as_deref() {
-        conn_args.push(format!("after: \"{}\"", escape_gql_string(c)));
-    }
-    let conn_args = conn_args.join(", ");
+    let conn_args = build_conn_args(limit, cursor.as_deref());
     let query = format!(
         "query {{ cryptoCoins(vsCurrency: \"{currency}\", count: {n}, {conn_args}) {selection} }}"
     );
@@ -38,4 +43,36 @@ pub async fn get_crypto_coins(
     Ok(CallToolResult::success(vec![rmcp::model::Content::text(
         serde_json::to_string(&data).map_err(ser_err)?,
     )]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_conn_args_uses_default_limit_without_cursor() {
+        let args = build_conn_args(None, None);
+        assert_eq!(args, format!("first: {DEFAULT_MCP_PAGE_SIZE}"));
+    }
+
+    #[test]
+    fn build_conn_args_uses_given_limit() {
+        let args = build_conn_args(Some(5), None);
+        assert_eq!(args, "first: 5");
+    }
+
+    #[test]
+    fn build_conn_args_includes_cursor_when_present() {
+        let args = build_conn_args(Some(10), Some("abc123"));
+        assert_eq!(args, "first: 10, after: \"abc123\"");
+    }
+
+    #[test]
+    fn build_conn_args_escapes_special_characters_in_cursor() {
+        let args = build_conn_args(None, Some("has\"quote\\slash"));
+        assert_eq!(
+            args,
+            format!("first: {DEFAULT_MCP_PAGE_SIZE}, after: \"has\\\"quote\\\\slash\"")
+        );
+    }
 }

--- a/finance-query-mcp/src/tools/dividends.rs
+++ b/finance-query-mcp/src/tools/dividends.rs
@@ -9,6 +9,15 @@ use crate::tools::gql::{
     wrap_nested_connection,
 };
 
+/// Split a comma-separated symbols param into a trimmed, non-empty list.
+fn split_symbols(symbols: &str) -> Vec<String> {
+    symbols
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
 /// Accepts one or more comma-separated symbols: a single symbol returns the
 /// flat shape with dividend `analytics` (CAGR, average payment, etc.) and
 /// paginated dividend history; multiple symbols return the batch
@@ -22,11 +31,7 @@ pub async fn get_dividends(
     limit: Option<u32>,
     cursor: Option<String>,
 ) -> Result<CallToolResult, McpError> {
-    let syms: Vec<String> = symbols
-        .split(',')
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .collect();
+    let syms = split_symbols(&symbols);
     if syms.len() == 1 {
         get_one_dividends(
             schema,
@@ -42,6 +47,32 @@ pub async fn get_dividends(
     }
 }
 
+/// Build the `dividends(...)` selection for the single-symbol path: the
+/// `dividends` list is the one paginated composite field, everything else
+/// (e.g. `analytics`) uses the plain default/valid field lists.
+fn build_dividends_selection(
+    field_list: Option<&[String]>,
+    limit: u32,
+    cursor: Option<&str>,
+) -> String {
+    let dividends_item_selection = DIVIDENDS_COMPOSITE_FIELDS
+        .iter()
+        .find(|(name, _)| *name == "dividends")
+        .map(|(_, sel)| *sel)
+        .unwrap_or("{ timestamp amount }");
+    let fields_csv = field_list.map(|fs| fs.join(","));
+    build_paginated_composite_selection(
+        fields_csv.as_deref(),
+        GQL_DIVIDENDS_VALID_FIELDS,
+        GQL_DIVIDENDS_DEFAULT_FIELDS,
+        DIVIDENDS_COMPOSITE_FIELDS,
+        "dividends",
+        dividends_item_selection,
+        Some(limit),
+        cursor,
+    )
+}
+
 async fn get_one_dividends(
     schema: &FinanceSchema,
     symbol: String,
@@ -51,20 +82,9 @@ async fn get_one_dividends(
     cursor: Option<String>,
 ) -> Result<CallToolResult, McpError> {
     let field_list = parse_fields(fields);
-    let dividends_item_selection = DIVIDENDS_COMPOSITE_FIELDS
-        .iter()
-        .find(|(name, _)| *name == "dividends")
-        .map(|(_, sel)| *sel)
-        .unwrap_or("{ timestamp amount }");
-    let fields_csv = field_list.as_ref().map(|fs| fs.join(","));
-    let selection = build_paginated_composite_selection(
-        fields_csv.as_deref(),
-        GQL_DIVIDENDS_VALID_FIELDS,
-        GQL_DIVIDENDS_DEFAULT_FIELDS,
-        DIVIDENDS_COMPOSITE_FIELDS,
-        "dividends",
-        dividends_item_selection,
-        Some(limit.unwrap_or(DEFAULT_MCP_PAGE_SIZE)),
+    let selection = build_dividends_selection(
+        field_list.as_deref(),
+        limit.unwrap_or(DEFAULT_MCP_PAGE_SIZE),
         cursor.as_deref(),
     );
     let r = range.as_deref().unwrap_or("max").to_lowercase();
@@ -84,6 +104,18 @@ async fn get_one_dividends(
     )]))
 }
 
+/// Build the outer `{ symbol [dividends { timestamp amount }] }` selection
+/// for a batch dividends response, omitting the nested `dividends` block
+/// entirely when not requested.
+fn build_batch_dividends_selection(want_dividends: bool) -> String {
+    let mut selection = String::from("{ symbol ");
+    if want_dividends {
+        selection.push_str("dividends { timestamp amount } ");
+    }
+    selection.push('}');
+    selection
+}
+
 async fn get_many_dividends(
     schema: &FinanceSchema,
     syms: Vec<String>,
@@ -100,11 +132,7 @@ async fn get_many_dividends(
         .as_ref()
         .map(|fs| fs.iter().any(|f| f == "dividends"))
         .unwrap_or(true);
-    let mut selection = String::from("{ symbol ");
-    if want_dividends {
-        selection.push_str("dividends { timestamp amount } ");
-    }
-    selection.push('}');
+    let selection = build_batch_dividends_selection(want_dividends);
 
     let syms_literal = gql_string_list_literal(&syms);
 
@@ -119,4 +147,76 @@ async fn get_many_dividends(
     Ok(CallToolResult::success(vec![rmcp::model::Content::text(
         text,
     )]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fields(names: &[&str]) -> Vec<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn split_symbols_trims_and_filters_empty_entries() {
+        assert_eq!(split_symbols("AAPL"), vec!["AAPL".to_string()]);
+        assert_eq!(
+            split_symbols("AAPL, MSFT ,GOOG"),
+            vec!["AAPL".to_string(), "MSFT".to_string(), "GOOG".to_string()]
+        );
+        assert_eq!(
+            split_symbols("AAPL,,MSFT,"),
+            vec!["AAPL".to_string(), "MSFT".to_string()]
+        );
+    }
+
+    #[test]
+    fn split_symbols_returns_empty_vec_for_blank_input() {
+        assert_eq!(split_symbols(""), Vec::<String>::new());
+        assert_eq!(split_symbols("   "), Vec::<String>::new());
+        assert_eq!(split_symbols(","), Vec::<String>::new());
+    }
+
+    #[test]
+    fn build_dividends_selection_defaults_include_dividends_and_analytics() {
+        let selection = build_dividends_selection(None, 25, None);
+
+        assert!(selection.contains("dividends"));
+        assert!(selection.contains("analytics"));
+        assert!(selection.contains("edges"));
+        assert!(selection.contains("pageInfo"));
+        assert!(selection.contains("first: 25"));
+    }
+
+    #[test]
+    fn build_dividends_selection_includes_cursor_when_present() {
+        let selection = build_dividends_selection(None, 10, Some("abc123"));
+
+        assert!(selection.contains("first: 10"));
+        assert!(selection.contains("after: \"abc123\""));
+    }
+
+    #[test]
+    fn build_dividends_selection_respects_explicit_field_list() {
+        let requested = fields(&["analytics"]);
+        let selection = build_dividends_selection(Some(&requested), 25, None);
+
+        assert!(selection.contains("analytics"));
+        assert!(selection.contains("totalPaid"));
+        assert!(!selection.contains("edges"));
+    }
+
+    #[test]
+    fn build_batch_dividends_selection_includes_dividends_block_when_requested() {
+        let selection = build_batch_dividends_selection(true);
+
+        assert_eq!(selection, "{ symbol dividends { timestamp amount } }");
+    }
+
+    #[test]
+    fn build_batch_dividends_selection_omits_dividends_block_when_not_requested() {
+        let selection = build_batch_dividends_selection(false);
+
+        assert_eq!(selection, "{ symbol }");
+    }
 }

--- a/finance-query-mcp/src/tools/edgar.rs
+++ b/finance-query-mcp/src/tools/edgar.rs
@@ -18,6 +18,30 @@ fn edgar_guard() -> Result<(), McpError> {
     Ok(())
 }
 
+/// Build the `(taxonomy: "...", concepts: [...])` argument clause for the
+/// `edgarFacts` field, omitting each part when absent/empty and omitting the
+/// parens entirely when neither part is present (bare `edgarFacts()` is
+/// invalid GraphQL syntax).
+fn build_edgar_facts_args(taxonomy: Option<&str>, concepts: Option<&[String]>) -> String {
+    let taxonomy_arg = match taxonomy {
+        Some(t) if !t.trim().is_empty() => format!("taxonomy: \"{}\"", escape_gql_string(t)),
+        _ => String::new(),
+    };
+    let concepts_arg = match concepts {
+        Some(cs) if !cs.is_empty() => format!("concepts: [{}]", gql_string_list_literal(cs)),
+        _ => String::new(),
+    };
+    let args: Vec<&str> = [taxonomy_arg.as_str(), concepts_arg.as_str()]
+        .into_iter()
+        .filter(|s| !s.is_empty())
+        .collect();
+    if args.is_empty() {
+        String::new()
+    } else {
+        format!("({})", args.join(", "))
+    }
+}
+
 pub async fn get_edgar_facts(
     schema: &FinanceSchema,
     symbol: String,
@@ -46,24 +70,8 @@ pub async fn get_edgar_facts(
         cursor.as_deref(),
     );
 
-    let taxonomy_arg = match &taxonomy {
-        Some(t) if !t.trim().is_empty() => format!("taxonomy: \"{}\"", escape_gql_string(t)),
-        _ => String::new(),
-    };
     let concept_list = parse_fields(concepts);
-    let concepts_arg = match &concept_list {
-        Some(cs) if !cs.is_empty() => format!("concepts: [{}]", gql_string_list_literal(cs)),
-        _ => String::new(),
-    };
-    let args: Vec<&str> = [taxonomy_arg.as_str(), concepts_arg.as_str()]
-        .into_iter()
-        .filter(|s| !s.is_empty())
-        .collect();
-    let args_str = if args.is_empty() {
-        String::new()
-    } else {
-        format!("({})", args.join(", "))
-    };
+    let args_str = build_edgar_facts_args(taxonomy.as_deref(), concept_list.as_deref());
 
     let query = format!(
         "query GetEdgarFacts($symbol: String!) {{ ticker(symbol: $symbol) {{ edgarFacts{args_str} {selection} }} }}"
@@ -152,4 +160,62 @@ pub async fn get_edgar_search(
     Ok(CallToolResult::success(vec![rmcp::model::Content::text(
         serde_json::to_string(&data).map_err(ser_err)?,
     )]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn edgar_guard_errs_without_env_var_and_ok_with_it() {
+        // Single test to avoid two tests racing on the same process-wide env var.
+        let saved = std::env::var("EDGAR_EMAIL").ok();
+
+        unsafe { std::env::remove_var("EDGAR_EMAIL") };
+        assert!(edgar_guard().is_err());
+
+        unsafe { std::env::set_var("EDGAR_EMAIL", "test@example.com") };
+        assert!(edgar_guard().is_ok());
+
+        match saved {
+            Some(v) => unsafe { std::env::set_var("EDGAR_EMAIL", v) },
+            None => unsafe { std::env::remove_var("EDGAR_EMAIL") },
+        }
+    }
+
+    #[test]
+    fn build_edgar_facts_args_includes_both_when_present() {
+        let concepts = vec!["Assets".to_string(), "Liabilities".to_string()];
+        let args = build_edgar_facts_args(Some("us-gaap"), Some(&concepts));
+        assert_eq!(
+            args,
+            "(taxonomy: \"us-gaap\", concepts: [\"Assets\", \"Liabilities\"])"
+        );
+    }
+
+    #[test]
+    fn build_edgar_facts_args_omits_taxonomy_when_blank() {
+        let concepts = vec!["Assets".to_string()];
+        let args = build_edgar_facts_args(Some("  "), Some(&concepts));
+        assert_eq!(args, "(concepts: [\"Assets\"])");
+    }
+
+    #[test]
+    fn build_edgar_facts_args_omits_concepts_when_empty() {
+        let empty: Vec<String> = Vec::new();
+        let args = build_edgar_facts_args(Some("us-gaap"), Some(&empty));
+        assert_eq!(args, "(taxonomy: \"us-gaap\")");
+    }
+
+    #[test]
+    fn build_edgar_facts_args_is_empty_when_neither_present() {
+        assert_eq!(build_edgar_facts_args(None, None), "");
+        assert_eq!(build_edgar_facts_args(Some(""), None), "");
+    }
+
+    #[test]
+    fn build_edgar_facts_args_escapes_taxonomy_string() {
+        let args = build_edgar_facts_args(Some("us\"gaap"), None);
+        assert_eq!(args, "(taxonomy: \"us\\\"gaap\")");
+    }
 }

--- a/finance-query-mcp/src/tools/feeds.rs
+++ b/finance-query-mcp/src/tools/feeds.rs
@@ -8,6 +8,37 @@ use crate::tools::gql::{
     gql_string_list_literal, parse_fields, unwrap_field, wrap_connection,
 };
 
+/// Parse the comma-separated `sources` param, falling back to this tool's
+/// historical default list when the caller omits it or supplies only blanks.
+fn parse_sources(sources: Option<&str>) -> Vec<&str> {
+    let list: Vec<&str> = match sources {
+        Some(raw) => raw
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .collect(),
+        None => vec![],
+    };
+    if list.is_empty() {
+        vec!["marketwatch", "bloomberg", "wsj", "fortune"]
+    } else {
+        list
+    }
+}
+
+/// Build the `feeds(...)` field argument list: sources, `first`, and an
+/// optional `after` cursor.
+fn build_feeds_args(sources: &[&str], limit: Option<u32>, cursor: Option<&str>) -> String {
+    let mut args = vec![
+        format!("sources: [{}]", gql_string_list_literal(sources)),
+        format!("first: {}", limit.unwrap_or(DEFAULT_MCP_PAGE_SIZE)),
+    ];
+    if let Some(c) = cursor {
+        args.push(format!("after: \"{}\"", escape_gql_string(c)));
+    }
+    format!("({})", args.join(", "))
+}
+
 pub async fn get_feeds(
     schema: &FinanceSchema,
     sources: Option<String>,
@@ -25,27 +56,8 @@ pub async fn get_feeds(
 
     // Preserve this tool's historical default sources (distinct from the
     // GraphQL field's own default) by always passing an explicit list.
-    let list: Vec<&str> = match sources.as_deref() {
-        Some(raw) => raw
-            .split(',')
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .collect(),
-        None => vec![],
-    };
-    let list: Vec<&str> = if list.is_empty() {
-        vec!["marketwatch", "bloomberg", "wsj", "fortune"]
-    } else {
-        list
-    };
-    let mut args = vec![
-        format!("sources: [{}]", gql_string_list_literal(&list)),
-        format!("first: {}", limit.unwrap_or(DEFAULT_MCP_PAGE_SIZE)),
-    ];
-    if let Some(c) = cursor.as_deref() {
-        args.push(format!("after: \"{}\"", escape_gql_string(c)));
-    }
-    let args_str = format!("({})", args.join(", "));
+    let list = parse_sources(sources.as_deref());
+    let args_str = build_feeds_args(&list, limit, cursor.as_deref());
 
     let query = format!("query {{ feeds{args_str} {selection} }}");
     let json = execute_query(schema, &query, async_graphql::Variables::default()).await?;
@@ -55,4 +67,70 @@ pub async fn get_feeds(
     Ok(CallToolResult::success(vec![rmcp::model::Content::text(
         text,
     )]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_sources_falls_back_to_defaults_when_none() {
+        assert_eq!(
+            parse_sources(None),
+            vec!["marketwatch", "bloomberg", "wsj", "fortune"]
+        );
+    }
+
+    #[test]
+    fn parse_sources_falls_back_to_defaults_when_empty_string() {
+        assert_eq!(
+            parse_sources(Some("")),
+            vec!["marketwatch", "bloomberg", "wsj", "fortune"]
+        );
+    }
+
+    #[test]
+    fn parse_sources_falls_back_to_defaults_when_only_blanks_and_commas() {
+        assert_eq!(
+            parse_sources(Some(" , , ")),
+            vec!["marketwatch", "bloomberg", "wsj", "fortune"]
+        );
+    }
+
+    #[test]
+    fn parse_sources_splits_and_trims_a_csv_list() {
+        assert_eq!(
+            parse_sources(Some("wsj, bloomberg ")),
+            vec!["wsj", "bloomberg"]
+        );
+    }
+
+    #[test]
+    fn parse_sources_preserves_single_source() {
+        assert_eq!(parse_sources(Some("wsj")), vec!["wsj"]);
+    }
+
+    #[test]
+    fn build_feeds_args_uses_default_limit_without_cursor() {
+        let args = build_feeds_args(&["wsj"], None, None);
+        assert_eq!(
+            args,
+            format!("(sources: [\"wsj\"], first: {DEFAULT_MCP_PAGE_SIZE})")
+        );
+    }
+
+    #[test]
+    fn build_feeds_args_includes_given_limit_and_cursor() {
+        let args = build_feeds_args(&["wsj", "fortune"], Some(5), Some("cur1"));
+        assert_eq!(
+            args,
+            "(sources: [\"wsj\", \"fortune\"], first: 5, after: \"cur1\")"
+        );
+    }
+
+    #[test]
+    fn build_feeds_args_escapes_special_characters_in_cursor() {
+        let args = build_feeds_args(&["wsj"], Some(1), Some("has\"quote"));
+        assert!(args.contains("after: \"has\\\"quote\""));
+    }
 }

--- a/finance-query-mcp/src/tools/financials.rs
+++ b/finance-query-mcp/src/tools/financials.rs
@@ -21,6 +21,27 @@ const FINANCIAL_LINE_ITEM_FIELDS: &[&str] = GQL_FINANCIAL_LINE_ITEM_VALID_FIELDS
 const FINANCIAL_LINE_ITEM_COMPOSITE_FIELDS: &[(&str, &str)] =
     SHARED_FINANCIAL_LINE_ITEM_COMPOSITE_FIELDS;
 
+/// Split a comma-separated `symbols` param into trimmed, non-empty symbols.
+fn split_symbols(symbols: &str) -> Vec<String> {
+    symbols
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+/// Build the `, metrics: [...]` argument suffix, or empty when no metrics
+/// were requested — mirrors the leading comma needed because it's always
+/// spliced after an already-present `statement`/`frequency` argument.
+fn build_metrics_arg(metric_list: Option<&[String]>) -> String {
+    match metric_list {
+        Some(list) if !list.is_empty() => {
+            format!(", metrics: [{}]", gql_string_list_literal(list))
+        }
+        _ => String::new(),
+    }
+}
+
 /// Accepts one or more comma-separated symbols: a single symbol returns the
 /// flat statement shape, multiple symbols return the batch `{financials, errors}` shape.
 pub async fn get_financials(
@@ -31,11 +52,7 @@ pub async fn get_financials(
     metrics: Option<String>,
     fields: Option<String>,
 ) -> Result<CallToolResult, McpError> {
-    let syms: Vec<String> = symbols
-        .split(',')
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .collect();
+    let syms = split_symbols(&symbols);
     if syms.len() == 1 {
         get_one_financials(
             schema,
@@ -73,12 +90,7 @@ async fn get_one_financials(
     let gql_st = statement_to_gql(st);
     let gql_freq = frequency_to_gql(freq);
     let metric_list = parse_fields(metrics);
-    let metrics_arg = match &metric_list {
-        Some(list) if !list.is_empty() => {
-            format!(", metrics: [{}]", gql_string_list_literal(list))
-        }
-        _ => String::new(),
-    };
+    let metrics_arg = build_metrics_arg(metric_list.as_deref());
     let field_list = parse_fields(fields);
     let selection = build_type_spec_selection(
         field_list.as_deref(),
@@ -121,12 +133,7 @@ async fn get_many_financials(
     let gql_st = statement_to_gql(st);
     let gql_freq = frequency_to_gql(freq);
     let metric_list = parse_fields(metrics);
-    let metrics_arg = match &metric_list {
-        Some(list) if !list.is_empty() => {
-            format!(", metrics: [{}]", gql_string_list_literal(list))
-        }
-        _ => String::new(),
-    };
+    let metrics_arg = build_metrics_arg(metric_list.as_deref());
     let syms_literal = gql_string_list_literal(&syms);
     let field_list = parse_fields(fields);
     // "statement" (`GqlSymbolFinancials`) is a list of composite
@@ -146,4 +153,60 @@ async fn get_many_financials(
     Ok(CallToolResult::success(vec![rmcp::model::Content::text(
         serde_json::to_string(&data).map_err(ser_err)?,
     )]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_symbols_returns_single_symbol_for_one_input() {
+        assert_eq!(split_symbols("AAPL"), vec!["AAPL".to_string()]);
+    }
+
+    #[test]
+    fn split_symbols_trims_whitespace_around_each_symbol() {
+        assert_eq!(
+            split_symbols("AAPL, MSFT , GOOG"),
+            vec!["AAPL".to_string(), "MSFT".to_string(), "GOOG".to_string()]
+        );
+    }
+
+    #[test]
+    fn split_symbols_drops_empty_entries_from_repeated_commas() {
+        assert_eq!(
+            split_symbols("AAPL,,MSFT,"),
+            vec!["AAPL".to_string(), "MSFT".to_string()]
+        );
+    }
+
+    #[test]
+    fn split_symbols_returns_empty_vec_for_empty_string() {
+        assert_eq!(split_symbols(""), Vec::<String>::new());
+    }
+
+    #[test]
+    fn split_symbols_returns_empty_vec_for_blank_input() {
+        assert_eq!(split_symbols("   "), Vec::<String>::new());
+    }
+
+    #[test]
+    fn build_metrics_arg_formats_a_gql_list_when_metrics_present() {
+        let metrics = vec!["revenue".to_string(), "netIncome".to_string()];
+        assert_eq!(
+            build_metrics_arg(Some(&metrics)),
+            ", metrics: [\"revenue\", \"netIncome\"]"
+        );
+    }
+
+    #[test]
+    fn build_metrics_arg_is_empty_when_metrics_is_none() {
+        assert_eq!(build_metrics_arg(None), "");
+    }
+
+    #[test]
+    fn build_metrics_arg_is_empty_when_metrics_list_is_empty() {
+        let empty: Vec<String> = Vec::new();
+        assert_eq!(build_metrics_arg(Some(&empty)), "");
+    }
 }

--- a/finance-query-mcp/src/tools/fred.rs
+++ b/finance-query-mcp/src/tools/fred.rs
@@ -9,6 +9,16 @@ use crate::tools::gql::{
     wrap_connection, wrap_nested_connection,
 };
 
+/// Look up the `observations` nested selection from `MACRO_SERIES_COMPOSITE_FIELDS`,
+/// falling back to a minimal `date`/`value` selection if the entry is ever missing.
+fn observations_selection() -> &'static str {
+    MACRO_SERIES_COMPOSITE_FIELDS
+        .iter()
+        .find(|(name, _)| *name == "observations")
+        .map(|(_, sel)| *sel)
+        .unwrap_or("{ date value }")
+}
+
 pub async fn get_fred_series(
     schema: &FinanceSchema,
     id: String,
@@ -22,11 +32,7 @@ pub async fn get_fred_series(
         ));
     }
     let field_list = parse_fields(fields);
-    let observations_item_selection = MACRO_SERIES_COMPOSITE_FIELDS
-        .iter()
-        .find(|(name, _)| *name == "observations")
-        .map(|(_, sel)| *sel)
-        .unwrap_or("{ date value }");
+    let observations_item_selection = observations_selection();
     let fields_csv = field_list.as_ref().map(|fs| fs.join(","));
     let selection = build_paginated_composite_selection(
         fields_csv.as_deref(),
@@ -48,6 +54,20 @@ pub async fn get_fred_series(
     )]))
 }
 
+/// Build the `treasuryYields(...)` field argument list: an optional `year`
+/// filter, always followed by `first` and an optional `after` cursor.
+fn build_treasury_args(year: Option<u32>, limit: Option<u32>, cursor: Option<&str>) -> String {
+    let mut args = Vec::new();
+    if let Some(y) = year {
+        args.push(format!("year: {y}"));
+    }
+    args.push(format!("first: {}", limit.unwrap_or(DEFAULT_MCP_PAGE_SIZE)));
+    if let Some(c) = cursor {
+        args.push(format!("after: \"{}\"", escape_gql_string(c)));
+    }
+    args.join(", ")
+}
+
 pub async fn get_treasury_yields(
     schema: &FinanceSchema,
     year: Option<u32>,
@@ -62,21 +82,55 @@ pub async fn get_treasury_yields(
         GQL_TREASURY_YIELD_VALID_FIELDS,
     );
     let selection = build_connection_selection(&inner_selection);
-    let mut args = Vec::new();
-    if let Some(y) = year {
-        args.push(format!("year: {y}"));
-    }
-    args.push(format!("first: {}", limit.unwrap_or(DEFAULT_MCP_PAGE_SIZE)));
-    if let Some(c) = cursor.as_deref() {
-        args.push(format!("after: \"{}\"", escape_gql_string(c)));
-    }
-    let query = format!(
-        "query {{ treasuryYields({}) {selection} }}",
-        args.join(", ")
-    );
+    let args = build_treasury_args(year, limit, cursor.as_deref());
+    let query = format!("query {{ treasuryYields({args}) {selection} }}");
     let json = execute_query(schema, &query, async_graphql::Variables::default()).await?;
     let data = wrap_connection(unwrap_field(json, "treasuryYields"));
     Ok(CallToolResult::success(vec![rmcp::model::Content::text(
         serde_json::to_string(&data).map_err(ser_err)?,
     )]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn observations_selection_returns_a_nonempty_brace_wrapped_selection() {
+        let sel = observations_selection();
+        assert!(sel.starts_with('{'));
+        assert!(sel.ends_with('}'));
+        assert!(sel.contains("date"));
+        assert!(sel.contains("value"));
+    }
+
+    #[test]
+    fn build_treasury_args_uses_default_limit_without_year_or_cursor() {
+        let args = build_treasury_args(None, None, None);
+        assert_eq!(args, format!("first: {DEFAULT_MCP_PAGE_SIZE}"));
+    }
+
+    #[test]
+    fn build_treasury_args_includes_year_before_first() {
+        let args = build_treasury_args(Some(2024), Some(10), None);
+        assert_eq!(args, "year: 2024, first: 10");
+    }
+
+    #[test]
+    fn build_treasury_args_includes_cursor_after_first() {
+        let args = build_treasury_args(None, Some(10), Some("cur1"));
+        assert_eq!(args, "first: 10, after: \"cur1\"");
+    }
+
+    #[test]
+    fn build_treasury_args_includes_year_first_and_cursor_together() {
+        let args = build_treasury_args(Some(2023), Some(5), Some("cur2"));
+        assert_eq!(args, "year: 2023, first: 5, after: \"cur2\"");
+    }
+
+    #[test]
+    fn build_treasury_args_escapes_special_characters_in_cursor() {
+        let args = build_treasury_args(None, None, Some("has\"quote"));
+        assert!(args.contains("after: \"has\\\"quote\""));
+    }
 }

--- a/finance-query-mcp/src/tools/gql.rs
+++ b/finance-query-mcp/src/tools/gql.rs
@@ -594,6 +594,68 @@ mod tests {
     }
 
     #[test]
+    fn wrap_connection_reshapes_edges_node_into_items_and_page_info() {
+        let canned = serde_json::json!({
+            "edges": [
+                {"node": {"symbol": "AAPL"}},
+                {"node": {"symbol": "MSFT"}},
+            ],
+            "pageInfo": {"hasNextPage": true, "endCursor": "abc123"},
+        });
+
+        let wrapped = wrap_connection(canned);
+
+        assert_eq!(
+            wrapped["items"],
+            serde_json::json!([{"symbol": "AAPL"}, {"symbol": "MSFT"}])
+        );
+        assert_eq!(wrapped["pageInfo"]["hasNextPage"], true);
+        assert_eq!(wrapped["pageInfo"]["endCursor"], "abc123");
+    }
+
+    #[test]
+    fn wrap_connection_handles_an_empty_page() {
+        let canned = serde_json::json!({
+            "edges": [],
+            "pageInfo": {"hasNextPage": false, "endCursor": null},
+        });
+
+        let wrapped = wrap_connection(canned);
+
+        assert_eq!(wrapped["items"], serde_json::json!([]));
+        assert_eq!(wrapped["pageInfo"]["hasNextPage"], false);
+    }
+
+    #[test]
+    fn wrap_nested_connection_only_reshapes_the_named_field() {
+        let canned = serde_json::json!({
+            "symbol": "AAPL",
+            "dividends": {
+                "edges": [{"node": {"amount": 0.24}}],
+                "pageInfo": {"hasNextPage": false, "endCursor": "xyz"},
+            },
+        });
+
+        let wrapped = wrap_nested_connection(canned, "dividends");
+
+        assert_eq!(wrapped["symbol"], "AAPL");
+        assert_eq!(
+            wrapped["dividends"]["items"],
+            serde_json::json!([{"amount": 0.24}])
+        );
+        assert_eq!(wrapped["dividends"]["pageInfo"]["endCursor"], "xyz");
+    }
+
+    #[test]
+    fn wrap_nested_connection_is_a_no_op_when_the_field_is_absent() {
+        let canned = serde_json::json!({"symbol": "AAPL"});
+
+        let wrapped = wrap_nested_connection(canned.clone(), "dividends");
+
+        assert_eq!(wrapped, canned);
+    }
+
+    #[test]
     fn build_type_spec_selection_falls_back_when_every_requested_field_is_unknown() {
         let requested = fields(&["bogus1", "bogus2"]);
         let selection = build_type_spec_selection(

--- a/finance-query-mcp/src/tools/helpers.rs
+++ b/finance-query-mcp/src/tools/helpers.rs
@@ -64,3 +64,94 @@ pub fn range_to_gql(s: &str) -> &'static str {
         TimeRange::Max => "MAX",
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_statement_type_accepts_known_values() {
+        assert_eq!(parse_statement_type("income"), Some(StatementType::Income));
+        assert_eq!(
+            parse_statement_type("balance"),
+            Some(StatementType::Balance)
+        );
+        assert_eq!(
+            parse_statement_type("cashflow"),
+            Some(StatementType::CashFlow)
+        );
+    }
+
+    #[test]
+    fn parse_statement_type_rejects_unknown_values() {
+        assert_eq!(parse_statement_type("bogus"), None);
+        assert_eq!(parse_statement_type(""), None);
+    }
+
+    #[test]
+    fn parse_frequency_accepts_known_values() {
+        assert_eq!(parse_frequency("annual"), Some(Frequency::Annual));
+        assert_eq!(parse_frequency("quarterly"), Some(Frequency::Quarterly));
+    }
+
+    #[test]
+    fn parse_frequency_rejects_unknown_values_instead_of_defaulting() {
+        // Deliberately fallible (see doc comment) — must not silently
+        // default an unrecognized frequency to `Annual`.
+        assert_eq!(parse_frequency("bogus"), None);
+        assert_eq!(parse_frequency(""), None);
+    }
+
+    #[test]
+    fn statement_to_gql_maps_every_variant() {
+        assert_eq!(statement_to_gql(StatementType::Income), "INCOME");
+        assert_eq!(statement_to_gql(StatementType::Balance), "BALANCE");
+        assert_eq!(statement_to_gql(StatementType::CashFlow), "CASH_FLOW");
+    }
+
+    #[test]
+    fn frequency_to_gql_maps_every_variant() {
+        assert_eq!(frequency_to_gql(Frequency::Annual), "ANNUAL");
+        assert_eq!(frequency_to_gql(Frequency::Quarterly), "QUARTERLY");
+    }
+
+    #[test]
+    fn interval_to_gql_maps_every_known_value() {
+        assert_eq!(interval_to_gql("1m"), "ONE_MINUTE");
+        assert_eq!(interval_to_gql("5m"), "FIVE_MINUTES");
+        assert_eq!(interval_to_gql("15m"), "FIFTEEN_MINUTES");
+        assert_eq!(interval_to_gql("30m"), "THIRTY_MINUTES");
+        assert_eq!(interval_to_gql("1h"), "ONE_HOUR");
+        assert_eq!(interval_to_gql("1d"), "ONE_DAY");
+        assert_eq!(interval_to_gql("1wk"), "ONE_WEEK");
+        assert_eq!(interval_to_gql("1mo"), "ONE_MONTH");
+        assert_eq!(interval_to_gql("3mo"), "THREE_MONTHS");
+    }
+
+    #[test]
+    fn interval_to_gql_falls_back_to_one_day_for_unknown_input() {
+        assert_eq!(interval_to_gql("not-a-real-interval"), "ONE_DAY");
+        assert_eq!(interval_to_gql(""), "ONE_DAY");
+    }
+
+    #[test]
+    fn range_to_gql_maps_every_known_value() {
+        assert_eq!(range_to_gql("1d"), "ONE_DAY");
+        assert_eq!(range_to_gql("5d"), "FIVE_DAYS");
+        assert_eq!(range_to_gql("1mo"), "ONE_MONTH");
+        assert_eq!(range_to_gql("3mo"), "THREE_MONTHS");
+        assert_eq!(range_to_gql("6mo"), "SIX_MONTHS");
+        assert_eq!(range_to_gql("1y"), "ONE_YEAR");
+        assert_eq!(range_to_gql("2y"), "TWO_YEARS");
+        assert_eq!(range_to_gql("5y"), "FIVE_YEARS");
+        assert_eq!(range_to_gql("10y"), "TEN_YEARS");
+        assert_eq!(range_to_gql("ytd"), "YEAR_TO_DATE");
+        assert_eq!(range_to_gql("max"), "MAX");
+    }
+
+    #[test]
+    fn range_to_gql_falls_back_to_one_month_for_unknown_input() {
+        assert_eq!(range_to_gql("not-a-real-range"), "ONE_MONTH");
+        assert_eq!(range_to_gql(""), "ONE_MONTH");
+    }
+}

--- a/finance-query-mcp/src/tools/indicators.rs
+++ b/finance-query-mcp/src/tools/indicators.rs
@@ -10,6 +10,53 @@ use crate::tools::gql::{
 };
 use crate::tools::helpers::{interval_to_gql, range_to_gql};
 
+/// Split a comma-separated `symbols` param into trimmed, non-empty symbols.
+fn split_symbols(symbols: &str) -> Vec<String> {
+    symbols
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+/// Whether the `indicators` composite sub-field should be expanded for the
+/// batch item selection: true when the caller didn't restrict `fields` at
+/// all, or explicitly asked for `indicators`.
+fn wants_indicators_field(field_list: Option<&[String]>) -> bool {
+    field_list
+        .map(|fs| fs.iter().any(|f| f == "indicators"))
+        .unwrap_or(true)
+}
+
+/// Build the `{ symbol [indicators { ... }] }` item selection for
+/// `indicatorsBatch`, omitting the nested `indicators` sub-selection
+/// entirely when the caller's `fields` excludes it.
+fn build_indicators_batch_item_selection(field_list: Option<&[String]>) -> String {
+    let mut item_selection = String::from("{ symbol ");
+    if wants_indicators_field(field_list) {
+        item_selection.push_str("indicators ");
+        item_selection.push_str(&build_type_spec_selection(
+            field_list,
+            GQL_INDICATORS_VALID_FIELDS,
+            GQL_INDICATORS_DEFAULT_FIELDS,
+            INDICATOR_COMPOSITE_FIELDS,
+        ));
+        item_selection.push(' ');
+    }
+    item_selection.push('}');
+    item_selection
+}
+
+/// Build the `first`/`after` connection argument list shared by paginated
+/// batch queries in this file.
+fn build_connection_args(limit: Option<u32>, cursor: Option<&str>) -> String {
+    let mut conn_args = vec![format!("first: {}", limit.unwrap_or(DEFAULT_MCP_PAGE_SIZE))];
+    if let Some(c) = cursor {
+        conn_args.push(format!("after: \"{}\"", escape_gql_string(c)));
+    }
+    conn_args.join(", ")
+}
+
 /// Accepts one or more comma-separated symbols: a single symbol returns the
 /// flat indicators shape, multiple symbols return the batch `{indicators, errors}` shape.
 pub async fn get_indicators(
@@ -21,11 +68,7 @@ pub async fn get_indicators(
     limit: Option<u32>,
     cursor: Option<String>,
 ) -> Result<CallToolResult, McpError> {
-    let syms: Vec<String> = symbols
-        .split(',')
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .collect();
+    let syms = split_symbols(&symbols);
     if syms.len() == 1 {
         get_one_indicators(
             schema,
@@ -83,29 +126,10 @@ async fn get_many_indicators(
     let field_list = parse_fields(fields);
     // "indicators" (`GqlIndicatorsSummary`) is composite and needs its own
     // nested sub-selection, not a bare field name.
-    let want_indicators = field_list
-        .as_ref()
-        .map(|fs| fs.iter().any(|f| f == "indicators"))
-        .unwrap_or(true);
-    let mut item_selection = String::from("{ symbol ");
-    if want_indicators {
-        item_selection.push_str("indicators ");
-        item_selection.push_str(&build_type_spec_selection(
-            field_list.as_deref(),
-            GQL_INDICATORS_VALID_FIELDS,
-            GQL_INDICATORS_DEFAULT_FIELDS,
-            INDICATOR_COMPOSITE_FIELDS,
-        ));
-        item_selection.push(' ');
-    }
-    item_selection.push('}');
+    let item_selection = build_indicators_batch_item_selection(field_list.as_deref());
     let selection = build_connection_selection(&item_selection);
 
-    let mut conn_args = vec![format!("first: {}", limit.unwrap_or(DEFAULT_MCP_PAGE_SIZE))];
-    if let Some(c) = cursor.as_deref() {
-        conn_args.push(format!("after: \"{}\"", escape_gql_string(c)));
-    }
-    let conn_args = conn_args.join(", ");
+    let conn_args = build_connection_args(limit, cursor.as_deref());
 
     let query = format!(
         "query {{ indicatorsBatch(symbols: [{}], interval: {gql_interval}, range: {gql_range}) {{ indicators({conn_args}) {} errors {{ symbol message }} }} }}",
@@ -116,4 +140,106 @@ async fn get_many_indicators(
     Ok(CallToolResult::success(vec![rmcp::model::Content::text(
         serde_json::to_string(&data).map_err(ser_err)?,
     )]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_symbols_returns_single_symbol_for_one_input() {
+        assert_eq!(split_symbols("AAPL"), vec!["AAPL".to_string()]);
+    }
+
+    #[test]
+    fn split_symbols_trims_whitespace_around_each_symbol() {
+        assert_eq!(
+            split_symbols("AAPL, MSFT , GOOG"),
+            vec!["AAPL".to_string(), "MSFT".to_string(), "GOOG".to_string()]
+        );
+    }
+
+    #[test]
+    fn split_symbols_drops_empty_entries_from_repeated_commas() {
+        assert_eq!(
+            split_symbols("AAPL,,MSFT,"),
+            vec!["AAPL".to_string(), "MSFT".to_string()]
+        );
+    }
+
+    #[test]
+    fn split_symbols_returns_empty_vec_for_empty_string() {
+        assert_eq!(split_symbols(""), Vec::<String>::new());
+    }
+
+    #[test]
+    fn wants_indicators_field_defaults_true_when_fields_is_none() {
+        assert!(wants_indicators_field(None));
+    }
+
+    #[test]
+    fn wants_indicators_field_false_when_fields_is_empty() {
+        // Unlike `None` (no restriction at all), an explicit empty list is a
+        // restriction that excludes everything, `indicators` included.
+        let empty: Vec<String> = Vec::new();
+        assert!(!wants_indicators_field(Some(&empty)));
+    }
+
+    #[test]
+    fn wants_indicators_field_true_when_explicitly_requested() {
+        let fields = vec!["symbol".to_string(), "indicators".to_string()];
+        assert!(wants_indicators_field(Some(&fields)));
+    }
+
+    #[test]
+    fn wants_indicators_field_false_when_fields_excludes_it() {
+        let fields = vec!["symbol".to_string()];
+        assert!(!wants_indicators_field(Some(&fields)));
+    }
+
+    #[test]
+    fn build_indicators_batch_item_selection_includes_indicators_by_default() {
+        let sel = build_indicators_batch_item_selection(None);
+        assert!(sel.starts_with("{ symbol indicators"));
+        assert!(sel.contains("sma10"));
+        assert!(sel.ends_with('}'));
+    }
+
+    #[test]
+    fn build_indicators_batch_item_selection_omits_indicators_when_excluded() {
+        let fields = vec!["symbol".to_string()];
+        let sel = build_indicators_batch_item_selection(Some(&fields));
+        assert_eq!(sel, "{ symbol }");
+        assert!(!sel.contains("indicators"));
+    }
+
+    #[test]
+    fn build_indicators_batch_item_selection_expands_nested_fields_when_requested() {
+        let fields = vec!["indicators".to_string(), "rsi14".to_string()];
+        let sel = build_indicators_batch_item_selection(Some(&fields));
+        assert!(sel.contains("indicators"));
+        assert!(sel.contains("rsi14"));
+        assert!(!sel.contains("sma10"));
+    }
+
+    #[test]
+    fn build_connection_args_uses_default_page_size_without_cursor() {
+        assert_eq!(
+            build_connection_args(None, None),
+            format!("first: {}", DEFAULT_MCP_PAGE_SIZE)
+        );
+    }
+
+    #[test]
+    fn build_connection_args_uses_given_limit() {
+        assert_eq!(build_connection_args(Some(5), None), "first: 5");
+    }
+
+    #[test]
+    fn build_connection_args_appends_escaped_cursor_when_present() {
+        assert_eq!(
+            build_connection_args(Some(10), Some("abc\"123")),
+            "first: 10, after: \"abc\\\"123\""
+        );
+    }
 }

--- a/finance-query-mcp/src/tools/market.rs
+++ b/finance-query-mcp/src/tools/market.rs
@@ -13,6 +13,27 @@ use crate::tools::gql::{
     build_type_spec_selection, execute_query, parse_fields, unwrap_field,
 };
 
+/// Builds the parenthesized `marketSummary(...)` argument list from the
+/// optional region/normalized-lang inputs; empty when neither is present
+/// (a GraphQL field with no filled args takes no parens at all).
+fn market_summary_args(region: Option<&str>, normalized_lang: Option<&str>) -> String {
+    let mut args = Vec::new();
+    if let Some(r) = region.filter(|r| !r.is_empty()) {
+        args.push(format!(
+            "region: \"{}\"",
+            crate::tools::gql::escape_gql_string(r)
+        ));
+    }
+    if let Some(l) = normalized_lang {
+        args.push(format!("lang: \"{l}\""));
+    }
+    if args.is_empty() {
+        String::new()
+    } else {
+        format!("({})", args.join(", "))
+    }
+}
+
 pub async fn get_market_summary(
     schema: &FinanceSchema,
     region: Option<String>,
@@ -25,21 +46,8 @@ pub async fn get_market_summary(
         GQL_MARKET_SUMMARY_VALID_FIELDS,
         GQL_MARKET_SUMMARY_DEFAULT_FIELDS,
     );
-    let mut args = Vec::new();
-    if let Some(r) = region.as_deref().filter(|r| !r.is_empty()) {
-        args.push(format!(
-            "region: \"{}\"",
-            crate::tools::gql::escape_gql_string(r)
-        ));
-    }
-    if let Some(l) = crate::lang::normalize(lang.as_deref()) {
-        args.push(format!("lang: \"{l}\""));
-    }
-    let args_str = if args.is_empty() {
-        String::new()
-    } else {
-        format!("({})", args.join(", "))
-    };
+    let normalized_lang = crate::lang::normalize(lang.as_deref());
+    let args_str = market_summary_args(region.as_deref(), normalized_lang.as_deref());
     let query = format!("query {{ marketSummary{args_str} {selection} }}");
     let json = execute_query(schema, &query, async_graphql::Variables::default()).await?;
     let data = unwrap_field(json, "marketSummary");
@@ -90,15 +98,11 @@ pub async fn get_trending(
     )]))
 }
 
-pub async fn get_indices(
-    schema: &FinanceSchema,
-    region: Option<String>,
-    fields: Option<String>,
-) -> Result<CallToolResult, McpError> {
-    // `region` is a `GqlIndicesRegion` enum, spliced as a literal (async-graphql
-    // renames enums SCREAMING_SNAKE_CASE — same as `financials.rs`'s statement type).
-    let gql_region = region
-        .as_deref()
+/// Parses a raw `region` param into its `GqlIndicesRegion` enum literal
+/// (async-graphql renames enums SCREAMING_SNAKE_CASE — same as
+/// `financials.rs`'s statement type); `None` for unparseable/absent input.
+fn indices_region_to_gql(region: Option<&str>) -> Option<&'static str> {
+    region
         .and_then(|s| s.parse::<IndicesRegion>().ok())
         .map(|r| match r {
             IndicesRegion::Americas => "AMERICAS",
@@ -106,7 +110,15 @@ pub async fn get_indices(
             IndicesRegion::AsiaPacific => "ASIA_PACIFIC",
             IndicesRegion::MiddleEastAfrica => "MIDDLE_EAST_AFRICA",
             IndicesRegion::Currencies => "CURRENCIES",
-        });
+        })
+}
+
+pub async fn get_indices(
+    schema: &FinanceSchema,
+    region: Option<String>,
+    fields: Option<String>,
+) -> Result<CallToolResult, McpError> {
+    let gql_region = indices_region_to_gql(region.as_deref());
     let args = gql_region
         .map(|r| format!("(region: {r})"))
         .unwrap_or_default();
@@ -218,4 +230,81 @@ pub async fn get_industry(
     Ok(CallToolResult::success(vec![rmcp::model::Content::text(
         serde_json::to_string(&data).map_err(ser_err)?,
     )]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn market_summary_args_empty_when_neither_present() {
+        assert_eq!(market_summary_args(None, None), "");
+    }
+
+    #[test]
+    fn market_summary_args_empty_when_region_is_empty_string() {
+        assert_eq!(market_summary_args(Some(""), None), "");
+    }
+
+    #[test]
+    fn market_summary_args_region_only() {
+        assert_eq!(market_summary_args(Some("US"), None), "(region: \"US\")");
+    }
+
+    #[test]
+    fn market_summary_args_lang_only() {
+        assert_eq!(market_summary_args(None, Some("ja")), "(lang: \"ja\")");
+    }
+
+    #[test]
+    fn market_summary_args_both_present() {
+        assert_eq!(
+            market_summary_args(Some("US"), Some("ja")),
+            "(region: \"US\", lang: \"ja\")"
+        );
+    }
+
+    #[test]
+    fn market_summary_args_escapes_region_string() {
+        // escape_gql_string backslash-escapes embedded quotes rather than
+        // stripping them, so the injected `"` is neutralized (can't close
+        // the string literal early) but still literally present — assert
+        // the exact escaped form, not just the absence of the raw input.
+        let result = market_summary_args(Some("US\"; { __schema"), None);
+        assert_eq!(result, "(region: \"US\\\"; { __schema\")");
+    }
+
+    #[test]
+    fn indices_region_to_gql_maps_every_known_variant_case_insensitively() {
+        assert_eq!(indices_region_to_gql(Some("americas")), Some("AMERICAS"));
+        assert_eq!(indices_region_to_gql(Some("AMERICAS")), Some("AMERICAS"));
+        assert_eq!(indices_region_to_gql(Some("am")), Some("AMERICAS"));
+        assert_eq!(indices_region_to_gql(Some("europe")), Some("EUROPE"));
+        assert_eq!(indices_region_to_gql(Some("eu")), Some("EUROPE"));
+        assert_eq!(
+            indices_region_to_gql(Some("asia-pacific")),
+            Some("ASIA_PACIFIC")
+        );
+        assert_eq!(indices_region_to_gql(Some("apac")), Some("ASIA_PACIFIC"));
+        assert_eq!(
+            indices_region_to_gql(Some("middle-east-africa")),
+            Some("MIDDLE_EAST_AFRICA")
+        );
+        assert_eq!(
+            indices_region_to_gql(Some("emea")),
+            Some("MIDDLE_EAST_AFRICA")
+        );
+        assert_eq!(
+            indices_region_to_gql(Some("currencies")),
+            Some("CURRENCIES")
+        );
+        assert_eq!(indices_region_to_gql(Some("fx")), Some("CURRENCIES"));
+    }
+
+    #[test]
+    fn indices_region_to_gql_none_for_absent_or_unknown_input() {
+        assert_eq!(indices_region_to_gql(None), None);
+        assert_eq!(indices_region_to_gql(Some("bogus")), None);
+        assert_eq!(indices_region_to_gql(Some("")), None);
+    }
 }

--- a/finance-query-mcp/src/tools/mod.rs
+++ b/finance-query-mcp/src/tools/mod.rs
@@ -879,3 +879,420 @@ impl FinanceTools {
         .await
     }
 }
+
+// ── Param-struct deserialization ─────────────────────────────────────────────
+//
+// Every `#[tool]` param struct must (a) deserialize when only its required
+// fields are present, defaulting every `Option<T>` to `None`, and (b)
+// preserve every field's value when the caller supplies all of them. These
+// are the two contracts an LLM caller actually relies on — no network, no
+// schema execution, just serde against canned JSON.
+
+#[cfg(test)]
+mod param_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn edgar_submissions_params_defaults_optionals_to_none() {
+        let p: EdgarSubmissionsParams = serde_json::from_value(json!({"symbol": "AAPL"})).unwrap();
+        assert_eq!(p.symbol, "AAPL");
+        assert_eq!(p.fields, None);
+        assert_eq!(p.limit, None);
+        assert_eq!(p.cursor, None);
+    }
+
+    #[test]
+    fn edgar_submissions_params_preserves_all_fields() {
+        let p: EdgarSubmissionsParams = serde_json::from_value(json!({
+            "symbol": "AAPL", "fields": "formType,filingDate", "limit": 10, "cursor": "abc"
+        }))
+        .unwrap();
+        assert_eq!(p.fields, Some("formType,filingDate".to_string()));
+        assert_eq!(p.limit, Some(10));
+        assert_eq!(p.cursor, Some("abc".to_string()));
+    }
+
+    #[test]
+    fn edgar_facts_params_defaults_optionals_to_none() {
+        let p: EdgarFactsParams = serde_json::from_value(json!({"symbol": "AAPL"})).unwrap();
+        assert_eq!(p.symbol, "AAPL");
+        assert_eq!(p.taxonomy, None);
+        assert_eq!(p.concepts, None);
+        assert_eq!(p.fields, None);
+        assert_eq!(p.limit, None);
+        assert_eq!(p.cursor, None);
+    }
+
+    #[test]
+    fn edgar_facts_params_preserves_all_fields() {
+        let p: EdgarFactsParams = serde_json::from_value(json!({
+            "symbol": "AAPL", "taxonomy": "ifrs-full", "concepts": "Revenues,Assets",
+            "fields": "concept,unit", "limit": 5, "cursor": "xyz"
+        }))
+        .unwrap();
+        assert_eq!(p.taxonomy, Some("ifrs-full".to_string()));
+        assert_eq!(p.concepts, Some("Revenues,Assets".to_string()));
+        assert_eq!(p.limit, Some(5));
+    }
+
+    #[test]
+    fn symbols_params_defaults_optionals_to_none() {
+        let p: SymbolsParams = serde_json::from_value(json!({"symbols": "AAPL,MSFT"})).unwrap();
+        assert_eq!(p.symbols, "AAPL,MSFT");
+        assert_eq!(p.lang, None);
+        assert_eq!(p.fields, None);
+        assert_eq!(p.limit, None);
+        assert_eq!(p.cursor, None);
+    }
+
+    #[test]
+    fn symbols_params_preserves_all_fields() {
+        let p: SymbolsParams = serde_json::from_value(json!({
+            "symbols": "AAPL", "lang": "ja", "fields": "symbol,shortName", "limit": 25, "cursor": "c1"
+        }))
+        .unwrap();
+        assert_eq!(p.lang, Some("ja".to_string()));
+        assert_eq!(p.fields, Some("symbol,shortName".to_string()));
+    }
+
+    #[test]
+    fn calendar_params_defaults_optionals_to_none() {
+        let p: CalendarParams = serde_json::from_value(json!({"symbols": "AAPL,MSFT"})).unwrap();
+        assert_eq!(p.symbols, "AAPL,MSFT");
+        assert_eq!(p.range, None);
+        assert_eq!(p.fields, None);
+    }
+
+    #[test]
+    fn chart_params_defaults_optionals_to_none() {
+        let p: ChartParams = serde_json::from_value(json!({"symbols": "AAPL"})).unwrap();
+        assert_eq!(p.interval, None);
+        assert_eq!(p.range, None);
+        assert_eq!(p.start, None);
+        assert_eq!(p.end, None);
+        assert_eq!(p.fields, None);
+        assert_eq!(p.limit, None);
+        assert_eq!(p.cursor, None);
+    }
+
+    #[test]
+    fn chart_params_preserves_all_fields() {
+        let p: ChartParams = serde_json::from_value(json!({
+            "symbols": "AAPL", "interval": "1d", "range": "1mo", "start": 1_700_000_000,
+            "end": 1_700_100_000, "fields": "meta,candles", "limit": 25, "cursor": "c1"
+        }))
+        .unwrap();
+        assert_eq!(p.start, Some(1_700_000_000));
+        assert_eq!(p.end, Some(1_700_100_000));
+    }
+
+    #[test]
+    fn financials_params_requires_statement() {
+        let err = serde_json::from_value::<FinancialsParams>(json!({"symbols": "AAPL"}));
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn financials_params_defaults_optionals_to_none() {
+        let p: FinancialsParams =
+            serde_json::from_value(json!({"symbols": "AAPL", "statement": "income"})).unwrap();
+        assert_eq!(p.statement, "income");
+        assert_eq!(p.frequency, None);
+        assert_eq!(p.metrics, None);
+        assert_eq!(p.fields, None);
+    }
+
+    #[test]
+    fn financials_params_preserves_metrics_and_fields() {
+        let p: FinancialsParams = serde_json::from_value(json!({
+            "symbols": "AAPL", "statement": "balance", "frequency": "quarterly",
+            "metrics": "totalRevenue,netIncome", "fields": "reportDate"
+        }))
+        .unwrap();
+        assert_eq!(p.metrics, Some("totalRevenue,netIncome".to_string()));
+        assert_eq!(p.frequency, Some("quarterly".to_string()));
+    }
+
+    #[test]
+    fn indicators_params_defaults_optionals_to_none() {
+        let p: IndicatorsParams = serde_json::from_value(json!({"symbols": "AAPL"})).unwrap();
+        assert_eq!(p.interval, None);
+        assert_eq!(p.range, None);
+        assert_eq!(p.limit, None);
+        assert_eq!(p.cursor, None);
+    }
+
+    #[test]
+    fn search_params_requires_query() {
+        let err = serde_json::from_value::<SearchParams>(json!({}));
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn search_params_defaults_optionals_to_none() {
+        let p: SearchParams = serde_json::from_value(json!({"query": "Apple"})).unwrap();
+        assert_eq!(p.query, "Apple");
+        assert_eq!(p.lang, None);
+        assert_eq!(p.limit, None);
+        assert_eq!(p.cursor, None);
+    }
+
+    #[test]
+    fn screener_params_requires_screener_type() {
+        let err = serde_json::from_value::<ScreenerParams>(json!({}));
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn screener_params_defaults_optionals_to_none() {
+        let p: ScreenerParams =
+            serde_json::from_value(json!({"screener_type": "day-gainers"})).unwrap();
+        assert_eq!(p.screener_type, "day-gainers");
+        assert_eq!(p.count, None);
+        assert_eq!(p.fields, None);
+    }
+
+    #[test]
+    fn news_params_allows_omitting_symbol_for_general_news() {
+        let p: NewsParams = serde_json::from_value(json!({})).unwrap();
+        assert_eq!(p.symbol, None);
+        assert_eq!(p.lang, None);
+        assert_eq!(p.fields, None);
+        assert_eq!(p.limit, None);
+        assert_eq!(p.cursor, None);
+    }
+
+    #[test]
+    fn news_params_preserves_symbol_when_present() {
+        let p: NewsParams = serde_json::from_value(json!({"symbol": "AAPL"})).unwrap();
+        assert_eq!(p.symbol, Some("AAPL".to_string()));
+    }
+
+    #[test]
+    fn market_summary_params_all_optional() {
+        let p: MarketSummaryParams = serde_json::from_value(json!({})).unwrap();
+        assert_eq!(p.region, None);
+        assert_eq!(p.lang, None);
+        assert_eq!(p.fields, None);
+    }
+
+    #[test]
+    fn fear_and_greed_params_all_optional() {
+        let p: FearAndGreedParams = serde_json::from_value(json!({})).unwrap();
+        assert_eq!(p.fields, None);
+    }
+
+    #[test]
+    fn dividends_params_defaults_optionals_to_none() {
+        let p: DividendsParams = serde_json::from_value(json!({"symbols": "AAPL,KO"})).unwrap();
+        assert_eq!(p.range, None);
+        assert_eq!(p.limit, None);
+        assert_eq!(p.cursor, None);
+    }
+
+    #[test]
+    fn risk_params_defaults_optionals_to_none() {
+        let p: RiskParams = serde_json::from_value(json!({"symbol": "AAPL"})).unwrap();
+        assert_eq!(p.interval, None);
+        assert_eq!(p.range, None);
+        assert_eq!(p.benchmark, None);
+        assert_eq!(p.fields, None);
+    }
+
+    #[test]
+    fn risk_params_preserves_benchmark() {
+        let p: RiskParams =
+            serde_json::from_value(json!({"symbol": "AAPL", "benchmark": "SPY"})).unwrap();
+        assert_eq!(p.benchmark, Some("SPY".to_string()));
+    }
+
+    #[test]
+    fn crypto_params_all_optional() {
+        let p: CryptoParams = serde_json::from_value(json!({})).unwrap();
+        assert_eq!(p.count, None);
+        assert_eq!(p.vs_currency, None);
+        assert_eq!(p.fields, None);
+        assert_eq!(p.limit, None);
+        assert_eq!(p.cursor, None);
+    }
+
+    #[test]
+    fn options_params_defaults_optionals_to_none() {
+        let p: OptionsParams = serde_json::from_value(json!({"symbol": "AAPL"})).unwrap();
+        assert_eq!(p.expiration, None);
+        assert_eq!(p.limit, None);
+        assert_eq!(p.cursor, None);
+    }
+
+    #[test]
+    fn recommendations_params_defaults_optionals_to_none() {
+        let p: RecommendationsParams = serde_json::from_value(json!({"symbol": "AAPL"})).unwrap();
+        assert_eq!(p.limit, None);
+        assert_eq!(p.fields, None);
+    }
+
+    #[test]
+    fn splits_params_defaults_optionals_to_none() {
+        let p: SplitsParams = serde_json::from_value(json!({"symbol": "AAPL"})).unwrap();
+        assert_eq!(p.range, None);
+        assert_eq!(p.fields, None);
+    }
+
+    #[test]
+    fn trending_params_all_optional() {
+        let p: TrendingParams = serde_json::from_value(json!({})).unwrap();
+        assert_eq!(p.region, None);
+        assert_eq!(p.fields, None);
+    }
+
+    #[test]
+    fn indices_params_all_optional() {
+        let p: IndicesParams = serde_json::from_value(json!({})).unwrap();
+        assert_eq!(p.region, None);
+        assert_eq!(p.fields, None);
+    }
+
+    #[test]
+    fn market_hours_params_all_optional() {
+        let p: MarketHoursParams = serde_json::from_value(json!({})).unwrap();
+        assert_eq!(p.region, None);
+        assert_eq!(p.fields, None);
+    }
+
+    #[test]
+    fn sector_params_requires_sector() {
+        let err = serde_json::from_value::<SectorParams>(json!({}));
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn sector_params_defaults_optionals_to_none() {
+        let p: SectorParams = serde_json::from_value(json!({"sector": "technology"})).unwrap();
+        assert_eq!(p.lang, None);
+        assert_eq!(p.fields, None);
+    }
+
+    #[test]
+    fn industry_params_requires_industry() {
+        let err = serde_json::from_value::<IndustryParams>(json!({}));
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn holders_params_requires_holder_type() {
+        let err = serde_json::from_value::<HoldersParams>(json!({"symbol": "AAPL"}));
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn holders_params_defaults_optionals_to_none() {
+        let p: HoldersParams =
+            serde_json::from_value(json!({"symbol": "AAPL", "holder_type": "institutional"}))
+                .unwrap();
+        assert_eq!(p.limit, None);
+        assert_eq!(p.cursor, None);
+        assert_eq!(p.fields, None);
+    }
+
+    #[test]
+    fn analysis_params_requires_analysis_type() {
+        let err = serde_json::from_value::<AnalysisParams>(json!({"symbol": "AAPL"}));
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn fred_series_params_defaults_optionals_to_none() {
+        let p: FredSeriesParams = serde_json::from_value(json!({"id": "FEDFUNDS"})).unwrap();
+        assert_eq!(p.fields, None);
+        assert_eq!(p.limit, None);
+        assert_eq!(p.cursor, None);
+    }
+
+    #[test]
+    fn treasury_yields_params_all_optional() {
+        let p: TreasuryYieldsParams = serde_json::from_value(json!({})).unwrap();
+        assert_eq!(p.year, None);
+        assert_eq!(p.fields, None);
+        assert_eq!(p.limit, None);
+        assert_eq!(p.cursor, None);
+    }
+
+    #[test]
+    fn transcripts_params_defaults_optionals_to_none() {
+        let p: TranscriptsParams = serde_json::from_value(json!({"symbol": "AAPL"})).unwrap();
+        assert_eq!(p.limit, None);
+        assert_eq!(p.lang, None);
+        assert_eq!(p.fields, None);
+        assert_eq!(p.paragraph_limit, None);
+        assert_eq!(p.paragraph_cursor, None);
+    }
+
+    #[test]
+    fn feeds_params_all_optional() {
+        let p: FeedsParams = serde_json::from_value(json!({})).unwrap();
+        assert_eq!(p.sources, None);
+        assert_eq!(p.fields, None);
+        assert_eq!(p.limit, None);
+        assert_eq!(p.cursor, None);
+    }
+
+    #[test]
+    fn lookup_params_requires_query() {
+        let err = serde_json::from_value::<LookupParams>(json!({}));
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn lookup_params_defaults_optionals_to_none() {
+        let p: LookupParams = serde_json::from_value(json!({"query": "Apple"})).unwrap();
+        assert_eq!(p.query_type, None);
+        assert_eq!(p.lang, None);
+        assert_eq!(p.fields, None);
+        assert_eq!(p.logo, None);
+    }
+
+    #[test]
+    fn lookup_params_preserves_logo_flag() {
+        let p: LookupParams =
+            serde_json::from_value(json!({"query": "Apple", "logo": true})).unwrap();
+        assert_eq!(p.logo, Some(true));
+    }
+
+    #[test]
+    fn batch_symbols_params_defaults_optionals_to_none() {
+        let p: BatchSymbolsParams =
+            serde_json::from_value(json!({"symbols": "AAPL,MSFT"})).unwrap();
+        assert_eq!(p.interval, None);
+        assert_eq!(p.range, None);
+        assert_eq!(p.fields, None);
+    }
+
+    #[test]
+    fn edgar_search_params_requires_query() {
+        let err = serde_json::from_value::<EdgarSearchParams>(json!({}));
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn edgar_search_params_defaults_optionals_to_none() {
+        let p: EdgarSearchParams = serde_json::from_value(json!({"query": "revenue"})).unwrap();
+        assert_eq!(p.forms, None);
+        assert_eq!(p.start_date, None);
+        assert_eq!(p.end_date, None);
+        assert_eq!(p.from, None);
+        assert_eq!(p.size, None);
+    }
+
+    #[test]
+    fn edgar_search_params_preserves_date_filters() {
+        let p: EdgarSearchParams = serde_json::from_value(json!({
+            "query": "revenue", "forms": "10-K,10-Q", "start_date": "2024-01-01",
+            "end_date": "2024-12-31", "from": 0, "size": 50
+        }))
+        .unwrap();
+        assert_eq!(p.forms, Some("10-K,10-Q".to_string()));
+        assert_eq!(p.from, Some(0));
+        assert_eq!(p.size, Some(50));
+    }
+}

--- a/finance-query-mcp/src/tools/news.rs
+++ b/finance-query-mcp/src/tools/news.rs
@@ -8,6 +8,28 @@ use crate::tools::gql::{
     parse_fields, unwrap_field, unwrap_ticker_field, wrap_connection,
 };
 
+/// Build the `, lang: "xx"` argument fragment, or an empty string when the
+/// language normalizes away (unset, English, or unrecognized).
+fn build_lang_arg(lang: Option<&str>) -> String {
+    match crate::lang::normalize(lang) {
+        Some(l) => format!(", lang: \"{}\"", l),
+        None => String::new(),
+    }
+}
+
+/// Build the `news(...)` connection args: the fixed upstream-fetch `count`,
+/// the page-size `first`, and an optional `after` cursor.
+fn build_conn_args(limit: Option<u32>, cursor: Option<&str>) -> String {
+    let mut args = vec![
+        "count: 10".to_string(),
+        format!("first: {}", limit.unwrap_or(DEFAULT_MCP_PAGE_SIZE)),
+    ];
+    if let Some(c) = cursor {
+        args.push(format!("after: \"{}\"", escape_gql_string(c)));
+    }
+    args.join(", ")
+}
+
 pub async fn get_news(
     schema: &FinanceSchema,
     symbol: Option<String>,
@@ -26,21 +48,11 @@ pub async fn get_news(
     );
     let selection = build_connection_selection(&inner_selection);
 
-    let lang_arg = match crate::lang::normalize(lang.as_deref()) {
-        Some(l) => format!(", lang: \"{}\"", l),
-        None => String::new(),
-    };
+    let lang_arg = build_lang_arg(lang.as_deref());
     // `count` bounds the overall upstream fetch (kept at its historical value
     // of 10, unchanged); `first`/`after` paginate a page out of that fetched
     // pool — the two are independent GraphQL args on the same field.
-    let mut conn_args = vec![
-        "count: 10".to_string(),
-        format!("first: {}", limit.unwrap_or(DEFAULT_MCP_PAGE_SIZE)),
-    ];
-    if let Some(c) = cursor.as_deref() {
-        conn_args.push(format!("after: \"{}\"", escape_gql_string(c)));
-    }
-    let conn_args = conn_args.join(", ");
+    let conn_args = build_conn_args(limit, cursor.as_deref());
 
     // Per-symbol and general news hit different root fields, so unwrap
     // inside each branch rather than probing both shapes afterward.
@@ -63,4 +75,54 @@ pub async fn get_news(
     Ok(CallToolResult::success(vec![rmcp::model::Content::text(
         text,
     )]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_lang_arg_is_empty_when_lang_is_none() {
+        assert_eq!(build_lang_arg(None), "");
+    }
+
+    #[test]
+    fn build_lang_arg_is_empty_for_english() {
+        assert_eq!(build_lang_arg(Some("en")), "");
+    }
+
+    #[test]
+    fn build_lang_arg_is_empty_for_unparseable_input() {
+        assert_eq!(build_lang_arg(Some("1234")), "");
+        assert_eq!(build_lang_arg(Some("")), "");
+    }
+
+    #[test]
+    fn build_lang_arg_includes_canonical_code_for_supported_language() {
+        assert_eq!(build_lang_arg(Some("ja")), ", lang: \"ja\"");
+    }
+
+    #[test]
+    fn build_conn_args_has_fixed_count_and_default_limit_without_cursor() {
+        let args = build_conn_args(None, None);
+        assert_eq!(args, format!("count: 10, first: {DEFAULT_MCP_PAGE_SIZE}"));
+    }
+
+    #[test]
+    fn build_conn_args_uses_given_limit() {
+        let args = build_conn_args(Some(3), None);
+        assert_eq!(args, "count: 10, first: 3");
+    }
+
+    #[test]
+    fn build_conn_args_includes_cursor_when_present() {
+        let args = build_conn_args(Some(3), Some("cur1"));
+        assert_eq!(args, "count: 10, first: 3, after: \"cur1\"");
+    }
+
+    #[test]
+    fn build_conn_args_escapes_special_characters_in_cursor() {
+        let args = build_conn_args(None, Some("has\"quote"));
+        assert!(args.contains("after: \"has\\\"quote\""));
+    }
 }

--- a/finance-query-mcp/src/tools/options.rs
+++ b/finance-query-mcp/src/tools/options.rs
@@ -44,6 +44,16 @@ fn build_options_selection(fields: Option<&[String]>, limit: u32, cursor: Option
     sel
 }
 
+/// Build the `(date: <ts>)` argument clause for `options`, omitting the
+/// parens entirely when no expiration was given — `options()` with empty
+/// parens is invalid GraphQL syntax, not "no arguments".
+fn build_options_date_arg(expiration: Option<i64>) -> String {
+    match expiration {
+        Some(ts) => format!("(date: {ts})"),
+        None => String::new(),
+    }
+}
+
 pub async fn get_options(
     schema: &FinanceSchema,
     symbol: String,
@@ -52,12 +62,7 @@ pub async fn get_options(
     limit: Option<u32>,
     cursor: Option<String>,
 ) -> Result<CallToolResult, McpError> {
-    // Parens must be omitted entirely when there's no argument — `options()`
-    // with empty parens is invalid GraphQL syntax, not "no arguments".
-    let date_arg = match expiration {
-        Some(ts) => format!("(date: {ts})"),
-        None => String::new(),
-    };
+    let date_arg = build_options_date_arg(expiration);
     let field_list = parse_fields(fields);
     let selection = build_options_selection(
         field_list.as_deref(),
@@ -78,4 +83,76 @@ pub async fn get_options(
     Ok(CallToolResult::success(vec![rmcp::model::Content::text(
         serde_json::to_string(&data).map_err(ser_err)?,
     )]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_options_date_arg_formats_the_expiration_timestamp() {
+        assert_eq!(
+            build_options_date_arg(Some(1700000000)),
+            "(date: 1700000000)"
+        );
+    }
+
+    #[test]
+    fn build_options_date_arg_is_empty_when_expiration_is_none() {
+        assert_eq!(build_options_date_arg(None), "");
+    }
+
+    #[test]
+    fn build_options_selection_includes_all_valid_fields_by_default() {
+        let sel = build_options_selection(None, 25, None);
+        for f in GQL_OPTIONS_VALID_FIELDS {
+            assert!(sel.contains(f), "missing field {f} in {sel}");
+        }
+    }
+
+    #[test]
+    fn build_options_selection_filters_to_requested_valid_fields() {
+        let fields = vec!["calls".to_string()];
+        let sel = build_options_selection(Some(&fields), 25, None);
+        assert!(sel.contains("calls"));
+        assert!(!sel.contains("puts"));
+        assert!(!sel.contains("expirationDates"));
+        assert!(!sel.contains("strikes"));
+    }
+
+    #[test]
+    fn build_options_selection_drops_unknown_fields_with_no_fallback() {
+        // Unlike `build_type_spec_selection`, this helper has no
+        // "fall back to defaults" behavior for an all-unknown field list.
+        let fields = vec!["bogus".to_string()];
+        let sel = build_options_selection(Some(&fields), 25, None);
+        assert_eq!(sel, "{ }");
+    }
+
+    #[test]
+    fn build_options_selection_expands_calls_and_puts_as_paginated_connections() {
+        let fields = vec!["calls".to_string(), "puts".to_string()];
+        let sel = build_options_selection(Some(&fields), 10, None);
+        assert!(sel.contains("calls(first: 10)"));
+        assert!(sel.contains("puts(first: 10)"));
+        assert!(sel.contains("contractSymbol"));
+        assert!(sel.contains("edges"));
+        assert!(sel.contains("pageInfo"));
+    }
+
+    #[test]
+    fn build_options_selection_appends_escaped_cursor_when_present() {
+        let fields = vec!["calls".to_string()];
+        let sel = build_options_selection(Some(&fields), 10, Some("a\"b"));
+        assert!(sel.contains("first: 10, after: \"a\\\"b\""));
+    }
+
+    #[test]
+    fn build_options_selection_falls_back_to_all_fields_when_fields_is_empty() {
+        let empty: Vec<String> = Vec::new();
+        let sel = build_options_selection(Some(&empty), 25, None);
+        for f in GQL_OPTIONS_VALID_FIELDS {
+            assert!(sel.contains(f));
+        }
+    }
 }

--- a/finance-query-mcp/src/tools/quotes.rs
+++ b/finance-query-mcp/src/tools/quotes.rs
@@ -11,6 +11,16 @@ use crate::tools::gql::{
 };
 use crate::tools::helpers::range_to_gql;
 
+/// Splits a comma-separated symbols param into trimmed, non-empty entries —
+/// tolerates surrounding whitespace and doubled/trailing commas.
+fn parse_symbols(symbols: &str) -> Vec<String> {
+    symbols
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
 /// Accepts one or more comma-separated symbols: a single symbol returns the
 /// flat quote shape, multiple symbols return the batch `{quotes, errors}` shape.
 pub async fn get_quote(
@@ -21,11 +31,7 @@ pub async fn get_quote(
     limit: Option<u32>,
     cursor: Option<String>,
 ) -> Result<CallToolResult, McpError> {
-    let syms: Vec<String> = symbols
-        .split(',')
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .collect();
+    let syms: Vec<String> = parse_symbols(&symbols);
     if syms.len() == 1 {
         get_one_quote(schema, syms.into_iter().next().unwrap(), lang, fields).await
     } else {
@@ -177,4 +183,53 @@ pub async fn get_splits(
     Ok(CallToolResult::success(vec![rmcp::model::Content::text(
         text,
     )]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_symbols_empty_string_yields_no_symbols() {
+        assert_eq!(parse_symbols(""), Vec::<String>::new());
+    }
+
+    #[test]
+    fn parse_symbols_single_symbol() {
+        assert_eq!(parse_symbols("AAPL"), vec!["AAPL".to_string()]);
+    }
+
+    #[test]
+    fn parse_symbols_multiple_symbols() {
+        assert_eq!(
+            parse_symbols("AAPL,MSFT,GOOG"),
+            vec!["AAPL".to_string(), "MSFT".to_string(), "GOOG".to_string()]
+        );
+    }
+
+    #[test]
+    fn parse_symbols_trims_surrounding_whitespace() {
+        assert_eq!(
+            parse_symbols(" AAPL , MSFT  "),
+            vec!["AAPL".to_string(), "MSFT".to_string()]
+        );
+    }
+
+    #[test]
+    fn parse_symbols_drops_empty_entries_from_doubled_commas() {
+        assert_eq!(
+            parse_symbols("AAPL,,MSFT"),
+            vec!["AAPL".to_string(), "MSFT".to_string()]
+        );
+    }
+
+    #[test]
+    fn parse_symbols_drops_empty_entries_from_trailing_comma() {
+        assert_eq!(parse_symbols("AAPL,"), vec!["AAPL".to_string()]);
+    }
+
+    #[test]
+    fn parse_symbols_all_whitespace_or_commas_yields_no_symbols() {
+        assert_eq!(parse_symbols(" , , "), Vec::<String>::new());
+    }
 }

--- a/finance-query-mcp/src/tools/risk.rs
+++ b/finance-query-mcp/src/tools/risk.rs
@@ -8,6 +8,25 @@ use crate::tools::gql::{
 };
 use crate::tools::helpers::{interval_to_gql, range_to_gql};
 
+/// Whether a benchmark was actually supplied, plus the GraphQL argument and
+/// operation-variable-declaration snippets to splice in when it was.
+/// GraphQL rejects a declared operation variable that's never referenced in
+/// the query body, so `$benchmark` can only be declared when it's used.
+fn benchmark_query_parts(benchmark: Option<&str>) -> (bool, &'static str, &'static str) {
+    let has_benchmark = benchmark.is_some_and(|b| !b.is_empty());
+    let bench_arg = if has_benchmark {
+        ", benchmark: $benchmark"
+    } else {
+        ""
+    };
+    let benchmark_decl = if has_benchmark {
+        ", $benchmark: String"
+    } else {
+        ""
+    };
+    (has_benchmark, bench_arg, benchmark_decl)
+}
+
 pub async fn get_risk(
     schema: &FinanceSchema,
     symbol: String,
@@ -18,19 +37,7 @@ pub async fn get_risk(
 ) -> Result<CallToolResult, McpError> {
     let gql_interval = interval_to_gql(interval.as_deref().unwrap_or("1d"));
     let gql_range = range_to_gql(range.as_deref().unwrap_or("1y"));
-    let has_benchmark = benchmark.as_deref().is_some_and(|b| !b.is_empty());
-    let bench_arg = if has_benchmark {
-        ", benchmark: $benchmark"
-    } else {
-        ""
-    };
-    // GraphQL rejects a declared operation variable that's never referenced
-    // in the query body, so $benchmark can only be declared when it's used.
-    let benchmark_decl = if has_benchmark {
-        ", $benchmark: String"
-    } else {
-        ""
-    };
+    let (_, bench_arg, benchmark_decl) = benchmark_query_parts(benchmark.as_deref());
 
     let field_list = parse_fields(fields);
     let selection = build_selection_or_default(
@@ -54,4 +61,27 @@ pub async fn get_risk(
     Ok(CallToolResult::success(vec![rmcp::model::Content::text(
         text,
     )]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn benchmark_query_parts_none_omits_arg_and_decl() {
+        assert_eq!(benchmark_query_parts(None), (false, "", ""));
+    }
+
+    #[test]
+    fn benchmark_query_parts_empty_string_omits_arg_and_decl() {
+        assert_eq!(benchmark_query_parts(Some("")), (false, "", ""));
+    }
+
+    #[test]
+    fn benchmark_query_parts_present_includes_arg_and_decl() {
+        assert_eq!(
+            benchmark_query_parts(Some("SPY")),
+            (true, ", benchmark: $benchmark", ", $benchmark: String")
+        );
+    }
 }

--- a/finance-query-mcp/src/tools/search.rs
+++ b/finance-query-mcp/src/tools/search.rs
@@ -129,3 +129,48 @@ pub async fn get_lookup(
         serde_json::to_string(&data).map_err(ser_err)?,
     )]))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lookup_type_to_gql_maps_known_aliases_case_insensitively() {
+        assert_eq!(lookup_type_to_gql("equity"), "EQUITY");
+        assert_eq!(lookup_type_to_gql("EQUITY"), "EQUITY");
+        assert_eq!(lookup_type_to_gql("Stock"), "EQUITY");
+        assert_eq!(lookup_type_to_gql("etf"), "ETF");
+        assert_eq!(lookup_type_to_gql("ETF"), "ETF");
+        assert_eq!(lookup_type_to_gql("index"), "INDEX");
+        assert_eq!(lookup_type_to_gql("future"), "FUTURE");
+    }
+
+    #[test]
+    fn lookup_type_to_gql_maps_mutual_fund_variants() {
+        assert_eq!(lookup_type_to_gql("mutualfund"), "MUTUAL_FUND");
+        assert_eq!(lookup_type_to_gql("mutual_fund"), "MUTUAL_FUND");
+        assert_eq!(lookup_type_to_gql("mutual-fund"), "MUTUAL_FUND");
+        assert_eq!(lookup_type_to_gql("Mutual-Fund"), "MUTUAL_FUND");
+    }
+
+    #[test]
+    fn lookup_type_to_gql_maps_currency_variants() {
+        assert_eq!(lookup_type_to_gql("currency"), "CURRENCY");
+        assert_eq!(lookup_type_to_gql("forex"), "CURRENCY");
+        assert_eq!(lookup_type_to_gql("fx"), "CURRENCY");
+    }
+
+    #[test]
+    fn lookup_type_to_gql_maps_crypto_variants() {
+        assert_eq!(lookup_type_to_gql("crypto"), "CRYPTOCURRENCY");
+        assert_eq!(lookup_type_to_gql("cryptocurrency"), "CRYPTOCURRENCY");
+        assert_eq!(lookup_type_to_gql("CRYPTO"), "CRYPTOCURRENCY");
+    }
+
+    #[test]
+    fn lookup_type_to_gql_falls_back_to_all_for_unknown_or_empty() {
+        assert_eq!(lookup_type_to_gql("all"), "ALL");
+        assert_eq!(lookup_type_to_gql("bogus"), "ALL");
+        assert_eq!(lookup_type_to_gql(""), "ALL");
+    }
+}

--- a/finance-query-mcp/src/tools/transcripts.rs
+++ b/finance-query-mcp/src/tools/transcripts.rs
@@ -22,26 +22,24 @@ fn transcript_selection(paragraph_limit: u32, paragraph_cursor: Option<&str>) ->
     )
 }
 
-#[allow(clippy::too_many_arguments)]
-pub async fn get_transcripts(
-    schema: &FinanceSchema,
-    symbol: String,
-    limit: Option<u32>,
-    lang: Option<String>,
-    fields: Option<String>,
-    paragraph_limit: Option<u32>,
-    paragraph_cursor: Option<String>,
-) -> Result<CallToolResult, McpError> {
+/// Build the `transcripts(...)` field argument list: optional `limit` and
+/// `lang`, omitted entirely (no parens) when both are absent.
+fn build_transcripts_args(limit: Option<u32>, lang: Option<&str>) -> String {
     let limit_arg = limit.map(|l| format!("limit: {l}"));
-    let lang_arg = crate::lang::normalize(lang.as_deref()).map(|l| format!("lang: \"{}\"", l));
+    let lang_arg = crate::lang::normalize(lang).map(|l| format!("lang: \"{}\"", l));
     let args: Vec<String> = [limit_arg, lang_arg].into_iter().flatten().collect();
-    let args_str = if args.is_empty() {
+    if args.is_empty() {
         String::new()
     } else {
         format!("({})", args.join(", "))
-    };
-    let field_list = parse_fields(fields);
-    let mut chosen: Vec<&str> = match field_list.as_deref() {
+    }
+}
+
+/// Choose the requested top-level transcript fields, validating against
+/// `GQL_TRANSCRIPT_VALID_FIELDS` and falling back to the curated defaults
+/// when the caller's list is absent, empty, or matches nothing valid.
+fn choose_transcript_fields(field_list: Option<&[String]>) -> Vec<&str> {
+    let mut chosen: Vec<&str> = match field_list {
         Some(fs) if !fs.is_empty() => fs
             .iter()
             .map(|f| f.trim())
@@ -52,20 +50,43 @@ pub async fn get_transcripts(
     if chosen.is_empty() {
         chosen = GQL_TRANSCRIPT_DEFAULT_FIELDS.to_vec();
     }
-    let transcript_nested = transcript_selection(
-        paragraph_limit.unwrap_or(DEFAULT_MCP_PAGE_SIZE),
-        paragraph_cursor.as_deref(),
-    );
+    chosen
+}
+
+/// Build the top-level transcript selection set, splicing the paginated
+/// `transcript_nested` sub-selection in wherever `transcript` was chosen.
+fn build_transcript_field_selection(chosen: &[&str], transcript_nested: &str) -> String {
     let mut selection = String::from("{ ");
     for f in chosen {
         selection.push_str(f);
-        if f == "transcript" {
+        if *f == "transcript" {
             selection.push(' ');
-            selection.push_str(&transcript_nested);
+            selection.push_str(transcript_nested);
         }
         selection.push(' ');
     }
     selection.push('}');
+    selection
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn get_transcripts(
+    schema: &FinanceSchema,
+    symbol: String,
+    limit: Option<u32>,
+    lang: Option<String>,
+    fields: Option<String>,
+    paragraph_limit: Option<u32>,
+    paragraph_cursor: Option<String>,
+) -> Result<CallToolResult, McpError> {
+    let args_str = build_transcripts_args(limit, lang.as_deref());
+    let field_list = parse_fields(fields);
+    let chosen = choose_transcript_fields(field_list.as_deref());
+    let transcript_nested = transcript_selection(
+        paragraph_limit.unwrap_or(DEFAULT_MCP_PAGE_SIZE),
+        paragraph_cursor.as_deref(),
+    );
+    let selection = build_transcript_field_selection(&chosen, &transcript_nested);
 
     let query = format!(
         "query GetTranscripts($symbol: String!) {{ ticker(symbol: $symbol) {{ transcripts{args_str} {selection} }} }}"
@@ -88,4 +109,109 @@ pub async fn get_transcripts(
     Ok(CallToolResult::success(vec![rmcp::model::Content::text(
         serde_json::to_string(&data).map_err(ser_err)?,
     )]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fields(names: &[&str]) -> Vec<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn transcript_selection_includes_first_and_no_cursor_by_default() {
+        let sel = transcript_selection(25, None);
+        assert!(sel.contains("paragraphs(first: 25)"));
+        assert!(!sel.contains("after:"));
+    }
+
+    #[test]
+    fn transcript_selection_includes_escaped_cursor_when_present() {
+        let sel = transcript_selection(10, Some("has\"quote"));
+        assert!(sel.contains("paragraphs(first: 10, after: \"has\\\"quote\")"));
+    }
+
+    #[test]
+    fn transcript_selection_contains_expected_structure() {
+        let sel = transcript_selection(25, None);
+        assert!(sel.contains("transcriptContent"));
+        assert!(sel.contains("speakerMapping"));
+        assert!(sel.contains("transcriptMetadata"));
+    }
+
+    #[test]
+    fn build_transcripts_args_is_empty_when_both_absent() {
+        assert_eq!(build_transcripts_args(None, None), "");
+    }
+
+    #[test]
+    fn build_transcripts_args_includes_limit_only() {
+        assert_eq!(build_transcripts_args(Some(4), None), "(limit: 4)");
+    }
+
+    #[test]
+    fn build_transcripts_args_includes_lang_only_for_supported_language() {
+        assert_eq!(build_transcripts_args(None, Some("ja")), "(lang: \"ja\")");
+    }
+
+    #[test]
+    fn build_transcripts_args_omits_english_lang() {
+        assert_eq!(build_transcripts_args(Some(2), Some("en")), "(limit: 2)");
+    }
+
+    #[test]
+    fn build_transcripts_args_combines_limit_and_lang() {
+        assert_eq!(
+            build_transcripts_args(Some(2), Some("ja")),
+            "(limit: 2, lang: \"ja\")"
+        );
+    }
+
+    #[test]
+    fn choose_transcript_fields_falls_back_to_defaults_when_none() {
+        assert_eq!(
+            choose_transcript_fields(None),
+            GQL_TRANSCRIPT_DEFAULT_FIELDS.to_vec()
+        );
+    }
+
+    #[test]
+    fn choose_transcript_fields_falls_back_to_defaults_when_empty() {
+        let empty = fields(&[]);
+        assert_eq!(
+            choose_transcript_fields(Some(&empty)),
+            GQL_TRANSCRIPT_DEFAULT_FIELDS.to_vec()
+        );
+    }
+
+    #[test]
+    fn choose_transcript_fields_falls_back_when_every_requested_field_is_unknown() {
+        let requested = fields(&["bogus1", "bogus2"]);
+        assert_eq!(
+            choose_transcript_fields(Some(&requested)),
+            GQL_TRANSCRIPT_DEFAULT_FIELDS.to_vec()
+        );
+    }
+
+    #[test]
+    fn choose_transcript_fields_keeps_only_valid_requested_fields() {
+        let requested = fields(&["title", "bogus", "quarter"]);
+        assert_eq!(
+            choose_transcript_fields(Some(&requested)),
+            vec!["title", "quarter"]
+        );
+    }
+
+    #[test]
+    fn build_transcript_field_selection_wraps_fields_in_braces() {
+        let sel = build_transcript_field_selection(&["title", "quarter"], "{ nested }");
+        assert_eq!(sel, "{ title quarter }");
+    }
+
+    #[test]
+    fn build_transcript_field_selection_splices_nested_selection_after_transcript() {
+        let sel = build_transcript_field_selection(&["title", "transcript"], "{ nested }");
+        assert_eq!(sel, "{ title transcript { nested } }");
+    }
 }


### PR DESCRIPTION
## Description
The `finance-query-mcp` crate's tool modules (20+ files under `src/tools/`) had thin unit test coverage relative to the rest of the codebase. This adds unit tests for the pure helper functions in each module — field selection, GraphQL query-arg building, symbol/lang parsing, and string escaping — the logic most prone to silent regressions since it's exercised indirectly by every tool call.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
<!-- List the key changes made in this PR -->
- Extract pure helper functions (previously inlined) for field selection, query-arg building, symbol/lang parsing, and GraphQL string escaping across `analysis`, `calendar`, `chart`, `crypto`, `dividends`, `edgar`, `feeds`, `financials`, `fred`, `gql`, `helpers`, `indicators`, `market`, `mod`, `news`, `options`, `quotes`, `risk`, `search`, and `transcripts`
- Add unit tests for each extracted helper, including edge cases (empty field lists vs. `None`, unparseable language codes, GraphQL injection-shaped input escaping)
- Fix a lifetime signature issue in `transcripts::choose_transcript_fields` surfaced while adding coverage

## Breaking Changes
None — test-only and internal helper extraction; no public API changes.

**Migration Guide:**
N/A

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] All tests pass (`cargo test`)

211/211 tests passing across all 20 MCP tool modules (`cargo test -p finance-query-mcp tools::`).

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues
Closes #280
