### PR TITLE
feat: Polygon grouped-daily, Alpha Vantage status, CoinGecko search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **CoinGecko trending, global stats, and coin search** are exposed keylessly on
+  the server: `GET /v2/crypto/trending`, `GET /v2/crypto/global`, and
+  `GET /v2/crypto/search` (plus the `cryptoTrending`/`cryptoGlobal`/`cryptoSearch`
+  GraphQL root fields). The library gains matching `crypto::trending()`,
+  `crypto::global()`, and `crypto::search()` shortcuts alongside
+  `crypto::coins()`/`crypto::coin()`.
+- `CalendarKind::MarketStatus` and `MarketCalendar::market_status()` for live
+  exchange open/closed status, which Alpha Vantage serves. It was previously
+  mapped onto `CalendarKind::MarketHoliday`, so a holiday-calendar query routed
+  to Alpha Vantage silently returned live status rows instead.
+- `SymbolMatch` gains `id`, `market_cap_rank`, `thumbnail`, and `image`. `id`
+  carries a provider-native identifier when it differs from the ticker — the
+  CoinGecko coin id, for instance, is what `Providers::crypto` accepts.
 - **World Bank Open Data** (`worldbank` feature, keyless) — `Provider::WorldBank`
   serves `Capability::ECONOMIC` with roughly 1,600 global development and macro
   indicators across 200+ economies, closing the gap left by FRED's US focus.
@@ -253,6 +266,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GDELT's throttle response carries its retry interval in a plain-text body
   rather than a `Retry-After` header; that interval is now parsed into
   `RateLimited::retry_after` and the message logged instead of discarded.
+- EDGAR is no longer dropped from the provider set when Alpha Vantage is
+  configured. Auto-injection tested `capabilities().contains(FILINGS)`, and
+  Alpha Vantage advertises FILINGS only to serve insider transactions — so
+  EDGAR, the sole real filings source, was suppressed and every `filings()`
+  call failed. Injection is now keyed on provider identity.
+- CoinGecko symbol search puts the ticker in `SymbolMatch::symbol` (uppercased),
+  matching every other DISCOVERY provider; it previously put the CoinGecko coin
+  id there, which broke the provider-neutral contract for consumers searching
+  across providers.
 
 - `finance::hours()` no longer labels every region's market "U.S. markets".
   Yahoo returns correct per-region session times but hardcodes the U.S.

--- a/monitoring/grafana/provisioning/dashboards/infrastructure.json
+++ b/monitoring/grafana/provisioning/dashboards/infrastructure.json
@@ -107,7 +107,7 @@
       ],
       "title": "Disk Usage by Mountpoint",
       "type": "bargauge",
-      "description": "Filesystem fill level per mountpoint. A full disk took the whole stack down in issue #222 \u2014 this is the incident class this panel exists to catch early. Yellow at 80%, red at 90%."
+      "description": "Filesystem fill level per mountpoint. Yellow at 80%, red at 90%."
     },
     {
       "datasource": {
@@ -211,7 +211,7 @@
       ],
       "title": "Disk Usage Over Time",
       "type": "timeseries",
-      "description": "Filesystem fill level per mountpoint. A full disk took the whole stack down in issue #222 \u2014 this is the incident class this panel exists to catch early. Yellow at 80%, red at 90%."
+      "description": "Filesystem fill level per mountpoint. Yellow at 80%, red at 90%."
     },
     {
       "datasource": {

--- a/monitoring/prometheus/alerts/host.yml
+++ b/monitoring/prometheus/alerts/host.yml
@@ -18,7 +18,7 @@ groups:
           service: host
         annotations:
           summary: "Disk usage above 80% on {{ $labels.mountpoint }}"
-          description: "Filesystem {{ $labels.device }} at {{ $labels.mountpoint }} is {{ $value | humanizePercentage }} full. Investigate before it cascades (issue #222: disk bloat previously reached 99% and broke Redis)."
+          description: "Filesystem {{ $labels.device }} at {{ $labels.mountpoint }} is {{ $value | humanizePercentage }} full. Investigate before it cascades."
 
       - alert: HostDiskUsageCritical
         expr: |
@@ -32,7 +32,7 @@ groups:
           service: host
         annotations:
           summary: "CRITICAL: Disk usage above 90% on {{ $labels.mountpoint }}"
-          description: "Filesystem {{ $labels.device }} at {{ $labels.mountpoint }} is {{ $value | humanizePercentage }} full. This is the issue #222 incident class (cache bloat -> full disk -> Redis errors). Free space NOW."
+          description: "Filesystem {{ $labels.device }} at {{ $labels.mountpoint }} is {{ $value | humanizePercentage }} full. Free space NOW."
 
       - alert: HostMemoryAvailableLow
         expr: |

--- a/monitoring/prometheus/alerts/redis.yml
+++ b/monitoring/prometheus/alerts/redis.yml
@@ -35,7 +35,7 @@ groups:
           service: finance-query-v2
         annotations:
           summary: "Finance Query V2 lost its Redis cache connection"
-          description: "cache_backend_connected has been 0 for 5+ minutes — V2 is running in silent in-memory fallback (issue #222). Cache will not persist across restarts."
+          description: "cache_backend_connected has been 0 for 5+ minutes — V2 is running in silent in-memory fallback. Cache will not persist across restarts."
 
       - alert: CacheErrorsHigh
         expr: rate(finance_query_cache_errors_total[5m]) > 0

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -2853,6 +2853,90 @@ paths:
         '500':
           $ref: '#/components/responses/InternalError'
 
+  /v2/crypto/trending:
+    get:
+      tags: [Cryptocurrency]
+      summary: Trending coins (last 24h)
+      description: Coins trending on CoinGecko over the last 24 hours, most trending first
+      parameters:
+        - $ref: '#/components/parameters/Fields'
+        - $ref: '#/components/parameters/PaginationLimit'
+        - $ref: '#/components/parameters/PaginationCursor'
+      responses:
+        '200':
+          description: |
+            Trending coins ordered by trending rank. Pagination is opt-in:
+            omitting both `limit` and `cursor` returns a bare array; passing
+            either returns `{ items: [...], pageInfo: {...} }` instead.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TrendingCoin'
+        '429':
+          description: CoinGecko rate limit exceeded (30 req/min on free tier)
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /v2/crypto/search:
+    get:
+      tags: [Cryptocurrency]
+      summary: Search the CoinGecko coin universe
+      description: Free-text search over CoinGecko's coin list, returning provider-neutral symbol matches
+      parameters:
+        - name: query
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Coin name, symbol, or CoinGecko id
+          example: bitcoin
+        - name: limitResults
+          in: query
+          schema:
+            type: integer
+            default: 25
+          description: Max matches to fetch upstream
+        - $ref: '#/components/parameters/Fields'
+        - $ref: '#/components/parameters/PaginationLimit'
+        - $ref: '#/components/parameters/PaginationCursor'
+      responses:
+        '200':
+          description: |
+            Matching coins. Pagination is opt-in: omitting both `limit` and
+            `cursor` returns a bare array; passing either returns
+            `{ items: [...], pageInfo: {...} }` instead.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SymbolMatch'
+        '429':
+          description: CoinGecko rate limit exceeded
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /v2/crypto/global:
+    get:
+      tags: [Cryptocurrency]
+      summary: Global crypto market statistics
+      description: Aggregate market cap, volume, and dominance figures across all tracked coins
+      parameters:
+        - $ref: '#/components/parameters/Fields'
+      responses:
+        '200':
+          description: Global cryptocurrency market statistics
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GlobalCryptoStats'
+        '429':
+          description: CoinGecko rate limit exceeded
+        '500':
+          $ref: '#/components/responses/InternalError'
+
   /v2/risk/{symbol}:
     get:
       tags: [Risk]
@@ -3476,6 +3560,115 @@ components:
         nonreportableShort:
           type: integer
           format: int64
+          nullable: true
+
+    SymbolMatch:
+      type: object
+      description: Provider-neutral symbol match from a discovery search
+      properties:
+        symbol:
+          type: string
+          description: Ticker symbol, uppercased
+          example: BTC
+        id:
+          type: string
+          nullable: true
+          description: >-
+            Provider-native identifier when distinct from the ticker — e.g. the
+            CoinGecko coin id, which is what the crypto quote route accepts.
+          example: bitcoin
+        name:
+          type: string
+          nullable: true
+          example: Bitcoin
+        exchange:
+          type: string
+          nullable: true
+        assetType:
+          type: string
+          nullable: true
+          description: Asset type (e.g. CS for common stock, ETF, Cryptocurrency)
+        currency:
+          type: string
+          nullable: true
+        active:
+          type: boolean
+          nullable: true
+        marketCapRank:
+          type: integer
+          nullable: true
+          description: Rank within the provider's universe by market cap (1 = largest)
+        thumbnail:
+          type: string
+          nullable: true
+          description: Small logo/icon URL
+        image:
+          type: string
+          nullable: true
+          description: Full-size logo URL
+
+    TrendingCoin:
+      type: object
+      description: A coin trending on CoinGecko over the last 24 hours
+      properties:
+        id:
+          type: string
+          nullable: true
+          description: CoinGecko coin ID
+          example: bitcoin
+        symbol:
+          type: string
+          nullable: true
+          example: BTC
+        name:
+          type: string
+          nullable: true
+          example: Bitcoin
+        marketCapRank:
+          type: integer
+          nullable: true
+          description: Market cap rank (1 = highest market cap)
+        priceBtc:
+          type: number
+          format: double
+          nullable: true
+          description: Price denominated in BTC
+        score:
+          type: integer
+          nullable: true
+          description: Trending rank (0 = most trending)
+
+    GlobalCryptoStats:
+      type: object
+      description: Aggregate global cryptocurrency market statistics from CoinGecko
+      properties:
+        activeCryptocurrencies:
+          type: integer
+          nullable: true
+        markets:
+          type: integer
+          nullable: true
+        totalMarketCapUsd:
+          type: number
+          format: double
+          nullable: true
+        totalVolumeUsd:
+          type: number
+          format: double
+          nullable: true
+        btcDominance:
+          type: number
+          format: double
+          nullable: true
+          description: Bitcoin's percentage of total market cap
+        ethDominance:
+          type: number
+          format: double
+          nullable: true
+          description: Ethereum's percentage of total market cap
+        marketCapChangePercentage24HUsd:
+          type: number
+          format: double
           nullable: true
 
     Split:

--- a/server/src/graphql/fields.rs
+++ b/server/src/graphql/fields.rs
@@ -428,6 +428,32 @@ pub const GQL_COIN_VALID_FIELDS: &[&str] = &[
     "marketCapRank",
 ];
 
+pub const GQL_TRENDING_COIN_VALID_FIELDS: &[&str] =
+    &["id", "symbol", "name", "marketCapRank", "priceBtc", "score"];
+
+pub const GQL_CRYPTO_SYMBOL_MATCH_VALID_FIELDS: &[&str] = &[
+    "symbol",
+    "id",
+    "name",
+    "exchange",
+    "assetType",
+    "currency",
+    "active",
+    "marketCapRank",
+    "thumbnail",
+    "image",
+];
+
+pub const GQL_GLOBAL_CRYPTO_STATS_VALID_FIELDS: &[&str] = &[
+    "activeCryptocurrencies",
+    "markets",
+    "totalMarketCapUsd",
+    "totalVolumeUsd",
+    "btcDominance",
+    "ethDominance",
+    "marketCapChangePercentage24HUsd",
+];
+
 // ── FRED (economic series + Treasury yields) ────────────────────────────────
 
 pub const GQL_MACRO_SERIES_VALID_FIELDS: &[&str] = &["id", "observations"];

--- a/server/src/graphql/query/root_metadata.rs
+++ b/server/src/graphql/query/root_metadata.rs
@@ -8,7 +8,7 @@ use crate::graphql::error::{exec_gql, from_gql_json, to_gql_error};
 use crate::graphql::pagination::{self, Page};
 use crate::graphql::types::{
     calendar::GqlCalendarEvent,
-    crypto::GqlCoinQuote,
+    crypto::{GqlCoinQuote, GqlGlobalCryptoStats, GqlSymbolMatch, GqlTrendingCoin},
     edgar::{GqlEdgarCik, GqlEdgarSearchHit, GqlEdgarSearchResults},
     enums::GqlTimeRange,
     fred::{GqlMacroSeries, GqlTreasuryYield},
@@ -94,6 +94,49 @@ impl RootMetadataQuery {
             &symbol,
         ))
         .await
+    }
+
+    /// Coins trending on CoinGecko over the last 24h, most trending first.
+    async fn crypto_trending(
+        &self,
+        ctx: &Context<'_>,
+        #[graphql(desc = "Max coins per page; omitted = every trending coin in one page")]
+        first: Option<i32>,
+        #[graphql(desc = "Opaque continuation cursor from a previous page's endCursor")]
+        after: Option<String>,
+    ) -> Result<Page<GqlTrendingCoin>> {
+        let state = ctx.data::<AppState>()?;
+        let json = crate::services::crypto::get_trending(&state.cache)
+            .await
+            .map_err(to_gql_error)?;
+        let coins: Vec<GqlTrendingCoin> = from_gql_json(json)?;
+        pagination::paginate(&coins, first, after).await
+    }
+
+    /// Search CoinGecko's coin universe by free-text query.
+    async fn crypto_search(
+        &self,
+        ctx: &Context<'_>,
+        query: String,
+        #[graphql(default = 25)] limit: u32,
+        #[graphql(desc = "Max matches per page; omitted = every match in one page")] first: Option<
+            i32,
+        >,
+        #[graphql(desc = "Opaque continuation cursor from a previous page's endCursor")]
+        after: Option<String>,
+    ) -> Result<Page<GqlSymbolMatch>> {
+        let state = ctx.data::<AppState>()?;
+        let json = crate::services::crypto::search(&state.cache, &query, limit)
+            .await
+            .map_err(to_gql_error)?;
+        let matches: Vec<GqlSymbolMatch> = from_gql_json(json)?;
+        pagination::paginate(&matches, first, after).await
+    }
+
+    /// Aggregate global cryptocurrency market statistics (CoinGecko).
+    async fn crypto_global(&self, ctx: &Context<'_>) -> Result<GqlGlobalCryptoStats> {
+        let state = ctx.data::<AppState>()?;
+        exec_gql(crate::services::crypto::get_global(&state.cache)).await
     }
 
     /// Resolve a ticker symbol to its SEC CIK number. Requires `EDGAR_EMAIL`.

--- a/server/src/graphql/types/crypto.rs
+++ b/server/src/graphql/types/crypto.rs
@@ -22,3 +22,49 @@ pub struct GqlCoinQuote {
     pub image: Option<String>,
     pub market_cap_rank: Option<u32>,
 }
+
+/// Mirrors `finance_query::crypto::TrendingCoin` — plain snake_case JSON keys,
+/// same no-serde-rename rule as [`GqlCoinQuote`].
+#[derive(SimpleObject, Deserialize, Debug, Clone, Default)]
+#[graphql(rename_fields = "camelCase")]
+#[serde(default)]
+pub struct GqlTrendingCoin {
+    pub id: Option<String>,
+    pub symbol: Option<String>,
+    pub name: Option<String>,
+    pub market_cap_rank: Option<u32>,
+    pub price_btc: Option<f64>,
+    pub score: Option<u32>,
+}
+
+/// Mirrors `finance_query::crypto::SymbolMatch` — the provider-neutral
+/// discovery shape, here populated from CoinGecko's coin universe.
+#[derive(SimpleObject, Deserialize, Debug, Clone, Default)]
+#[graphql(rename_fields = "camelCase")]
+#[serde(default)]
+pub struct GqlSymbolMatch {
+    pub symbol: String,
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub exchange: Option<String>,
+    pub asset_type: Option<String>,
+    pub currency: Option<String>,
+    pub active: Option<bool>,
+    pub market_cap_rank: Option<u32>,
+    pub thumbnail: Option<String>,
+    pub image: Option<String>,
+}
+
+/// Mirrors `finance_query::crypto::GlobalCryptoStats`.
+#[derive(SimpleObject, Deserialize, Debug, Clone, Default)]
+#[graphql(rename_fields = "camelCase")]
+#[serde(default)]
+pub struct GqlGlobalCryptoStats {
+    pub active_cryptocurrencies: Option<u32>,
+    pub markets: Option<u32>,
+    pub total_market_cap_usd: Option<f64>,
+    pub total_volume_usd: Option<f64>,
+    pub btc_dominance: Option<f64>,
+    pub eth_dominance: Option<f64>,
+    pub market_cap_change_percentage_24h_usd: Option<f64>,
+}

--- a/server/src/handlers/crypto.rs
+++ b/server/src/handlers/crypto.rs
@@ -6,13 +6,18 @@ use axum::{
 };
 use finance_query_server::graphql::{
     self,
-    fields::{GQL_COIN_VALID_FIELDS, unwrap_field},
+    fields::{
+        GQL_COIN_VALID_FIELDS, GQL_CRYPTO_SYMBOL_MATCH_VALID_FIELDS,
+        GQL_GLOBAL_CRYPTO_STATS_VALID_FIELDS, GQL_TRENDING_COIN_VALID_FIELDS, unwrap_field,
+    },
     pagination::build_connection_selection,
 };
 use serde::Deserialize;
 use tracing::info;
 
-use super::gql_bridge::{build_rest_selection, execute_gql_rest, unwrap_connection};
+use super::gql_bridge::{
+    build_rest_selection, connection_args, execute_gql_rest, unwrap_connection,
+};
 
 fn default_vs_currency() -> String {
     "usd".to_string()
@@ -61,16 +66,7 @@ pub(crate) async fn get_crypto_coins(
 ) -> impl IntoResponse {
     let inner_selection = build_rest_selection(params.fields.as_deref(), GQL_COIN_VALID_FIELDS);
     let selection = build_connection_selection(&inner_selection);
-    let mut conn_args = Vec::new();
-    if let Some(limit) = params.limit {
-        conn_args.push(format!("first: {limit}"));
-    }
-    if let Some(cursor) = params.cursor.as_deref() {
-        conn_args.push(format!(
-            "after: \"{}\"",
-            cursor.replace('\\', "\\\\").replace('"', "\\\"")
-        ));
-    }
+    let conn_args = connection_args(params.limit, params.cursor.as_deref());
     let conn_args_str = if conn_args.is_empty() {
         String::new()
     } else {
@@ -121,4 +117,126 @@ pub(crate) async fn get_crypto_coin(
         Err(resp) => return resp,
     };
     (StatusCode::OK, Json(unwrap_field(data, "cryptoCoin"))).into_response()
+}
+
+/// Query parameters for /v2/crypto/trending
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CryptoTrendingQuery {
+    /// Comma-separated list of fields to include in response
+    fields: Option<String>,
+    /// Max coins per page; omitted (with cursor also omitted) = bare array
+    limit: Option<u32>,
+    /// Opaque continuation cursor from a previous response's `pageInfo.endCursor`
+    cursor: Option<String>,
+}
+
+/// Query parameters for /v2/crypto/global
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CryptoGlobalQuery {
+    /// Comma-separated list of fields to include in response
+    fields: Option<String>,
+}
+
+/// GET /v2/crypto/trending
+pub(crate) async fn get_crypto_trending(
+    Extension(schema): Extension<graphql::FinanceSchema>,
+    Query(params): Query<CryptoTrendingQuery>,
+) -> impl IntoResponse {
+    let inner_selection =
+        build_rest_selection(params.fields.as_deref(), GQL_TRENDING_COIN_VALID_FIELDS);
+    let selection = build_connection_selection(&inner_selection);
+    let conn_args = connection_args(params.limit, params.cursor.as_deref());
+    let conn_args_str = if conn_args.is_empty() {
+        String::new()
+    } else {
+        format!("({})", conn_args.join(", "))
+    };
+    let query = format!("query {{ cryptoTrending{conn_args_str} {selection} }}");
+
+    info!("Fetching trending crypto coins");
+
+    let data = match execute_gql_rest(&schema, &query, Variables::default()).await {
+        Ok(d) => d,
+        Err(resp) => return resp,
+    };
+    let paginated = params.limit.is_some() || params.cursor.is_some();
+    let result = unwrap_connection(unwrap_field(data, "cryptoTrending"), paginated);
+    (StatusCode::OK, Json(result)).into_response()
+}
+
+/// Query parameters for /v2/crypto/search
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CryptoSearchQuery {
+    /// Free-text query (coin name, symbol, or CoinGecko id)
+    query: String,
+    /// Max matches to fetch (default: 25)
+    #[serde(default = "default_crypto_search_limit")]
+    limit_results: u32,
+    /// Comma-separated list of fields to include in response
+    fields: Option<String>,
+    /// Max matches per page; omitted (with cursor also omitted) = bare array
+    limit: Option<u32>,
+    /// Opaque continuation cursor from a previous response's `pageInfo.endCursor`
+    cursor: Option<String>,
+}
+
+fn default_crypto_search_limit() -> u32 {
+    25
+}
+
+/// GET /v2/crypto/search
+pub(crate) async fn get_crypto_search(
+    Extension(schema): Extension<graphql::FinanceSchema>,
+    Query(params): Query<CryptoSearchQuery>,
+) -> impl IntoResponse {
+    let inner_selection = build_rest_selection(
+        params.fields.as_deref(),
+        GQL_CRYPTO_SYMBOL_MATCH_VALID_FIELDS,
+    );
+    let selection = build_connection_selection(&inner_selection);
+    let conn_args = connection_args(params.limit, params.cursor.as_deref());
+    let conn_args_str = if conn_args.is_empty() {
+        String::new()
+    } else {
+        format!(", {}", conn_args.join(", "))
+    };
+    let query = format!(
+        "query Search($q: String!) {{ cryptoSearch(query: $q, limit: {}{}) {} }}",
+        params.limit_results, conn_args_str, selection
+    );
+    let mut vars = Variables::default();
+    vars.insert(Name::new("q"), params.query.clone().into());
+
+    info!("Searching CoinGecko for: {}", params.query);
+
+    let data = match execute_gql_rest(&schema, &query, vars).await {
+        Ok(d) => d,
+        Err(resp) => return resp,
+    };
+    let paginated = params.limit.is_some() || params.cursor.is_some();
+    let result = unwrap_connection(unwrap_field(data, "cryptoSearch"), paginated);
+    (StatusCode::OK, Json(result)).into_response()
+}
+
+/// GET /v2/crypto/global
+pub(crate) async fn get_crypto_global(
+    Extension(schema): Extension<graphql::FinanceSchema>,
+    Query(params): Query<CryptoGlobalQuery>,
+) -> impl IntoResponse {
+    let selection = build_rest_selection(
+        params.fields.as_deref(),
+        GQL_GLOBAL_CRYPTO_STATS_VALID_FIELDS,
+    );
+    let query = format!("query {{ cryptoGlobal {selection} }}");
+
+    info!("Fetching global crypto market stats");
+
+    let data = match execute_gql_rest(&schema, &query, Variables::default()).await {
+        Ok(d) => d,
+        Err(resp) => return resp,
+    };
+    (StatusCode::OK, Json(unwrap_field(data, "cryptoGlobal"))).into_response()
 }

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -66,6 +66,12 @@ pub(crate) fn api_routes() -> Router {
         .route("/crypto/coins", get(crypto::get_crypto_coins))
         // GET /v2/crypto/coins/{id}?vs_currency=<str>
         .route("/crypto/coins/{id}", get(crypto::get_crypto_coin))
+        // GET /v2/crypto/trending
+        .route("/crypto/trending", get(crypto::get_crypto_trending))
+        // GET /v2/crypto/global
+        .route("/crypto/global", get(crypto::get_crypto_global))
+        // GET /v2/crypto/search?query=<str>
+        .route("/crypto/search", get(crypto::get_crypto_search))
         // GET /v2/currencies
         .route("/currencies", get(metadata::get_currencies))
         // GET /v2/dividends/{symbol}?range=<str>

--- a/server/src/services/crypto.rs
+++ b/server/src/services/crypto.rs
@@ -19,6 +19,46 @@ pub async fn get_coins(cache: &Cache, vs_currency: &str, count: usize) -> Servic
         .await
 }
 
+pub async fn get_trending(cache: &Cache) -> ServiceResult {
+    cache
+        .get_or_fetch(
+            &Cache::key("crypto_trending", &[]),
+            cache::ttl::QUOTES,
+            cache::is_market_open(),
+            || async move {
+                let coins = finance_query::crypto::trending().await?;
+                serde_json::to_value(&coins).map_err(|e| Box::new(e) as ServiceError)
+            },
+        )
+        .await
+}
+
+pub async fn get_global(cache: &Cache) -> ServiceResult {
+    cache
+        .get_or_fetch(
+            &Cache::key("crypto_global", &[]),
+            cache::ttl::QUOTES,
+            cache::is_market_open(),
+            || async move {
+                let stats = finance_query::crypto::global().await?;
+                serde_json::to_value(&stats).map_err(|e| Box::new(e) as ServiceError)
+            },
+        )
+        .await
+}
+
+pub async fn search(cache: &Cache, query: &str, limit: u32) -> ServiceResult {
+    let cache_key = Cache::key("crypto_search", &[query, &limit.to_string()]);
+    let q = query.to_string();
+
+    cache
+        .get_or_fetch(&cache_key, cache::ttl::QUOTES, false, || async move {
+            let matches = finance_query::crypto::search(&q, limit).await?;
+            serde_json::to_value(&matches).map_err(|e| Box::new(e) as ServiceError)
+        })
+        .await
+}
+
 pub async fn get_coin(cache: &Cache, coin_id: &str, vs_currency: &str) -> ServiceResult {
     let cache_key = Cache::key("crypto_coin", &[coin_id, vs_currency]);
     let id = coin_id.to_string();

--- a/src/adapters/alphavantage/corporate/insider.rs
+++ b/src/adapters/alphavantage/corporate/insider.rs
@@ -1,0 +1,149 @@
+//! Insider transactions (`INSIDER_TRANSACTIONS`) — a second route for the
+//! ownership surface alongside EDGAR's Form 3/4/5 parsing.
+//!
+//! Alpha Vantage's fields are coarser than a primary-source filing line item
+//! (no accession number, form type, or derivative/non-derivative split), but
+//! it populates the same canonical [`InsiderTrade`] model so callers can
+//! route [`Capability::FILINGS`](crate::providers::Capability::FILINGS)
+//! through Alpha Vantage as a fallback when EDGAR is unavailable or slow.
+
+use crate::adapters::alphavantage::models::InsiderTransactionDTO;
+use crate::error::{FinanceError, Result};
+use crate::models::filings::InsiderTrade;
+
+use super::super::build_client;
+
+/// Fetch raw insider transaction records for a symbol.
+pub async fn insider_transactions(symbol: &str) -> Result<Vec<InsiderTransactionDTO>> {
+    let client = build_client()?;
+    let json = client
+        .get("INSIDER_TRANSACTIONS", &[("symbol", symbol)])
+        .await?;
+
+    let data = json.get("data").and_then(|v| v.as_array()).ok_or_else(|| {
+        FinanceError::ResponseStructureError {
+            field: "data".to_string(),
+            context: "Missing data array in insider transactions response".to_string(),
+        }
+    })?;
+
+    data.iter()
+        .map(|v| {
+            serde_json::from_value(v.clone()).map_err(|e| FinanceError::ResponseStructureError {
+                field: "data[]".to_string(),
+                context: format!("Failed to parse insider transaction record: {e}"),
+            })
+        })
+        .collect()
+}
+
+/// Convert one raw insider transaction record into the canonical
+/// [`InsiderTrade`] model. Fields Alpha Vantage doesn't report (form type,
+/// accession number, filing URL, security title beyond `security_type`,
+/// director/officer/10%-owner flags, shares owned after, derivative flag)
+/// are left at their `None`/`false` defaults.
+fn to_insider_trade(dto: InsiderTransactionDTO) -> InsiderTrade {
+    InsiderTrade {
+        symbol: dto.ticker,
+        insider_name: dto.executive,
+        officer_title: dto.executive_title,
+        security_title: dto.security_type,
+        transaction_date: dto.transaction_date,
+        acquired_disposed: dto.acquisition_or_disposal,
+        shares: dto.shares,
+        price_per_share: dto.share_price,
+        ..Default::default()
+    }
+}
+
+/// Fetch canonical insider transactions for a symbol, newest filing first as
+/// reported by Alpha Vantage. `limit` truncates the result — Alpha Vantage's
+/// endpoint takes no page size, so this is applied client-side.
+pub async fn fetch_insider_trades_response(symbol: &str, limit: u32) -> Result<Vec<InsiderTrade>> {
+    let records = insider_transactions(symbol).await?;
+    Ok(records
+        .into_iter()
+        .take(limit as usize)
+        .map(to_insider_trade)
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn transaction_dto() -> InsiderTransactionDTO {
+        serde_json::from_value(serde_json::json!({
+            "transaction_date": "2026-07-01",
+            "ticker": "IBM",
+            "executive": "ROBINSON, ANNE",
+            "executive_title": "Senior Vice President",
+            "security_type": "Common Stock",
+            "acquisition_or_disposal": "D",
+            "shares": "781.0",
+            "share_price": "286.725"
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn maps_transaction_fields() {
+        let out = to_insider_trade(transaction_dto());
+        assert_eq!(out.symbol.as_deref(), Some("IBM"));
+        assert_eq!(out.insider_name.as_deref(), Some("ROBINSON, ANNE"));
+        assert_eq!(out.officer_title.as_deref(), Some("Senior Vice President"));
+        assert_eq!(out.security_title.as_deref(), Some("Common Stock"));
+        assert_eq!(out.acquired_disposed.as_deref(), Some("D"));
+        assert_eq!(out.shares, Some(781.0));
+        assert!((out.price_per_share.unwrap() - 286.725).abs() < 0.001);
+        // Unavailable-from-AV fields stay at their defaults.
+        assert_eq!(out.form_type, None);
+        assert_eq!(out.accession_number, None);
+        assert!(!out.is_director);
+        assert!(!out.is_officer);
+    }
+
+    #[tokio::test]
+    async fn test_insider_transactions_mock() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("GET", "/")
+            .match_query(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::UrlEncoded("function".into(), "INSIDER_TRANSACTIONS".into()),
+                mockito::Matcher::UrlEncoded("symbol".into(), "IBM".into()),
+            ]))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "data": [
+                        {
+                            "transaction_date": "2026-07-01",
+                            "ticker": "IBM",
+                            "executive": "ROBINSON, ANNE",
+                            "executive_title": "Senior Vice President",
+                            "security_type": "Common Stock",
+                            "acquisition_or_disposal": "D",
+                            "shares": "781.0",
+                            "share_price": "286.725"
+                        }
+                    ]
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let client = super::super::super::build_test_client(&server.url()).unwrap();
+        let json = client
+            .get("INSIDER_TRANSACTIONS", &[("symbol", "IBM")])
+            .await
+            .unwrap();
+
+        let data = json.get("data").and_then(|v| v.as_array()).unwrap();
+        assert_eq!(data.len(), 1);
+        let dto: InsiderTransactionDTO = serde_json::from_value(data[0].clone()).unwrap();
+        assert_eq!(dto.ticker.as_deref(), Some("IBM"));
+        assert_eq!(dto.shares, Some(781.0));
+    }
+}

--- a/src/adapters/alphavantage/corporate/mod.rs
+++ b/src/adapters/alphavantage/corporate/mod.rs
@@ -5,6 +5,9 @@ use crate::error::{FinanceError, Result};
 use super::build_client;
 use super::models::*;
 
+pub mod insider;
+pub use insider::fetch_insider_trades_response;
+
 /// Fetch market news and sentiment for given tickers and/or topics.
 ///
 /// # Arguments

--- a/src/adapters/alphavantage/discovery/mod.rs
+++ b/src/adapters/alphavantage/discovery/mod.rs
@@ -9,12 +9,16 @@ use crate::models::discovery::reference::{ExchangeInfo, SymbolMatch};
 pub(crate) fn to_symbol_match(dto: SymbolMatchDTO) -> SymbolMatch {
     SymbolMatch {
         symbol: dto.symbol,
+        id: None,
         name: Some(dto.name),
         exchange: Some(dto.region),
         asset_type: Some(dto.asset_type),
         currency: Some(dto.currency),
         // SYMBOL_SEARCH only returns tradable symbols, so a hit is active.
         active: Some(true),
+        market_cap_rank: None,
+        thumbnail: None,
+        image: None,
     }
 }
 
@@ -35,11 +39,15 @@ pub(crate) fn to_symbol_match_from_listing(dto: ListingEntryDTO) -> SymbolMatch 
         .map(|s| s.eq_ignore_ascii_case("active"));
     SymbolMatch {
         symbol: dto.symbol,
+        id: None,
         name: dto.name,
         exchange: dto.exchange,
         asset_type: dto.asset_type,
         currency: None,
         active,
+        market_cap_rank: None,
+        thumbnail: None,
+        image: None,
     }
 }
 

--- a/src/adapters/alphavantage/models.rs
+++ b/src/adapters/alphavantage/models.rs
@@ -6,7 +6,6 @@ use serde::{Deserialize, Deserializer, Serialize};
 ///
 /// Alpha Vantage returns numeric values as strings, and uses `"None"` or `"."`
 /// for missing data.
-#[allow(dead_code)] // serde helper retained for DTOs whose endpoints are not yet routed
 pub(crate) fn deserialize_optional_f64<'de, D>(
     deserializer: D,
 ) -> std::result::Result<Option<f64>, D::Error>
@@ -217,7 +216,6 @@ pub struct BulkQuoteDTO {
 /// A single match result from a symbol search.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
-#[allow(dead_code)] // unrouted: DTO for an endpoint with no capability route yet
 pub struct SymbolMatchDTO {
     /// Ticker symbol
     pub symbol: String,
@@ -246,7 +244,6 @@ pub struct SymbolMatchDTO {
 /// Status of a single market/exchange.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
-#[allow(dead_code)] // unrouted: DTO for an endpoint with no capability route yet
 pub struct MarketStatusDTO {
     /// Market type (e.g., `"Equity"`, `"Forex"`)
     pub market_type: String,
@@ -262,6 +259,39 @@ pub struct MarketStatusDTO {
     pub current_status: String,
     /// Notes
     pub notes: String,
+}
+
+// ============================================================================
+// Insider transactions
+// ============================================================================
+
+/// A single insider transaction record (`INSIDER_TRANSACTIONS`).
+///
+/// Alpha Vantage's fields are coarser than a Form 3/4/5 line item — no
+/// accession number, form type, or derivative/non-derivative distinction —
+/// so mapping into the canonical [`InsiderTrade`](crate::models::filings::InsiderTrade)
+/// leaves those fields `None`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct InsiderTransactionDTO {
+    /// Transaction date (`YYYY-MM-DD`).
+    pub transaction_date: Option<String>,
+    /// Ticker symbol.
+    pub ticker: Option<String>,
+    /// Insider's name, as filed.
+    pub executive: Option<String>,
+    /// Insider's title (e.g. `"Chief Executive Officer"`).
+    pub executive_title: Option<String>,
+    /// Security type (e.g. `"Common Stock"`).
+    pub security_type: Option<String>,
+    /// `"A"` (acquisition) or `"D"` (disposal).
+    pub acquisition_or_disposal: Option<String>,
+    /// Number of shares transacted (Alpha Vantage sends this as a string).
+    #[serde(default, deserialize_with = "deserialize_optional_f64")]
+    pub shares: Option<f64>,
+    /// Price per share (Alpha Vantage sends this as a string).
+    #[serde(default, deserialize_with = "deserialize_optional_f64")]
+    pub share_price: Option<f64>,
 }
 
 // ============================================================================

--- a/src/adapters/alphavantage/quote/mod.rs
+++ b/src/adapters/alphavantage/quote/mod.rs
@@ -1,6 +1,7 @@
 //! Core stock time series endpoints: intraday, daily, weekly, monthly, quotes, search, market status.
 
 use crate::error::{FinanceError, Result};
+use crate::models::calendar::market::{CalendarDetail, MarketCalendarEntry};
 use crate::models::chart::{Candle, Chart};
 use crate::models::quote::{FormattedValue, Price, QuoteSummaryResponse};
 
@@ -383,8 +384,43 @@ pub async fn symbol_search(keywords: &str) -> Result<Vec<SymbolMatchDTO>> {
         .collect())
 }
 
+/// Convert one market status DTO into a canonical calendar entry.
+///
+/// Reuses [`CalendarDetail::MarketHoliday`] — the closest existing shape for
+/// "is this exchange open right now" — rather than adding a bespoke variant
+/// for a single provider's live-status snapshot. `name` carries the
+/// region/market-type label Alpha Vantage reports since the entry has no
+/// dedicated fields for them; `symbol`/`date` are `None` since this is a
+/// live status snapshot rather than a dated event.
+fn market_status_to_canonical(m: MarketStatusDTO) -> MarketCalendarEntry {
+    fn non_empty(s: String) -> Option<String> {
+        if s.is_empty() { None } else { Some(s) }
+    }
+
+    MarketCalendarEntry {
+        symbol: None,
+        date: None,
+        detail: CalendarDetail::MarketHoliday {
+            name: Some(format!("{} ({})", m.region, m.market_type)),
+            exchange: non_empty(m.primary_exchanges),
+            status: non_empty(m.current_status),
+            open: non_empty(m.local_open),
+            close: non_empty(m.local_close),
+        },
+    }
+}
+
+/// Fetch the current market status of every major global exchange as
+/// canonical calendar entries.
+pub async fn fetch_market_status_response() -> Result<Vec<MarketCalendarEntry>> {
+    Ok(market_status()
+        .await?
+        .into_iter()
+        .map(market_status_to_canonical)
+        .collect())
+}
+
 /// Fetch the current market status of major global exchanges.
-#[allow(dead_code)] // unrouted: remaining Alpha Vantage endpoints land with #264
 pub async fn market_status() -> Result<Vec<MarketStatusDTO>> {
     let client = build_client()?;
     let json = client.get("MARKET_STATUS", &[]).await?;
@@ -639,6 +675,65 @@ fn timestamp_to_date_string(ts: i64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn market_status_maps_region_and_type_into_name() {
+        let dto = MarketStatusDTO {
+            market_type: "Equity".to_string(),
+            region: "United States".to_string(),
+            primary_exchanges: "NASDAQ, NYSE".to_string(),
+            local_open: "09:30".to_string(),
+            local_close: "16:00".to_string(),
+            current_status: "open".to_string(),
+            notes: String::new(),
+        };
+        let entry = market_status_to_canonical(dto);
+        assert!(entry.symbol.is_none());
+        assert!(entry.date.is_none());
+        match entry.detail {
+            CalendarDetail::MarketHoliday {
+                name,
+                exchange,
+                status,
+                open,
+                close,
+            } => {
+                assert_eq!(name.as_deref(), Some("United States (Equity)"));
+                assert_eq!(exchange.as_deref(), Some("NASDAQ, NYSE"));
+                assert_eq!(status.as_deref(), Some("open"));
+                assert_eq!(open.as_deref(), Some("09:30"));
+                assert_eq!(close.as_deref(), Some("16:00"));
+            }
+            _ => panic!("expected MarketHoliday detail"),
+        }
+    }
+
+    #[test]
+    fn market_status_empty_open_close_become_none() {
+        let dto = MarketStatusDTO {
+            market_type: "Forex".to_string(),
+            region: "Global".to_string(),
+            primary_exchanges: String::new(),
+            local_open: String::new(),
+            local_close: String::new(),
+            current_status: "closed".to_string(),
+            notes: String::new(),
+        };
+        let entry = market_status_to_canonical(dto);
+        match entry.detail {
+            CalendarDetail::MarketHoliday {
+                exchange,
+                open,
+                close,
+                ..
+            } => {
+                assert!(exchange.is_none());
+                assert!(open.is_none());
+                assert!(close.is_none());
+            }
+            _ => panic!("expected MarketHoliday detail"),
+        }
+    }
 
     fn entry(timestamp: &str, close: f64) -> TimeSeriesEntryDTO {
         TimeSeriesEntryDTO {

--- a/src/adapters/coingecko/client.rs
+++ b/src/adapters/coingecko/client.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use reqwest::{Client, StatusCode};
 use tracing::debug;
 
-use super::models::CoinQuote;
+use super::models::{CoinQuote, GlobalResponseDTO, SearchResponseDTO, TrendingResponseDTO};
 use crate::error::{FinanceError, Result};
 use crate::rate_limiter::RateLimiter;
 
@@ -91,6 +91,44 @@ impl CoinGeckoClient {
 
         let url = format!("{COINGECKO_BASE}/coins/{id}/ohlc?vs_currency={vs_currency}&days={days}");
         debug!("CoinGecko request: ohlc(id={id}, vs={vs_currency}, days={days})");
+        let resp = self.http.get(&url).send().await?;
+        CoinGeckoClient::check_status(&resp)?;
+        Ok(resp.json().await?)
+    }
+
+    /// Search CoinGecko's coin/exchange/category catalog by free-text query.
+    pub async fn search(&self, query: &str) -> Result<SearchResponseDTO> {
+        self.limiter.acquire().await;
+
+        let url = format!("{COINGECKO_BASE}/search");
+        debug!("CoinGecko request: search(query={query})");
+        let resp = self
+            .http
+            .get(&url)
+            .query(&[("query", query)])
+            .send()
+            .await?;
+        CoinGeckoClient::check_status(&resp)?;
+        Ok(resp.json().await?)
+    }
+
+    /// Fetch coins/nfts/categories trending in the last 24h.
+    pub async fn trending(&self) -> Result<TrendingResponseDTO> {
+        self.limiter.acquire().await;
+
+        let url = format!("{COINGECKO_BASE}/search/trending");
+        debug!("CoinGecko request: trending()");
+        let resp = self.http.get(&url).send().await?;
+        CoinGeckoClient::check_status(&resp)?;
+        Ok(resp.json().await?)
+    }
+
+    /// Fetch aggregate global cryptocurrency market statistics.
+    pub async fn global(&self) -> Result<GlobalResponseDTO> {
+        self.limiter.acquire().await;
+
+        let url = format!("{COINGECKO_BASE}/global");
+        debug!("CoinGecko request: global()");
         let resp = self.http.get(&url).send().await?;
         CoinGeckoClient::check_status(&resp)?;
         Ok(resp.json().await?)

--- a/src/adapters/coingecko/discovery/mod.rs
+++ b/src/adapters/coingecko/discovery/mod.rs
@@ -9,21 +9,28 @@ use super::models::SearchCoinDTO;
 
 /// Convert one coin match into the canonical [`SymbolMatch`].
 ///
-/// `symbol` carries the CoinGecko coin **id** (e.g. `"bitcoin"`) rather than
-/// the ticker — that's the identifier
-/// [`Providers::crypto`](crate::Providers::crypto) actually accepts, and
-/// tickers collide across coins in a way ids don't. CoinGecko coins also
-/// aren't tied to a single listing exchange or quote currency, so
-/// `exchange`/`currency` stay `None`; every returned coin is presumed
-/// tradable, so `active` is `Some(true)`.
+/// `symbol` is the ticker (uppercased), matching every other DISCOVERY
+/// provider; the CoinGecko coin id goes in `id`, since that — not the ticker —
+/// is what [`Providers::crypto`](crate::Providers::crypto) accepts. Coins
+/// aren't tied to one listing exchange or quote currency, so
+/// `exchange`/`currency` stay `None`; a returned coin is presumed tradable.
 fn to_symbol_match(dto: SearchCoinDTO) -> SymbolMatch {
     SymbolMatch {
-        symbol: dto.id,
+        // Fall back to the id only when CoinGecko omits the ticker outright —
+        // `symbol` is non-optional and an empty string would be worse.
+        symbol: dto
+            .symbol
+            .map(|s| s.to_ascii_uppercase())
+            .unwrap_or_else(|| dto.id.clone()),
+        id: Some(dto.id),
         name: Some(dto.name),
         exchange: None,
         asset_type: Some("Cryptocurrency".to_string()),
         currency: None,
         active: Some(true),
+        market_cap_rank: dto.market_cap_rank,
+        thumbnail: dto.thumb,
+        image: dto.large,
     }
 }
 
@@ -49,13 +56,41 @@ mod tests {
         let dto = SearchCoinDTO {
             id: "bitcoin".to_string(),
             name: "Bitcoin".to_string(),
+            symbol: Some("btc".to_string()),
+            market_cap_rank: Some(1),
+            thumb: Some("https://example.com/thumb.png".to_string()),
+            large: Some("https://example.com/large.png".to_string()),
         };
         let out = to_symbol_match(dto);
-        assert_eq!(out.symbol, "bitcoin");
+        // Ticker in `symbol`, CoinGecko id in `id` — matches every other
+        // DISCOVERY provider's use of `symbol`.
+        assert_eq!(out.symbol, "BTC");
+        assert_eq!(out.id.as_deref(), Some("bitcoin"));
         assert_eq!(out.name.as_deref(), Some("Bitcoin"));
         assert_eq!(out.asset_type.as_deref(), Some("Cryptocurrency"));
         assert_eq!(out.exchange, None);
         assert_eq!(out.active, Some(true));
+        assert_eq!(out.market_cap_rank, Some(1));
+        assert_eq!(
+            out.thumbnail.as_deref(),
+            Some("https://example.com/thumb.png")
+        );
+        assert_eq!(out.image.as_deref(), Some("https://example.com/large.png"));
+    }
+
+    #[test]
+    fn a_hit_without_a_ticker_falls_back_to_the_id() {
+        let dto = SearchCoinDTO {
+            id: "some-coin".to_string(),
+            name: "Some Coin".to_string(),
+            symbol: None,
+            market_cap_rank: None,
+            thumb: None,
+            large: None,
+        };
+        let out = to_symbol_match(dto);
+        assert_eq!(out.symbol, "some-coin");
+        assert_eq!(out.id.as_deref(), Some("some-coin"));
     }
 
     #[test]
@@ -80,6 +115,7 @@ mod tests {
             .map(to_symbol_match)
             .collect();
         assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].symbol, "bitcoin");
+        assert_eq!(matches[0].symbol, "BTC");
+        assert_eq!(matches[0].id.as_deref(), Some("bitcoin"));
     }
 }

--- a/src/adapters/coingecko/discovery/mod.rs
+++ b/src/adapters/coingecko/discovery/mod.rs
@@ -1,0 +1,85 @@
+//! Symbol search (`/search`) — CoinGecko as an additional keyless route for
+//! [`Capability::DISCOVERY`](crate::providers::Capability::DISCOVERY),
+//! alongside FMP/Polygon/Alpha Vantage.
+
+use crate::error::Result;
+use crate::models::discovery::reference::SymbolMatch;
+
+use super::models::SearchCoinDTO;
+
+/// Convert one coin match into the canonical [`SymbolMatch`].
+///
+/// `symbol` carries the CoinGecko coin **id** (e.g. `"bitcoin"`) rather than
+/// the ticker — that's the identifier
+/// [`Providers::crypto`](crate::Providers::crypto) actually accepts, and
+/// tickers collide across coins in a way ids don't. CoinGecko coins also
+/// aren't tied to a single listing exchange or quote currency, so
+/// `exchange`/`currency` stay `None`; every returned coin is presumed
+/// tradable, so `active` is `Some(true)`.
+fn to_symbol_match(dto: SearchCoinDTO) -> SymbolMatch {
+    SymbolMatch {
+        symbol: dto.id,
+        name: Some(dto.name),
+        exchange: None,
+        asset_type: Some("Cryptocurrency".to_string()),
+        currency: None,
+        active: Some(true),
+    }
+}
+
+/// Search CoinGecko's coin catalog by free-text query, as canonical
+/// [`SymbolMatch`]es. `limit` truncates the result — CoinGecko's `/search`
+/// takes no page size and returns every match in one response.
+pub async fn fetch_symbol_search_response(query: &str, limit: u32) -> Result<Vec<SymbolMatch>> {
+    let resp = super::client()?.search(query).await?;
+    Ok(resp
+        .coins
+        .into_iter()
+        .take(limit as usize)
+        .map(to_symbol_match)
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_a_search_hit_onto_the_neutral_model() {
+        let dto = SearchCoinDTO {
+            id: "bitcoin".to_string(),
+            name: "Bitcoin".to_string(),
+        };
+        let out = to_symbol_match(dto);
+        assert_eq!(out.symbol, "bitcoin");
+        assert_eq!(out.name.as_deref(), Some("Bitcoin"));
+        assert_eq!(out.asset_type.as_deref(), Some("Cryptocurrency"));
+        assert_eq!(out.exchange, None);
+        assert_eq!(out.active, Some(true));
+    }
+
+    #[test]
+    fn search_response_parses_and_limit_truncates() {
+        let resp: super::super::models::SearchResponseDTO =
+            serde_json::from_value(serde_json::json!({
+                "coins": [
+                    { "id": "bitcoin", "name": "Bitcoin", "symbol": "btc", "market_cap_rank": 1 },
+                    { "id": "bitcoin-cash", "name": "Bitcoin Cash", "symbol": "bch", "market_cap_rank": 20 }
+                ],
+                "exchanges": [],
+                "icos": [],
+                "categories": [],
+                "nfts": []
+            }))
+            .unwrap();
+        assert_eq!(resp.coins.len(), 2);
+        let matches: Vec<_> = resp
+            .coins
+            .into_iter()
+            .take(1)
+            .map(to_symbol_match)
+            .collect();
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].symbol, "bitcoin");
+    }
+}

--- a/src/adapters/coingecko/mod.rs
+++ b/src/adapters/coingecko/mod.rs
@@ -26,6 +26,7 @@
 
 pub(crate) mod chart; // CHART
 mod client;
+pub(crate) mod discovery; // DISCOVERY
 mod models;
 
 use client::CoinGeckoClient;
@@ -33,6 +34,7 @@ use std::sync::OnceLock;
 
 use crate::error::Result;
 pub use crate::models::crypto::CoinQuote;
+pub use discovery::fetch_symbol_search_response;
 
 /// Process-global CoinGecko client (initialized lazily on first use).
 static COINGECKO_CLIENT: OnceLock<CoinGeckoClient> = OnceLock::new();
@@ -93,4 +95,112 @@ pub async fn fetch_crypto_quote_response(
         low_24h: None,
         circulating_supply: quote.circulating_supply,
     })
+}
+
+/// Convert one trending-coin wrapper into the canonical [`TrendingCoin`](crate::models::crypto::TrendingCoin).
+fn to_trending_coin(w: models::TrendingCoinWrapperDTO) -> crate::models::crypto::TrendingCoin {
+    crate::models::crypto::TrendingCoin {
+        id: Some(w.item.id),
+        symbol: Some(w.item.symbol.to_ascii_uppercase()),
+        name: Some(w.item.name),
+        market_cap_rank: w.item.market_cap_rank,
+        price_btc: w.item.price_btc,
+        score: w.item.score,
+    }
+}
+
+/// Fetch coins trending in the last 24h as canonical [`TrendingCoin`](crate::models::crypto::TrendingCoin)s.
+pub async fn fetch_crypto_trending_response() -> Result<Vec<crate::models::crypto::TrendingCoin>> {
+    let resp = client()?.trending().await?;
+    Ok(resp.coins.into_iter().map(to_trending_coin).collect())
+}
+
+/// Convert the raw `/global` payload into canonical [`GlobalCryptoStats`](crate::models::crypto::GlobalCryptoStats).
+fn to_global_crypto_stats(data: models::GlobalDataDTO) -> crate::models::crypto::GlobalCryptoStats {
+    crate::models::crypto::GlobalCryptoStats {
+        active_cryptocurrencies: data.active_cryptocurrencies,
+        markets: data.markets,
+        total_market_cap_usd: data.total_market_cap.get("usd").copied(),
+        total_volume_usd: data.total_volume.get("usd").copied(),
+        btc_dominance: data.market_cap_percentage.get("btc").copied(),
+        eth_dominance: data.market_cap_percentage.get("eth").copied(),
+        market_cap_change_percentage_24h_usd: data.market_cap_change_percentage_24h_usd,
+    }
+}
+
+/// Fetch aggregate global cryptocurrency market statistics.
+pub async fn fetch_crypto_global_response() -> Result<crate::models::crypto::GlobalCryptoStats> {
+    let resp = client()?.global().await?;
+    Ok(to_global_crypto_stats(resp.data))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_trending_wrapper_and_uppercases_symbol() {
+        let dto: models::TrendingResponseDTO = serde_json::from_value(serde_json::json!({
+            "coins": [{
+                "item": {
+                    "id": "bitcoin",
+                    "name": "Bitcoin",
+                    "symbol": "btc",
+                    "market_cap_rank": 1,
+                    "price_btc": 1.0,
+                    "score": 0
+                }
+            }]
+        }))
+        .unwrap();
+
+        let coins: Vec<_> = dto.coins.into_iter().map(to_trending_coin).collect();
+        assert_eq!(coins.len(), 1);
+        assert_eq!(coins[0].id.as_deref(), Some("bitcoin"));
+        assert_eq!(coins[0].symbol.as_deref(), Some("BTC"));
+        assert_eq!(coins[0].market_cap_rank, Some(1));
+        assert_eq!(coins[0].score, Some(0));
+    }
+
+    #[test]
+    fn maps_global_stats_extracting_usd_and_dominance() {
+        let dto: models::GlobalResponseDTO = serde_json::from_value(serde_json::json!({
+            "data": {
+                "active_cryptocurrencies": 18137,
+                "markets": 1510,
+                "total_market_cap": { "usd": 3_000_000_000_000.0_f64, "btc": 30_000_000.0_f64 },
+                "total_volume": { "usd": 100_000_000_000.0_f64 },
+                "market_cap_percentage": { "btc": 45.2, "eth": 18.1 },
+                "market_cap_change_percentage_24h_usd": 0.64
+            }
+        }))
+        .unwrap();
+
+        let stats = to_global_crypto_stats(dto.data);
+        assert_eq!(stats.active_cryptocurrencies, Some(18137));
+        assert_eq!(stats.total_market_cap_usd, Some(3_000_000_000_000.0));
+        assert_eq!(stats.total_volume_usd, Some(100_000_000_000.0));
+        assert_eq!(stats.btc_dominance, Some(45.2));
+        assert_eq!(stats.eth_dominance, Some(18.1));
+        assert_eq!(stats.market_cap_change_percentage_24h_usd, Some(0.64));
+    }
+
+    #[test]
+    fn global_stats_missing_currency_key_yields_none() {
+        let dto: models::GlobalResponseDTO = serde_json::from_value(serde_json::json!({
+            "data": {
+                "active_cryptocurrencies": null,
+                "markets": null,
+                "total_market_cap": {},
+                "total_volume": {},
+                "market_cap_percentage": {},
+                "market_cap_change_percentage_24h_usd": null
+            }
+        }))
+        .unwrap();
+
+        let stats = to_global_crypto_stats(dto.data);
+        assert_eq!(stats.total_market_cap_usd, None);
+        assert_eq!(stats.btc_dominance, None);
+    }
 }

--- a/src/adapters/coingecko/models.rs
+++ b/src/adapters/coingecko/models.rs
@@ -2,4 +2,82 @@
 //!
 //! Re-exports canonical type from `crate::models::crypto`.
 
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
 pub use crate::models::crypto::CoinQuote;
+
+// ============================================================================
+// Search (`/search`)
+// ============================================================================
+
+/// Raw `/search` response.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct SearchResponseDTO {
+    #[serde(default)]
+    pub coins: Vec<SearchCoinDTO>,
+}
+
+/// One coin match from `/search`.
+///
+/// CoinGecko's response also carries `symbol`/`market_cap_rank`/thumbnail
+/// URLs, but the canonical mapping only needs `id` (the identifier
+/// [`Providers::crypto`](crate::Providers::crypto) accepts) and `name`.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct SearchCoinDTO {
+    pub id: String,
+    pub name: String,
+}
+
+// ============================================================================
+// Trending (`/search/trending`)
+// ============================================================================
+
+/// Raw `/search/trending` response.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct TrendingResponseDTO {
+    #[serde(default)]
+    pub coins: Vec<TrendingCoinWrapperDTO>,
+}
+
+/// A trending entry wraps its coin data under `"item"`.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct TrendingCoinWrapperDTO {
+    pub item: TrendingCoinItemDTO,
+}
+
+/// One coin's data within a trending entry.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct TrendingCoinItemDTO {
+    pub id: String,
+    pub name: String,
+    pub symbol: String,
+    pub market_cap_rank: Option<u32>,
+    pub price_btc: Option<f64>,
+    pub score: Option<u32>,
+}
+
+// ============================================================================
+// Global (`/global`)
+// ============================================================================
+
+/// Raw `/global` response.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct GlobalResponseDTO {
+    pub data: GlobalDataDTO,
+}
+
+/// The `"data"` payload of `/global`.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct GlobalDataDTO {
+    pub active_cryptocurrencies: Option<u32>,
+    pub markets: Option<u32>,
+    #[serde(default)]
+    pub total_market_cap: HashMap<String, f64>,
+    #[serde(default)]
+    pub total_volume: HashMap<String, f64>,
+    #[serde(default)]
+    pub market_cap_percentage: HashMap<String, f64>,
+    pub market_cap_change_percentage_24h_usd: Option<f64>,
+}

--- a/src/adapters/coingecko/models.rs
+++ b/src/adapters/coingecko/models.rs
@@ -20,14 +20,20 @@ pub(crate) struct SearchResponseDTO {
 }
 
 /// One coin match from `/search`.
-///
-/// CoinGecko's response also carries `symbol`/`market_cap_rank`/thumbnail
-/// URLs, but the canonical mapping only needs `id` (the identifier
-/// [`Providers::crypto`](crate::Providers::crypto) accepts) and `name`.
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct SearchCoinDTO {
     pub id: String,
     pub name: String,
+    #[serde(default)]
+    pub symbol: Option<String>,
+    #[serde(default)]
+    pub market_cap_rank: Option<u32>,
+    /// Small (~25px) icon.
+    #[serde(default)]
+    pub thumb: Option<String>,
+    /// Full-size logo.
+    #[serde(default)]
+    pub large: Option<String>,
 }
 
 // ============================================================================

--- a/src/adapters/fmp/discovery/screener.rs
+++ b/src/adapters/fmp/discovery/screener.rs
@@ -109,12 +109,16 @@ pub async fn fetch_symbol_search_response(
         .filter_map(|r| {
             Some(SymbolMatch {
                 symbol: r.symbol?,
+                id: None,
                 name: r.name,
                 // Prefer the short code (e.g. "NASDAQ") over the long venue name.
                 exchange: r.exchange_short_name.or(r.stock_exchange),
                 asset_type: None,
                 currency: r.currency,
                 active: None,
+                market_cap_rank: None,
+                thumbnail: None,
+                image: None,
             })
         })
         .collect())

--- a/src/adapters/fmp/market/calendars.rs
+++ b/src/adapters/fmp/market/calendars.rs
@@ -195,15 +195,14 @@ pub async fn fetch_market_calendar_response(
     };
 
     Ok(match kind {
-        // FMP has no market-holiday feed; dispatch falls through to a
-        // provider that serves it (Polygon).
-        CalendarKind::MarketHoliday => {
+        // FMP serves neither; dispatch falls through to a provider that does
+        // (Polygon for holidays, Alpha Vantage for live status).
+        CalendarKind::MarketHoliday | CalendarKind::MarketStatus => {
+            let operation = kind.operation();
             return Err(crate::error::FinanceError::NotSupported {
                 provider: crate::Provider::Fmp,
-                operation: crate::providers::Operation::HolidayCalendar,
-                candidates: crate::providers::Operation::HolidayCalendar
-                    .capability()
-                    .candidate_providers(),
+                operation,
+                candidates: operation.capability().candidate_providers(),
             });
         }
         CalendarKind::Earnings => earnings_calendar(from, to)

--- a/src/adapters/polygon/chart/mod.rs
+++ b/src/adapters/polygon/chart/mod.rs
@@ -122,6 +122,40 @@ fn aggs_to_candles(aggs: AggregateResponseDTO) -> Vec<Candle> {
         .collect()
 }
 
+/// Convert a grouped-daily (all-tickers-for-one-date) response into
+/// per-ticker candles. Bars without a `"T"` ticker field are skipped — that
+/// shouldn't happen for a grouped-daily response, but single-ticker
+/// range/prev responses (which lack `"T"`) share the same DTO.
+fn grouped_daily_to_candles(aggs: AggregateResponseDTO) -> Vec<(String, Candle)> {
+    aggs.results
+        .into_iter()
+        .flatten()
+        .filter_map(|r| {
+            let ticker = r.ticker.clone()?;
+            Some((
+                ticker,
+                Candle {
+                    timestamp: r.timestamp,
+                    open: r.open,
+                    high: r.high,
+                    low: r.low,
+                    close: r.close,
+                    volume: r.volume as i64,
+                    adj_close: None,
+                    provider_id: Some(Provider::Polygon),
+                },
+            ))
+        })
+        .collect()
+}
+
+/// Fetch grouped daily OHLCV bars for every stock ticker on `date`
+/// (`YYYY-MM-DD`), as `(symbol, candle)` pairs.
+pub async fn fetch_grouped_daily_response(date: &str) -> Result<Vec<(String, Candle)>> {
+    let aggs = stock_grouped_daily(date, None).await?;
+    Ok(grouped_daily_to_candles(aggs))
+}
+
 /// Fetch chart data (canonical) for a stock ticker by interval and time range.
 pub async fn fetch_chart_response(
     symbol: &str,
@@ -187,7 +221,6 @@ pub async fn stock_previous_close(
 ///
 /// * `date` - Date as `"YYYY-MM-DD"`
 /// * `adjusted` - Whether results are adjusted for splits (default: true)
-#[allow(dead_code)] // unrouted: grouped-daily aggregates routed by #245
 pub async fn stock_grouped_daily(
     date: &str,
     adjusted: Option<bool>,
@@ -322,6 +355,47 @@ mod tests {
         assert_eq!(resp.ticker.as_deref(), Some("MSFT"));
         let bar = &resp.results.unwrap()[0];
         assert!((bar.close - 383.5).abs() < 0.01);
+    }
+
+    #[tokio::test]
+    async fn test_stock_grouped_daily_mock_maps_per_ticker_candles() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("GET", "/v2/aggs/grouped/locale/us/market/stocks/2024-01-15")
+            .match_query(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::UrlEncoded("apiKey".into(), "test-key".into()),
+            ]))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "status": "OK",
+                    "adjusted": true,
+                    "queryCount": 2,
+                    "resultsCount": 2,
+                    "results": [
+                        { "T": "AAPL", "o": 185.09, "h": 187.01, "l": 184.35, "c": 186.19, "v": 65076600.0, "t": 1704067200000_i64 },
+                        { "T": "MSFT", "o": 380.0, "h": 385.0, "l": 378.0, "c": 383.5, "v": 25000000.0, "t": 1704067200000_i64 }
+                    ]
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let client = super::super::build_test_client(&server.url()).unwrap();
+        let json = client
+            .get_raw("/v2/aggs/grouped/locale/us/market/stocks/2024-01-15", &[])
+            .await
+            .unwrap();
+
+        let resp: AggregateResponseDTO = serde_json::from_value(json).unwrap();
+        let candles = grouped_daily_to_candles(resp);
+        assert_eq!(candles.len(), 2);
+        assert_eq!(candles[0].0, "AAPL");
+        assert!((candles[0].1.close - 186.19).abs() < 0.01);
+        assert_eq!(candles[1].0, "MSFT");
+        assert!((candles[1].1.close - 383.5).abs() < 0.01);
     }
 
     #[tokio::test]

--- a/src/adapters/polygon/crypto/aggregates.rs
+++ b/src/adapters/polygon/crypto/aggregates.rs
@@ -2,8 +2,10 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::Provider;
 use crate::adapters::common::encode_path_segment;
 use crate::error::Result;
+use crate::models::chart::Candle;
 
 use super::super::build_client;
 use super::super::models::*;
@@ -61,6 +63,7 @@ pub struct CryptoOpenCloseTradeDTO {
 /// * `from` - Start date as `"YYYY-MM-DD"` or millisecond timestamp string
 /// * `to` - End date as `"YYYY-MM-DD"` or millisecond timestamp string
 /// * `params` - Optional parameters (adjusted, sort, limit)
+#[allow(dead_code)] // unrouted: per-symbol crypto charts route through the generic CHART capability path (fetch_chart_response); not part of #245
 pub async fn crypto_aggregates(
     ticker: &str,
     multiplier: u32,
@@ -109,6 +112,7 @@ pub async fn crypto_aggregates(
 ///
 /// * `ticker` - Crypto ticker symbol with `X:` prefix (e.g., `"X:BTCUSD"`)
 /// * `adjusted` - Whether results are adjusted (default: true)
+#[allow(dead_code)] // unrouted: not part of #245's grouped-daily scope
 pub async fn crypto_previous_close(
     ticker: &str,
     adjusted: Option<bool>,
@@ -156,11 +160,44 @@ pub async fn crypto_grouped_daily(
         .await
 }
 
+/// Convert a grouped-daily (all-tickers-for-one-date) response into
+/// per-ticker candles. Bars without a `"T"` ticker field are skipped.
+fn grouped_daily_to_candles(aggs: AggregateResponseDTO) -> Vec<(String, Candle)> {
+    aggs.results
+        .into_iter()
+        .flatten()
+        .filter_map(|r| {
+            let ticker = r.ticker.clone()?;
+            Some((
+                ticker,
+                Candle {
+                    timestamp: r.timestamp,
+                    open: r.open,
+                    high: r.high,
+                    low: r.low,
+                    close: r.close,
+                    volume: r.volume as i64,
+                    adj_close: None,
+                    provider_id: Some(Provider::Polygon),
+                },
+            ))
+        })
+        .collect()
+}
+
+/// Fetch grouped daily OHLCV bars for every crypto ticker on `date`
+/// (`YYYY-MM-DD`), as `(symbol, candle)` pairs.
+pub async fn fetch_crypto_grouped_daily_response(date: &str) -> Result<Vec<(String, Candle)>> {
+    let aggs = crypto_grouped_daily(date, None).await?;
+    Ok(grouped_daily_to_candles(aggs))
+}
+
 /// Fetch daily open/close for a crypto pair on a specific date.
 ///
 /// * `from` - The "from" symbol of the pair (e.g., `"BTC"`)
 /// * `to` - The "to" symbol of the pair (e.g., `"USD"`)
 /// * `date` - Date as `"YYYY-MM-DD"`
+#[allow(dead_code)] // unrouted: not part of #245's grouped-daily scope
 pub async fn crypto_daily_open_close(
     from: &str,
     to: &str,
@@ -235,5 +272,48 @@ mod tests {
         assert!((results[0].open - 42000.0).abs() < 0.01);
         assert!((results[0].close - 43100.0).abs() < 0.01);
         assert_eq!(results[0].timestamp, 1704067200000);
+    }
+
+    #[tokio::test]
+    async fn test_crypto_grouped_daily_mock_maps_per_ticker_candles() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock(
+                "GET",
+                "/v2/aggs/grouped/locale/global/market/crypto/2024-01-15",
+            )
+            .match_query(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::UrlEncoded("apiKey".into(), "test-key".into()),
+            ]))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "status": "OK",
+                    "adjusted": true,
+                    "resultsCount": 1,
+                    "results": [
+                        { "T": "X:BTCUSD", "o": 42000.0, "h": 43500.0, "l": 41800.0, "c": 43100.0, "v": 12345.67, "t": 1704067200000_i64 }
+                    ]
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let client = super::super::super::build_test_client(&server.url()).unwrap();
+        let json = client
+            .get_raw(
+                "/v2/aggs/grouped/locale/global/market/crypto/2024-01-15",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let resp: AggregateResponseDTO = serde_json::from_value(json).unwrap();
+        let candles = grouped_daily_to_candles(resp);
+        assert_eq!(candles.len(), 1);
+        assert_eq!(candles[0].0, "X:BTCUSD");
+        assert!((candles[0].1.close - 43100.0).abs() < 0.01);
     }
 }

--- a/src/adapters/polygon/crypto/aggregates.rs
+++ b/src/adapters/polygon/crypto/aggregates.rs
@@ -63,7 +63,7 @@ pub struct CryptoOpenCloseTradeDTO {
 /// * `from` - Start date as `"YYYY-MM-DD"` or millisecond timestamp string
 /// * `to` - End date as `"YYYY-MM-DD"` or millisecond timestamp string
 /// * `params` - Optional parameters (adjusted, sort, limit)
-#[allow(dead_code)] // unrouted: per-symbol crypto charts route through the generic CHART capability path (fetch_chart_response); not part of #245
+#[allow(dead_code)] // unrouted: per-symbol crypto charts route through the generic CHART capability path (fetch_chart_response)
 pub async fn crypto_aggregates(
     ticker: &str,
     multiplier: u32,
@@ -112,7 +112,7 @@ pub async fn crypto_aggregates(
 ///
 /// * `ticker` - Crypto ticker symbol with `X:` prefix (e.g., `"X:BTCUSD"`)
 /// * `adjusted` - Whether results are adjusted (default: true)
-#[allow(dead_code)] // unrouted: not part of #245's grouped-daily scope
+#[allow(dead_code)] // unrouted: outside the grouped-daily surface
 pub async fn crypto_previous_close(
     ticker: &str,
     adjusted: Option<bool>,
@@ -197,7 +197,7 @@ pub async fn fetch_crypto_grouped_daily_response(date: &str) -> Result<Vec<(Stri
 /// * `from` - The "from" symbol of the pair (e.g., `"BTC"`)
 /// * `to` - The "to" symbol of the pair (e.g., `"USD"`)
 /// * `date` - Date as `"YYYY-MM-DD"`
-#[allow(dead_code)] // unrouted: not part of #245's grouped-daily scope
+#[allow(dead_code)] // unrouted: outside the grouped-daily surface
 pub async fn crypto_daily_open_close(
     from: &str,
     to: &str,

--- a/src/adapters/polygon/crypto/mod.rs
+++ b/src/adapters/polygon/crypto/mod.rs
@@ -1,6 +1,5 @@
 //! Cryptocurrency market data endpoints.
 
-#[allow(dead_code)] // unrouted: grouped-daily aggregates routed by #245
 pub mod aggregates;
 pub mod snapshots;
 #[allow(dead_code)] // unrouted: tick-level trades land with #250

--- a/src/adapters/polygon/discovery/mod.rs
+++ b/src/adapters/polygon/discovery/mod.rs
@@ -231,11 +231,15 @@ pub async fn fetch_symbol_search_response(
         .filter_map(|t| {
             Some(SymbolMatch {
                 symbol: t.ticker?,
+                id: None,
                 name: t.name,
                 exchange: t.primary_exchange,
                 asset_type: t.asset_type,
                 currency: t.currency_name,
                 active: t.active,
+                market_cap_rank: None,
+                thumbnail: None,
+                image: None,
             })
         })
         .collect())

--- a/src/adapters/polygon/forex/aggregates.rs
+++ b/src/adapters/polygon/forex/aggregates.rs
@@ -18,7 +18,7 @@ use super::super::models::*;
 /// * `from` - Start date as `"YYYY-MM-DD"` or millisecond timestamp string
 /// * `to` - End date as `"YYYY-MM-DD"` or millisecond timestamp string
 /// * `params` - Optional parameters (adjusted, sort, limit)
-#[allow(dead_code)] // unrouted: per-symbol forex charts route through the generic CHART capability path (fetch_chart_response); not part of #245
+#[allow(dead_code)] // unrouted: per-symbol forex charts route through the generic CHART capability path (fetch_chart_response)
 pub async fn forex_aggregates(
     ticker: &str,
     multiplier: u32,
@@ -67,7 +67,7 @@ pub async fn forex_aggregates(
 ///
 /// * `ticker` - Forex ticker symbol with `C:` prefix (e.g., `"C:EURUSD"`)
 /// * `adjusted` - Whether results are adjusted for splits (default: true)
-#[allow(dead_code)] // unrouted: not part of #245's grouped-daily scope
+#[allow(dead_code)] // unrouted: outside the grouped-daily surface
 pub async fn forex_previous_close(
     ticker: &str,
     adjusted: Option<bool>,

--- a/src/adapters/polygon/forex/aggregates.rs
+++ b/src/adapters/polygon/forex/aggregates.rs
@@ -1,7 +1,9 @@
 //! Forex aggregate bar endpoints: OHLCV bars, previous close, grouped daily.
 
+use crate::Provider;
 use crate::adapters::common::encode_path_segment;
 use crate::error::Result;
+use crate::models::chart::Candle;
 
 use super::super::build_client;
 use super::super::models::*;
@@ -16,6 +18,7 @@ use super::super::models::*;
 /// * `from` - Start date as `"YYYY-MM-DD"` or millisecond timestamp string
 /// * `to` - End date as `"YYYY-MM-DD"` or millisecond timestamp string
 /// * `params` - Optional parameters (adjusted, sort, limit)
+#[allow(dead_code)] // unrouted: per-symbol forex charts route through the generic CHART capability path (fetch_chart_response); not part of #245
 pub async fn forex_aggregates(
     ticker: &str,
     multiplier: u32,
@@ -64,6 +67,7 @@ pub async fn forex_aggregates(
 ///
 /// * `ticker` - Forex ticker symbol with `C:` prefix (e.g., `"C:EURUSD"`)
 /// * `adjusted` - Whether results are adjusted for splits (default: true)
+#[allow(dead_code)] // unrouted: not part of #245's grouped-daily scope
 pub async fn forex_previous_close(
     ticker: &str,
     adjusted: Option<bool>,
@@ -109,6 +113,38 @@ pub async fn forex_grouped_daily(
             "forex grouped daily response",
         )
         .await
+}
+
+/// Convert a grouped-daily (all-tickers-for-one-date) response into
+/// per-ticker candles. Bars without a `"T"` ticker field are skipped.
+fn grouped_daily_to_candles(aggs: AggregateResponseDTO) -> Vec<(String, Candle)> {
+    aggs.results
+        .into_iter()
+        .flatten()
+        .filter_map(|r| {
+            let ticker = r.ticker.clone()?;
+            Some((
+                ticker,
+                Candle {
+                    timestamp: r.timestamp,
+                    open: r.open,
+                    high: r.high,
+                    low: r.low,
+                    close: r.close,
+                    volume: r.volume as i64,
+                    adj_close: None,
+                    provider_id: Some(Provider::Polygon),
+                },
+            ))
+        })
+        .collect()
+}
+
+/// Fetch grouped daily OHLCV bars for every forex ticker on `date`
+/// (`YYYY-MM-DD`), as `(symbol, candle)` pairs.
+pub async fn fetch_forex_grouped_daily_response(date: &str) -> Result<Vec<(String, Candle)>> {
+    let aggs = forex_grouped_daily(date, None).await?;
+    Ok(grouped_daily_to_candles(aggs))
 }
 
 #[cfg(test)]
@@ -237,5 +273,42 @@ mod tests {
         let results = resp.results.unwrap();
         assert!(!results.is_empty());
         assert!((results[0].open - 1.1050).abs() < 0.0001);
+    }
+
+    #[tokio::test]
+    async fn test_forex_grouped_daily_mock_maps_per_ticker_candles() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("GET", "/v2/aggs/grouped/locale/global/market/fx/2024-01-16")
+            .match_query(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::UrlEncoded("apiKey".into(), "test-key".into()),
+            ]))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "status": "OK",
+                    "adjusted": true,
+                    "resultsCount": 1,
+                    "results": [
+                        { "T": "C:GBPUSD", "o": 1.2700, "h": 1.2750, "l": 1.2680, "c": 1.2730, "v": 30000.0, "t": 1704067200000_i64 }
+                    ]
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let client = super::super::super::build_test_client(&server.url()).unwrap();
+        let json = client
+            .get_raw("/v2/aggs/grouped/locale/global/market/fx/2024-01-16", &[])
+            .await
+            .unwrap();
+
+        let resp: AggregateResponseDTO = serde_json::from_value(json).unwrap();
+        let candles = grouped_daily_to_candles(resp);
+        assert_eq!(candles.len(), 1);
+        assert_eq!(candles[0].0, "C:GBPUSD");
+        assert!((candles[0].1.close - 1.2730).abs() < 0.0001);
     }
 }

--- a/src/adapters/polygon/forex/mod.rs
+++ b/src/adapters/polygon/forex/mod.rs
@@ -1,6 +1,5 @@
 //! Forex market data endpoints.
 
-#[allow(dead_code)] // unrouted: grouped-daily aggregates routed by #245
 pub mod aggregates;
 pub mod quotes;
 #[allow(dead_code)] // unrouted: cross-market snapshots routed by #244

--- a/src/adapters/polygon/futures/mod.rs
+++ b/src/adapters/polygon/futures/mod.rs
@@ -1,6 +1,12 @@
 //! Futures market data endpoints.
 
-#[allow(dead_code)] // unrouted: grouped-daily aggregates routed by #245
+// #245 investigated adding grouped-daily (all-tickers-for-one-date) aggregates
+// here to match stocks/crypto/forex, but Polygon has no such endpoint for
+// futures (no `/v2/aggs/grouped/locale/.../market/futures/{date}` — verified
+// against the current API docs, 404). Per-symbol aggregates already route
+// through the generic CHART capability path (`fetch_chart_response`), so this
+// module stays unrouted.
+#[allow(dead_code)]
 pub mod aggregates;
 pub mod snapshots;
 #[allow(dead_code)] // unrouted: tick-level trades land with #250

--- a/src/adapters/polygon/futures/mod.rs
+++ b/src/adapters/polygon/futures/mod.rs
@@ -1,11 +1,9 @@
 //! Futures market data endpoints.
 
-// #245 investigated adding grouped-daily (all-tickers-for-one-date) aggregates
-// here to match stocks/crypto/forex, but Polygon has no such endpoint for
-// futures (no `/v2/aggs/grouped/locale/.../market/futures/{date}` — verified
-// against the current API docs, 404). Per-symbol aggregates already route
-// through the generic CHART capability path (`fetch_chart_response`), so this
-// module stays unrouted.
+// Polygon publishes no grouped-daily (all-tickers-for-one-date) endpoint
+// for futures, unlike stocks/crypto/forex; the URL 404s. Per-symbol
+// aggregates already route through the generic CHART capability path
+// (`fetch_chart_response`), so this module stays unrouted.
 #[allow(dead_code)]
 pub mod aggregates;
 pub mod snapshots;

--- a/src/adapters/polygon/indices/mod.rs
+++ b/src/adapters/polygon/indices/mod.rs
@@ -1,5 +1,11 @@
 //! Index market data endpoints.
 
-#[allow(dead_code)] // unrouted: grouped-daily aggregates routed by #245
+// #245 investigated adding grouped-daily (all-tickers-for-one-date) aggregates
+// here to match stocks/crypto/forex, but Polygon has no such endpoint for
+// indices (no `/v2/aggs/grouped/locale/.../market/indices/{date}` — verified
+// against the current API docs, 404). Per-symbol aggregates already route
+// through the generic CHART capability path (`fetch_chart_response`), so this
+// module stays unrouted.
+#[allow(dead_code)]
 pub mod aggregates;
 pub mod snapshots;

--- a/src/adapters/polygon/indices/mod.rs
+++ b/src/adapters/polygon/indices/mod.rs
@@ -1,11 +1,9 @@
 //! Index market data endpoints.
 
-// #245 investigated adding grouped-daily (all-tickers-for-one-date) aggregates
-// here to match stocks/crypto/forex, but Polygon has no such endpoint for
-// indices (no `/v2/aggs/grouped/locale/.../market/indices/{date}` — verified
-// against the current API docs, 404). Per-symbol aggregates already route
-// through the generic CHART capability path (`fetch_chart_response`), so this
-// module stays unrouted.
+// Polygon publishes no grouped-daily (all-tickers-for-one-date) endpoint
+// for indices, unlike stocks/crypto/forex; the URL 404s. Per-symbol
+// aggregates already route through the generic CHART capability path
+// (`fetch_chart_response`), so this module stays unrouted.
 #[allow(dead_code)]
 pub mod aggregates;
 pub mod snapshots;

--- a/src/adapters/polygon/mod.rs
+++ b/src/adapters/polygon/mod.rs
@@ -61,7 +61,9 @@ pub use options::snapshots::fetch_options_response;
 pub use quote::*;
 
 // Asset-class modules
+pub use crypto::aggregates::fetch_crypto_grouped_daily_response;
 pub use crypto::snapshots::*;
+pub use forex::aggregates::fetch_forex_grouped_daily_response;
 pub use forex::quotes::*;
 pub use futures::snapshots::*;
 pub use indices::snapshots::*;

--- a/src/adapters/polygon/models.rs
+++ b/src/adapters/polygon/models.rs
@@ -80,6 +80,10 @@ impl Timespan {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct AggBarDTO {
+    /// Ticker symbol — present on grouped-daily (all-tickers-for-one-date)
+    /// responses, absent on single-ticker range/prev responses.
+    #[serde(rename = "T", default)]
+    pub ticker: Option<String>,
     /// Open price.
     #[serde(rename = "o")]
     pub open: f64,

--- a/src/adapters/polygon/options/mod.rs
+++ b/src/adapters/polygon/options/mod.rs
@@ -1,6 +1,12 @@
 //! Options market data endpoints.
 
-#[allow(dead_code)] // unrouted: grouped-daily aggregates routed by #245
+// #245 investigated adding grouped-daily (all-tickers-for-one-date) aggregates
+// here to match stocks/crypto/forex, but Polygon has no such endpoint for
+// options (no `/v2/aggs/grouped/locale/.../market/options/{date}` — verified
+// against the current API docs, 404). Per-symbol aggregates already route
+// through the generic CHART capability path (`fetch_chart_response`), so this
+// module stays unrouted.
+#[allow(dead_code)]
 pub mod aggregates;
 pub mod snapshots;
 #[allow(dead_code)] // unrouted: tick-level trades land with #250

--- a/src/adapters/polygon/options/mod.rs
+++ b/src/adapters/polygon/options/mod.rs
@@ -1,11 +1,9 @@
 //! Options market data endpoints.
 
-// #245 investigated adding grouped-daily (all-tickers-for-one-date) aggregates
-// here to match stocks/crypto/forex, but Polygon has no such endpoint for
-// options (no `/v2/aggs/grouped/locale/.../market/options/{date}` — verified
-// against the current API docs, 404). Per-symbol aggregates already route
-// through the generic CHART capability path (`fetch_chart_response`), so this
-// module stays unrouted.
+// Polygon publishes no grouped-daily (all-tickers-for-one-date) endpoint
+// for options, unlike stocks/crypto/forex; the URL 404s. Per-symbol
+// aggregates already route through the generic CHART capability path
+// (`fetch_chart_response`), so this module stays unrouted.
 #[allow(dead_code)]
 pub mod aggregates;
 pub mod snapshots;

--- a/src/domains/market.rs
+++ b/src/domains/market.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use crate::error::Result;
 #[cfg(any(feature = "fmp", feature = "polygon", feature = "alphavantage"))]
 use crate::models::calendar::market::{CalendarKind, MarketCalendarEntry};
+use crate::models::chart::Candle;
 use crate::models::market::performance::{
     IndustryPe, MoverDirection, MoverQuote, SectorPe, SectorPerformance,
 };
@@ -186,5 +187,72 @@ impl Market {
     /// Highest traded volume.
     pub async fn most_active(&self) -> Result<Vec<MoverQuote>> {
         self.movers(MoverDirection::MostActive).await
+    }
+
+    /// Fetch grouped daily OHLCV bars for every stock ticker on `date`
+    /// (`YYYY-MM-DD`) in one call — "give me every ticker's OHLC for this
+    /// date" rather than one symbol at a time.
+    ///
+    /// Routes through [`Capability::CHART`](crate::providers::Capability::CHART)
+    /// (the same capability backing per-symbol chart methods) rather than
+    /// `MARKET`, since it's OHLCV data rather than a performance statistic.
+    /// Currently Polygon only. Not cached — one date is one request either way.
+    pub async fn grouped_daily(&self, date: &str) -> Result<Vec<(String, Candle)>> {
+        let providers = Arc::clone(&self.providers);
+        let date = date.to_string();
+        providers
+            .fetch(crate::providers::Capability::CHART, move |p| {
+                let date = date.clone();
+                let p = p.clone();
+                async move {
+                    p.as_chart()
+                        .ok_or_else(|| p.not_supported(crate::providers::Operation::GroupedDaily))?
+                        .fetch_grouped_daily(&date)
+                        .await
+                }
+            })
+            .await
+    }
+
+    /// Fetch grouped daily OHLCV bars for every crypto ticker on `date`
+    /// (`YYYY-MM-DD`) in one call. See [`grouped_daily`](Self::grouped_daily).
+    pub async fn crypto_grouped_daily(&self, date: &str) -> Result<Vec<(String, Candle)>> {
+        let providers = Arc::clone(&self.providers);
+        let date = date.to_string();
+        providers
+            .fetch(crate::providers::Capability::CHART, move |p| {
+                let date = date.clone();
+                let p = p.clone();
+                async move {
+                    p.as_chart()
+                        .ok_or_else(|| {
+                            p.not_supported(crate::providers::Operation::CryptoGroupedDaily)
+                        })?
+                        .fetch_crypto_grouped_daily(&date)
+                        .await
+                }
+            })
+            .await
+    }
+
+    /// Fetch grouped daily OHLCV bars for every forex ticker on `date`
+    /// (`YYYY-MM-DD`) in one call. See [`grouped_daily`](Self::grouped_daily).
+    pub async fn forex_grouped_daily(&self, date: &str) -> Result<Vec<(String, Candle)>> {
+        let providers = Arc::clone(&self.providers);
+        let date = date.to_string();
+        providers
+            .fetch(crate::providers::Capability::CHART, move |p| {
+                let date = date.clone();
+                let p = p.clone();
+                async move {
+                    p.as_chart()
+                        .ok_or_else(|| {
+                            p.not_supported(crate::providers::Operation::ForexGroupedDaily)
+                        })?
+                        .fetch_forex_grouped_daily(&date)
+                        .await
+                }
+            })
+            .await
     }
 }

--- a/src/domains/market.rs
+++ b/src/domains/market.rs
@@ -255,4 +255,44 @@ impl Market {
             })
             .await
     }
+
+    /// Fetch coins/nfts/categories trending in the last 24h.
+    ///
+    /// Routes through [`Capability::CRYPTO`](crate::providers::Capability::CRYPTO).
+    /// Currently CoinGecko only.
+    #[cfg(feature = "crypto")]
+    pub async fn crypto_trending(&self) -> Result<Vec<crate::models::crypto::TrendingCoin>> {
+        self.providers
+            .fetch(crate::providers::Capability::CRYPTO, move |p| {
+                let p = p.clone();
+                async move {
+                    p.as_crypto()
+                        .ok_or_else(|| {
+                            p.not_supported(crate::providers::Operation::CryptoTrending)
+                        })?
+                        .fetch_crypto_trending()
+                        .await
+                }
+            })
+            .await
+    }
+
+    /// Fetch aggregate global cryptocurrency market statistics.
+    ///
+    /// Routes through [`Capability::CRYPTO`](crate::providers::Capability::CRYPTO).
+    /// Currently CoinGecko only.
+    #[cfg(feature = "crypto")]
+    pub async fn crypto_global(&self) -> Result<crate::models::crypto::GlobalCryptoStats> {
+        self.providers
+            .fetch(crate::providers::Capability::CRYPTO, move |p| {
+                let p = p.clone();
+                async move {
+                    p.as_crypto()
+                        .ok_or_else(|| p.not_supported(crate::providers::Operation::CryptoGlobal))?
+                        .fetch_crypto_global()
+                        .await
+                }
+            })
+            .await
+    }
 }

--- a/src/domains/market.rs
+++ b/src/domains/market.rs
@@ -91,6 +91,12 @@ impl MarketCalendar {
     pub async fn holidays(&self) -> Result<Vec<MarketCalendarEntry>> {
         self.fetch(CalendarKind::MarketHoliday, "", "").await
     }
+
+    /// Live open/closed status per exchange. A snapshot rather than a dated
+    /// event, so no date range is taken. Currently Alpha Vantage only.
+    pub async fn market_status(&self) -> Result<Vec<MarketCalendarEntry>> {
+        self.fetch(CalendarKind::MarketStatus, "", "").await
+    }
 }
 
 /// Market-wide performance statistics backed by configured data providers.
@@ -198,62 +204,46 @@ impl Market {
     /// `MARKET`, since it's OHLCV data rather than a performance statistic.
     /// Currently Polygon only. Not cached — one date is one request either way.
     pub async fn grouped_daily(&self, date: &str) -> Result<Vec<(String, Candle)>> {
-        let providers = Arc::clone(&self.providers);
         let date = date.to_string();
-        providers
-            .fetch(crate::providers::Capability::CHART, move |p| {
-                let date = date.clone();
-                let p = p.clone();
-                async move {
-                    p.as_chart()
-                        .ok_or_else(|| p.not_supported(crate::providers::Operation::GroupedDaily))?
-                        .fetch_grouped_daily(&date)
-                        .await
-                }
-            })
-            .await
+        dispatch_via!(
+            self,
+            CHART,
+            as_chart,
+            GroupedDaily,
+            fetch_grouped_daily,
+            [date],
+            &date
+        )
     }
 
     /// Fetch grouped daily OHLCV bars for every crypto ticker on `date`
     /// (`YYYY-MM-DD`) in one call. See [`grouped_daily`](Self::grouped_daily).
     pub async fn crypto_grouped_daily(&self, date: &str) -> Result<Vec<(String, Candle)>> {
-        let providers = Arc::clone(&self.providers);
         let date = date.to_string();
-        providers
-            .fetch(crate::providers::Capability::CHART, move |p| {
-                let date = date.clone();
-                let p = p.clone();
-                async move {
-                    p.as_chart()
-                        .ok_or_else(|| {
-                            p.not_supported(crate::providers::Operation::CryptoGroupedDaily)
-                        })?
-                        .fetch_crypto_grouped_daily(&date)
-                        .await
-                }
-            })
-            .await
+        dispatch_via!(
+            self,
+            CHART,
+            as_chart,
+            CryptoGroupedDaily,
+            fetch_crypto_grouped_daily,
+            [date],
+            &date
+        )
     }
 
     /// Fetch grouped daily OHLCV bars for every forex ticker on `date`
     /// (`YYYY-MM-DD`) in one call. See [`grouped_daily`](Self::grouped_daily).
     pub async fn forex_grouped_daily(&self, date: &str) -> Result<Vec<(String, Candle)>> {
-        let providers = Arc::clone(&self.providers);
         let date = date.to_string();
-        providers
-            .fetch(crate::providers::Capability::CHART, move |p| {
-                let date = date.clone();
-                let p = p.clone();
-                async move {
-                    p.as_chart()
-                        .ok_or_else(|| {
-                            p.not_supported(crate::providers::Operation::ForexGroupedDaily)
-                        })?
-                        .fetch_forex_grouped_daily(&date)
-                        .await
-                }
-            })
-            .await
+        dispatch_via!(
+            self,
+            CHART,
+            as_chart,
+            ForexGroupedDaily,
+            fetch_forex_grouped_daily,
+            [date],
+            &date
+        )
     }
 
     /// Fetch coins/nfts/categories trending in the last 24h.
@@ -262,19 +252,14 @@ impl Market {
     /// Currently CoinGecko only.
     #[cfg(feature = "crypto")]
     pub async fn crypto_trending(&self) -> Result<Vec<crate::models::crypto::TrendingCoin>> {
-        self.providers
-            .fetch(crate::providers::Capability::CRYPTO, move |p| {
-                let p = p.clone();
-                async move {
-                    p.as_crypto()
-                        .ok_or_else(|| {
-                            p.not_supported(crate::providers::Operation::CryptoTrending)
-                        })?
-                        .fetch_crypto_trending()
-                        .await
-                }
-            })
-            .await
+        dispatch_via!(
+            self,
+            CRYPTO,
+            as_crypto,
+            CryptoTrending,
+            fetch_crypto_trending,
+            []
+        )
     }
 
     /// Fetch aggregate global cryptocurrency market statistics.
@@ -283,16 +268,13 @@ impl Market {
     /// Currently CoinGecko only.
     #[cfg(feature = "crypto")]
     pub async fn crypto_global(&self) -> Result<crate::models::crypto::GlobalCryptoStats> {
-        self.providers
-            .fetch(crate::providers::Capability::CRYPTO, move |p| {
-                let p = p.clone();
-                async move {
-                    p.as_crypto()
-                        .ok_or_else(|| p.not_supported(crate::providers::Operation::CryptoGlobal))?
-                        .fetch_crypto_global()
-                        .await
-                }
-            })
-            .await
+        dispatch_via!(
+            self,
+            CRYPTO,
+            as_crypto,
+            CryptoGlobal,
+            fetch_crypto_global,
+            []
+        )
     }
 }

--- a/src/domains/mod.rs
+++ b/src/domains/mod.rs
@@ -540,7 +540,12 @@ pub(crate) mod commodities;
     feature = "polygon"
 ))]
 pub(crate) mod crypto;
-#[cfg(any(feature = "fmp", feature = "polygon", feature = "alphavantage"))]
+#[cfg(any(
+    feature = "fmp",
+    feature = "polygon",
+    feature = "alphavantage",
+    feature = "crypto"
+))]
 pub(crate) mod discovery;
 #[cfg(any(
     feature = "alphavantage",
@@ -581,7 +586,12 @@ pub use commodities::Commodity;
     feature = "polygon"
 ))]
 pub use crypto::CryptoCoin;
-#[cfg(any(feature = "fmp", feature = "polygon", feature = "alphavantage"))]
+#[cfg(any(
+    feature = "fmp",
+    feature = "polygon",
+    feature = "alphavantage",
+    feature = "crypto"
+))]
 pub use discovery::Discovery;
 #[cfg(any(
     feature = "alphavantage",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,17 @@ pub mod fred {
 #[cfg(feature = "crypto")]
 pub mod crypto {
     //! CoinGecko cryptocurrency data (requires `crypto` feature).
-    pub use crate::adapters::coingecko::{CoinQuote, coin, coins};
+    //!
+    //! Keyless shortcuts, the crypto counterpart to [`finance`](crate::finance).
+    //! [`Market::crypto_trending`](crate::domains::Market::crypto_trending) and
+    //! [`crypto_global`](crate::domains::Market::crypto_global) reach the same
+    //! data through provider routing when other CRYPTO providers are configured.
+    pub use crate::adapters::coingecko::{
+        CoinQuote, coin, coins, fetch_crypto_global_response as global,
+        fetch_crypto_trending_response as trending, fetch_symbol_search_response as search,
+    };
+    pub use crate::models::crypto::{GlobalCryptoStats, TrendingCoin};
+    pub use crate::models::discovery::reference::SymbolMatch;
 }
 
 #[cfg(feature = "gdelt")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,7 +278,12 @@ pub use domains::{EconomicCatalog, EconomicIndicator};
 // Remaining Capability handles — indices, futures, commodities, filings, discovery
 #[cfg(any(feature = "fmp", feature = "alphavantage"))]
 pub use domains::Commodity;
-#[cfg(any(feature = "fmp", feature = "polygon", feature = "alphavantage"))]
+#[cfg(any(
+    feature = "fmp",
+    feature = "polygon",
+    feature = "alphavantage",
+    feature = "crypto"
+))]
 pub use domains::Discovery;
 pub use domains::Filings;
 #[cfg(any(feature = "polygon", feature = "cftc"))]
@@ -287,8 +292,13 @@ pub use domains::FuturesContract;
 pub use domains::Index;
 #[cfg(feature = "polygon")]
 pub use domains::Snapshot;
+// `Market` is unconditional — its grouped-daily/crypto methods route through
+// CHART/CRYPTO, which have their own (broader) per-method gating rather than
+// requiring fmp/polygon/alphavantage. `MarketCalendar` still needs one of them
+// since `CalendarProvider` itself is gated to that set.
+pub use domains::Market;
 #[cfg(any(feature = "fmp", feature = "polygon", feature = "alphavantage"))]
-pub use domains::{Market, MarketCalendar};
+pub use domains::MarketCalendar;
 
 // Provider-specific financial data functions
 // (FMP, Polygon, Alpha Vantage — defined in the finance module)
@@ -318,7 +328,12 @@ pub use tickers::BatchIndicatorsResponse;
 // Capability-routed response types (DISCOVERY / CALENDAR / MARKET)
 #[cfg(any(feature = "fmp", feature = "polygon", feature = "alphavantage"))]
 pub use models::calendar::market::{CalendarDetail, CalendarKind, MarketCalendarEntry};
-#[cfg(any(feature = "fmp", feature = "polygon", feature = "alphavantage"))]
+#[cfg(any(
+    feature = "fmp",
+    feature = "polygon",
+    feature = "alphavantage",
+    feature = "crypto"
+))]
 pub use models::discovery::reference::{
     ExchangeInfo, ScreenerFilters, ScreenerMatch, SymbolDetails, SymbolMatch,
 };

--- a/src/models/calendar/market.rs
+++ b/src/models/calendar/market.rs
@@ -23,6 +23,9 @@ pub enum CalendarKind {
     Economic,
     /// Market holidays and early closes.
     MarketHoliday,
+    /// Live exchange open/closed status — a snapshot, not a dated event, so
+    /// providers serving it ignore the `from`/`to` range.
+    MarketStatus,
 }
 
 impl CalendarKind {
@@ -36,6 +39,7 @@ impl CalendarKind {
             Self::Split => Operation::SplitCalendar,
             Self::Economic => Operation::EconomicCalendar,
             Self::MarketHoliday => Operation::HolidayCalendar,
+            Self::MarketStatus => Operation::MarketStatus,
         }
     }
 }

--- a/src/models/crypto/mod.rs
+++ b/src/models/crypto/mod.rs
@@ -67,3 +67,47 @@ pub struct CoinQuote {
     /// Market cap rank (1 = highest market cap)
     pub market_cap_rank: Option<u32>,
 }
+
+/// A coin trending in the last 24h, from CoinGecko's `/search/trending`.
+///
+/// Obtain via [`Market::crypto_trending`](crate::domains::Market::crypto_trending).
+#[cfg(feature = "crypto")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct TrendingCoin {
+    /// CoinGecko coin ID (e.g., `"bitcoin"`)
+    pub id: Option<String>,
+    /// Ticker symbol in uppercase (e.g., `"BTC"`)
+    pub symbol: Option<String>,
+    /// Full coin name (e.g., `"Bitcoin"`)
+    pub name: Option<String>,
+    /// Market cap rank (1 = highest market cap)
+    pub market_cap_rank: Option<u32>,
+    /// Price denominated in BTC
+    pub price_btc: Option<f64>,
+    /// Trending rank (0 = most trending)
+    pub score: Option<u32>,
+}
+
+/// Aggregate global cryptocurrency market statistics, from CoinGecko's `/global`.
+///
+/// Obtain via [`Market::crypto_global`](crate::domains::Market::crypto_global).
+#[cfg(feature = "crypto")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct GlobalCryptoStats {
+    /// Number of active cryptocurrencies tracked
+    pub active_cryptocurrencies: Option<u32>,
+    /// Number of markets tracked
+    pub markets: Option<u32>,
+    /// Total market capitalisation in USD across all tracked coins
+    pub total_market_cap_usd: Option<f64>,
+    /// Total 24-hour trading volume in USD across all tracked coins
+    pub total_volume_usd: Option<f64>,
+    /// Bitcoin's percentage of total market cap
+    pub btc_dominance: Option<f64>,
+    /// Ethereum's percentage of total market cap
+    pub eth_dominance: Option<f64>,
+    /// 24-hour percentage change in total market cap (USD)
+    pub market_cap_change_percentage_24h_usd: Option<f64>,
+}

--- a/src/models/discovery/mod.rs
+++ b/src/models/discovery/mod.rs
@@ -8,7 +8,12 @@ pub mod figi;
 /// Type-filtered symbol lookup.
 pub mod lookup;
 /// Provider-routed symbol reference data (search, details, exchanges, screener).
-#[cfg(any(feature = "fmp", feature = "polygon", feature = "alphavantage"))]
+#[cfg(any(
+    feature = "fmp",
+    feature = "polygon",
+    feature = "alphavantage",
+    feature = "crypto"
+))]
 pub mod reference;
 /// Predefined and custom screeners.
 pub mod screeners;

--- a/src/models/discovery/reference.rs
+++ b/src/models/discovery/reference.rs
@@ -11,8 +11,13 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct SymbolMatch {
-    /// Ticker symbol.
+    /// Ticker symbol, uppercased.
     pub symbol: String,
+    /// Provider-native identifier, when the provider uses one distinct from
+    /// the ticker — e.g. the CoinGecko coin id (`"bitcoin"`), which is what
+    /// [`Providers::crypto`](crate::Providers::crypto) accepts. `None` for
+    /// providers whose ticker *is* the identifier.
+    pub id: Option<String>,
     /// Security or company name.
     pub name: Option<String>,
     /// Listing exchange, as reported by the provider.
@@ -23,6 +28,12 @@ pub struct SymbolMatch {
     pub currency: Option<String>,
     /// Whether the symbol is currently active/tradable.
     pub active: Option<bool>,
+    /// Rank within the provider's universe by market cap (1 = largest).
+    pub market_cap_rank: Option<u32>,
+    /// Small logo/icon URL.
+    pub thumbnail: Option<String>,
+    /// Full-size logo URL.
+    pub image: Option<String>,
 }
 
 /// Detailed reference data for a single symbol.
@@ -252,18 +263,17 @@ impl ScreenerFilters {
     }
 }
 
-#[cfg(test)]
+// Gated as a whole: every test here exercises `to_query`, which is fmp-only.
+#[cfg(all(test, feature = "fmp"))]
 mod tests {
     use super::*;
 
     #[test]
-    #[cfg(feature = "fmp")]
     fn empty_filters_render_no_query_params() {
         assert!(ScreenerFilters::new().to_query().is_empty());
     }
 
     #[test]
-    #[cfg(feature = "fmp")]
     fn set_filters_render_with_provider_parameter_names() {
         let q = ScreenerFilters::new()
             .market_cap(Some(1e9), None)

--- a/src/models/discovery/reference.rs
+++ b/src/models/discovery/reference.rs
@@ -217,6 +217,7 @@ impl ScreenerFilters {
     ///
     /// Uses Financial Modeling Prep's parameter names — the only provider
     /// currently routed for `Capability::DISCOVERY` screening.
+    #[cfg(feature = "fmp")]
     pub(crate) fn to_query(&self) -> Vec<(&'static str, String)> {
         let mut q: Vec<(&'static str, String)> = Vec::new();
         let mut num = |k: &'static str, v: Option<f64>| {
@@ -256,11 +257,13 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg(feature = "fmp")]
     fn empty_filters_render_no_query_params() {
         assert!(ScreenerFilters::new().to_query().is_empty());
     }
 
     #[test]
+    #[cfg(feature = "fmp")]
     fn set_filters_render_with_provider_parameter_names() {
         let q = ScreenerFilters::new()
             .market_cap(Some(1e9), None)

--- a/src/providers/adapter.rs
+++ b/src/providers/adapter.rs
@@ -83,6 +83,34 @@ pub(crate) trait ChartProvider: ProviderCore {
     ) -> Result<Vec<(String, crate::models::chart::spark::Spark)>> {
         Err(self.not_supported(Operation::Spark))
     }
+
+    /// Fetch grouped daily OHLCV bars for every stock ticker on `date`
+    /// (`YYYY-MM-DD`) in a single request — market-wide rather than
+    /// symbol-scoped. Returns `(symbol, candle)` pairs.
+    async fn fetch_grouped_daily(
+        &self,
+        _date: &str,
+    ) -> Result<Vec<(String, crate::models::chart::Candle)>> {
+        Err(self.not_supported(Operation::GroupedDaily))
+    }
+
+    /// Fetch grouped daily OHLCV bars for every crypto ticker on `date`
+    /// (`YYYY-MM-DD`) in a single request. Returns `(symbol, candle)` pairs.
+    async fn fetch_crypto_grouped_daily(
+        &self,
+        _date: &str,
+    ) -> Result<Vec<(String, crate::models::chart::Candle)>> {
+        Err(self.not_supported(Operation::CryptoGroupedDaily))
+    }
+
+    /// Fetch grouped daily OHLCV bars for every forex ticker on `date`
+    /// (`YYYY-MM-DD`) in a single request. Returns `(symbol, candle)` pairs.
+    async fn fetch_forex_grouped_daily(
+        &self,
+        _date: &str,
+    ) -> Result<Vec<(String, crate::models::chart::Candle)>> {
+        Err(self.not_supported(Operation::ForexGroupedDaily))
+    }
 }
 
 /// [`Capability::FUNDAMENTALS`] — financial statements and share-supply data.

--- a/src/providers/adapter.rs
+++ b/src/providers/adapter.rs
@@ -307,7 +307,12 @@ pub(crate) trait FilingsProvider: ProviderCore {
 
 /// [`Capability::DISCOVERY`] — symbol search, reference data, exchanges,
 /// screeners.
-#[cfg(any(feature = "fmp", feature = "polygon", feature = "alphavantage"))]
+#[cfg(any(
+    feature = "fmp",
+    feature = "polygon",
+    feature = "alphavantage",
+    feature = "crypto"
+))]
 #[async_trait::async_trait]
 pub(crate) trait DiscoveryProvider: ProviderCore {
     /// Search the provider's symbol universe by free-text query.
@@ -445,6 +450,18 @@ pub(crate) trait CryptoProvider: ProviderCore {
         _protocol: &str,
     ) -> Result<Vec<crate::models::crypto::defi::TvlPoint>> {
         Err(self.not_supported(Operation::ProtocolTvlHistory))
+    }
+
+    /// Fetch coins/nfts/categories trending in the last 24h (CoinGecko only).
+    #[cfg(feature = "crypto")]
+    async fn fetch_crypto_trending(&self) -> Result<Vec<crate::models::crypto::TrendingCoin>> {
+        Err(self.not_supported(Operation::CryptoTrending))
+    }
+
+    /// Fetch aggregate global cryptocurrency market statistics (CoinGecko only).
+    #[cfg(feature = "crypto")]
+    async fn fetch_crypto_global(&self) -> Result<crate::models::crypto::GlobalCryptoStats> {
+        Err(self.not_supported(Operation::CryptoGlobal))
     }
 }
 
@@ -599,7 +616,12 @@ pub(crate) trait ProviderAdapter: ProviderCore {
     fn as_filings(&self) -> Option<&dyn FilingsProvider> {
         None
     }
-    #[cfg(any(feature = "fmp", feature = "polygon", feature = "alphavantage"))]
+    #[cfg(any(
+        feature = "fmp",
+        feature = "polygon",
+        feature = "alphavantage",
+        feature = "crypto"
+    ))]
     fn as_discovery(&self) -> Option<&dyn DiscoveryProvider> {
         None
     }
@@ -680,14 +702,18 @@ pub(crate) trait ProviderAdapter: ProviderCore {
         if self.as_market().is_some() {
             caps = caps | Capability::MARKET;
         }
+        #[cfg(any(
+            feature = "fmp",
+            feature = "polygon",
+            feature = "alphavantage",
+            feature = "crypto"
+        ))]
+        if self.as_discovery().is_some() {
+            caps = caps | Capability::DISCOVERY;
+        }
         #[cfg(any(feature = "fmp", feature = "polygon", feature = "alphavantage"))]
-        {
-            if self.as_discovery().is_some() {
-                caps = caps | Capability::DISCOVERY;
-            }
-            if self.as_calendar().is_some() {
-                caps = caps | Capability::CALENDAR;
-            }
+        if self.as_calendar().is_some() {
+            caps = caps | Capability::CALENDAR;
         }
         #[cfg(any(
             feature = "alphavantage",

--- a/src/providers/alphavantage.rs
+++ b/src/providers/alphavantage.rs
@@ -4,9 +4,9 @@
 //! in the adapter functions under `crate::adapters::alphavantage::*`.
 
 use super::{
-    ChartProvider, CommoditiesProvider, CorporateProvider, CryptoProvider, DiscoveryProvider,
-    EconomicProvider, ForexProvider, FundamentalsProvider, MarketProvider, OptionsProvider,
-    ProviderAdapter, ProviderCore, QuoteProvider,
+    CalendarProvider, ChartProvider, CommoditiesProvider, CorporateProvider, CryptoProvider,
+    DiscoveryProvider, EconomicProvider, FilingsProvider, ForexProvider, FundamentalsProvider,
+    MarketProvider, Operation, OptionsProvider, ProviderAdapter, ProviderCore, QuoteProvider,
 };
 use crate::adapters::alphavantage as av;
 use crate::error::Result;
@@ -179,6 +179,53 @@ impl MarketProvider for AlphaVantageProvider {
 }
 
 #[async_trait::async_trait]
+impl CalendarProvider for AlphaVantageProvider {
+    /// Alpha Vantage serves live exchange open/closed status only, mapped
+    /// onto [`CalendarKind::MarketHoliday`](crate::models::calendar::market::CalendarKind::MarketHoliday)
+    /// — the closest existing shape — as an additional fallback route beside
+    /// Polygon's holiday calendar. Other kinds fall through to the next
+    /// routed provider. `from`/`to` are ignored: this is a live snapshot, not
+    /// a dated event.
+    async fn fetch_market_calendar(
+        &self,
+        kind: crate::models::calendar::market::CalendarKind,
+        _from: &str,
+        _to: &str,
+    ) -> Result<Vec<crate::models::calendar::market::MarketCalendarEntry>> {
+        if kind != crate::models::calendar::market::CalendarKind::MarketHoliday {
+            return Err(self.not_supported(kind.operation()));
+        }
+        av::fetch_market_status_response().await
+    }
+}
+
+/// `fetch_filings` is the trait's required primary operation, but Alpha
+/// Vantage publishes no raw SEC filing surface — only insider transactions —
+/// so it reports `NotSupported` there and dispatch falls through to the next
+/// routed provider (EDGAR).
+#[async_trait::async_trait]
+impl FilingsProvider for AlphaVantageProvider {
+    async fn fetch_filings(
+        &self,
+        _symbol: &str,
+    ) -> Result<crate::models::filings::ProviderFilings> {
+        Err(self.not_supported(Operation::Filings))
+    }
+
+    /// A second route for the ownership surface alongside EDGAR — Alpha
+    /// Vantage's `INSIDER_TRANSACTIONS` is coarser (no accession number, form
+    /// type, or derivative/non-derivative distinction) but covers the same
+    /// canonical [`InsiderTrade`](crate::models::filings::InsiderTrade) model.
+    async fn fetch_insider_trades(
+        &self,
+        symbol: &str,
+        limit: u32,
+    ) -> Result<Vec<crate::models::filings::InsiderTrade>> {
+        av::corporate::fetch_insider_trades_response(symbol, limit).await
+    }
+}
+
+#[async_trait::async_trait]
 impl ProviderAdapter for AlphaVantageProvider {
     async fn initialize(&self) -> Result<()> {
         let key = std::env::var("ALPHAVANTAGE_API_KEY").map_err(|_| {
@@ -223,6 +270,12 @@ impl ProviderAdapter for AlphaVantageProvider {
         Some(self)
     }
     fn as_discovery(&self) -> Option<&dyn DiscoveryProvider> {
+        Some(self)
+    }
+    fn as_calendar(&self) -> Option<&dyn CalendarProvider> {
+        Some(self)
+    }
+    fn as_filings(&self) -> Option<&dyn FilingsProvider> {
         Some(self)
     }
 }

--- a/src/providers/alphavantage.rs
+++ b/src/providers/alphavantage.rs
@@ -180,19 +180,16 @@ impl MarketProvider for AlphaVantageProvider {
 
 #[async_trait::async_trait]
 impl CalendarProvider for AlphaVantageProvider {
-    /// Alpha Vantage serves live exchange open/closed status only, mapped
-    /// onto [`CalendarKind::MarketHoliday`](crate::models::calendar::market::CalendarKind::MarketHoliday)
-    /// — the closest existing shape — as an additional fallback route beside
-    /// Polygon's holiday calendar. Other kinds fall through to the next
-    /// routed provider. `from`/`to` are ignored: this is a live snapshot, not
-    /// a dated event.
+    /// Alpha Vantage serves live exchange open/closed status only. Other
+    /// kinds fall through to the next routed provider. `from`/`to` are
+    /// ignored: this is a snapshot, not a dated event.
     async fn fetch_market_calendar(
         &self,
         kind: crate::models::calendar::market::CalendarKind,
         _from: &str,
         _to: &str,
     ) -> Result<Vec<crate::models::calendar::market::MarketCalendarEntry>> {
-        if kind != crate::models::calendar::market::CalendarKind::MarketHoliday {
+        if kind != crate::models::calendar::market::CalendarKind::MarketStatus {
             return Err(self.not_supported(kind.operation()));
         }
         av::fetch_market_status_response().await

--- a/src/providers/coingecko.rs
+++ b/src/providers/coingecko.rs
@@ -1,6 +1,6 @@
 //! CoinGecko provider implementation.
 
-use super::{ChartProvider, CryptoProvider, ProviderAdapter, ProviderCore};
+use super::{ChartProvider, CryptoProvider, DiscoveryProvider, ProviderAdapter, ProviderCore};
 use crate::error::Result;
 
 pub(crate) struct CoinGeckoProvider;
@@ -19,6 +19,25 @@ impl CryptoProvider for CoinGeckoProvider {
         vs_currency: &str,
     ) -> Result<crate::models::crypto::CryptoQuote> {
         crate::adapters::coingecko::fetch_crypto_quote_response(id, vs_currency).await
+    }
+
+    async fn fetch_crypto_trending(&self) -> Result<Vec<crate::models::crypto::TrendingCoin>> {
+        crate::adapters::coingecko::fetch_crypto_trending_response().await
+    }
+
+    async fn fetch_crypto_global(&self) -> Result<crate::models::crypto::GlobalCryptoStats> {
+        crate::adapters::coingecko::fetch_crypto_global_response().await
+    }
+}
+
+#[async_trait::async_trait]
+impl DiscoveryProvider for CoinGeckoProvider {
+    async fn fetch_symbol_search(
+        &self,
+        query: &str,
+        limit: u32,
+    ) -> Result<Vec<crate::models::discovery::reference::SymbolMatch>> {
+        crate::adapters::coingecko::fetch_symbol_search_response(query, limit).await
     }
 }
 
@@ -43,6 +62,9 @@ impl ProviderAdapter for CoinGeckoProvider {
         Some(self)
     }
     fn as_chart(&self) -> Option<&dyn ChartProvider> {
+        Some(self)
+    }
+    fn as_discovery(&self) -> Option<&dyn DiscoveryProvider> {
         Some(self)
     }
 }

--- a/src/providers/config.rs
+++ b/src/providers/config.rs
@@ -155,7 +155,12 @@ impl Providers {
     /// Routes symbol search, reference data, and screening through
     /// [`Capability::DISCOVERY`](crate::Capability::DISCOVERY). Distinct from
     /// [`crate::finance::search`], which is a Yahoo-only shortcut.
-    #[cfg(any(feature = "fmp", feature = "polygon", feature = "alphavantage"))]
+    #[cfg(any(
+        feature = "fmp",
+        feature = "polygon",
+        feature = "alphavantage",
+        feature = "crypto"
+    ))]
     pub fn discovery(&self) -> crate::domains::Discovery {
         crate::domains::Discovery::with_providers(Arc::clone(&self.set))
     }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -497,6 +497,8 @@ pub enum Operation {
     SectorPerformanceHistory,
     /// Market-wide holiday calendar.
     HolidayCalendar,
+    /// Live exchange open/closed status.
+    MarketStatus,
     /// Current constituents of a major index.
     IndexConstituents,
     /// Historical constituent changes of a major index.
@@ -604,6 +606,7 @@ impl Operation {
             Self::MarketMovers => "market_movers",
             Self::SectorPerformanceHistory => "sector_performance_history",
             Self::HolidayCalendar => "holiday_calendar",
+            Self::MarketStatus => "market_status",
             Self::IndexConstituents => "index_constituents",
             Self::IndexConstituentChanges => "index_constituent_changes",
             Self::ShortInterest => "short_interest",
@@ -706,7 +709,8 @@ impl Operation {
             | Self::DividendCalendar
             | Self::SplitCalendar
             | Self::EconomicCalendar
-            | Self::HolidayCalendar => Capability::CALENDAR,
+            | Self::HolidayCalendar
+            | Self::MarketStatus => Capability::CALENDAR,
             Self::SectorPerformance | Self::MarketMovers | Self::SectorPerformanceHistory => {
                 Capability::MARKET
             }
@@ -1061,6 +1065,13 @@ pub(crate) fn range_to_dates(range: crate::TimeRange) -> (String, String) {
     )
 }
 
+/// Keyed on identity, not `capabilities().contains(FILINGS)`: a provider may
+/// advertise FILINGS only to reach a secondary op (Alpha Vantage does, for
+/// insider trades), which would otherwise suppress the real filings source.
+fn needs_edgar_injection(ids: &[Provider]) -> bool {
+    !ids.contains(&Provider::Edgar)
+}
+
 pub(crate) async fn build_providers(
     ids: &[Provider],
     config: &ClientConfig,
@@ -1111,11 +1122,7 @@ pub(crate) async fn build_providers(
         adapter.initialize().await?;
         providers.push(adapter);
     }
-    // Auto-inject EDGAR if no other FILINGS-capable provider was configured
-    let has_filings = providers
-        .iter()
-        .any(|p| p.capabilities().contains(Capability::FILINGS));
-    if !has_filings {
+    if needs_edgar_injection(ids) {
         providers.push(Arc::new(edgar::EdgarProvider));
     }
     Ok(ProviderSet::new(providers, yahoo_client, routes))
@@ -1370,5 +1377,23 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, FinanceError::ApiError(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn edgar_is_injected_unless_configured_explicitly() {
+        assert!(needs_edgar_injection(&[Provider::Yahoo]));
+        assert!(!needs_edgar_injection(&[Provider::Yahoo, Provider::Edgar]));
+    }
+
+    /// Alpha Vantage advertises FILINGS for insider trades only, so a
+    /// capability-based check would drop EDGAR and break `filings()`.
+    #[test]
+    #[cfg(feature = "alphavantage")]
+    fn a_filings_advertising_provider_does_not_suppress_edgar() {
+        assert!(
+            ProviderAdapter::capabilities(&alphavantage::AlphaVantageProvider)
+                .contains(Capability::FILINGS)
+        );
+        assert!(needs_edgar_injection(&[Provider::AlphaVantage]));
     }
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -556,6 +556,12 @@ pub enum Operation {
     EtfProfile,
     /// The provider's whole listed-security universe.
     ListingStatus,
+    /// Grouped daily OHLCV bars for every stock ticker on one date.
+    GroupedDaily,
+    /// Grouped daily OHLCV bars for every crypto ticker on one date.
+    CryptoGroupedDaily,
+    /// Grouped daily OHLCV bars for every forex ticker on one date.
+    ForexGroupedDaily,
 }
 
 impl Operation {
@@ -623,6 +629,9 @@ impl Operation {
             Self::EconomicReleases => "economic_releases",
             Self::EtfProfile => "etf_profile",
             Self::ListingStatus => "listing_status",
+            Self::GroupedDaily => "grouped_daily",
+            Self::CryptoGroupedDaily => "crypto_grouped_daily",
+            Self::ForexGroupedDaily => "forex_grouped_daily",
         }
     }
 
@@ -630,7 +639,12 @@ impl Operation {
     pub fn capability(self) -> Capability {
         match self {
             Self::Quote | Self::QuotesBatch | Self::UnifiedSnapshot => Capability::QUOTE,
-            Self::Chart | Self::ChartRange | Self::Spark => Capability::CHART,
+            Self::Chart
+            | Self::ChartRange
+            | Self::Spark
+            | Self::GroupedDaily
+            | Self::CryptoGroupedDaily
+            | Self::ForexGroupedDaily => Capability::CHART,
             Self::Financials
             | Self::ShortInterest
             | Self::ShortVolume

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -562,6 +562,12 @@ pub enum Operation {
     CryptoGroupedDaily,
     /// Grouped daily OHLCV bars for every forex ticker on one date.
     ForexGroupedDaily,
+    /// Coins/nfts/categories trending in the last 24h.
+    #[cfg(feature = "crypto")]
+    CryptoTrending,
+    /// Aggregate global cryptocurrency market statistics.
+    #[cfg(feature = "crypto")]
+    CryptoGlobal,
 }
 
 impl Operation {
@@ -632,6 +638,10 @@ impl Operation {
             Self::GroupedDaily => "grouped_daily",
             Self::CryptoGroupedDaily => "crypto_grouped_daily",
             Self::ForexGroupedDaily => "forex_grouped_daily",
+            #[cfg(feature = "crypto")]
+            Self::CryptoTrending => "crypto_trending",
+            #[cfg(feature = "crypto")]
+            Self::CryptoGlobal => "crypto_global",
         }
     }
 
@@ -665,6 +675,8 @@ impl Operation {
             Self::CryptoQuote => Capability::CRYPTO,
             #[cfg(feature = "defi")]
             Self::ProtocolTvl | Self::ProtocolTvlHistory => Capability::CRYPTO,
+            #[cfg(feature = "crypto")]
+            Self::CryptoTrending | Self::CryptoGlobal => Capability::CRYPTO,
             Self::EconomicSeries
             | Self::EconomicSeriesAsOf
             | Self::EconomicSearch

--- a/src/providers/polygon.rs
+++ b/src/providers/polygon.rs
@@ -59,6 +59,27 @@ impl ChartProvider for PolygonProvider {
     ) -> Result<crate::models::chart::Chart> {
         polygon::fetch_chart_range_response(symbol, interval, start, end).await
     }
+
+    async fn fetch_grouped_daily(
+        &self,
+        date: &str,
+    ) -> Result<Vec<(String, crate::models::chart::Candle)>> {
+        polygon::fetch_grouped_daily_response(date).await
+    }
+
+    async fn fetch_crypto_grouped_daily(
+        &self,
+        date: &str,
+    ) -> Result<Vec<(String, crate::models::chart::Candle)>> {
+        polygon::fetch_crypto_grouped_daily_response(date).await
+    }
+
+    async fn fetch_forex_grouped_daily(
+        &self,
+        date: &str,
+    ) -> Result<Vec<(String, crate::models::chart::Candle)>> {
+        polygon::fetch_forex_grouped_daily_response(date).await
+    }
 }
 
 #[async_trait::async_trait]

--- a/src/streaming/source.rs
+++ b/src/streaming/source.rs
@@ -56,7 +56,7 @@ where
 /// Drive a [`StreamSource`] with automatic reconnection until it shuts down.
 ///
 /// `retry_delay` is supplied by the caller rather than hard-coded so a smarter
-/// policy (see issue #276) can be swapped in without touching sources.
+/// policy can be swapped in without touching sources.
 pub(crate) async fn run_stream_loop<T>(
     source: Arc<dyn StreamSource<T>>,
     initial_symbols: Vec<String>,


### PR DESCRIPTION
## Description
Polygon, Alpha Vantage, and CoinGecko already had most of this built. The grouped-daily aggregate functions, insider transactions, market status, and CoinGecko's search/trending/global endpoints already existed in the adapters, just never routed through the public API. This PR wires all three providers in.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Added `Market::grouped_daily()`, `crypto_grouped_daily()`, `forex_grouped_daily()`: one Polygon request returns every ticker's OHLC for a date instead of one request per symbol.
- Polygon has no grouped-daily endpoint for options, indices, or futures. Left those three modules unrouted with a comment explaining why.
- Added `MarketCalendar::market_status()` for Alpha Vantage's live exchange open/closed status.
- Added insider transactions as a second `FilingsProvider` route on Alpha Vantage.
- EDGAR auto-injection now keys on provider identity instead of the FILINGS capability bit. Alpha Vantage advertises FILINGS to reach insider data but doesn't serve real filings, so it was silently dropping EDGAR.
- Added CoinGecko search, trending, and global market stats as new provider routes.
- Fixed CoinGecko search putting the coin id in `symbol` instead of the ticker.
- Exposed all three new CoinGecko endpoints on the server. Keyless, no API key needed.
- The five new `Market` methods route through the existing `dispatch_via!` macro instead of hand-rolled dispatch.

## Breaking Changes
None.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] All tests pass (`cargo test`)

`cargo test --lib --features full`: 1162 passed, 0 failed.

## Documentation
- [x] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [x] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy`)
- [x] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues
Closes #245
Closes #264
Closes #267