### PR TITLE
feat: GDELT and CFTC keyless providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`-borrowed`, `pool2`, `staking`), which describe the same capital and would
   double-count. DefiLlama serves no prices, so `quote()` falls through to
   another routed provider.
+- **GDELT DOC 2.0** (`gdelt` feature, keyless) — `Provider::Gdelt` serves the
+  news slice of `Capability::CORPORATE` from GDELT's worldwide online news
+  index (65 languages, updated roughly every 15 minutes), giving `Ticker::news()`
+  a keyless alternative to Yahoo's scraper and Alpha Vantage's 25 req/day
+  quota. GDELT has no ticker vocabulary, so the symbol itself (quoted for an
+  exact phrase match) is the search term — precision over recall. GDELT has
+  no corporate calendar, so `fetch_events` reports `NotSupported`.
 - Alpha Vantage gains the `DISCOVERY` capability and ETF coverage:
   `Ticker::etf_profile()` returns a fund's profile and portfolio holdings
   (heaviest first) — no other wired provider serves ETF composition —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   quota. GDELT has no ticker vocabulary, so the symbol itself (quoted for an
   exact phrase match) is the search term — precision over recall. GDELT has
   no corporate calendar, so `fetch_events` reports `NotSupported`.
+- **CFTC Commitments of Traders** (`cftc` feature, keyless) —
+  `Provider::Cftc` serves `Capability::FUTURES` with weekly futures
+  positioning by trader category (commercial hedgers, swap dealers, managed
+  money, other reportables, small traders) via
+  `FuturesContract::commitments_of_traders()`, reading the disaggregated
+  futures-only combined report from `publicreporting.cftc.gov`. A curated
+  table maps common Yahoo-style continuous futures roots (`"GC=F"`, `"CL=F"`,
+  …) to their CFTC contract code; anything else is passed through as a raw
+  `cftc_contract_market_code`. New public model `CommitmentsOfTraders` /
+  `CotObservation`. Covers physical commodities only (agriculture, energy,
+  metals) — CFTC reports financial futures (equity indices, rates,
+  currencies) separately in the Traders in Financial Futures report, which
+  this adapter does not serve; CFTC publishes no price quotes at all, so
+  `fetch_futures_quote` reports `NotSupported` and falls through to another
+  routed provider (e.g. Polygon).
 - Alpha Vantage gains the `DISCOVERY` capability and ETF coverage:
   `Ticker::etf_profile()` returns a fund's profile and portfolio holdings
   (heaviest first) — no other wired provider serves ETF composition —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,8 +122,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   index (65 languages, updated roughly every 15 minutes), giving `Ticker::news()`
   a keyless alternative to Yahoo's scraper and Alpha Vantage's 25 req/day
   quota. GDELT has no ticker vocabulary, so the symbol itself (quoted for an
-  exact phrase match) is the search term — precision over recall. GDELT has
-  no corporate calendar, so `fetch_events` reports `NotSupported`.
+  exact phrase match) is the search term — precision over recall. GDELT
+  rejects phrases under 5 characters, so shorter tickers (`AAPL`, `TSLA`, …)
+  error with `InvalidParameter` and dispatch falls through to another
+  CORPORATE provider. GDELT has no corporate calendar, so `fetch_events`
+  reports `NotSupported`.
 - **CFTC Commitments of Traders** (`cftc` feature, keyless) —
   `Provider::Cftc` serves `Capability::FUTURES` with weekly futures
   positioning by trader category (commercial hedgers, swap dealers, managed
@@ -139,6 +142,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   this adapter does not serve; CFTC publishes no price quotes at all, so
   `fetch_futures_quote` reports `NotSupported` and falls through to another
   routed provider (e.g. Polygon).
+- Both keyless providers are exposed on the server: `GET /v2/gdelt/news/{symbol}`
+  and `GET /v2/cftc/cot/{symbol}`, plus the `gdeltNews`/`commitmentsOfTraders`
+  GraphQL root fields. The library gains `gdelt::news()` and
+  `cftc::commitments_of_traders()` shortcuts so neither needs provider routing.
 - Alpha Vantage gains the `DISCOVERY` capability and ETF coverage:
   `Ticker::etf_profile()` returns a fund's profile and portfolio holdings
   (heaviest first) — no other wired provider serves ETF composition —
@@ -240,6 +247,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   session is dropped so the next caller builds a fresh one.
 
 ### Fixed
+
+- `FinanceError::RateLimited` rendered as "Rate limited (retry after Nones)"
+  when no retry hint was available, and "Some(30)s" when there was one.
+- GDELT's throttle response carries its retry interval in a plain-text body
+  rather than a `Retry-After` header; that interval is now parsed into
+  `RateLimited::retry_after` and the message logged instead of discarded.
 
 - `finance::hours()` no longer labels every region's market "U.S. markets".
   Yahoo returns correct per-region session times but hardcodes the U.S.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,7 @@ full = [
     "finra",
     "openfigi",
     "defi",
+    "gdelt",
 ]
 # Enable DataFrame conversions with polars
 dataframe = ["dep:polars"]
@@ -147,6 +148,8 @@ finra = []
 openfigi = []
 # Enable DefiLlama DeFi TVL, chain rankings, and stablecoin supplies (keyless)
 defi = []
+# Enable GDELT DOC 2.0 global news search (keyless)
+gdelt = []
 # Enable offline VADER lexicon-based news/transcript sentiment scoring
 sentiment = ["dep:vader_sentiment"]
 # Enable Alpha Vantage financial data API
@@ -196,6 +199,7 @@ features = [
     "finra",
     "openfigi",
     "defi",
+    "gdelt",
 ]
 rustdoc-args = ["--cfg", "docsrs"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,7 @@ full = [
     "openfigi",
     "defi",
     "gdelt",
+    "cftc",
 ]
 # Enable DataFrame conversions with polars
 dataframe = ["dep:polars"]
@@ -150,6 +151,8 @@ openfigi = []
 defi = []
 # Enable GDELT DOC 2.0 global news search (keyless)
 gdelt = []
+# Enable CFTC Commitments of Traders futures positioning data (keyless)
+cftc = []
 # Enable offline VADER lexicon-based news/transcript sentiment scoring
 sentiment = ["dep:vader_sentiment"]
 # Enable Alpha Vantage financial data API
@@ -200,6 +203,7 @@ features = [
     "openfigi",
     "defi",
     "gdelt",
+    "cftc",
 ]
 rustdoc-args = ["--cfg", "docsrs"]
 

--- a/docs/library/providers/index.md
+++ b/docs/library/providers/index.md
@@ -32,6 +32,7 @@ Yahoo Finance is always available with no configuration. All others are opt-in v
 | **FINRA** | `finra` | Keyless (non-commercial) | *(keyless)* |
 | **OpenFIGI** | `openfigi` | Keyless 25 req/min | `OPENFIGI_API_KEY` *(optional)* |
 | **DefiLlama** | `defi` | Keyless | *(keyless)* |
+| **GDELT DOC 2.0** | `gdelt` | Keyless (~1 req/5s) | *(keyless)* |
 | **SEC EDGAR** | *(always available)* | Keyless | *(email via `edgar::init`)* |
 
 ```toml

--- a/docs/library/providers/index.md
+++ b/docs/library/providers/index.md
@@ -33,6 +33,7 @@ Yahoo Finance is always available with no configuration. All others are opt-in v
 | **OpenFIGI** | `openfigi` | Keyless 25 req/min | `OPENFIGI_API_KEY` *(optional)* |
 | **DefiLlama** | `defi` | Keyless | *(keyless)* |
 | **GDELT DOC 2.0** | `gdelt` | Keyless (~1 req/5s) | *(keyless)* |
+| **CFTC** | `cftc` | Keyless | *(keyless)* |
 | **SEC EDGAR** | *(always available)* | Keyless | *(email via `edgar::init`)* |
 
 ```toml

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Finance library (our own)
-finance-query = { path = "..", features = ["indicators", "fred", "crypto", "risk", "sentiment"] }
+finance-query = { path = "..", features = ["indicators", "fred", "crypto", "risk", "sentiment", "gdelt", "cftc"] }
 
 # GraphQL
 async-graphql = { version = "7", features = ["graphiql"] }

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -69,6 +69,8 @@ tags:
     description: Portfolio risk analytics (VaR, Sharpe, drawdown, beta)
   - name: Feeds
     description: RSS/Atom news feeds from financial publishers
+  - name: Futures
+    description: CFTC Commitments of Traders futures positioning (keyless)
 
 paths:
   /v2/health:
@@ -2780,6 +2782,77 @@ paths:
         '500':
           $ref: '#/components/responses/InternalError'
 
+  /v2/gdelt/news/{symbol}:
+    get:
+      tags: [News]
+      summary: Worldwide news for a symbol (GDELT)
+      description: >-
+        News mentioning the ticker, indexed by GDELT DOC 2.0 across 65
+        languages over a trailing two-week window. Keyless. Distinct from
+        `/v2/news/{symbol}`, which is Yahoo-sourced.
+      parameters:
+        - name: symbol
+          in: path
+          required: true
+          schema:
+            type: string
+          example: AAPL
+        - $ref: '#/components/parameters/Fields'
+        - $ref: '#/components/parameters/PaginationLimit'
+        - $ref: '#/components/parameters/PaginationCursor'
+      responses:
+        '200':
+          description: |
+            Matching articles. Pagination is opt-in: omitting both `limit` and
+            `cursor` returns a bare array; passing either returns
+            `{ items: [...], pageInfo: {...} }` instead.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/NewsArticle'
+        '429':
+          description: GDELT throttled the request (~1 req/5s)
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /v2/cftc/cot/{symbol}:
+    get:
+      tags: [Futures]
+      summary: CFTC Commitments of Traders positioning
+      description: >-
+        Weekly futures positioning by trader category (commercial hedgers, swap
+        dealers, managed money, other reportables, small traders) from the CFTC
+        disaggregated futures-only report. Keyless. Covers physical commodities
+        only — agriculture, energy, and metals.
+      parameters:
+        - name: symbol
+          in: path
+          required: true
+          schema:
+            type: string
+          description: >-
+            Yahoo-style continuous futures root (GC=F, SI=F, PL=F, HG=F, CL=F,
+            NG=F, ZC=F, ZW=F, ZS=F) or a raw CFTC contract market code.
+          example: GC=F
+        - $ref: '#/components/parameters/Fields'
+        - $ref: '#/components/parameters/PaginationLimit'
+        - $ref: '#/components/parameters/PaginationCursor'
+      responses:
+        '200':
+          description: Weekly positioning series, oldest first
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CommitmentsOfTraders'
+        '404':
+          description: No CFTC rows for this contract code/symbol
+        '429':
+          description: CFTC public reporting API throttled the request
+        '500':
+          $ref: '#/components/responses/InternalError'
+
   /v2/risk/{symbol}:
     get:
       tags: [Risk]
@@ -3311,6 +3384,99 @@ components:
           type: integer
           nullable: true
           description: Market cap rank (1 = highest market cap)
+
+    CommitmentsOfTraders:
+      type: object
+      description: Weekly CFTC Commitments of Traders positioning for one futures market
+      properties:
+        symbol:
+          type: string
+          description: The symbol the series was requested with
+          example: GC=F
+        marketAndExchangeName:
+          type: string
+          example: GOLD - COMMODITY EXCHANGE INC.
+        cftcContractMarketCode:
+          type: string
+          example: '088691'
+        observations:
+          type: array
+          description: Weekly report rows, oldest first
+          items:
+            $ref: '#/components/schemas/CotObservation'
+
+    CotObservation:
+      type: object
+      description: One weekly COT report row, broken down by trader category
+      properties:
+        reportDate:
+          type: string
+          description: Report date (YYYY-MM-DD) — the Tuesday the report is as of
+          example: '2026-07-28'
+        openInterest:
+          type: integer
+          format: int64
+          nullable: true
+        producerMerchantLong:
+          type: integer
+          format: int64
+          nullable: true
+        producerMerchantShort:
+          type: integer
+          format: int64
+          nullable: true
+        swapDealerLong:
+          type: integer
+          format: int64
+          nullable: true
+        swapDealerShort:
+          type: integer
+          format: int64
+          nullable: true
+        swapDealerSpread:
+          type: integer
+          format: int64
+          nullable: true
+        managedMoneyLong:
+          type: integer
+          format: int64
+          nullable: true
+        managedMoneyShort:
+          type: integer
+          format: int64
+          nullable: true
+        managedMoneySpread:
+          type: integer
+          format: int64
+          nullable: true
+        otherReportableLong:
+          type: integer
+          format: int64
+          nullable: true
+        otherReportableShort:
+          type: integer
+          format: int64
+          nullable: true
+        otherReportableSpread:
+          type: integer
+          format: int64
+          nullable: true
+        totalReportableLong:
+          type: integer
+          format: int64
+          nullable: true
+        totalReportableShort:
+          type: integer
+          format: int64
+          nullable: true
+        nonreportableLong:
+          type: integer
+          format: int64
+          nullable: true
+        nonreportableShort:
+          type: integer
+          format: int64
+          nullable: true
 
     Split:
       type: object

--- a/server/src/graphql/error.rs
+++ b/server/src/graphql/error.rs
@@ -42,6 +42,7 @@ pub fn to_gql_error(err: Box<dyn std::error::Error + Send + Sync>) -> Error {
 fn finance_error_to_gql(err: &FinanceError) -> Error {
     let (code, status) = match err {
         FinanceError::SymbolNotFound { .. } => ("NOT_FOUND", 404),
+        FinanceError::InvalidParameter { .. } => ("BAD_REQUEST", 400),
         FinanceError::RateLimited { .. } => ("RATE_LIMITED", 429),
         FinanceError::Timeout { .. } => ("TIMEOUT", 408),
         FinanceError::AuthenticationFailed { .. } => ("UNAUTHORIZED", 401),

--- a/server/src/graphql/fields.rs
+++ b/server/src/graphql/fields.rs
@@ -308,6 +308,25 @@ pub const GQL_NEWS_VALID_FIELDS: &[&str] = &["title", "link", "source", "img", "
 /// `sentiment` is composite (`GqlSentiment`) and needs its own nested sub-selection.
 pub const NEWS_COMPOSITE_FIELDS: &[(&str, &str)] = &[("sentiment", "{ label score confidence }")];
 
+// ── CFTC Commitments of Traders (keyless) ───────────────────────────────────
+
+pub const GQL_COT_VALID_FIELDS: &[&str] = &[
+    "symbol",
+    "marketAndExchangeName",
+    "cftcContractMarketCode",
+    "observations",
+];
+
+/// `observations` is a paginated list of `GqlCotObservation`.
+pub const COT_COMPOSITE_FIELDS: &[(&str, &str)] = &[(
+    "observations",
+    "{ reportDate openInterest producerMerchantLong producerMerchantShort \
+       swapDealerLong swapDealerShort swapDealerSpread managedMoneyLong \
+       managedMoneyShort managedMoneySpread otherReportableLong \
+       otherReportableShort otherReportableSpread totalReportableLong \
+       totalReportableShort nonreportableLong nonreportableShort }",
+)];
+
 /// Valid GraphQL field names for `GqlFeedEntry` (top-level `feeds` root field).
 pub const GQL_FEEDS_VALID_FIELDS: &[&str] = &["title", "url", "published", "summary", "source"];
 

--- a/server/src/graphql/query/root_metadata.rs
+++ b/server/src/graphql/query/root_metadata.rs
@@ -12,7 +12,9 @@ use crate::graphql::types::{
     edgar::{GqlEdgarCik, GqlEdgarSearchHit, GqlEdgarSearchResults},
     enums::GqlTimeRange,
     fred::{GqlMacroSeries, GqlTreasuryYield},
+    keyless::GqlCommitmentsOfTraders,
     metadata::{GqlCurrency, GqlExchange, GqlMarketHours, GqlQuoteTypeData},
+    news::GqlNews,
 };
 
 #[derive(Default)]
@@ -53,6 +55,43 @@ impl RootMetadataQuery {
             &state.cache,
             &id,
             &vs_currency,
+        ))
+        .await
+    }
+
+    /// Worldwide news mentioning `symbol`, from GDELT DOC 2.0 (keyless).
+    ///
+    /// Distinct from the Yahoo-sourced `ticker { news }`: GDELT indexes news
+    /// across 65 languages, matched on the ticker as an exact phrase.
+    async fn gdelt_news(
+        &self,
+        ctx: &Context<'_>,
+        symbol: String,
+        #[graphql(desc = "Max articles per page; omitted = every article in one page")]
+        first: Option<i32>,
+        #[graphql(desc = "Opaque continuation cursor from a previous page's endCursor")]
+        after: Option<String>,
+    ) -> Result<Page<GqlNews>> {
+        let state = ctx.data::<AppState>()?;
+        let json = crate::services::keyless::get_gdelt_news(&state.cache, &symbol)
+            .await
+            .map_err(to_gql_error)?;
+        let entries: Vec<GqlNews> = from_gql_json(json)?;
+        pagination::paginate(&entries, first, after).await
+    }
+
+    /// Weekly CFTC Commitments of Traders positioning for a futures contract
+    /// (keyless). Accepts a Yahoo-style continuous futures root (`"GC=F"`,
+    /// `"CL=F"`, …) or a raw CFTC contract market code.
+    async fn commitments_of_traders(
+        &self,
+        ctx: &Context<'_>,
+        symbol: String,
+    ) -> Result<GqlCommitmentsOfTraders> {
+        let state = ctx.data::<AppState>()?;
+        exec_gql(crate::services::keyless::get_commitments_of_traders(
+            &state.cache,
+            &symbol,
         ))
         .await
     }

--- a/server/src/graphql/types/keyless.rs
+++ b/server/src/graphql/types/keyless.rs
@@ -1,0 +1,63 @@
+//! GraphQL types for the keyless providers that have no other schema home:
+//! CFTC Commitments of Traders. (GDELT news reuses `GqlNews`, since it
+//! populates the same canonical `News` model as every other news source.)
+
+use async_graphql::{ComplexObject, Result, SimpleObject};
+use serde::Deserialize;
+
+use crate::graphql::pagination::{self, Page};
+
+/// Mirrors `finance_query::cftc::CommitmentsOfTraders`.
+#[derive(SimpleObject, Deserialize, Debug, Clone, Default)]
+#[graphql(rename_fields = "camelCase", complex)]
+#[serde(default)]
+pub struct GqlCommitmentsOfTraders {
+    /// The symbol the series was requested with (`"GC=F"`, or a raw CFTC code).
+    pub symbol: String,
+    /// CFTC's own market and exchange name.
+    pub market_and_exchange_name: String,
+    /// CFTC contract market code identifying this market.
+    pub cftc_contract_market_code: String,
+    /// Weekly observations, oldest first. Paginated via the resolver below.
+    #[graphql(skip)]
+    pub observations: Vec<GqlCotObservation>,
+}
+
+#[ComplexObject(rename_fields = "camelCase")]
+impl GqlCommitmentsOfTraders {
+    /// Weekly report rows, oldest first.
+    async fn observations(
+        &self,
+        #[graphql(desc = "Max rows to return; omitted = every row in one page")] first: Option<i32>,
+        #[graphql(desc = "Opaque continuation cursor from a previous page's endCursor")]
+        after: Option<String>,
+    ) -> Result<Page<GqlCotObservation>> {
+        pagination::paginate(&self.observations, first, after).await
+    }
+}
+
+/// Mirrors `finance_query::cftc::CotObservation` — one weekly report row,
+/// broken down by trader category.
+#[derive(SimpleObject, Deserialize, Debug, Clone, Default)]
+#[graphql(rename_fields = "camelCase")]
+#[serde(default)]
+pub struct GqlCotObservation {
+    /// Report date (`YYYY-MM-DD`) — the Tuesday the report is as of.
+    pub report_date: String,
+    pub open_interest: Option<i64>,
+    pub producer_merchant_long: Option<i64>,
+    pub producer_merchant_short: Option<i64>,
+    pub swap_dealer_long: Option<i64>,
+    pub swap_dealer_short: Option<i64>,
+    pub swap_dealer_spread: Option<i64>,
+    pub managed_money_long: Option<i64>,
+    pub managed_money_short: Option<i64>,
+    pub managed_money_spread: Option<i64>,
+    pub other_reportable_long: Option<i64>,
+    pub other_reportable_short: Option<i64>,
+    pub other_reportable_spread: Option<i64>,
+    pub total_reportable_long: Option<i64>,
+    pub total_reportable_short: Option<i64>,
+    pub nonreportable_long: Option<i64>,
+    pub nonreportable_short: Option<i64>,
+}

--- a/server/src/graphql/types/mod.rs
+++ b/server/src/graphql/types/mod.rs
@@ -13,6 +13,7 @@ pub mod fred;
 pub mod holders;
 pub mod indicators;
 pub mod industry;
+pub mod keyless;
 pub mod market;
 pub mod metadata;
 pub mod news;

--- a/server/src/handlers/gql_bridge.rs
+++ b/server/src/handlers/gql_bridge.rs
@@ -141,6 +141,23 @@ pub(crate) fn unwrap_connection(data: serde_json::Value, paginated: bool) -> ser
     }
 }
 
+/// Render REST's `limit`/`cursor` params as GraphQL `first`/`after` arguments.
+/// Empty when the caller opted out of pagination — callers decide whether to
+/// wrap the result in parens or append it to an existing argument list.
+pub(crate) fn connection_args(limit: Option<u32>, cursor: Option<&str>) -> Vec<String> {
+    let mut args = Vec::new();
+    if let Some(limit) = limit {
+        args.push(format!("first: {limit}"));
+    }
+    if let Some(cursor) = cursor {
+        args.push(format!(
+            "after: \"{}\"",
+            crate::graphql::fields::escape_gql_string(cursor)
+        ));
+    }
+    args
+}
+
 // Map a REST interval string to a GqlInterval enum literal for GraphQL query building.
 pub(crate) fn interval_to_gql(s: &str) -> &'static str {
     use finance_query::Interval;

--- a/server/src/handlers/keyless.rs
+++ b/server/src/handlers/keyless.rs
@@ -1,0 +1,127 @@
+//! REST handlers for the keyless providers: GDELT global news search and
+//! CFTC Commitments of Traders. Neither needs an API key.
+
+use async_graphql::{Name, Variables};
+use axum::{
+    extract::{Extension, Path, Query},
+    http::StatusCode,
+    response::{IntoResponse, Json},
+};
+use finance_query_server::graphql::{
+    self,
+    fields::{
+        COT_COMPOSITE_FIELDS, GQL_COT_VALID_FIELDS, GQL_NEWS_VALID_FIELDS, NEWS_COMPOSITE_FIELDS,
+        unwrap_field,
+    },
+    pagination::{
+        build_connection_selection, build_paginated_composite_selection, unwrap_nested_connection,
+    },
+};
+use serde::Deserialize;
+use tracing::info;
+
+use super::gql_bridge::{
+    build_rest_composite_selection, connection_args, execute_gql_rest, unwrap_connection,
+};
+
+/// Query parameters for /v2/gdelt/news/{symbol}
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct GdeltNewsQuery {
+    /// Comma-separated list of fields to include in response
+    fields: Option<String>,
+    /// Max articles per page; omitted (with cursor also omitted) = bare array
+    limit: Option<u32>,
+    /// Opaque continuation cursor from a previous response's `pageInfo.endCursor`
+    cursor: Option<String>,
+}
+
+/// Query parameters for /v2/cftc/cot/{symbol}
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CotQuery {
+    /// Comma-separated list of fields to include in response
+    fields: Option<String>,
+    /// Max weekly observations per page; omitted (with cursor also omitted) =
+    /// every observation as a bare array
+    limit: Option<u32>,
+    /// Opaque continuation cursor from a previous response's `pageInfo.endCursor`
+    cursor: Option<String>,
+}
+
+/// GET /v2/gdelt/news/{symbol}
+pub(crate) async fn get_gdelt_news(
+    Extension(schema): Extension<graphql::FinanceSchema>,
+    Path(symbol): Path<String>,
+    Query(params): Query<GdeltNewsQuery>,
+) -> impl IntoResponse {
+    let inner_selection = build_rest_composite_selection(
+        params.fields.as_deref(),
+        GQL_NEWS_VALID_FIELDS,
+        NEWS_COMPOSITE_FIELDS,
+    );
+    let selection = build_connection_selection(&inner_selection);
+    let conn_args = connection_args(params.limit, params.cursor.as_deref());
+    let conn_args_str = if conn_args.is_empty() {
+        String::new()
+    } else {
+        format!(", {}", conn_args.join(", "))
+    };
+    let query = format!(
+        "query GdeltNews($symbol: String!) {{ gdeltNews(symbol: $symbol{conn_args_str}) {selection} }}"
+    );
+    let mut vars = Variables::default();
+    vars.insert(Name::new("symbol"), symbol.clone().into());
+
+    info!("Fetching GDELT news for: {symbol}");
+
+    let data = match execute_gql_rest(&schema, &query, vars).await {
+        Ok(d) => d,
+        Err(resp) => return resp,
+    };
+    let paginated = params.limit.is_some() || params.cursor.is_some();
+    let result = unwrap_connection(unwrap_field(data, "gdeltNews"), paginated);
+    (StatusCode::OK, Json(result)).into_response()
+}
+
+/// GET /v2/cftc/cot/{symbol}
+pub(crate) async fn get_commitments_of_traders(
+    Extension(schema): Extension<graphql::FinanceSchema>,
+    Path(symbol): Path<String>,
+    Query(params): Query<CotQuery>,
+) -> impl IntoResponse {
+    let observations_item_selection = COT_COMPOSITE_FIELDS
+        .iter()
+        .find(|(name, _)| *name == "observations")
+        .map(|(_, sel)| *sel)
+        .unwrap_or("{ reportDate openInterest }");
+    let selection = build_paginated_composite_selection(
+        params.fields.as_deref(),
+        GQL_COT_VALID_FIELDS,
+        GQL_COT_VALID_FIELDS,
+        COT_COMPOSITE_FIELDS,
+        "observations",
+        observations_item_selection,
+        params.limit,
+        params.cursor.as_deref(),
+    );
+    let query = format!(
+        "query Cot($symbol: String!) {{ commitmentsOfTraders(symbol: $symbol) {selection} }}"
+    );
+    let mut vars = Variables::default();
+    vars.insert(Name::new("symbol"), symbol.clone().into());
+
+    info!("Fetching CFTC Commitments of Traders for: {symbol}");
+
+    let data = match execute_gql_rest(&schema, &query, vars).await {
+        Ok(d) => d,
+        Err(resp) => return resp,
+    };
+    let paginated = params.limit.is_some() || params.cursor.is_some();
+    let result = unwrap_nested_connection(
+        unwrap_field(data, "commitmentsOfTraders"),
+        "observations",
+        paginated,
+    );
+    (StatusCode::OK, Json(result)).into_response()
+}

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -17,6 +17,7 @@ mod fred;
 mod gql_bridge;
 mod holders;
 mod indicators;
+mod keyless;
 mod market;
 mod metadata;
 mod news;
@@ -52,6 +53,11 @@ pub(crate) fn api_routes() -> Router {
         // GET /v2/capital-gains?symbols=<csv>&range=<str>
         .route("/capital-gains", get(events::get_batch_capital_gains))
         .route("/calendar", get(calendar::get_calendar))
+        // GET /v2/cftc/cot/{symbol}
+        .route(
+            "/cftc/cot/{symbol}",
+            get(keyless::get_commitments_of_traders),
+        )
         // GET /v2/chart/{symbol}?interval=<str>&range=<str>&events=<bool>&patterns=<bool>
         .route("/chart/{symbol}", get(chart::get_chart))
         // GET /v2/charts?symbols=<csv>&interval=<str>&range=<str>&patterns=<bool>
@@ -96,6 +102,8 @@ pub(crate) fn api_routes() -> Router {
         .route("/fred/series/{id}", get(fred::get_fred_series))
         // GET /v2/fred/treasury-yields?year=<u32>
         .route("/fred/treasury-yields", get(fred::get_fred_treasury_yields))
+        // GET /v2/gdelt/news/{symbol}
+        .route("/gdelt/news/{symbol}", get(keyless::get_gdelt_news))
         // GET /v2/health - version-prefixed health check
         .route("/health", get(system::health_check))
         // GET /v2/holders/{symbol}/{holder_type}

--- a/server/src/services/keyless.rs
+++ b/server/src/services/keyless.rs
@@ -1,0 +1,39 @@
+//! Keyless provider services: GDELT global news search and CFTC Commitments
+//! of Traders. Both call the library's keyless shortcut modules directly —
+//! neither needs an API key or provider routing.
+
+use crate::cache::{self, Cache};
+
+use super::{ServiceError, ServiceResult};
+
+/// Worldwide news mentioning `symbol`, from GDELT DOC 2.0.
+///
+/// GDELT self-paces to ~1 request per 5 seconds process-wide, so this is
+/// cached aggressively — an uncached burst would serialise behind that
+/// limiter.
+pub async fn get_gdelt_news(cache: &Cache, symbol: &str) -> ServiceResult {
+    let cache_key = Cache::key("gdelt_news", &[symbol]);
+    let sym = symbol.to_string();
+
+    cache
+        .get_or_fetch(&cache_key, cache::ttl::GENERAL_NEWS, false, || async move {
+            let news = finance_query::gdelt::news(&sym).await?;
+            serde_json::to_value(&news).map_err(|e| Box::new(e) as ServiceError)
+        })
+        .await
+}
+
+/// Weekly CFTC Commitments of Traders positioning for a futures contract.
+///
+/// Reports publish weekly, so the response is cached for a long interval.
+pub async fn get_commitments_of_traders(cache: &Cache, symbol: &str) -> ServiceResult {
+    let cache_key = Cache::key("cftc_cot", &[symbol]);
+    let sym = symbol.to_string();
+
+    cache
+        .get_or_fetch(&cache_key, cache::ttl::FINANCIALS, false, || async move {
+            let cot = finance_query::cftc::commitments_of_traders(&sym).await?;
+            serde_json::to_value(&cot).map_err(|e| Box::new(e) as ServiceError)
+        })
+        .await
+}

--- a/server/src/services/mod.rs
+++ b/server/src/services/mod.rs
@@ -14,6 +14,7 @@ pub mod financials;
 pub mod fred;
 pub mod holders;
 pub mod indicators;
+pub mod keyless;
 pub mod market;
 pub mod metadata;
 pub mod news;

--- a/src/adapters/cftc/client.rs
+++ b/src/adapters/cftc/client.rs
@@ -1,0 +1,114 @@
+//! CFTC Commitments of Traders HTTP client (Socrata public reporting API).
+//!
+//! Keyless and unauthenticated. Socrata's anonymous tier throttles by
+//! rolling-hour request count rather than per-second, so the client only
+//! self-paces enough to avoid looking like a burst.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use reqwest::{Client, StatusCode};
+use tracing::debug;
+
+use super::models::{CftcError, CotRow};
+use crate::adapters::common::keyless_http_client;
+use crate::error::{FinanceError, Result};
+use crate::rate_limiter::RateLimiter;
+
+/// The disaggregated futures-only combined report (Socrata dataset
+/// `72hh-3qpy`) — what "Commitments of Traders" means for the physical
+/// commodities it covers (agriculture, energy, metals). Financial futures
+/// (equity indices, rates, currencies) are reported separately by the CFTC
+/// in the Traders in Financial Futures report, which this adapter does not
+/// serve.
+pub(super) const CFTC_BASE: &str = "https://publicreporting.cftc.gov/resource/72hh-3qpy.json";
+
+/// Weekly reports; 104 rows covers roughly two years of history per call.
+const ROW_LIMIT: u32 = 104;
+
+pub(super) struct CftcClient {
+    http: Client,
+    limiter: Arc<RateLimiter>,
+    base_url: String,
+}
+
+impl CftcClient {
+    pub(super) fn new(
+        timeout: Duration,
+        limiter: Arc<RateLimiter>,
+        base_url: impl Into<String>,
+    ) -> Result<Self> {
+        Ok(Self {
+            http: keyless_http_client(timeout)?,
+            limiter,
+            base_url: base_url.into(),
+        })
+    }
+
+    /// Fetch weekly COT rows for one `cftc_contract_market_code`, newest
+    /// first (the order requested via Socrata's `$order`).
+    pub(super) async fn commitments_of_traders(&self, contract_code: &str) -> Result<Vec<CotRow>> {
+        self.limiter.acquire().await;
+
+        let where_clause = format!("cftc_contract_market_code='{}'", escape_soql(contract_code));
+        debug!("CFTC request: {where_clause}");
+
+        let resp = self
+            .http
+            .get(&self.base_url)
+            .query(&[
+                ("$where", where_clause.as_str()),
+                ("$order", "report_date_as_yyyy_mm_dd DESC"),
+                ("$limit", &ROW_LIMIT.to_string()),
+            ])
+            .send()
+            .await?;
+        let status = resp.status();
+        let bytes = resp.bytes().await?;
+
+        if !status.is_success() {
+            return Err(Self::map_error(status, &bytes, contract_code));
+        }
+
+        serde_json::from_slice(&bytes).map_err(|e| FinanceError::ResponseStructureError {
+            field: "cftc.commitments_of_traders".to_string(),
+            context: format!("unrecognised CFTC payload: {e}"),
+        })
+    }
+
+    fn map_error(status: StatusCode, body: &[u8], contract_code: &str) -> FinanceError {
+        // Checked before the body: a throttled response carries no useful
+        // explanation of the query.
+        if status == StatusCode::TOO_MANY_REQUESTS {
+            return FinanceError::RateLimited { retry_after: None };
+        }
+        if let Ok(err) = serde_json::from_slice::<CftcError>(body)
+            && let Some(message) = err.message
+        {
+            return FinanceError::ApiError(format!("CFTC ({contract_code}): {message}"));
+        }
+        FinanceError::ExternalApiError {
+            api: "CFTC".to_string(),
+            status: status.as_u16(),
+        }
+    }
+}
+
+/// Escape a value for safe inclusion inside a SoQL string literal by
+/// doubling embedded single quotes (SoQL's own escaping convention),
+/// preventing a crafted symbol from breaking out of the `$where` clause.
+fn escape_soql(value: &str) -> String {
+    value.replace('\'', "''")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedded_quotes_are_doubled() {
+        assert_eq!(escape_soql("088691"), "088691");
+        assert_eq!(escape_soql("O'BRIEN"), "O''BRIEN");
+        assert_eq!(escape_soql("088691' OR '1'='1"), "088691'' OR ''1''=''1");
+    }
+}

--- a/src/adapters/cftc/futures/mod.rs
+++ b/src/adapters/cftc/futures/mod.rs
@@ -114,9 +114,7 @@ pub(crate) fn to_canonical(symbol: &str, mut rows: Vec<CotRow>) -> Result<Commit
 }
 
 /// Fetch the canonical Commitments of Traders series for a futures symbol.
-pub(crate) async fn fetch_commitments_of_traders_response(
-    symbol: &str,
-) -> Result<CommitmentsOfTraders> {
+pub async fn fetch_commitments_of_traders_response(symbol: &str) -> Result<CommitmentsOfTraders> {
     let code = resolve_contract_code(symbol);
     let rows = super::client()?.commitments_of_traders(&code).await?;
     to_canonical(symbol, rows)

--- a/src/adapters/cftc/futures/mod.rs
+++ b/src/adapters/cftc/futures/mod.rs
@@ -1,0 +1,235 @@
+//! `FUTURES` capability for CFTC — Commitments of Traders positioning.
+//!
+//! CFTC publishes no price quotes, so this adapter only ever serves
+//! [`fetch_commitments_of_traders_response`]; the provider bridge reports
+//! `NotSupported` for a plain futures quote.
+
+use crate::error::{FinanceError, Result};
+use crate::models::futures::cot::{CommitmentsOfTraders, CotObservation};
+
+use super::models::CotRow;
+
+/// Curated root-symbol → CFTC `cftc_contract_market_code` table, covering
+/// the benchmark contract per commodity group in the disaggregated
+/// futures-only report. Keys are the Yahoo-style continuous futures symbols
+/// used elsewhere in this library (e.g. `providers.futures("GC=F")`).
+///
+/// Anything not listed here is treated as a literal CFTC contract code
+/// already — the passthrough form, e.g. `providers.futures("067651")` for
+/// NYMEX WTI directly, or any other code from CFTC's own market list.
+const CURATED_CODES: &[(&str, &str)] = &[
+    ("GC=F", "088691"), // Gold - COMMODITY EXCHANGE INC.
+    ("SI=F", "084691"), // Silver - COMMODITY EXCHANGE INC.
+    ("PL=F", "076651"), // Platinum - NEW YORK MERCANTILE EXCHANGE
+    ("HG=F", "085692"), // Copper- #1 - COMMODITY EXCHANGE INC.
+    ("CL=F", "067651"), // WTI-PHYSICAL - NEW YORK MERCANTILE EXCHANGE
+    ("NG=F", "03565B"), // HENRY HUB - NEW YORK MERCANTILE EXCHANGE
+    ("ZC=F", "002602"), // CORN - CHICAGO BOARD OF TRADE
+    ("ZW=F", "001602"), // WHEAT-SRW - CHICAGO BOARD OF TRADE
+    ("ZS=F", "005602"), // SOYBEANS - CHICAGO BOARD OF TRADE
+];
+
+/// Resolve a futures symbol to a CFTC `cftc_contract_market_code`.
+///
+/// Recognised Yahoo-style continuous futures roots (`"GC=F"`, `"CL=F"`, …)
+/// resolve through [`CURATED_CODES`]; anything else is treated as a literal
+/// contract code, uppercased and trimmed.
+pub(crate) fn resolve_contract_code(symbol: &str) -> String {
+    let upper = symbol.trim().to_uppercase();
+    CURATED_CODES
+        .iter()
+        .find(|(root, _)| *root == upper)
+        .map(|(_, code)| (*code).to_string())
+        .unwrap_or(upper)
+}
+
+/// Parse a Socrata numeric-as-string field into `Option<i64>`. Values arrive
+/// as decimal strings (e.g. `"316244"`); a missing or unparseable field
+/// becomes `None` rather than `0`, so "not reported" is never confused with
+/// "reported as zero".
+fn parse_i64(value: &Option<String>) -> Option<i64> {
+    value.as_deref().and_then(|v| v.trim().parse::<i64>().ok())
+}
+
+/// The report date column arrives as a full timestamp
+/// (`"2026-07-28T00:00:00.000"`); only the date part is documented.
+fn report_date(row: &CotRow) -> String {
+    row.report_date_as_yyyy_mm_dd
+        .as_deref()
+        .map(|d| d.split('T').next().unwrap_or(d).to_string())
+        .unwrap_or_default()
+}
+
+fn to_observation(row: &CotRow) -> CotObservation {
+    CotObservation {
+        report_date: report_date(row),
+        open_interest: parse_i64(&row.open_interest_all),
+        producer_merchant_long: parse_i64(&row.prod_merc_positions_long),
+        producer_merchant_short: parse_i64(&row.prod_merc_positions_short),
+        swap_dealer_long: parse_i64(&row.swap_positions_long_all),
+        swap_dealer_short: parse_i64(&row.swap_positions_short_all),
+        swap_dealer_spread: parse_i64(&row.swap_positions_spread_all),
+        managed_money_long: parse_i64(&row.m_money_positions_long_all),
+        managed_money_short: parse_i64(&row.m_money_positions_short_all),
+        managed_money_spread: parse_i64(&row.m_money_positions_spread),
+        other_reportable_long: parse_i64(&row.other_rept_positions_long),
+        other_reportable_short: parse_i64(&row.other_rept_positions_short),
+        other_reportable_spread: parse_i64(&row.other_rept_positions_spread),
+        total_reportable_long: parse_i64(&row.tot_rept_positions_long_all),
+        total_reportable_short: parse_i64(&row.tot_rept_positions_short),
+        nonreportable_long: parse_i64(&row.nonrept_positions_long_all),
+        nonreportable_short: parse_i64(&row.nonrept_positions_short_all),
+    }
+}
+
+/// Map raw rows (newest-first, the API's own order) onto the canonical
+/// [`CommitmentsOfTraders`], reversed into chronological order to match
+/// every other history-shaped model in the library.
+pub(crate) fn to_canonical(symbol: &str, mut rows: Vec<CotRow>) -> Result<CommitmentsOfTraders> {
+    if rows.is_empty() {
+        return Err(FinanceError::SymbolNotFound {
+            symbol: Some(symbol.to_string()),
+            context: "CFTC reported no Commitments of Traders rows for this contract code/symbol"
+                .to_string(),
+        });
+    }
+    rows.reverse();
+
+    let market_and_exchange_name = rows
+        .last()
+        .and_then(|r| r.market_and_exchange_names.clone())
+        .unwrap_or_default();
+    let cftc_contract_market_code = rows
+        .last()
+        .and_then(|r| r.cftc_contract_market_code.clone())
+        .unwrap_or_default();
+    let observations = rows.iter().map(to_observation).collect();
+
+    Ok(CommitmentsOfTraders {
+        symbol: symbol.to_string(),
+        market_and_exchange_name,
+        cftc_contract_market_code,
+        observations,
+    })
+}
+
+/// Fetch the canonical Commitments of Traders series for a futures symbol.
+pub(crate) async fn fetch_commitments_of_traders_response(
+    symbol: &str,
+) -> Result<CommitmentsOfTraders> {
+    let code = resolve_contract_code(symbol);
+    let rows = super::client()?.commitments_of_traders(&code).await?;
+    to_canonical(symbol, rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn curated_root_symbols_resolve_to_their_contract_code() {
+        assert_eq!(resolve_contract_code("GC=F"), "088691");
+        assert_eq!(resolve_contract_code("cl=f"), "067651");
+        assert_eq!(resolve_contract_code(" ng=f "), "03565B");
+    }
+
+    #[test]
+    fn unrecognised_symbol_passes_through_as_a_literal_contract_code() {
+        assert_eq!(resolve_contract_code("088691"), "088691");
+        assert_eq!(resolve_contract_code("06765a"), "06765A");
+    }
+
+    #[test]
+    fn missing_or_unparseable_figures_are_none_not_zero() {
+        let row = CotRow {
+            market_and_exchange_names: None,
+            cftc_contract_market_code: None,
+            report_date_as_yyyy_mm_dd: None,
+            open_interest_all: None,
+            prod_merc_positions_long: Some("not-a-number".to_string()),
+            prod_merc_positions_short: None,
+            swap_positions_long_all: None,
+            swap_positions_short_all: None,
+            swap_positions_spread_all: None,
+            m_money_positions_long_all: None,
+            m_money_positions_short_all: None,
+            m_money_positions_spread: None,
+            other_rept_positions_long: None,
+            other_rept_positions_short: None,
+            other_rept_positions_spread: None,
+            tot_rept_positions_long_all: None,
+            tot_rept_positions_short: None,
+            nonrept_positions_long_all: None,
+            nonrept_positions_short_all: None,
+        };
+        let obs = to_observation(&row);
+        assert_eq!(obs.open_interest, None);
+        assert_eq!(obs.producer_merchant_long, None);
+    }
+
+    #[test]
+    fn report_date_trims_the_time_of_day_component() {
+        let mut row = blank_row();
+        row.report_date_as_yyyy_mm_dd = Some("2026-07-28T00:00:00.000".to_string());
+        assert_eq!(report_date(&row), "2026-07-28");
+    }
+
+    #[test]
+    fn empty_rows_map_to_symbol_not_found() {
+        let err = to_canonical("NOSUCHCODE", Vec::new()).unwrap_err();
+        assert!(
+            matches!(err, FinanceError::SymbolNotFound { .. }),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn rows_are_reversed_into_chronological_order() {
+        let mut newest = blank_row();
+        newest.report_date_as_yyyy_mm_dd = Some("2026-07-28T00:00:00.000".to_string());
+        newest.market_and_exchange_names = Some("GOLD - COMMODITY EXCHANGE INC.".to_string());
+        newest.cftc_contract_market_code = Some("088691".to_string());
+        newest.open_interest_all = Some("384603".to_string());
+
+        let mut oldest = blank_row();
+        oldest.report_date_as_yyyy_mm_dd = Some("2026-07-14T00:00:00.000".to_string());
+        oldest.market_and_exchange_names = Some("GOLD - COMMODITY EXCHANGE INC.".to_string());
+        oldest.cftc_contract_market_code = Some("088691".to_string());
+        oldest.open_interest_all = Some("383689".to_string());
+
+        // API order: newest first.
+        let series = to_canonical("GC=F", vec![newest, oldest]).unwrap();
+        assert_eq!(
+            series.market_and_exchange_name,
+            "GOLD - COMMODITY EXCHANGE INC."
+        );
+        assert_eq!(series.cftc_contract_market_code, "088691");
+        assert_eq!(series.observations.len(), 2);
+        assert_eq!(series.observations[0].report_date, "2026-07-14");
+        assert_eq!(series.observations[1].report_date, "2026-07-28");
+    }
+
+    fn blank_row() -> CotRow {
+        CotRow {
+            market_and_exchange_names: None,
+            cftc_contract_market_code: None,
+            report_date_as_yyyy_mm_dd: None,
+            open_interest_all: None,
+            prod_merc_positions_long: None,
+            prod_merc_positions_short: None,
+            swap_positions_long_all: None,
+            swap_positions_short_all: None,
+            swap_positions_spread_all: None,
+            m_money_positions_long_all: None,
+            m_money_positions_short_all: None,
+            m_money_positions_spread: None,
+            other_rept_positions_long: None,
+            other_rept_positions_short: None,
+            other_rept_positions_spread: None,
+            tot_rept_positions_long_all: None,
+            tot_rept_positions_short: None,
+            nonrept_positions_long_all: None,
+            nonrept_positions_short_all: None,
+        }
+    }
+}

--- a/src/adapters/cftc/mod.rs
+++ b/src/adapters/cftc/mod.rs
@@ -1,0 +1,223 @@
+//! CFTC Commitments of Traders — keyless weekly futures positioning.
+//!
+//! Requires the **`cftc`** feature flag.
+//!
+//! Nothing in the library exposed positioning data (long/short/spread by
+//! trader category) before this adapter; `Capability::FUTURES` previously
+//! meant Polygon-only price quotes. The CFTC publishes its weekly
+//! Commitments of Traders reports itself, keylessly, through
+//! `publicreporting.cftc.gov`'s Socrata API — this adapter serves the
+//! disaggregated futures-only combined report, the one most commonly meant
+//! by "COT data" for physical commodities.
+//!
+//! # Scope
+//!
+//! Only physical-commodity futures are covered (agriculture, energy,
+//! metals) via a curated table of benchmark contracts, or any raw
+//! `cftc_contract_market_code` passed straight through. Financial futures (equity indices, rates,
+//! currencies) are reported separately by the CFTC in the Traders in
+//! Financial Futures report, which this adapter does not serve — the CFTC
+//! itself has no price-quote data at all, so [`Provider::Cftc`](crate::Provider::Cftc)
+//! only ever answers [`FuturesContract::commitments_of_traders`](crate::FuturesContract::commitments_of_traders),
+//! reporting `NotSupported` for a plain quote.
+
+pub(crate) mod client;
+pub(crate) mod futures;
+pub(crate) mod models;
+
+use std::time::Duration;
+
+use crate::adapters::singleton::keyless_limiter;
+use crate::error::Result;
+use client::CftcClient;
+
+/// Self-imposed pacing. Socrata's anonymous tier throttles by rolling-hour
+/// count rather than per-second; this only keeps a burst from looking
+/// abusive.
+const CFTC_RATE_PER_SEC: f64 = 5.0;
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+keyless_limiter!(rate = CFTC_RATE_PER_SEC);
+
+/// Build a client against the live API, reusing the shared token bucket.
+fn client() -> Result<CftcClient> {
+    CftcClient::new(DEFAULT_TIMEOUT, shared_limiter(), client::CFTC_BASE)
+}
+
+pub(crate) use futures::fetch_commitments_of_traders_response;
+
+#[cfg(test)]
+mod tests {
+    use super::futures::{resolve_contract_code, to_canonical};
+    use super::*;
+    use crate::error::FinanceError;
+    use crate::rate_limiter::RateLimiter;
+    use std::sync::Arc;
+
+    fn test_client(base_url: &str) -> CftcClient {
+        CftcClient::new(
+            Duration::from_secs(5),
+            Arc::new(RateLimiter::new(100.0)),
+            base_url,
+        )
+        .unwrap()
+    }
+
+    /// Verbatim shape (trimmed to the mapped columns) from
+    /// `publicreporting.cftc.gov/resource/72hh-3qpy.json`, three weekly gold
+    /// rows, newest first.
+    fn rows_payload() -> String {
+        serde_json::json!([
+            {
+                "market_and_exchange_names": "GOLD - COMMODITY EXCHANGE INC.",
+                "cftc_contract_market_code": "088691",
+                "report_date_as_yyyy_mm_dd": "2026-07-28T00:00:00.000",
+                "open_interest_all": "384603",
+                "prod_merc_positions_long": "15367",
+                "prod_merc_positions_short": "35916",
+                "swap_positions_long_all": "23661",
+                "swap__positions_short_all": "215421",
+                "swap__positions_spread_all": "36432",
+                "m_money_positions_long_all": "135093",
+                "m_money_positions_short_all": "15298",
+                "m_money_positions_spread": "18384",
+                "other_rept_positions_long": "84529",
+                "other_rept_positions_short": "22254",
+                "other_rept_positions_spread": "9753",
+                "tot_rept_positions_long_all": "323219",
+                "tot_rept_positions_short": "353458",
+                "nonrept_positions_long_all": "61384",
+                "nonrept_positions_short_all": "31145"
+            },
+            {
+                "market_and_exchange_names": "GOLD - COMMODITY EXCHANGE INC.",
+                "cftc_contract_market_code": "088691",
+                "report_date_as_yyyy_mm_dd": "2026-07-21T00:00:00.000",
+                "open_interest_all": "383368",
+                "prod_merc_positions_long": "15561",
+                "prod_merc_positions_short": "34882",
+                "swap_positions_long_all": "24959",
+                "swap__positions_short_all": "218837",
+                "swap__positions_spread_all": "39937",
+                "m_money_positions_long_all": "141487",
+                "m_money_positions_short_all": "16656",
+                "m_money_positions_spread": "17872",
+                "other_rept_positions_long": "83298",
+                "other_rept_positions_short": "24219",
+                "other_rept_positions_spread": "14111",
+                "tot_rept_positions_long_all": "337225",
+                "tot_rept_positions_short": "366514",
+                "nonrept_positions_long_all": "46143",
+                "nonrept_positions_short_all": "16854"
+            }
+        ])
+        .to_string()
+    }
+
+    #[tokio::test]
+    async fn gold_rows_map_to_a_chronological_canonical_series() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(rows_payload())
+            .create_async()
+            .await;
+
+        let rows = test_client(&server.url())
+            .commitments_of_traders(&resolve_contract_code("GC=F"))
+            .await
+            .unwrap();
+        let series = to_canonical("GC=F", rows).unwrap();
+
+        assert_eq!(series.symbol, "GC=F");
+        assert_eq!(
+            series.market_and_exchange_name,
+            "GOLD - COMMODITY EXCHANGE INC."
+        );
+        assert_eq!(series.cftc_contract_market_code, "088691");
+        assert_eq!(series.observations.len(), 2);
+        // Reversed into chronological order despite the API's newest-first payload.
+        assert_eq!(series.observations[0].report_date, "2026-07-21");
+        assert_eq!(series.observations[1].report_date, "2026-07-28");
+        assert_eq!(series.observations[1].open_interest, Some(384603));
+        assert_eq!(series.observations[1].managed_money_long, Some(135093));
+        assert_eq!(series.observations[1].managed_money_short, Some(15298));
+        assert_eq!(series.observations[1].swap_dealer_short, Some(215421));
+    }
+
+    #[tokio::test]
+    async fn unknown_contract_code_maps_to_symbol_not_found() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body("[]")
+            .create_async()
+            .await;
+
+        let rows = test_client(&server.url())
+            .commitments_of_traders("999999")
+            .await
+            .unwrap();
+        let err = to_canonical("999999", rows).unwrap_err();
+        assert!(
+            matches!(err, FinanceError::SymbolNotFound { .. }),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_rejected_query_carries_cftcs_message() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/")
+            .match_query(mockito::Matcher::Any)
+            .with_status(400)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "message": "Query coordinator error: query.soql.no-such-column"
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let err = test_client(&server.url())
+            .commitments_of_traders("088691")
+            .await
+            .unwrap_err();
+        match err {
+            FinanceError::ApiError(msg) => {
+                assert!(msg.contains("no-such-column"), "got {msg}");
+            }
+            other => panic!("expected ApiError, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn http_error_maps_to_external_api_error() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/")
+            .match_query(mockito::Matcher::Any)
+            .with_status(503)
+            .create_async()
+            .await;
+
+        let err = test_client(&server.url())
+            .commitments_of_traders("088691")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, FinanceError::ExternalApiError { status: 503, .. }),
+            "{err:?}"
+        );
+    }
+}

--- a/src/adapters/cftc/mod.rs
+++ b/src/adapters/cftc/mod.rs
@@ -45,7 +45,7 @@ fn client() -> Result<CftcClient> {
     CftcClient::new(DEFAULT_TIMEOUT, shared_limiter(), client::CFTC_BASE)
 }
 
-pub(crate) use futures::fetch_commitments_of_traders_response;
+pub use futures::fetch_commitments_of_traders_response;
 
 #[cfg(test)]
 mod tests {

--- a/src/adapters/cftc/models.rs
+++ b/src/adapters/cftc/models.rs
@@ -1,0 +1,61 @@
+//! CFTC Commitments of Traders (disaggregated futures-only) wire types.
+//!
+//! `publicreporting.cftc.gov`'s Socrata API serves every numeric column as a
+//! JSON string (Socrata's `number` column type round-trips through strings),
+//! so every figure here is `Option<String>` and parsed on the way to the
+//! canonical model. Only the columns this adapter maps are modelled — the
+//! full dataset carries well over a hundred (old/other/all variants,
+//! percent-of-open-interest, trader counts, concentration ratios, …).
+
+use serde::Deserialize;
+
+/// One weekly row of the disaggregated futures-only combined report.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct CotRow {
+    #[serde(default)]
+    pub market_and_exchange_names: Option<String>,
+    #[serde(default)]
+    pub cftc_contract_market_code: Option<String>,
+    #[serde(default)]
+    pub report_date_as_yyyy_mm_dd: Option<String>,
+    #[serde(default)]
+    pub open_interest_all: Option<String>,
+    #[serde(default)]
+    pub prod_merc_positions_long: Option<String>,
+    #[serde(default)]
+    pub prod_merc_positions_short: Option<String>,
+    #[serde(default)]
+    pub swap_positions_long_all: Option<String>,
+    // Socrata's own column name has the double underscore — not a typo.
+    #[serde(default, rename = "swap__positions_short_all")]
+    pub swap_positions_short_all: Option<String>,
+    #[serde(default, rename = "swap__positions_spread_all")]
+    pub swap_positions_spread_all: Option<String>,
+    #[serde(default)]
+    pub m_money_positions_long_all: Option<String>,
+    #[serde(default)]
+    pub m_money_positions_short_all: Option<String>,
+    #[serde(default)]
+    pub m_money_positions_spread: Option<String>,
+    #[serde(default)]
+    pub other_rept_positions_long: Option<String>,
+    #[serde(default)]
+    pub other_rept_positions_short: Option<String>,
+    #[serde(default)]
+    pub other_rept_positions_spread: Option<String>,
+    #[serde(default)]
+    pub tot_rept_positions_long_all: Option<String>,
+    #[serde(default)]
+    pub tot_rept_positions_short: Option<String>,
+    #[serde(default)]
+    pub nonrept_positions_long_all: Option<String>,
+    #[serde(default)]
+    pub nonrept_positions_short_all: Option<String>,
+}
+
+/// A rejected-query error body: `{"message": "..."}`.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct CftcError {
+    #[serde(default)]
+    pub message: Option<String>,
+}

--- a/src/adapters/gdelt/client.rs
+++ b/src/adapters/gdelt/client.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use reqwest::{Client, StatusCode};
-use tracing::debug;
+use tracing::{debug, warn};
 
 use super::models::GdeltDocResponse;
 use crate::adapters::common::keyless_http_client;
@@ -64,7 +64,7 @@ impl GdeltClient {
         let bytes = resp.bytes().await?;
 
         if !status.is_success() {
-            return Err(Self::map_error(status));
+            return Err(Self::map_error(status, &bytes));
         }
 
         // GDELT answers throttled/malformed requests with a plain-text
@@ -83,13 +83,67 @@ impl GdeltClient {
         })
     }
 
-    fn map_error(status: StatusCode) -> FinanceError {
+    /// GDELT states its throttle in a plain-text body ("Please limit requests
+    /// to one every 5 seconds…") rather than a `Retry-After` header, so the
+    /// interval is recovered from the text and the body logged — staying
+    /// `RateLimited` keeps `is_retriable` and any retry policy working.
+    fn map_error(status: StatusCode, body: &[u8]) -> FinanceError {
         match status {
-            StatusCode::TOO_MANY_REQUESTS => FinanceError::RateLimited { retry_after: None },
+            StatusCode::TOO_MANY_REQUESTS => {
+                let text = String::from_utf8_lossy(body);
+                let text = text.trim();
+                if !text.is_empty() {
+                    warn!("GDELT throttled the request: {text}");
+                }
+                FinanceError::RateLimited {
+                    retry_after: parse_throttle_seconds(text),
+                }
+            }
             s => FinanceError::ExternalApiError {
                 api: "GDELT".to_string(),
                 status: s.as_u16(),
             },
         }
+    }
+}
+
+/// Pull the retry interval out of GDELT's throttle text, which reads
+/// "Please limit requests to one every 5 seconds…".
+fn parse_throttle_seconds(text: &str) -> Option<u64> {
+    let rest = text.split_once("one every")?.1;
+    let (num, _) = rest.trim_start().split_once(' ')?;
+    num.parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn throttle_interval_is_recovered_from_the_message() {
+        assert_eq!(
+            parse_throttle_seconds("Please limit requests to one every 5 seconds or contact x"),
+            Some(5)
+        );
+    }
+
+    #[test]
+    fn an_unrecognised_throttle_message_yields_no_interval() {
+        assert_eq!(parse_throttle_seconds("slow down"), None);
+        assert_eq!(parse_throttle_seconds(""), None);
+    }
+
+    #[test]
+    fn throttle_maps_to_rate_limited_with_the_parsed_interval() {
+        let err = GdeltClient::map_error(
+            StatusCode::TOO_MANY_REQUESTS,
+            b"Please limit requests to one every 5 seconds.",
+        );
+        assert!(matches!(
+            err,
+            FinanceError::RateLimited {
+                retry_after: Some(5)
+            }
+        ));
     }
 }

--- a/src/adapters/gdelt/client.rs
+++ b/src/adapters/gdelt/client.rs
@@ -1,0 +1,95 @@
+//! GDELT DOC 2.0 API HTTP client.
+//!
+//! Keyless and unauthenticated. GDELT documents no formal quota for the DOC
+//! API but asks callers to keep requests to roughly one every 5 seconds, so
+//! the client paces itself to that rate rather than waiting to be throttled.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use reqwest::{Client, StatusCode};
+use tracing::debug;
+
+use super::models::GdeltDocResponse;
+use crate::adapters::common::keyless_http_client;
+use crate::error::{FinanceError, Result};
+use crate::rate_limiter::RateLimiter;
+
+pub(super) const GDELT_BASE: &str = "https://api.gdeltproject.org/api/v2/doc/doc";
+
+pub(super) struct GdeltClient {
+    http: Client,
+    limiter: Arc<RateLimiter>,
+    base_url: String,
+}
+
+impl GdeltClient {
+    pub(super) fn new(
+        timeout: Duration,
+        limiter: Arc<RateLimiter>,
+        base_url: impl Into<String>,
+    ) -> Result<Self> {
+        Ok(Self {
+            http: keyless_http_client(timeout)?,
+            limiter,
+            base_url: base_url.into(),
+        })
+    }
+
+    /// Fetch up to `max_records` articles matching `query` within the last
+    /// `timespan` (a GDELT duration like `"2w"`).
+    pub(super) async fn article_search(
+        &self,
+        query: &str,
+        timespan: &str,
+        max_records: u32,
+    ) -> Result<GdeltDocResponse> {
+        self.limiter.acquire().await;
+
+        debug!("GDELT request: {query}");
+
+        let resp = self
+            .http
+            .get(&self.base_url)
+            .query(&[
+                ("query", query),
+                ("mode", "artlist"),
+                ("format", "json"),
+                ("timespan", timespan),
+                ("maxrecords", &max_records.to_string()),
+            ])
+            .send()
+            .await?;
+        let status = resp.status();
+        let bytes = resp.bytes().await?;
+
+        if !status.is_success() {
+            return Err(Self::map_error(status));
+        }
+
+        // GDELT answers throttled/malformed requests with a plain-text
+        // message rather than JSON (no content-type negotiation on error),
+        // so a parse failure surfaces that text instead of a raw serde error.
+        serde_json::from_slice(&bytes).map_err(|_| {
+            let text = String::from_utf8_lossy(&bytes).trim().to_string();
+            FinanceError::ResponseStructureError {
+                field: "gdelt.articles".to_string(),
+                context: if text.is_empty() {
+                    "unrecognised GDELT response".to_string()
+                } else {
+                    text
+                },
+            }
+        })
+    }
+
+    fn map_error(status: StatusCode) -> FinanceError {
+        match status {
+            StatusCode::TOO_MANY_REQUESTS => FinanceError::RateLimited { retry_after: None },
+            s => FinanceError::ExternalApiError {
+                api: "GDELT".to_string(),
+                status: s.as_u16(),
+            },
+        }
+    }
+}

--- a/src/adapters/gdelt/corporate/mod.rs
+++ b/src/adapters/gdelt/corporate/mod.rs
@@ -18,6 +18,10 @@ const MAX_RECORDS: u32 = 50;
 /// still returning *something* for a quietly-traded symbol.
 const TIMESPAN: &str = "2w";
 
+/// GDELT rejects quoted phrases shorter than this with "The specified phrase
+/// is too short", which rules out most US tickers (AAPL, TSLA, AMD, …).
+const MIN_PHRASE_LEN: usize = 5;
+
 /// Build the DOC 2.0 `query` parameter for a ticker symbol.
 ///
 /// GDELT has no ticker vocabulary of its own — [`Ticker::news`](crate::Ticker::news)
@@ -28,21 +32,40 @@ const TIMESPAN: &str = "2w";
 /// rather than every article about the underlying company by name, which
 /// would require a separate symbol-to-company-name lookup this adapter
 /// doesn't perform.
-pub(crate) fn build_query(symbol: &str) -> String {
-    format!("\"{}\"", symbol.trim())
+pub(crate) fn build_query(symbol: &str) -> Result<String> {
+    let symbol = symbol.trim();
+    if symbol.len() < MIN_PHRASE_LEN {
+        return Err(crate::error::FinanceError::InvalidParameter {
+            param: "symbol".to_string(),
+            reason: format!(
+                "GDELT rejects phrase queries shorter than {MIN_PHRASE_LEN} characters, so it \
+                 cannot serve news for {symbol:?}; route CORPORATE to another provider for \
+                 short tickers"
+            ),
+        });
+    }
+    Ok(format!("\"{symbol}\""))
 }
 
 /// Fetch canonical news articles for a symbol.
-pub(crate) async fn fetch_news_response(symbol: &str) -> Result<Vec<News>> {
-    let query = build_query(symbol);
+pub async fn fetch_news_response(symbol: &str) -> Result<Vec<News>> {
+    let query = build_query(symbol)?;
     let response = super::client()?
         .article_search(&query, TIMESPAN, MAX_RECORDS)
         .await?;
-    Ok(response.articles.into_iter().map(to_news).collect())
+    // One clock read for the batch, so every article's relative time is
+    // measured against the same instant.
+    let now = Utc::now();
+    Ok(response
+        .articles
+        .into_iter()
+        .map(|a| to_news_at(a, now))
+        .collect())
 }
 
-/// Map one GDELT article onto the canonical [`News`] model.
-pub(crate) fn to_news(article: GdeltArticle) -> News {
+/// Map one GDELT article onto the canonical [`News`] model, with `now` as the
+/// reference point for the relative `time` string.
+pub(crate) fn to_news_at(article: GdeltArticle, now: DateTime<Utc>) -> News {
     News {
         title: article.title.unwrap_or_default(),
         link: article.url,
@@ -51,7 +74,7 @@ pub(crate) fn to_news(article: GdeltArticle) -> News {
         time: article
             .seendate
             .as_deref()
-            .map(|d| relative_time_at(d, Utc::now()))
+            .map(|d| relative_time_at(d, now))
             .unwrap_or_default(),
         provider_id: Some(crate::Provider::Gdelt),
         #[cfg(feature = "sentiment")]
@@ -107,8 +130,23 @@ mod tests {
 
     #[test]
     fn query_wraps_the_symbol_in_quotes_for_an_exact_match() {
-        assert_eq!(build_query("AAPL"), "\"AAPL\"");
-        assert_eq!(build_query(" TSLA "), "\"TSLA\"");
+        assert_eq!(build_query("GOOGL").unwrap(), "\"GOOGL\"");
+        assert_eq!(build_query(" BRK.B ").unwrap(), "\"BRK.B\"");
+    }
+
+    #[test]
+    fn a_symbol_below_gdelts_phrase_minimum_is_rejected_up_front() {
+        // GDELT answers "The specified phrase is too short" for these, which
+        // would otherwise surface as an opaque parse error.
+        for symbol in ["AAPL", "TSLA", "AMD", "F"] {
+            assert!(
+                matches!(
+                    build_query(symbol),
+                    Err(crate::error::FinanceError::InvalidParameter { .. })
+                ),
+                "{symbol} should be rejected"
+            );
+        }
     }
 
     #[test]
@@ -189,7 +227,7 @@ mod tests {
             domain: None,
             socialimage: None,
         };
-        let news = to_news(article);
+        let news = to_news_at(article, fixed_now());
         assert_eq!(news.title, "");
         assert_eq!(news.link, "https://example.com/a");
         assert_eq!(news.source, "");

--- a/src/adapters/gdelt/corporate/mod.rs
+++ b/src/adapters/gdelt/corporate/mod.rs
@@ -1,0 +1,200 @@
+//! `CORPORATE` capability for GDELT — news only. GDELT has no corporate
+//! calendar (earnings/dividends/splits), so this adapter never implements
+//! `fetch_events`.
+
+use chrono::{DateTime, NaiveDateTime, Utc};
+
+use crate::error::Result;
+use crate::models::corporate::news::News;
+
+use super::models::GdeltArticle;
+
+/// Articles requested per symbol query. Generous enough to cover a busy
+/// news day without paging (the DOC API caps at 250 per call anyway).
+const MAX_RECORDS: u32 = 50;
+
+/// Lookback window for a symbol query. GDELT's `timespan` takes a bare
+/// integer + unit (`h`/`d`/`w`/`m`); two weeks balances freshness against
+/// still returning *something* for a quietly-traded symbol.
+const TIMESPAN: &str = "2w";
+
+/// Build the DOC 2.0 `query` parameter for a ticker symbol.
+///
+/// GDELT has no ticker vocabulary of its own — [`Ticker::news`](crate::Ticker::news)
+/// only ever hands this a bare symbol, never a company name — so the symbol
+/// itself, quoted for an exact phrase match, is the search term. This
+/// favours precision over recall: it surfaces articles that print the
+/// ticker verbatim (common in financial press, e.g. `"(NASDAQ: AAPL)"`)
+/// rather than every article about the underlying company by name, which
+/// would require a separate symbol-to-company-name lookup this adapter
+/// doesn't perform.
+pub(crate) fn build_query(symbol: &str) -> String {
+    format!("\"{}\"", symbol.trim())
+}
+
+/// Fetch canonical news articles for a symbol.
+pub(crate) async fn fetch_news_response(symbol: &str) -> Result<Vec<News>> {
+    let query = build_query(symbol);
+    let response = super::client()?
+        .article_search(&query, TIMESPAN, MAX_RECORDS)
+        .await?;
+    Ok(response.articles.into_iter().map(to_news).collect())
+}
+
+/// Map one GDELT article onto the canonical [`News`] model.
+pub(crate) fn to_news(article: GdeltArticle) -> News {
+    News {
+        title: article.title.unwrap_or_default(),
+        link: article.url,
+        source: article.domain.unwrap_or_default(),
+        img: article.socialimage.unwrap_or_default(),
+        time: article
+            .seendate
+            .as_deref()
+            .map(|d| relative_time_at(d, Utc::now()))
+            .unwrap_or_default(),
+        provider_id: Some(crate::Provider::Gdelt),
+        #[cfg(feature = "sentiment")]
+        sentiment: None,
+    }
+}
+
+/// Convert a GDELT `seendate` into a relative time string (`"3 hours ago"`),
+/// matching the other `CORPORATE` providers' convention for [`News::time`].
+/// Falls back to the raw string when the timestamp doesn't parse, rather
+/// than dropping it silently.
+fn relative_time_at(seendate: &str, now: DateTime<Utc>) -> String {
+    let Some(seen) = parse_seendate(seendate) else {
+        return seendate.to_string();
+    };
+    let minutes = now.signed_duration_since(seen).num_minutes();
+    if minutes < 1 {
+        "just now".to_string()
+    } else if minutes < 60 {
+        format!("{minutes} minute{} ago", plural(minutes))
+    } else if minutes < 60 * 24 {
+        let hours = minutes / 60;
+        format!("{hours} hour{} ago", plural(hours))
+    } else {
+        let days = minutes / (60 * 24);
+        format!("{days} day{} ago", plural(days))
+    }
+}
+
+fn plural(n: i64) -> &'static str {
+    if n == 1 { "" } else { "s" }
+}
+
+/// Parse GDELT's `seendate`. The documented form is `"YYYYMMDDTHHMMSSZ"`;
+/// the bare `"YYYYMMDDHHMMSS"` form (no separators) is also accepted since
+/// GDELT's own request-side date parameters use it and some responses have
+/// been observed to echo it back, so a format drift doesn't blank out every
+/// article's time.
+fn parse_seendate(seendate: &str) -> Option<DateTime<Utc>> {
+    NaiveDateTime::parse_from_str(seendate, "%Y%m%dT%H%M%SZ")
+        .or_else(|_| NaiveDateTime::parse_from_str(seendate, "%Y%m%d%H%M%S"))
+        .ok()
+        .map(|naive| naive.and_utc())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixed_now() -> DateTime<Utc> {
+        "2026-08-05T12:00:00Z".parse().unwrap()
+    }
+
+    #[test]
+    fn query_wraps_the_symbol_in_quotes_for_an_exact_match() {
+        assert_eq!(build_query("AAPL"), "\"AAPL\"");
+        assert_eq!(build_query(" TSLA "), "\"TSLA\"");
+    }
+
+    #[test]
+    fn iso_basic_seendate_parses() {
+        assert_eq!(
+            parse_seendate("20260805T113000Z"),
+            Some("2026-08-05T11:30:00Z".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn bare_seendate_without_separators_also_parses() {
+        assert_eq!(
+            parse_seendate("20260805113000"),
+            Some("2026-08-05T11:30:00Z".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn unparseable_seendate_returns_none() {
+        assert_eq!(parse_seendate("not-a-date"), None);
+    }
+
+    #[test]
+    fn recent_article_reads_minutes_ago() {
+        // 30 minutes before fixed_now().
+        assert_eq!(
+            relative_time_at("20260805T113000Z", fixed_now()),
+            "30 minutes ago"
+        );
+    }
+
+    #[test]
+    fn single_minute_is_not_pluralised() {
+        assert_eq!(
+            relative_time_at("20260805T115900Z", fixed_now()),
+            "1 minute ago"
+        );
+    }
+
+    #[test]
+    fn same_minute_reads_just_now() {
+        assert_eq!(
+            relative_time_at("20260805T120000Z", fixed_now()),
+            "just now"
+        );
+    }
+
+    #[test]
+    fn hours_old_article_reads_hours_ago() {
+        // 3 hours before fixed_now().
+        assert_eq!(
+            relative_time_at("20260805T090000Z", fixed_now()),
+            "3 hours ago"
+        );
+    }
+
+    #[test]
+    fn days_old_article_reads_days_ago() {
+        // 2 days before fixed_now().
+        assert_eq!(
+            relative_time_at("20260803T120000Z", fixed_now()),
+            "2 days ago"
+        );
+    }
+
+    #[test]
+    fn unparseable_seendate_survives_as_the_raw_string() {
+        assert_eq!(relative_time_at("garbage", fixed_now()), "garbage");
+    }
+
+    #[test]
+    fn article_without_a_title_maps_to_an_empty_string_not_a_panic() {
+        let article = GdeltArticle {
+            url: "https://example.com/a".to_string(),
+            title: None,
+            seendate: None,
+            domain: None,
+            socialimage: None,
+        };
+        let news = to_news(article);
+        assert_eq!(news.title, "");
+        assert_eq!(news.link, "https://example.com/a");
+        assert_eq!(news.source, "");
+        assert_eq!(news.img, "");
+        assert_eq!(news.time, "");
+        assert_eq!(news.provider_id, Some(crate::Provider::Gdelt));
+    }
+}

--- a/src/adapters/gdelt/mod.rs
+++ b/src/adapters/gdelt/mod.rs
@@ -1,0 +1,200 @@
+//! GDELT DOC 2.0 — keyless global news search and monitoring.
+//!
+//! Requires the **`gdelt`** feature flag.
+//!
+//! News previously came from Yahoo (a scraper, fragile to page changes) or
+//! Alpha Vantage (keyed, 25 req/day). GDELT indexes worldwide online news
+//! across 65 languages, updated roughly every 15 minutes, entirely keyless —
+//! closing that gap for the news slice of `Capability::CORPORATE`.
+//!
+//! # Query derivation
+//!
+//! GDELT has no ticker vocabulary of its own, so [`fetch_news_response`]
+//! (via [`corporate::build_query`]) searches GDELT for the ticker symbol
+//! itself, quoted for an exact phrase match. See that function's doc comment
+//! for the precision/recall tradeoff this implies.
+//!
+//! GDELT has no concept of a corporate calendar (earnings/dividends/splits),
+//! so the provider bridge reports [`crate::error::FinanceError::NotSupported`]
+//! for that operation rather than implementing it here.
+
+pub(crate) mod client;
+pub(crate) mod corporate;
+pub(crate) mod models;
+
+use std::time::Duration;
+
+use crate::adapters::singleton::keyless_limiter;
+use crate::error::Result;
+use client::GdeltClient;
+
+/// Self-imposed pacing: GDELT asks callers to keep requests to roughly one
+/// every 5 seconds.
+const GDELT_RATE_PER_SEC: f64 = 0.2;
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+keyless_limiter!(rate = GDELT_RATE_PER_SEC);
+
+/// Build a client against the live API, reusing the shared token bucket.
+fn client() -> Result<GdeltClient> {
+    GdeltClient::new(DEFAULT_TIMEOUT, shared_limiter(), client::GDELT_BASE)
+}
+
+pub(crate) use corporate::fetch_news_response;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::FinanceError;
+    use crate::rate_limiter::RateLimiter;
+    use std::sync::Arc;
+
+    fn test_client(base_url: &str) -> GdeltClient {
+        GdeltClient::new(
+            Duration::from_secs(5),
+            Arc::new(RateLimiter::new(100.0)),
+            base_url,
+        )
+        .unwrap()
+    }
+
+    /// Verbatim shape from `api.gdeltproject.org/api/v2/doc/doc`, trimmed to
+    /// two articles.
+    fn articles_payload() -> String {
+        serde_json::json!({
+            "articles": [
+                {
+                    "url": "https://example.com/news/aapl-earnings",
+                    "url_mobile": "",
+                    "title": "Apple (NASDAQ: AAPL) beats earnings estimates",
+                    "seendate": "20260805T113000Z",
+                    "socialimage": "https://example.com/img.jpg",
+                    "domain": "example.com",
+                    "language": "English",
+                    "sourcecountry": "United States"
+                },
+                {
+                    "url": "https://example.fr/actu/aapl",
+                    "title": "Apple annonce des resultats records",
+                    "seendate": "20260805T090000Z",
+                    "domain": "example.fr",
+                    "language": "French",
+                    "sourcecountry": "France"
+                }
+            ]
+        })
+        .to_string()
+    }
+
+    #[tokio::test]
+    async fn articles_map_to_canonical_news() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(articles_payload())
+            .create_async()
+            .await;
+
+        let response = test_client(&server.url())
+            .article_search("\"AAPL\"", "2w", 50)
+            .await
+            .unwrap();
+
+        assert_eq!(response.articles.len(), 2);
+        let news: Vec<_> = response
+            .articles
+            .into_iter()
+            .map(super::corporate::to_news)
+            .collect();
+        assert_eq!(news[0].link, "https://example.com/news/aapl-earnings");
+        assert_eq!(news[0].source, "example.com");
+        assert_eq!(news[0].img, "https://example.com/img.jpg");
+        // No socialimage on the second article — must not become "null".
+        assert_eq!(news[1].img, "");
+    }
+
+    #[tokio::test]
+    async fn throttled_response_maps_to_rate_limited() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/")
+            .match_query(mockito::Matcher::Any)
+            .with_status(429)
+            .create_async()
+            .await;
+
+        let err = test_client(&server.url())
+            .article_search("\"AAPL\"", "2w", 50)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, FinanceError::RateLimited { .. }), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn plain_text_throttle_message_is_not_treated_as_valid_json() {
+        // GDELT answers over-quota requests with a 200 and a plain-text
+        // message rather than JSON — must not silently parse as zero articles.
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_body("Please limit requests to one every 5 seconds")
+            .create_async()
+            .await;
+
+        let err = test_client(&server.url())
+            .article_search("\"AAPL\"", "2w", 50)
+            .await
+            .unwrap_err();
+        match err {
+            FinanceError::ResponseStructureError { context, .. } => {
+                assert!(context.contains("limit requests"), "got {context}");
+            }
+            other => panic!("expected ResponseStructureError, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn http_error_maps_to_external_api_error() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/")
+            .match_query(mockito::Matcher::Any)
+            .with_status(503)
+            .create_async()
+            .await;
+
+        let err = test_client(&server.url())
+            .article_search("\"AAPL\"", "2w", 50)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, FinanceError::ExternalApiError { status: 503, .. }),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_articles_array_maps_to_an_empty_vec() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(serde_json::json!({"articles": []}).to_string())
+            .create_async()
+            .await;
+
+        let response = test_client(&server.url())
+            .article_search("\"NOSUCHTICKER\"", "2w", 50)
+            .await
+            .unwrap();
+        assert!(response.articles.is_empty());
+    }
+}

--- a/src/adapters/gdelt/mod.rs
+++ b/src/adapters/gdelt/mod.rs
@@ -14,6 +14,11 @@
 //! itself, quoted for an exact phrase match. See that function's doc comment
 //! for the precision/recall tradeoff this implies.
 //!
+//! GDELT rejects phrases under 5 characters, so symbols shorter than that
+//! (`AAPL`, `TSLA`, `AMD`, …) error with `InvalidParameter` and dispatch
+//! falls through to another CORPORATE provider. In practice GDELT serves
+//! longer tickers and non-US symbols.
+//!
 //! GDELT has no concept of a corporate calendar (earnings/dividends/splits),
 //! so the provider bridge reports [`crate::error::FinanceError::NotSupported`]
 //! for that operation rather than implementing it here.
@@ -41,7 +46,7 @@ fn client() -> Result<GdeltClient> {
     GdeltClient::new(DEFAULT_TIMEOUT, shared_limiter(), client::GDELT_BASE)
 }
 
-pub(crate) use corporate::fetch_news_response;
+pub use corporate::fetch_news_response;
 
 #[cfg(test)]
 mod tests {
@@ -108,7 +113,7 @@ mod tests {
         let news: Vec<_> = response
             .articles
             .into_iter()
-            .map(super::corporate::to_news)
+            .map(|a| super::corporate::to_news_at(a, chrono::Utc::now()))
             .collect();
         assert_eq!(news[0].link, "https://example.com/news/aapl-earnings");
         assert_eq!(news[0].source, "example.com");

--- a/src/adapters/gdelt/models.rs
+++ b/src/adapters/gdelt/models.rs
@@ -2,7 +2,7 @@
 //!
 //! `mode=artlist&format=json` answers with a single `articles` array. GDELT
 //! reports more fields than modelled here (`url_mobile`, `language`,
-//! `sourcecountry`, …) — only the ones [`super::corporate::to_news`] maps
+//! `sourcecountry`, …) — only the ones [`super::corporate::to_news_at`] maps
 //! onto the canonical [`crate::models::corporate::news::News`] are kept.
 //! GDELT sometimes omits a field entirely (rather than sending an empty
 //! string) for older or thinly-indexed sources, so everything but `url` is

--- a/src/adapters/gdelt/models.rs
+++ b/src/adapters/gdelt/models.rs
@@ -1,0 +1,33 @@
+//! GDELT DOC 2.0 API wire types.
+//!
+//! `mode=artlist&format=json` answers with a single `articles` array. GDELT
+//! reports more fields than modelled here (`url_mobile`, `language`,
+//! `sourcecountry`, …) — only the ones [`super::corporate::to_news`] maps
+//! onto the canonical [`crate::models::corporate::news::News`] are kept.
+//! GDELT sometimes omits a field entirely (rather than sending an empty
+//! string) for older or thinly-indexed sources, so everything but `url` is
+//! optional.
+
+use serde::Deserialize;
+
+/// The envelope returned by `mode=artlist`.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub(crate) struct GdeltDocResponse {
+    #[serde(default)]
+    pub articles: Vec<GdeltArticle>,
+}
+
+/// One article as returned by the DOC 2.0 API's `artlist` mode.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct GdeltArticle {
+    pub url: String,
+    #[serde(default)]
+    pub title: Option<String>,
+    /// `"YYYYMMDDTHHMMSSZ"` — when GDELT first indexed the article.
+    #[serde(default)]
+    pub seendate: Option<String>,
+    #[serde(default)]
+    pub domain: Option<String>,
+    #[serde(default)]
+    pub socialimage: Option<String>,
+}

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -26,6 +26,7 @@
 //! | `finra` | [FINRA Query API](https://developer.finra.org/) | Keyless (non-commercial) | 1 | Daily short-sale volume by security, from the primary source |
 //! | `openfigi` | [OpenFIGI](https://www.openfigi.com/api) | Keyless (25 req/min) | 1 | CUSIP/ISIN/SEDOL/FIGI to ticker resolution |
 //! | `defi` | [DefiLlama](https://defillama.com/docs/api) | Keyless | 3 | Protocol TVL (current + history), chain rankings, stablecoin supplies |
+//! | `gdelt` | [GDELT DOC 2.0](https://www.gdeltproject.org/) | Keyless (~1 req/5s) | 1 | Worldwide online news search across 65 languages, updated every 15 minutes |
 //! | *(always)* | [SEC EDGAR](https://www.sec.gov/edgar) | 10 req/sec | 5+ | Filing history, XBRL financials, full-text search (keyless, requires contact email) |
 //!
 //! # Quick comparison
@@ -100,6 +101,10 @@ pub(crate) mod openfigi;
 /// DefiLlama DeFi TVL and stablecoin data (keyless, requires `defi` feature).
 #[cfg(feature = "defi")]
 pub(crate) mod defillama;
+
+/// GDELT DOC 2.0 global news search (keyless, requires `gdelt` feature).
+#[cfg(feature = "gdelt")]
+pub(crate) mod gdelt;
 
 /// SEC EDGAR API client (always available, requires init with contact email).
 pub(crate) mod edgar;

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -27,6 +27,7 @@
 //! | `openfigi` | [OpenFIGI](https://www.openfigi.com/api) | Keyless (25 req/min) | 1 | CUSIP/ISIN/SEDOL/FIGI to ticker resolution |
 //! | `defi` | [DefiLlama](https://defillama.com/docs/api) | Keyless | 3 | Protocol TVL (current + history), chain rankings, stablecoin supplies |
 //! | `gdelt` | [GDELT DOC 2.0](https://www.gdeltproject.org/) | Keyless (~1 req/5s) | 1 | Worldwide online news search across 65 languages, updated every 15 minutes |
+//! | `cftc` | [CFTC Public Reporting](https://publicreporting.cftc.gov/) | Keyless | 1 | Weekly Commitments of Traders futures positioning (disaggregated futures-only report) |
 //! | *(always)* | [SEC EDGAR](https://www.sec.gov/edgar) | 10 req/sec | 5+ | Filing history, XBRL financials, full-text search (keyless, requires contact email) |
 //!
 //! # Quick comparison
@@ -105,6 +106,10 @@ pub(crate) mod defillama;
 /// GDELT DOC 2.0 global news search (keyless, requires `gdelt` feature).
 #[cfg(feature = "gdelt")]
 pub(crate) mod gdelt;
+
+/// CFTC Commitments of Traders futures positioning (keyless, requires `cftc` feature).
+#[cfg(feature = "cftc")]
+pub(crate) mod cftc;
 
 /// SEC EDGAR API client (always available, requires init with contact email).
 pub(crate) mod edgar;

--- a/src/domains/futures.rs
+++ b/src/domains/futures.rs
@@ -11,7 +11,11 @@ domain_handle! {
     ///
     /// Created via [`Providers::futures`](crate::Providers::futures).
     pub struct FuturesContract { symbol, symbol }
-    cache: crate::models::futures::FuturesQuote, chart
+    cache: crate::models::futures::FuturesQuote, chart,
+    extra: {
+        #[cfg(feature = "cftc")]
+        cot_cache: crate::models::futures::cot::CommitmentsOfTraders,
+    }
 }
 
 impl FuturesContract {
@@ -40,6 +44,33 @@ impl FuturesContract {
     /// ([`TimeRange::default_interval`]).
     pub async fn history(&self, range: TimeRange) -> Result<Chart> {
         self.chart(range.default_interval(), range).await
+    }
+
+    /// Fetch weekly CFTC Commitments of Traders positioning for this futures
+    /// contract — long/short/spread broken down by trader category
+    /// (commercial hedgers, swap dealers, managed money, other reportables,
+    /// small traders).
+    ///
+    /// Routed through `Capability::FUTURES`; only [`Provider::Cftc`](crate::Provider::Cftc)
+    /// serves it, so route `FUTURES` to include it. CFTC covers physical
+    /// commodities only (agriculture, energy, metals) via the disaggregated
+    /// futures-only report — the symbol is either a recognised Yahoo-style
+    /// continuous futures root (`"GC=F"`, `"CL=F"`, …) or a raw CFTC
+    /// `cftc_contract_market_code` passed straight through.
+    #[cfg(feature = "cftc")]
+    pub async fn commitments_of_traders(
+        &self,
+    ) -> Result<crate::models::futures::cot::CommitmentsOfTraders> {
+        fetch_via!(
+            cache: cot_cache,
+            self,
+            symbol,
+            FUTURES,
+            as_futures,
+            CommitmentsOfTraders,
+            fetch_commitments_of_traders,
+            crate::models::futures::cot::CommitmentsOfTraders
+        )
     }
 }
 

--- a/src/domains/mod.rs
+++ b/src/domains/mod.rs
@@ -559,7 +559,7 @@ pub(crate) mod filings;
     feature = "polygon"
 ))]
 pub(crate) mod forex;
-#[cfg(feature = "polygon")]
+#[cfg(any(feature = "polygon", feature = "cftc"))]
 pub(crate) mod futures;
 #[cfg(any(feature = "polygon", feature = "fmp"))]
 pub(crate) mod indices;
@@ -600,7 +600,7 @@ pub use filings::Filings;
     feature = "polygon"
 ))]
 pub use forex::ForexPair;
-#[cfg(feature = "polygon")]
+#[cfg(any(feature = "polygon", feature = "cftc"))]
 pub use futures::FuturesContract;
 #[cfg(any(feature = "polygon", feature = "fmp"))]
 pub use indices::Index;

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,7 +29,10 @@ pub enum FinanceError {
     },
 
     /// Rate limit exceeded
-    #[error("Rate limited (retry after {retry_after:?}s)")]
+    #[error("Rate limited{}", match retry_after {
+        Some(s) => format!(" (retry after {s}s)"),
+        None => String::new(),
+    })]
     RateLimited {
         /// Seconds until retry is allowed
         retry_after: Option<u64>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,28 @@ pub mod crypto {
     pub use crate::adapters::coingecko::{CoinQuote, coin, coins};
 }
 
+#[cfg(feature = "gdelt")]
+pub mod gdelt {
+    //! GDELT global news search (requires `gdelt` feature, keyless).
+    //!
+    //! Keyless shortcut for callers that want GDELT specifically;
+    //! [`Ticker::news`](crate::Ticker::news) reaches the same data through
+    //! `Capability::CORPORATE` when GDELT is routed.
+    pub use crate::adapters::gdelt::fetch_news_response as news;
+    pub use crate::models::corporate::news::News;
+}
+
+#[cfg(feature = "cftc")]
+pub mod cftc {
+    //! CFTC Commitments of Traders positioning (requires `cftc` feature, keyless).
+    //!
+    //! Keyless shortcut;
+    //! [`FuturesContract::commitments_of_traders`](crate::FuturesContract::commitments_of_traders)
+    //! reaches the same data through `Capability::FUTURES` when CFTC is routed.
+    pub use crate::adapters::cftc::fetch_commitments_of_traders_response as commitments_of_traders;
+    pub use crate::models::futures::cot::{CommitmentsOfTraders, CotObservation};
+}
+
 #[cfg(feature = "openfigi")]
 pub mod openfigi {
     //! Security-identifier resolution via OpenFIGI (requires `openfigi`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,7 +259,7 @@ pub use domains::Commodity;
 #[cfg(any(feature = "fmp", feature = "polygon", feature = "alphavantage"))]
 pub use domains::Discovery;
 pub use domains::Filings;
-#[cfg(feature = "polygon")]
+#[cfg(any(feature = "polygon", feature = "cftc"))]
 pub use domains::FuturesContract;
 #[cfg(any(feature = "polygon", feature = "fmp"))]
 pub use domains::Index;
@@ -390,8 +390,10 @@ pub use models::economic::{
     feature = "polygon"
 ))]
 pub use models::forex::ForexQuote;
-#[cfg(feature = "polygon")]
+#[cfg(any(feature = "polygon", feature = "cftc"))]
 pub use models::futures::FuturesQuote;
+#[cfg(feature = "cftc")]
+pub use models::futures::cot::{CommitmentsOfTraders, CotObservation};
 #[cfg(any(feature = "polygon", feature = "fmp"))]
 pub use models::indices::{IndexConstituent, IndexConstituentChange, IndexQuote, MajorIndex};
 #[cfg(feature = "polygon")]

--- a/src/models/futures/cot.rs
+++ b/src/models/futures/cot.rs
@@ -1,0 +1,69 @@
+//! CFTC Commitments of Traders models.
+//!
+//! Populated by the CFTC adapter (`cftc` feature). Reports weekly futures
+//! positioning by trader category: commercial hedgers (producer/merchant),
+//! swap dealers, managed money (large speculators), other reportables, and
+//! small traders (the "nonreportable" residual below CFTC reporting
+//! thresholds). Source: the disaggregated futures-only combined report —
+//! physical commodities only (agriculture, energy, metals). Equity, rate,
+//! and currency futures are reported separately by the CFTC in the Traders
+//! in Financial Futures report, which is not covered here.
+
+use serde::{Deserialize, Serialize};
+
+/// Weekly Commitments of Traders positioning for one futures market.
+///
+/// Obtain via [`FuturesContract::commitments_of_traders`](crate::FuturesContract::commitments_of_traders).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct CommitmentsOfTraders {
+    /// The symbol this was requested with (e.g. `"GC=F"`, or a raw CFTC
+    /// `cftc_contract_market_code`).
+    pub symbol: String,
+    /// CFTC's own market and exchange name (e.g. `"GOLD - COMMODITY EXCHANGE INC."`).
+    pub market_and_exchange_name: String,
+    /// CFTC contract market code identifying this market.
+    pub cftc_contract_market_code: String,
+    /// Weekly observations, oldest first.
+    pub observations: Vec<CotObservation>,
+}
+
+/// One weekly report row, broken down by trader category.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct CotObservation {
+    /// Report date (`YYYY-MM-DD`) — the Tuesday the report is as of.
+    pub report_date: String,
+    /// Total open interest, all reporting categories combined.
+    pub open_interest: Option<i64>,
+    /// Commercial hedgers (producers/merchants/processors/users): long side.
+    pub producer_merchant_long: Option<i64>,
+    /// Commercial hedgers: short side.
+    pub producer_merchant_short: Option<i64>,
+    /// Swap dealers: long side.
+    pub swap_dealer_long: Option<i64>,
+    /// Swap dealers: short side.
+    pub swap_dealer_short: Option<i64>,
+    /// Swap dealers: spread positions.
+    pub swap_dealer_spread: Option<i64>,
+    /// Managed money (large speculators): long side.
+    pub managed_money_long: Option<i64>,
+    /// Managed money: short side.
+    pub managed_money_short: Option<i64>,
+    /// Managed money: spread positions.
+    pub managed_money_spread: Option<i64>,
+    /// Other reportable traders: long side.
+    pub other_reportable_long: Option<i64>,
+    /// Other reportable traders: short side.
+    pub other_reportable_short: Option<i64>,
+    /// Other reportable traders: spread positions.
+    pub other_reportable_spread: Option<i64>,
+    /// Sum of all reportable categories: long side.
+    pub total_reportable_long: Option<i64>,
+    /// Sum of all reportable categories: short side.
+    pub total_reportable_short: Option<i64>,
+    /// Small traders below CFTC reporting thresholds (residual): long side.
+    pub nonreportable_long: Option<i64>,
+    /// Small traders below CFTC reporting thresholds: short side.
+    pub nonreportable_short: Option<i64>,
+}

--- a/src/models/futures/mod.rs
+++ b/src/models/futures/mod.rs
@@ -5,6 +5,10 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Commitments of Traders weekly positioning models (CFTC).
+#[cfg(feature = "cftc")]
+pub mod cot;
+
 /// A futures contract quote.
 ///
 /// Obtain via [`Ticker::quote`](crate::Ticker::quote) using the futures symbol (e.g., `"GC=F"`).

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -65,8 +65,8 @@ pub mod economic;
     feature = "polygon"
 ))]
 pub mod forex;
-/// Futures market data models — Polygon.
-#[cfg(feature = "polygon")]
+/// Futures market data models — Polygon / CFTC.
+#[cfg(any(feature = "polygon", feature = "cftc"))]
 pub mod futures;
 /// Stock market index data models — Polygon / FMP.
 #[cfg(any(feature = "polygon", feature = "fmp"))]

--- a/src/providers/adapter.rs
+++ b/src/providers/adapter.rs
@@ -512,13 +512,23 @@ pub(crate) trait IndicesProvider: ProviderCore {
 }
 
 /// [`Capability::FUTURES`] — futures contract quotes.
-#[cfg(feature = "polygon")]
+#[cfg(any(feature = "polygon", feature = "cftc"))]
 #[async_trait::async_trait]
 pub(crate) trait FuturesProvider: ProviderCore {
     async fn fetch_futures_quote(
         &self,
         symbol: &str,
     ) -> Result<crate::models::futures::FuturesQuote>;
+
+    /// Fetch weekly CFTC Commitments of Traders positioning for a futures
+    /// symbol, broken down by trader category.
+    #[cfg(feature = "cftc")]
+    async fn fetch_commitments_of_traders(
+        &self,
+        _symbol: &str,
+    ) -> Result<crate::models::futures::cot::CommitmentsOfTraders> {
+        Err(self.not_supported(Operation::CommitmentsOfTraders))
+    }
 }
 
 /// [`Capability::COMMODITIES`] — commodity price quotes.
@@ -608,7 +618,7 @@ pub(crate) trait ProviderAdapter: ProviderCore {
     fn as_indices(&self) -> Option<&dyn IndicesProvider> {
         None
     }
-    #[cfg(feature = "polygon")]
+    #[cfg(any(feature = "polygon", feature = "cftc"))]
     fn as_futures(&self) -> Option<&dyn FuturesProvider> {
         None
     }
@@ -687,7 +697,7 @@ pub(crate) trait ProviderAdapter: ProviderCore {
         if self.as_indices().is_some() {
             caps = caps | Capability::INDICES;
         }
-        #[cfg(feature = "polygon")]
+        #[cfg(any(feature = "polygon", feature = "cftc"))]
         if self.as_futures().is_some() {
             caps = caps | Capability::FUTURES;
         }

--- a/src/providers/cftc.rs
+++ b/src/providers/cftc.rs
@@ -1,0 +1,41 @@
+//! CFTC Commitments of Traders provider implementation (keyless).
+//!
+//! CFTC publishes no price quotes, so `fetch_futures_quote` — `FuturesProvider`'s
+//! required primary operation — reports `NotSupported` and dispatch falls
+//! through to a quoting provider (e.g. Polygon); `fetch_commitments_of_traders`
+//! is the operation this provider actually serves.
+
+use super::{FuturesProvider, Operation, ProviderAdapter, ProviderCore};
+use crate::error::Result;
+
+pub(crate) struct CftcProvider;
+
+impl ProviderCore for CftcProvider {
+    fn id(&self) -> super::Provider {
+        super::Provider::Cftc
+    }
+}
+
+#[async_trait::async_trait]
+impl FuturesProvider for CftcProvider {
+    async fn fetch_futures_quote(
+        &self,
+        _symbol: &str,
+    ) -> Result<crate::models::futures::FuturesQuote> {
+        Err(self.not_supported(Operation::FuturesQuote))
+    }
+
+    async fn fetch_commitments_of_traders(
+        &self,
+        symbol: &str,
+    ) -> Result<crate::models::futures::cot::CommitmentsOfTraders> {
+        crate::adapters::cftc::fetch_commitments_of_traders_response(symbol).await
+    }
+}
+
+#[async_trait::async_trait]
+impl ProviderAdapter for CftcProvider {
+    fn as_futures(&self) -> Option<&dyn FuturesProvider> {
+        Some(self)
+    }
+}

--- a/src/providers/config.rs
+++ b/src/providers/config.rs
@@ -139,7 +139,7 @@ impl Providers {
     }
 
     /// Create a [`FuturesContract`](crate::FuturesContract) handle backed by this provider set.
-    #[cfg(feature = "polygon")]
+    #[cfg(any(feature = "polygon", feature = "cftc"))]
     pub fn futures(&self, symbol: impl Into<String>) -> crate::domains::FuturesContract {
         crate::domains::FuturesContract::with_providers(symbol.into().into(), Arc::clone(&self.set))
     }

--- a/src/providers/gdelt.rs
+++ b/src/providers/gdelt.rs
@@ -1,0 +1,37 @@
+//! GDELT DOC 2.0 provider implementation (keyless).
+//!
+//! Serves only the news half of `CORPORATE` — GDELT has no corporate
+//! calendar (earnings/dividends/splits), so `fetch_events` reports
+//! `NotSupported` and dispatch falls through to the next routed provider.
+
+use super::{CorporateProvider, Operation, ProviderAdapter, ProviderCore};
+use crate::error::Result;
+
+pub(crate) struct GdeltProvider;
+
+impl ProviderCore for GdeltProvider {
+    fn id(&self) -> super::Provider {
+        super::Provider::Gdelt
+    }
+}
+
+#[async_trait::async_trait]
+impl CorporateProvider for GdeltProvider {
+    async fn fetch_news(&self, symbol: &str) -> Result<Vec<crate::models::corporate::news::News>> {
+        crate::adapters::gdelt::fetch_news_response(symbol).await
+    }
+
+    async fn fetch_events(
+        &self,
+        _symbol: &str,
+    ) -> Result<crate::models::chart::events::ChartEvents> {
+        Err(self.not_supported(Operation::Events))
+    }
+}
+
+#[async_trait::async_trait]
+impl ProviderAdapter for GdeltProvider {
+    fn as_corporate(&self) -> Option<&dyn CorporateProvider> {
+        Some(self)
+    }
+}

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -12,6 +12,8 @@ pub(crate) mod alphavantage;
 pub(crate) mod binance;
 #[cfg(feature = "bls")]
 pub(crate) mod bls;
+#[cfg(feature = "cftc")]
+pub(crate) mod cftc;
 #[cfg(feature = "crypto")]
 pub(crate) mod coingecko;
 #[cfg(feature = "defi")]
@@ -98,6 +100,10 @@ pub enum Provider {
     /// GDELT DOC 2.0 global news search (requires `gdelt` feature, keyless).
     #[cfg(feature = "gdelt")]
     Gdelt,
+    /// CFTC Commitments of Traders futures positioning (requires `cftc`
+    /// feature, keyless).
+    #[cfg(feature = "cftc")]
+    Cftc,
     /// SEC EDGAR filings (always available, keyless).
     Edgar,
 }
@@ -137,6 +143,8 @@ impl Provider {
             "defillama" => Some(Self::DefiLlama),
             #[cfg(feature = "gdelt")]
             "gdelt" => Some(Self::Gdelt),
+            #[cfg(feature = "cftc")]
+            "cftc" => Some(Self::Cftc),
             "edgar" => Some(Self::Edgar),
             _ => None,
         }
@@ -174,6 +182,8 @@ impl Provider {
             Self::DefiLlama => "defillama",
             #[cfg(feature = "gdelt")]
             Self::Gdelt => "gdelt",
+            #[cfg(feature = "cftc")]
+            Self::Cftc => "cftc",
             Self::Edgar => "edgar",
         }
     }
@@ -212,6 +222,8 @@ impl Provider {
         v.push(Self::DefiLlama);
         #[cfg(feature = "gdelt")]
         v.push(Self::Gdelt);
+        #[cfg(feature = "cftc")]
+        v.push(Self::Cftc);
         v.push(Self::Edgar);
         v
     }
@@ -254,6 +266,8 @@ impl Provider {
             Self::DefiLlama => ProviderAdapter::capabilities(&defillama::DefiLlamaProvider),
             #[cfg(feature = "gdelt")]
             Self::Gdelt => ProviderAdapter::capabilities(&gdelt::GdeltProvider),
+            #[cfg(feature = "cftc")]
+            Self::Cftc => ProviderAdapter::capabilities(&cftc::CftcProvider),
             Self::Edgar => ProviderAdapter::capabilities(&edgar::EdgarProvider),
         }
     }
@@ -505,6 +519,9 @@ pub enum Operation {
     /// Historical total value locked in a DeFi protocol.
     #[cfg(feature = "defi")]
     ProtocolTvlHistory,
+    /// Weekly CFTC Commitments of Traders futures positioning.
+    #[cfg(feature = "cftc")]
+    CommitmentsOfTraders,
     /// Aggregated analyst price-target consensus.
     PriceTargetConsensus,
     /// Price-target publication activity over trailing windows.
@@ -587,6 +604,8 @@ impl Operation {
             Self::ProtocolTvl => "protocol_tvl",
             #[cfg(feature = "defi")]
             Self::ProtocolTvlHistory => "protocol_tvl_history",
+            #[cfg(feature = "cftc")]
+            Self::CommitmentsOfTraders => "commitments_of_traders",
             Self::PriceTargetConsensus => "price_target_consensus",
             Self::PriceTargetSummary => "price_target_summary",
             Self::RatingConsensus => "rating_consensus",
@@ -642,6 +661,8 @@ impl Operation {
                 Capability::INDICES
             }
             Self::FuturesQuote => Capability::FUTURES,
+            #[cfg(feature = "cftc")]
+            Self::CommitmentsOfTraders => Capability::FUTURES,
             Self::CommoditiesQuote => Capability::COMMODITIES,
             Self::Filings
             | Self::FilingSections
@@ -1057,6 +1078,8 @@ pub(crate) async fn build_providers(
             Provider::DefiLlama => Arc::new(defillama::DefiLlamaProvider),
             #[cfg(feature = "gdelt")]
             Provider::Gdelt => Arc::new(gdelt::GdeltProvider),
+            #[cfg(feature = "cftc")]
+            Provider::Cftc => Arc::new(cftc::CftcProvider),
             Provider::Edgar => Arc::new(edgar::EdgarProvider),
         };
         adapter.initialize().await?;

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -27,6 +27,8 @@ pub(crate) mod fmp;
 pub(crate) mod frankfurter;
 #[cfg(feature = "fred")]
 pub(crate) mod fred;
+#[cfg(feature = "gdelt")]
+pub(crate) mod gdelt;
 #[cfg(feature = "kraken")]
 pub(crate) mod kraken;
 #[cfg(feature = "polygon")]
@@ -93,6 +95,9 @@ pub enum Provider {
     /// DefiLlama DeFi TVL data (requires `defi` feature, keyless).
     #[cfg(feature = "defi")]
     DefiLlama,
+    /// GDELT DOC 2.0 global news search (requires `gdelt` feature, keyless).
+    #[cfg(feature = "gdelt")]
+    Gdelt,
     /// SEC EDGAR filings (always available, keyless).
     Edgar,
 }
@@ -130,6 +135,8 @@ impl Provider {
             "finra" => Some(Self::Finra),
             #[cfg(feature = "defi")]
             "defillama" => Some(Self::DefiLlama),
+            #[cfg(feature = "gdelt")]
+            "gdelt" => Some(Self::Gdelt),
             "edgar" => Some(Self::Edgar),
             _ => None,
         }
@@ -165,6 +172,8 @@ impl Provider {
             Self::Finra => "finra",
             #[cfg(feature = "defi")]
             Self::DefiLlama => "defillama",
+            #[cfg(feature = "gdelt")]
+            Self::Gdelt => "gdelt",
             Self::Edgar => "edgar",
         }
     }
@@ -201,6 +210,8 @@ impl Provider {
         v.push(Self::Finra);
         #[cfg(feature = "defi")]
         v.push(Self::DefiLlama);
+        #[cfg(feature = "gdelt")]
+        v.push(Self::Gdelt);
         v.push(Self::Edgar);
         v
     }
@@ -241,6 +252,8 @@ impl Provider {
             Self::Finra => ProviderAdapter::capabilities(&finra::FinraProvider),
             #[cfg(feature = "defi")]
             Self::DefiLlama => ProviderAdapter::capabilities(&defillama::DefiLlamaProvider),
+            #[cfg(feature = "gdelt")]
+            Self::Gdelt => ProviderAdapter::capabilities(&gdelt::GdeltProvider),
             Self::Edgar => ProviderAdapter::capabilities(&edgar::EdgarProvider),
         }
     }
@@ -1042,6 +1055,8 @@ pub(crate) async fn build_providers(
             Provider::Finra => Arc::new(finra::FinraProvider),
             #[cfg(feature = "defi")]
             Provider::DefiLlama => Arc::new(defillama::DefiLlamaProvider),
+            #[cfg(feature = "gdelt")]
+            Provider::Gdelt => Arc::new(gdelt::GdeltProvider),
             Provider::Edgar => Arc::new(edgar::EdgarProvider),
         };
         adapter.initialize().await?;


### PR DESCRIPTION
## Description

Two keyless providers: GDELT for worldwide news search, CFTC for weekly futures positioning. Both are reachable over REST and GraphQL with no API key.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Changes

Each provider is behind its own feature flag and is off by default.

| Feature | Provider | What you get |
|---------|----------|--------------|
| `gdelt` | GDELT DOC 2.0 | News slice of `Capability::CORPORATE` across 65 languages, updated roughly every 15 minutes |
| `cftc` | CFTC Public Reporting | `FuturesContract::commitments_of_traders()`, weekly long/short/spread by trader category |

CFTC covers physical commodities only, via the disaggregated futures-only report. A curated table maps Yahoo-style continuous roots (`GC=F`, `CL=F`) to CFTC contract codes, and anything else passes through as a raw code. New public models: `CommitmentsOfTraders` and `CotObservation`.

Neither provider serves the required primary operation of its capability trait. CFTC publishes no quotes and GDELT has no corporate calendar, so both report `NotSupported` there and dispatch falls through to the next routed provider.

GDELT's API rejects quoted phrases under 5 characters, so shorter symbols are turned away up front with `InvalidParameter` and fall through to another CORPORATE provider instead of failing mid-request. Its throttle interval arrives in a plain-text body rather than a `Retry-After` header, so it gets parsed out into `RateLimited::retry_after`. The server returns 400 for `InvalidParameter`, which previously fell through to the catch-all 500.

On the server: `GET /v2/gdelt/news/{symbol}` and `GET /v2/cftc/cot/{symbol}`, with `gdeltNews` and `commitmentsOfTraders` GraphQL root fields, field allow-lists, and OpenAPI schemas. COT observations paginate through the existing nested-connection bridge. `gdelt::news()` and `cftc::commitments_of_traders()` are library shortcuts, so neither needs provider routing.

## Breaking Changes

None. All new surface is behind new feature flags.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed

Verified against the live APIs through a local server. `/v2/cftc/cot/GC=F` returns real weekly gold positioning, and GDELT's rejection and throttle paths both surface correctly.

## Documentation
- [x] Code documentation updated (doc comments)
- [x] CHANGELOG.md updated
- [x] OpenAPI spec updated

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Code formatted (`cargo fmt`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues
Closes #259
Closes #270
