### PR TITLE
feat: retry policy, provider health, and streaming backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -275,6 +275,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   matching every other DISCOVERY provider; it previously put the CoinGecko coin
   id there, which broke the provider-neutral contract for consumers searching
   across providers.
+- `RetryPolicy` honored an error's `retry_after` hint with no ceiling, so a
+  hostile or buggy upstream could park a caller indefinitely. Capped by the
+  new `max_retry_after` (default 5 minutes), kept separate from `max_delay`
+  so legitimate multi-minute hints are still honored.
+- A stream whose session came up and then failed a few seconds in — auth
+  rejection, subscription error, idle kill — reset the reconnect counter
+  every cycle and retried forever despite `max_reconnect_attempts`. The
+  healthy-session threshold is now 60s, independent of the (short) base
+  delay it was keyed to.
+- A zero base delay produced the maximum delay instead of zero at high
+  attempt counts (`0.0 * inf` is NaN, and `f64::min` returns the other
+  operand for NaN).
 
 - `finance::hours()` no longer labels every region's market "U.S. markets".
   Yahoo returns correct per-region session times but hardcodes the U.S.

--- a/src/adapters/singleton.rs
+++ b/src/adapters/singleton.rs
@@ -54,6 +54,17 @@ macro_rules! provider_singleton_state {
                     reason: $already_init_reason.to_string(),
                 })
         }
+
+        /// The shared rate limiter backing this provider's singleton, for
+        /// health/budget introspection (issue #276). `None` before `init`/
+        /// `init_with_timeout` has been called.
+        #[allow(dead_code)]
+        pub(crate) fn rate_limiter()
+        -> ::std::option::Option<::std::sync::Arc<crate::rate_limiter::RateLimiter>> {
+            $static_name
+                .get()
+                .map(|s| ::std::sync::Arc::clone(&s.limiter))
+        }
     };
 }
 

--- a/src/adapters/singleton.rs
+++ b/src/adapters/singleton.rs
@@ -56,7 +56,7 @@ macro_rules! provider_singleton_state {
         }
 
         /// The shared rate limiter backing this provider's singleton, for
-        /// health/budget introspection (issue #276). `None` before `init`/
+        /// health/budget introspection. `None` before `init`/
         /// `init_with_timeout` has been called.
         #[allow(dead_code)]
         pub(crate) fn rate_limiter()

--- a/src/backoff.rs
+++ b/src/backoff.rs
@@ -19,9 +19,37 @@ pub(crate) fn exponential_delay(
     max: Duration,
 ) -> Duration {
     let base_secs = base.as_secs_f64();
+    // A zero base stays zero: `0.0 * inf` is NaN at high attempt counts, and
+    // `f64::min` returns the *other* operand for NaN, which would silently
+    // promote a no-delay config to the cap.
+    if base_secs <= 0.0 {
+        return Duration::ZERO;
+    }
     let factor = multiplier.max(1.0).powi(attempt as i32);
     let secs = (base_secs * factor).min(max.as_secs_f64());
     Duration::from_secs_f64(secs.max(0.0))
+}
+
+/// The four knobs every backoff sequence here needs, so `RetryPolicy` and
+/// `ReconnectConfig` share one implementation instead of two copies of the
+/// same nested `with_jitter(exponential_delay(..))` call.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct BackoffParams {
+    pub base: Duration,
+    pub max: Duration,
+    pub multiplier: f64,
+    pub jitter: f64,
+}
+
+impl BackoffParams {
+    /// Jittered delay before the retry/reconnect numbered `attempt` (0-indexed).
+    pub(crate) fn delay_for(&self, attempt: u32, seed: &mut u64) -> Duration {
+        with_jitter(
+            exponential_delay(attempt, self.base, self.multiplier, self.max),
+            self.jitter,
+            seed,
+        )
+    }
 }
 
 /// Apply a `+/- jitter` fraction (clamped to `0.0..=1.0`) of randomness to a
@@ -90,6 +118,19 @@ mod tests {
         let max = Duration::from_secs(60);
         // A multiplier < 1.0 is clamped to 1.0 - the delay never shrinks.
         assert_eq!(exponential_delay(5, base, 0.1, max), base);
+    }
+
+    #[test]
+    fn a_zero_base_delay_stays_zero_at_every_attempt() {
+        // `0.0 * inf` is NaN, and `f64::min` would return the cap instead.
+        let max = Duration::from_secs(60);
+        for attempt in [0, 1, 10, 100, 1000] {
+            assert_eq!(
+                exponential_delay(attempt, Duration::ZERO, 2.0, max),
+                Duration::ZERO,
+                "attempt {attempt}"
+            );
+        }
     }
 
     #[test]

--- a/src/backoff.rs
+++ b/src/backoff.rs
@@ -1,0 +1,139 @@
+//! Shared exponential-backoff-with-jitter delay computation.
+//!
+//! Used by both provider dispatch retries ([`crate::providers::config::ProvidersBuilder::retry`])
+//! and streaming reconnection (`src/streaming/source.rs`) so the two features
+//! share one tested implementation instead of two hand-rolled copies.
+
+use std::time::Duration;
+
+/// Deterministic exponential delay for a zero-indexed attempt number, before
+/// jitter is applied.
+///
+/// `attempt` `0` is the delay before the *first* retry/reconnect. Grows by
+/// `multiplier` per attempt (clamped to at least `1.0` so a misconfigured
+/// multiplier can't shrink the delay), capped at `max`.
+pub(crate) fn exponential_delay(
+    attempt: u32,
+    base: Duration,
+    multiplier: f64,
+    max: Duration,
+) -> Duration {
+    let base_secs = base.as_secs_f64();
+    let factor = multiplier.max(1.0).powi(attempt as i32);
+    let secs = (base_secs * factor).min(max.as_secs_f64());
+    Duration::from_secs_f64(secs.max(0.0))
+}
+
+/// Apply a `+/- jitter` fraction (clamped to `0.0..=1.0`) of randomness to a
+/// delay, so many concurrently-retrying callers don't retry in lockstep.
+///
+/// Uses a tiny internal xorshift64 PRNG seeded by the caller rather than
+/// pulling in a `rand` dependency for this one call site — the jitter only
+/// needs to be "random enough to desynchronize retries," not
+/// cryptographically strong.
+pub(crate) fn with_jitter(delay: Duration, jitter: f64, seed: &mut u64) -> Duration {
+    let jitter = jitter.clamp(0.0, 1.0);
+    if jitter == 0.0 {
+        return delay;
+    }
+    let r = next_unit_f64(seed);
+    // r in [0,1) -> factor in [1-jitter, 1+jitter]
+    let factor = 1.0 + (r * 2.0 - 1.0) * jitter;
+    Duration::from_secs_f64((delay.as_secs_f64() * factor).max(0.0))
+}
+
+/// Advance the xorshift64 state and return a value in `[0.0, 1.0)`.
+fn next_unit_f64(state: &mut u64) -> f64 {
+    if *state == 0 {
+        // xorshift is stuck at 0 forever; recover with a fixed nonzero seed.
+        *state = 0x9E3779B97F4A7C15;
+    }
+    *state ^= *state << 13;
+    *state ^= *state >> 7;
+    *state ^= *state << 17;
+    (*state >> 11) as f64 / (1u64 << 53) as f64
+}
+
+/// A seed for [`with_jitter`] derived from the current time, so independent
+/// reconnect loops/retry sequences don't share the same jitter sequence.
+pub(crate) fn seed_from_time() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0x2545_F491_4F6C_DD1D);
+    // XOR with a fixed odd constant so a `nanos` of 0 (unlikely, but possible
+    // in a mocked clock) still yields a nonzero, well-mixed seed.
+    nanos ^ 0x9E3779B97F4A7C15
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exponential_delay_doubles_by_default_and_caps() {
+        let base = Duration::from_secs(1);
+        let max = Duration::from_secs(10);
+        assert_eq!(exponential_delay(0, base, 2.0, max), Duration::from_secs(1));
+        assert_eq!(exponential_delay(1, base, 2.0, max), Duration::from_secs(2));
+        assert_eq!(exponential_delay(2, base, 2.0, max), Duration::from_secs(4));
+        assert_eq!(exponential_delay(3, base, 2.0, max), Duration::from_secs(8));
+        // Would be 16s uncapped; must clamp to max.
+        assert_eq!(exponential_delay(4, base, 2.0, max), max);
+        assert_eq!(exponential_delay(10, base, 2.0, max), max);
+    }
+
+    #[test]
+    fn exponential_delay_rejects_shrinking_multiplier() {
+        let base = Duration::from_secs(2);
+        let max = Duration::from_secs(60);
+        // A multiplier < 1.0 is clamped to 1.0 - the delay never shrinks.
+        assert_eq!(exponential_delay(5, base, 0.1, max), base);
+    }
+
+    #[test]
+    fn with_jitter_zero_is_identity() {
+        let delay = Duration::from_secs(4);
+        let mut seed = 12345u64;
+        assert_eq!(with_jitter(delay, 0.0, &mut seed), delay);
+    }
+
+    #[test]
+    fn with_jitter_stays_within_bounds() {
+        let delay = Duration::from_secs(10);
+        let mut seed = seed_from_time();
+        for _ in 0..1000 {
+            let jittered = with_jitter(delay, 0.2, &mut seed);
+            assert!(jittered.as_secs_f64() >= 8.0 - 1e-9);
+            assert!(jittered.as_secs_f64() <= 12.0 + 1e-9);
+        }
+    }
+
+    #[test]
+    fn with_jitter_full_range_never_negative() {
+        let delay = Duration::from_millis(1);
+        let mut seed = 1u64;
+        for _ in 0..1000 {
+            let jittered = with_jitter(delay, 1.0, &mut seed);
+            assert!(jittered.as_secs_f64() >= 0.0);
+            assert!(jittered.as_secs_f64() <= 0.002 + 1e-9);
+        }
+    }
+
+    #[test]
+    fn seed_from_time_is_nonzero() {
+        assert_ne!(seed_from_time(), 0);
+    }
+
+    #[test]
+    fn jitter_sequence_is_not_constant() {
+        // Sanity check that the PRNG actually advances rather than returning
+        // the same jittered value every call.
+        let delay = Duration::from_secs(10);
+        let mut seed = 42u64;
+        let a = with_jitter(delay, 0.3, &mut seed);
+        let b = with_jitter(delay, 0.3, &mut seed);
+        assert_ne!(a, b);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,7 @@ pub mod edgar {
 }
 
 // Internal modules
+mod backoff;
 mod constants;
 mod models;
 mod providers;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,7 +255,7 @@ pub mod translation;
 // ============================================================================
 pub mod domains;
 pub use providers::config::{Providers, ProvidersBuilder};
-pub use providers::{Capability, Fetch, Operation, Provider};
+pub use providers::{Capability, Fetch, Operation, Provider, ProviderHealth, RetryPolicy};
 pub use ticker::{ClientHandle, Ticker, TickerBuilder};
 
 // Domain-specific query handles — constructable via Providers factory methods.

--- a/src/providers/adapter.rs
+++ b/src/providers/adapter.rs
@@ -600,7 +600,7 @@ pub(crate) trait ProviderAdapter: ProviderCore {
 
     /// Best-effort estimate of remaining rate-limit budget — tokens
     /// currently available in this provider's own token bucket, for
-    /// [`super::Providers::health`] (issue #276). Peeking never consumes a
+    /// [`super::Providers::health`]. Peeking never consumes a
     /// token.
     ///
     /// `None` by default: providers with no local rate limiter to peek (e.g.

--- a/src/providers/adapter.rs
+++ b/src/providers/adapter.rs
@@ -598,6 +598,18 @@ pub(crate) trait ProviderAdapter: ProviderCore {
         Ok(())
     }
 
+    /// Best-effort estimate of remaining rate-limit budget — tokens
+    /// currently available in this provider's own token bucket, for
+    /// [`super::Providers::health`] (issue #276). Peeking never consumes a
+    /// token.
+    ///
+    /// `None` by default: providers with no local rate limiter to peek (e.g.
+    /// Yahoo) or whose singleton hasn't been initialized yet return `None`
+    /// rather than a misleading number.
+    fn rate_limit_remaining(&self) -> Option<f64> {
+        None
+    }
+
     fn as_quote(&self) -> Option<&dyn QuoteProvider> {
         None
     }

--- a/src/providers/alphavantage.rs
+++ b/src/providers/alphavantage.rs
@@ -236,6 +236,10 @@ impl ProviderAdapter for AlphaVantageProvider {
         Ok(())
     }
 
+    fn rate_limit_remaining(&self) -> Option<f64> {
+        av::rate_limiter().and_then(|l| l.available_estimate())
+    }
+
     fn as_quote(&self) -> Option<&dyn QuoteProvider> {
         Some(self)
     }

--- a/src/providers/config.rs
+++ b/src/providers/config.rs
@@ -331,10 +331,10 @@ impl ProvidersBuilder {
     }
 
     /// Opt into retrying `FinanceError::RateLimited` errors during dispatch
-    /// (issue #276). See [`RetryPolicy`] for the exact semantics.
+    /// See [`RetryPolicy`] for the exact semantics.
     ///
     /// **Default is no retry** — omitting this call preserves the exact
-    /// pre-#276 behavior: a `RateLimited` error is treated like any other
+    /// prior behavior: a `RateLimited` error is treated like any other
     /// failure and dispatch moves straight to the next routed provider.
     pub fn retry(mut self, policy: RetryPolicy) -> Self {
         self.retry = Some(policy);

--- a/src/providers/config.rs
+++ b/src/providers/config.rs
@@ -1,6 +1,8 @@
 use crate::adapters::yahoo::client::ClientConfig;
 use crate::error::Result;
-use crate::providers::{Fetch, Provider, ProviderSet, Routes, build_providers};
+use crate::providers::{
+    Fetch, Provider, ProviderHealth, ProviderSet, RetryPolicy, Routes, build_providers,
+};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -214,6 +216,31 @@ impl Providers {
     pub fn filings(&self, symbol: impl Into<String>) -> crate::domains::Filings {
         crate::domains::Filings::with_providers(symbol.into().into(), Arc::clone(&self.set))
     }
+
+    /// Snapshot recent health for every configured provider.
+    ///
+    /// Each [`ProviderHealth`] entry reflects up to the last 20 dispatch
+    /// outcomes recorded in-process for that provider (recency window is
+    /// internal and unspecified beyond "recent"), plus a best-effort
+    /// rate-limit budget estimate where the provider exposes one. Purely
+    /// observational — it does not affect routing or retries.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use finance_query::Providers;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let providers = Providers::builder().build().await?;
+    /// for health in providers.health() {
+    ///     println!("{:?}: healthy={}", health.provider, health.is_healthy);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn health(&self) -> Vec<ProviderHealth> {
+        self.set.health()
+    }
 }
 
 /// Builder for [`Providers`].
@@ -222,6 +249,7 @@ pub struct ProvidersBuilder {
     provider_ids: Vec<Provider>,
     config: ClientConfig,
     routes: Routes,
+    retry: Option<RetryPolicy>,
 }
 
 impl Default for ProvidersBuilder {
@@ -230,6 +258,7 @@ impl Default for ProvidersBuilder {
             provider_ids: vec![Provider::Yahoo],
             config: ClientConfig::default(),
             routes: Routes::new(Fetch::Sequential),
+            retry: None,
         }
     }
 }
@@ -301,12 +330,25 @@ impl ProvidersBuilder {
         self
     }
 
+    /// Opt into retrying `FinanceError::RateLimited` errors during dispatch
+    /// (issue #276). See [`RetryPolicy`] for the exact semantics.
+    ///
+    /// **Default is no retry** — omitting this call preserves the exact
+    /// pre-#276 behavior: a `RateLimited` error is treated like any other
+    /// failure and dispatch moves straight to the next routed provider.
+    pub fn retry(mut self, policy: RetryPolicy) -> Self {
+        self.retry = Some(policy);
+        self
+    }
+
     /// Build the [`Providers`] instance, initialising all configured providers.
     pub async fn build(self) -> Result<Providers> {
         #[cfg(feature = "translation")]
         crate::translation::Lang::parse(&self.config.lang)?;
         let lang = self.config.lang.clone();
-        let set = build_providers(&self.provider_ids, &self.config, self.routes).await?;
+        let set = build_providers(&self.provider_ids, &self.config, self.routes)
+            .await?
+            .with_retry_policy(self.retry);
         Ok(Providers {
             set: Arc::new(set),
             lang,

--- a/src/providers/fmp.rs
+++ b/src/providers/fmp.rs
@@ -331,6 +331,10 @@ impl ProviderAdapter for FmpProvider {
         Ok(())
     }
 
+    fn rate_limit_remaining(&self) -> Option<f64> {
+        crate::adapters::fmp::rate_limiter().and_then(|l| l.available_estimate())
+    }
+
     fn as_quote(&self) -> Option<&dyn QuoteProvider> {
         Some(self)
     }

--- a/src/providers/fred.rs
+++ b/src/providers/fred.rs
@@ -67,6 +67,10 @@ impl ProviderAdapter for FredProvider {
         Ok(())
     }
 
+    fn rate_limit_remaining(&self) -> Option<f64> {
+        crate::adapters::fred::rate_limiter().and_then(|l| l.available_estimate())
+    }
+
     fn as_economic(&self) -> Option<&dyn EconomicProvider> {
         Some(self)
     }

--- a/src/providers/health.rs
+++ b/src/providers/health.rs
@@ -1,0 +1,182 @@
+//! Lightweight in-memory provider health tracking ([`ProviderHealth`]),
+//! exposed via [`crate::Providers::health`].
+
+use super::Provider;
+use std::collections::{HashMap, VecDeque};
+use std::sync::Mutex;
+
+/// How many recent call outcomes each provider's health snapshot considers.
+const WINDOW: usize = 20;
+
+/// Snapshot of one provider's recent health and (where derivable) remaining
+/// rate-limit budget.
+///
+/// Purely observational — computed from the last [`WINDOW`] dispatch
+/// outcomes recorded in-process by [`super::ProviderSet`]; it is not a
+/// circuit breaker and does not itself change dispatch behavior (routing and
+/// [`RetryPolicy`](super::retry::RetryPolicy) are unaffected by it).
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct ProviderHealth {
+    /// The provider this snapshot describes.
+    pub provider: Provider,
+    /// `true` when at least half of the recent recorded outcomes succeeded,
+    /// or when no calls have been recorded yet (optimistic default).
+    pub is_healthy: bool,
+    /// Successes among the last [`WINDOW`] recorded outcomes.
+    pub recent_successes: u32,
+    /// Failures among the last [`WINDOW`] recorded outcomes.
+    pub recent_failures: u32,
+    /// The most recent failure's message, if the last recorded outcome (or
+    /// any within the window) failed and none have succeeded since.
+    pub last_error: Option<String>,
+    /// Best-effort estimate of remaining rate-limit budget (tokens in the
+    /// adapter's own token bucket), when the provider exposes one via
+    /// [`super::ProviderAdapter::rate_limit_remaining`]. `None` for providers
+    /// with no local rate limiter to peek (e.g. Yahoo) or that haven't been
+    /// initialized.
+    pub requests_remaining_estimate: Option<f64>,
+}
+
+#[derive(Default)]
+struct ProviderHealthState {
+    outcomes: VecDeque<bool>,
+    last_error: Option<String>,
+}
+
+/// Per-provider ring buffer of recent success/failure outcomes.
+///
+/// A `std::sync::Mutex` per tracker (not per provider) is fine here: critical
+/// sections are a handful of `VecDeque` pushes, never held across an `.await`.
+pub(crate) struct HealthTracker {
+    state: Mutex<HashMap<Provider, ProviderHealthState>>,
+}
+
+impl HealthTracker {
+    pub(crate) fn new() -> Self {
+        Self {
+            state: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Record one dispatch outcome for `provider`.
+    pub(crate) fn record(&self, provider: Provider, success: bool, error: Option<String>) {
+        let mut guard = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let entry = guard.entry(provider).or_default();
+        entry.outcomes.push_back(success);
+        if entry.outcomes.len() > WINDOW {
+            entry.outcomes.pop_front();
+        }
+        if success {
+            entry.last_error = None;
+        } else if let Some(e) = error {
+            entry.last_error = Some(e);
+        }
+    }
+
+    /// Snapshot the current health for `provider` (optimistic default with no
+    /// recorded calls yet).
+    pub(crate) fn snapshot(&self, provider: Provider) -> ProviderHealth {
+        let guard = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        match guard.get(&provider) {
+            Some(state) => {
+                let total = state.outcomes.len();
+                let successes = state.outcomes.iter().filter(|o| **o).count();
+                let failures = total - successes;
+                ProviderHealth {
+                    provider,
+                    is_healthy: total == 0 || successes * 2 >= total,
+                    recent_successes: successes as u32,
+                    recent_failures: failures as u32,
+                    last_error: state.last_error.clone(),
+                    requests_remaining_estimate: None,
+                }
+            }
+            None => ProviderHealth {
+                provider,
+                is_healthy: true,
+                recent_successes: 0,
+                recent_failures: 0,
+                last_error: None,
+                requests_remaining_estimate: None,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_provider_with_no_calls_is_healthy_by_default() {
+        let tracker = HealthTracker::new();
+        let health = tracker.snapshot(Provider::Yahoo);
+        assert!(health.is_healthy);
+        assert_eq!(health.recent_successes, 0);
+        assert_eq!(health.recent_failures, 0);
+        assert!(health.last_error.is_none());
+    }
+
+    #[test]
+    fn all_successes_are_healthy() {
+        let tracker = HealthTracker::new();
+        for _ in 0..5 {
+            tracker.record(Provider::Yahoo, true, None);
+        }
+        let health = tracker.snapshot(Provider::Yahoo);
+        assert!(health.is_healthy);
+        assert_eq!(health.recent_successes, 5);
+        assert_eq!(health.recent_failures, 0);
+    }
+
+    #[test]
+    fn a_majority_of_failures_is_unhealthy() {
+        let tracker = HealthTracker::new();
+        tracker.record(Provider::Yahoo, true, None);
+        tracker.record(Provider::Yahoo, false, Some("boom".to_string()));
+        tracker.record(Provider::Yahoo, false, Some("boom again".to_string()));
+        let health = tracker.snapshot(Provider::Yahoo);
+        assert!(!health.is_healthy);
+        assert_eq!(health.recent_successes, 1);
+        assert_eq!(health.recent_failures, 2);
+        assert_eq!(health.last_error.as_deref(), Some("boom again"));
+    }
+
+    #[test]
+    fn a_success_clears_the_last_error() {
+        let tracker = HealthTracker::new();
+        tracker.record(Provider::Yahoo, false, Some("boom".to_string()));
+        tracker.record(Provider::Yahoo, true, None);
+        let health = tracker.snapshot(Provider::Yahoo);
+        assert!(health.last_error.is_none());
+    }
+
+    #[test]
+    fn window_evicts_the_oldest_outcome() {
+        let tracker = HealthTracker::new();
+        // Fill the window with failures, then enough successes to push every
+        // failure out of the window.
+        for _ in 0..WINDOW {
+            tracker.record(Provider::Yahoo, false, Some("boom".to_string()));
+        }
+        assert!(!tracker.snapshot(Provider::Yahoo).is_healthy);
+        for _ in 0..WINDOW {
+            tracker.record(Provider::Yahoo, true, None);
+        }
+        let health = tracker.snapshot(Provider::Yahoo);
+        assert!(health.is_healthy);
+        assert_eq!(health.recent_successes, WINDOW as u32);
+        assert_eq!(health.recent_failures, 0);
+    }
+
+    #[test]
+    fn providers_are_tracked_independently() {
+        let tracker = HealthTracker::new();
+        tracker.record(Provider::Yahoo, true, None);
+        tracker.record(Provider::Edgar, false, Some("boom".to_string()));
+        tracker.record(Provider::Edgar, false, Some("boom".to_string()));
+        assert!(tracker.snapshot(Provider::Yahoo).is_healthy);
+        assert!(!tracker.snapshot(Provider::Edgar).is_healthy);
+    }
+}

--- a/src/providers/health.rs
+++ b/src/providers/health.rs
@@ -27,8 +27,8 @@ pub struct ProviderHealth {
     pub recent_successes: u32,
     /// Failures among the last [`WINDOW`] recorded outcomes.
     pub recent_failures: u32,
-    /// The most recent failure's message, if the last recorded outcome (or
-    /// any within the window) failed and none have succeeded since.
+    /// The most recent failure's message. Cleared by any success, so it is
+    /// set only when the latest recorded outcome was a failure.
     pub last_error: Option<String>,
     /// Best-effort estimate of remaining rate-limit budget (tokens in the
     /// adapter's own token bucket), when the provider exposes one via
@@ -78,28 +78,17 @@ impl HealthTracker {
     /// recorded calls yet).
     pub(crate) fn snapshot(&self, provider: Provider) -> ProviderHealth {
         let guard = self.state.lock().unwrap_or_else(|e| e.into_inner());
-        match guard.get(&provider) {
-            Some(state) => {
-                let total = state.outcomes.len();
-                let successes = state.outcomes.iter().filter(|o| **o).count();
-                let failures = total - successes;
-                ProviderHealth {
-                    provider,
-                    is_healthy: total == 0 || successes * 2 >= total,
-                    recent_successes: successes as u32,
-                    recent_failures: failures as u32,
-                    last_error: state.last_error.clone(),
-                    requests_remaining_estimate: None,
-                }
-            }
-            None => ProviderHealth {
-                provider,
-                is_healthy: true,
-                recent_successes: 0,
-                recent_failures: 0,
-                last_error: None,
-                requests_remaining_estimate: None,
-            },
+        let state = guard.get(&provider);
+        let total = state.map_or(0, |s| s.outcomes.len());
+        let successes = state.map_or(0, |s| s.outcomes.iter().filter(|o| **o).count());
+        ProviderHealth {
+            provider,
+            // No calls recorded yet reads as healthy (0 >= 0), the optimistic default.
+            is_healthy: successes * 2 >= total,
+            recent_successes: successes as u32,
+            recent_failures: (total - successes) as u32,
+            last_error: state.and_then(|s| s.last_error.clone()),
+            requests_remaining_estimate: None,
         }
     }
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -2,6 +2,8 @@
 
 pub(crate) mod adapter;
 pub mod config;
+pub(crate) mod health;
+pub(crate) mod retry;
 
 #[cfg(test)]
 pub(crate) mod mock;
@@ -46,8 +48,12 @@ use futures::stream::StreamExt;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 pub(crate) use adapter::*;
+pub(crate) use health::HealthTracker;
+pub use health::ProviderHealth;
+pub use retry::RetryPolicy;
 
 /// Typed identifier for a financial data provider.
 ///
@@ -760,6 +766,13 @@ pub(crate) struct ProviderSet {
     providers: Vec<Arc<dyn ProviderAdapter>>,
     yahoo_client: Option<Arc<YahooClient>>,
     routes: Routes,
+    /// Opt-in retry policy (issue #276). `None` (the default) preserves the
+    /// pre-#276 behavior exactly: a `RateLimited` error is treated like any
+    /// other failure and dispatch moves straight to the next candidate.
+    retry_policy: Option<RetryPolicy>,
+    /// In-memory recent success/failure tracker, always active (cheap to
+    /// maintain) and surfaced on request via [`ProviderSet::health`].
+    health: HealthTracker,
 }
 
 impl std::fmt::Debug for ProviderSet {
@@ -785,7 +798,30 @@ impl ProviderSet {
             providers,
             yahoo_client,
             routes,
+            retry_policy: None,
+            health: HealthTracker::new(),
         }
+    }
+
+    /// Opt into [`RetryPolicy`]-driven retry of `RateLimited` errors.
+    /// `None` (the default from [`new`](Self::new)) preserves pre-#276
+    /// behavior exactly.
+    pub(crate) fn with_retry_policy(mut self, policy: Option<RetryPolicy>) -> Self {
+        self.retry_policy = policy;
+        self
+    }
+
+    /// Snapshot recent health for every configured provider, in the order
+    /// they were added (see [`crate::Providers::health`]).
+    pub(crate) fn health(&self) -> Vec<ProviderHealth> {
+        self.providers
+            .iter()
+            .map(|p| {
+                let mut snapshot = self.health.snapshot(p.id());
+                snapshot.requests_remaining_estimate = p.rate_limit_remaining();
+                snapshot
+            })
+            .collect()
     }
 
     /// Returns the providers to use for a given capability, respecting any
@@ -835,6 +871,46 @@ impl ProviderSet {
             .unwrap_or_else(|| Self::no_provider(cap))
     }
 
+    /// Call `f(p)`, retrying in place on `FinanceError::RateLimited` per
+    /// `self.retry_policy` (issue #276). With no policy configured this is
+    /// exactly `f(p).await` — zero behavior change for existing callers.
+    async fn call_with_retry<T, F, Fut>(&self, p: &Arc<dyn ProviderAdapter>, f: &F) -> Result<T>
+    where
+        F: Fn(&Arc<dyn ProviderAdapter>) -> Fut,
+        Fut: std::future::Future<Output = Result<T>>,
+    {
+        let Some(policy) = self.retry_policy.as_ref() else {
+            return f(p).await;
+        };
+        let mut seed = crate::backoff::seed_from_time();
+        let mut attempt: u32 = 0;
+        loop {
+            match f(p).await {
+                Ok(v) => return Ok(v),
+                Err(FinanceError::RateLimited { retry_after })
+                    if attempt + 1 < policy.max_attempts =>
+                {
+                    let delay =
+                        policy.delay_for(attempt, retry_after.map(Duration::from_secs), &mut seed);
+                    tokio::time::sleep(delay).await;
+                    attempt += 1;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    /// Record a candidate's outcome in the health tracker. `NotSupported`
+    /// isn't a provider failure (it just means "try the next candidate"), so
+    /// it's excluded from health accounting entirely.
+    fn record_health<T>(&self, provider: Provider, result: &Result<T>) {
+        match result {
+            Ok(_) => self.health.record(provider, true, None),
+            Err(FinanceError::NotSupported { .. }) => {}
+            Err(e) => self.health.record(provider, false, Some(e.to_string())),
+        }
+    }
+
     pub(crate) async fn fetch<T, F, Fut>(&self, cap: Capability, f: F) -> Result<T>
     where
         F: Fn(&Arc<dyn ProviderAdapter>) -> Fut,
@@ -849,7 +925,9 @@ impl ProviderSet {
                 let mut last = None;
                 let mut unsupported = None;
                 for p in &candidates {
-                    match f(p).await {
+                    let result = self.call_with_retry(p, &f).await;
+                    self.record_health(p.id(), &result);
+                    match result {
                         Ok(v) => return Ok(v),
                         Err(e @ FinanceError::NotSupported { .. }) => unsupported = Some(e),
                         Err(e) => last = Some(e),
@@ -860,7 +938,16 @@ impl ProviderSet {
             Fetch::Parallel => {
                 let mut futs = futures::stream::FuturesUnordered::new();
                 for p in &candidates {
-                    futs.push(f(p));
+                    let id = p.id();
+                    // Capture `&f` (Copy) rather than `f` itself — `f: F` isn't
+                    // necessarily `Copy`, and `async move` would otherwise try
+                    // (and fail) to move it out on every loop iteration.
+                    let f_ref = &f;
+                    futs.push(async move {
+                        let result = self.call_with_retry(p, f_ref).await;
+                        self.record_health(id, &result);
+                        result
+                    });
                 }
                 let mut last = None;
                 let mut unsupported = None;
@@ -1395,5 +1482,183 @@ mod tests {
                 .contains(Capability::FILINGS)
         );
         assert!(needs_edgar_injection(&[Provider::AlphaVantage]));
+    }
+
+    /// A [`ChartProvider`] that returns `RateLimited` for its first
+    /// `fail_times` calls, then succeeds — for exercising [`RetryPolicy`].
+    struct FlakyChartProvider {
+        id: Provider,
+        fail_times: usize,
+        calls: std::sync::atomic::AtomicUsize,
+    }
+
+    impl FlakyChartProvider {
+        fn new(id: Provider, fail_times: usize) -> Self {
+            Self {
+                id,
+                fail_times,
+                calls: std::sync::atomic::AtomicUsize::new(0),
+            }
+        }
+
+        fn call_count(&self) -> usize {
+            self.calls.load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    impl ProviderCore for FlakyChartProvider {
+        fn id(&self) -> Provider {
+            self.id
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ChartProvider for FlakyChartProvider {
+        async fn fetch_chart(
+            &self,
+            symbol: &str,
+            _: crate::Interval,
+            _: crate::TimeRange,
+        ) -> Result<crate::models::chart::Chart> {
+            let n = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if n < self.fail_times {
+                return Err(FinanceError::RateLimited {
+                    retry_after: Some(0),
+                });
+            }
+            Ok(crate::models::chart::Chart {
+                symbol: symbol.to_string(),
+                meta: Default::default(),
+                candles: Vec::new(),
+                interval: None,
+                range: None,
+                provider_id: Some(self.id),
+            })
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ProviderAdapter for FlakyChartProvider {
+        fn as_chart(&self) -> Option<&dyn ChartProvider> {
+            Some(self)
+        }
+    }
+
+    async fn fetch_chart_via(set: &ProviderSet) -> Result<crate::models::chart::Chart> {
+        set.fetch(Capability::CHART, |p| {
+            let p = p.clone();
+            async move {
+                p.as_chart()
+                    .ok_or_else(|| p.not_supported(Operation::Chart))?
+                    .fetch_chart("AAPL", crate::Interval::OneDay, crate::TimeRange::FiveDays)
+                    .await
+            }
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn no_retry_policy_means_a_single_attempt_per_candidate() {
+        let provider = Arc::new(FlakyChartProvider::new(Provider::Yahoo, usize::MAX));
+        let set = ProviderSet::new(
+            vec![provider.clone() as Arc<dyn ProviderAdapter>],
+            None,
+            Routes::new(Fetch::Sequential),
+        );
+        let err = fetch_chart_via(&set).await.unwrap_err();
+        assert!(matches!(err, FinanceError::RateLimited { .. }));
+        assert_eq!(
+            provider.call_count(),
+            1,
+            "no retry policy set: exactly one attempt"
+        );
+    }
+
+    #[tokio::test]
+    async fn retry_policy_retries_rate_limited_then_succeeds() {
+        let provider = Arc::new(FlakyChartProvider::new(Provider::Yahoo, 2));
+        let set = ProviderSet::new(
+            vec![provider.clone() as Arc<dyn ProviderAdapter>],
+            None,
+            Routes::new(Fetch::Sequential),
+        )
+        .with_retry_policy(Some(RetryPolicy::new(5)));
+
+        let chart = fetch_chart_via(&set)
+            .await
+            .expect("should eventually succeed");
+        assert_eq!(chart.symbol, "AAPL");
+        // 2 failures + 1 success = 3 calls.
+        assert_eq!(provider.call_count(), 3);
+    }
+
+    #[tokio::test]
+    async fn retry_policy_exhausts_and_falls_through_to_next_provider() {
+        let always_limited = Arc::new(FlakyChartProvider::new(Provider::Yahoo, usize::MAX));
+        let succeeds = Arc::new(FlakyChartProvider::new(Provider::Edgar, 0));
+        let mut routes = Routes::new(Fetch::Sequential);
+        routes
+            .map
+            .insert(Capability::CHART, vec![Provider::Yahoo, Provider::Edgar]);
+        let set = ProviderSet::new(
+            vec![
+                always_limited.clone() as Arc<dyn ProviderAdapter>,
+                succeeds.clone() as Arc<dyn ProviderAdapter>,
+            ],
+            None,
+            routes,
+        )
+        .with_retry_policy(Some(RetryPolicy::new(3)));
+
+        let chart = fetch_chart_via(&set).await.expect("falls through to Edgar");
+        assert_eq!(chart.provider_id, Some(Provider::Edgar));
+        // Exhausts all 3 attempts on the first candidate before falling through.
+        assert_eq!(always_limited.call_count(), 3);
+        assert_eq!(succeeds.call_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn health_reflects_failures_and_recovers_after_success() {
+        let provider = Arc::new(FlakyChartProvider::new(Provider::Yahoo, 1));
+        let set = ProviderSet::new(
+            vec![provider.clone() as Arc<dyn ProviderAdapter>],
+            None,
+            Routes::new(Fetch::Sequential),
+        );
+
+        // First call fails (RateLimited), recorded as a failure.
+        assert!(fetch_chart_via(&set).await.is_err());
+        let health = set.health();
+        assert_eq!(health.len(), 1);
+        assert_eq!(health[0].provider, Provider::Yahoo);
+        assert_eq!(health[0].recent_failures, 1);
+        assert!(health[0].last_error.is_some());
+
+        // Second call succeeds, clearing last_error.
+        assert!(fetch_chart_via(&set).await.is_ok());
+        let health = set.health();
+        assert_eq!(health[0].recent_successes, 1);
+        assert!(health[0].last_error.is_none());
+    }
+
+    #[test]
+    fn not_supported_is_excluded_from_health_accounting() {
+        let tracker = health::HealthTracker::new();
+        // A NotSupported "failure" must not count against health.
+        let err: Result<()> = Err(FinanceError::NotSupported {
+            provider: Provider::Yahoo,
+            operation: Operation::Spark,
+            candidates: vec![],
+        });
+        // Exercise the same logic ProviderSet::record_health uses.
+        match &err {
+            Ok(_) => tracker.record(Provider::Yahoo, true, None),
+            Err(FinanceError::NotSupported { .. }) => {}
+            Err(e) => tracker.record(Provider::Yahoo, false, Some(e.to_string())),
+        }
+        let health = tracker.snapshot(Provider::Yahoo);
+        assert!(health.is_healthy);
+        assert_eq!(health.recent_successes, 0);
+        assert_eq!(health.recent_failures, 0);
     }
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -766,8 +766,8 @@ pub(crate) struct ProviderSet {
     providers: Vec<Arc<dyn ProviderAdapter>>,
     yahoo_client: Option<Arc<YahooClient>>,
     routes: Routes,
-    /// Opt-in retry policy (issue #276). `None` (the default) preserves the
-    /// pre-#276 behavior exactly: a `RateLimited` error is treated like any
+    /// Opt-in retry policy. `None` (the default) preserves the prior
+    /// behavior exactly: a `RateLimited` error is treated like any
     /// other failure and dispatch moves straight to the next candidate.
     retry_policy: Option<RetryPolicy>,
     /// In-memory recent success/failure tracker, always active (cheap to
@@ -804,8 +804,8 @@ impl ProviderSet {
     }
 
     /// Opt into [`RetryPolicy`]-driven retry of `RateLimited` errors.
-    /// `None` (the default from [`new`](Self::new)) preserves pre-#276
-    /// behavior exactly.
+    /// `None` (the default from [`new`](Self::new)) preserves the prior
+    /// no-retry behavior exactly.
     pub(crate) fn with_retry_policy(mut self, policy: Option<RetryPolicy>) -> Self {
         self.retry_policy = policy;
         self
@@ -872,7 +872,7 @@ impl ProviderSet {
     }
 
     /// Call `f(p)`, retrying in place on `FinanceError::RateLimited` per
-    /// `self.retry_policy` (issue #276). With no policy configured this is
+    /// `self.retry_policy`. With no policy configured this is
     /// exactly `f(p).await` — zero behavior change for existing callers.
     async fn call_with_retry<T, F, Fut>(&self, p: &Arc<dyn ProviderAdapter>, f: &F) -> Result<T>
     where
@@ -1641,24 +1641,33 @@ mod tests {
         assert!(health[0].last_error.is_none());
     }
 
-    #[test]
-    fn not_supported_is_excluded_from_health_accounting() {
-        let tracker = health::HealthTracker::new();
-        // A NotSupported "failure" must not count against health.
-        let err: Result<()> = Err(FinanceError::NotSupported {
-            provider: Provider::Yahoo,
-            operation: Operation::Spark,
-            candidates: vec![],
-        });
-        // Exercise the same logic ProviderSet::record_health uses.
-        match &err {
-            Ok(_) => tracker.record(Provider::Yahoo, true, None),
-            Err(FinanceError::NotSupported { .. }) => {}
-            Err(e) => tracker.record(Provider::Yahoo, false, Some(e.to_string())),
+    /// A provider that only implements `as_quote`, so a CHART dispatch hits
+    /// its `NotSupported` path — which must not count against its health.
+    struct QuoteOnlyProvider;
+
+    impl ProviderCore for QuoteOnlyProvider {
+        fn id(&self) -> Provider {
+            Provider::Yahoo
         }
-        let health = tracker.snapshot(Provider::Yahoo);
-        assert!(health.is_healthy);
-        assert_eq!(health.recent_successes, 0);
-        assert_eq!(health.recent_failures, 0);
+    }
+
+    #[async_trait::async_trait]
+    impl ProviderAdapter for QuoteOnlyProvider {}
+
+    #[tokio::test]
+    async fn not_supported_is_excluded_from_health_accounting() {
+        let set = ProviderSet::new(
+            vec![Arc::new(QuoteOnlyProvider) as Arc<dyn ProviderAdapter>],
+            None,
+            Routes::new(Fetch::Sequential),
+        );
+        // Goes through the real `record_health`, not a copy of its match.
+        assert!(fetch_chart_via(&set).await.is_err());
+
+        let health = set.health();
+        assert!(health[0].is_healthy);
+        assert_eq!(health[0].recent_successes, 0);
+        assert_eq!(health[0].recent_failures, 0);
+        assert!(health[0].last_error.is_none());
     }
 }

--- a/src/providers/polygon.rs
+++ b/src/providers/polygon.rs
@@ -277,6 +277,10 @@ impl ProviderAdapter for PolygonProvider {
         Ok(())
     }
 
+    fn rate_limit_remaining(&self) -> Option<f64> {
+        polygon::rate_limiter().and_then(|l| l.available_estimate())
+    }
+
     fn as_quote(&self) -> Option<&dyn QuoteProvider> {
         Some(self)
     }

--- a/src/providers/retry.rs
+++ b/src/providers/retry.rs
@@ -1,0 +1,170 @@
+//! Opt-in retry policy for provider dispatch ([`RetryPolicy`]).
+
+use std::time::Duration;
+
+/// Retry policy for [`super::ProviderSet`] dispatch, opt-in via
+/// [`crate::Providers::builder`]`().`[`retry`](super::config::ProvidersBuilder::retry)`(..)`.
+///
+/// When configured, a candidate provider that returns
+/// [`FinanceError::RateLimited`](crate::error::FinanceError::RateLimited) is
+/// retried in place — honoring the error's `retry_after` hint verbatim when
+/// present, or this policy's own exponential-backoff-plus-jitter delay
+/// otherwise — up to `max_attempts` times before dispatch falls through to
+/// the next routed provider (or fails, if it was the last).
+///
+/// Other error kinds are never retried by this policy: a `RateLimited` is the
+/// one error a policy-level retry can reliably fix by waiting; anything else
+/// (auth failures, 5xx, not-found, ...) is left to the existing
+/// sequential/parallel provider fallback.
+///
+/// **Default is no retry** — a [`Providers`](crate::Providers) built without
+/// calling `.retry(..)` behaves exactly as before this policy existed.
+///
+/// # Example
+///
+/// ```no_run
+/// use finance_query::{Providers, RetryPolicy};
+/// use std::time::Duration;
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let providers = Providers::builder()
+///     .retry(RetryPolicy::new(3).base_delay(Duration::from_millis(500)))
+///     .build()
+///     .await?;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
+pub struct RetryPolicy {
+    /// Maximum number of attempts per provider candidate, including the
+    /// first try. Values below `1` are treated as `1` (no retry).
+    pub max_attempts: u32,
+    /// Delay before the first retry when the error carries no `retry_after`
+    /// hint. Default: 500ms.
+    pub base_delay: Duration,
+    /// Multiplier applied to the delay after each retry (clamped to at least
+    /// `1.0`). Default: `2.0`.
+    pub multiplier: f64,
+    /// Jitter fraction (`0.0..=1.0`) applied to the computed delay so many
+    /// concurrent callers don't retry in lockstep. Default: `0.2`.
+    pub jitter: f64,
+    /// Upper bound on the computed delay. Never applied to an explicit
+    /// `retry_after` hint — that value is honored verbatim. Default: 30s.
+    pub max_delay: Duration,
+}
+
+impl RetryPolicy {
+    /// A policy allowing up to `max_attempts` tries per candidate provider,
+    /// with sane defaults for the rest (500ms base delay, 2x multiplier, 20%
+    /// jitter, 30s cap).
+    pub fn new(max_attempts: u32) -> Self {
+        Self {
+            max_attempts: max_attempts.max(1),
+            base_delay: Duration::from_millis(500),
+            multiplier: 2.0,
+            jitter: 0.2,
+            max_delay: Duration::from_secs(30),
+        }
+    }
+
+    /// Override the base delay (see [`RetryPolicy::base_delay`] field docs).
+    pub fn base_delay(mut self, delay: Duration) -> Self {
+        self.base_delay = delay;
+        self
+    }
+
+    /// Override the backoff multiplier (see [`RetryPolicy::multiplier`] field docs).
+    pub fn multiplier(mut self, multiplier: f64) -> Self {
+        self.multiplier = multiplier;
+        self
+    }
+
+    /// Override the jitter fraction (see [`RetryPolicy::jitter`] field docs).
+    pub fn jitter(mut self, jitter: f64) -> Self {
+        self.jitter = jitter.clamp(0.0, 1.0);
+        self
+    }
+
+    /// Override the max delay cap (see [`RetryPolicy::max_delay`] field docs).
+    pub fn max_delay(mut self, max_delay: Duration) -> Self {
+        self.max_delay = max_delay;
+        self
+    }
+
+    /// Delay before the retry numbered `attempt` (0-indexed: `0` is the delay
+    /// before the first retry), honoring an explicit `retry_after` hint
+    /// verbatim when present.
+    pub(crate) fn delay_for(
+        &self,
+        attempt: u32,
+        retry_after: Option<Duration>,
+        seed: &mut u64,
+    ) -> Duration {
+        match retry_after {
+            Some(explicit) => explicit,
+            None => crate::backoff::with_jitter(
+                crate::backoff::exponential_delay(
+                    attempt,
+                    self.base_delay,
+                    self.multiplier,
+                    self.max_delay,
+                ),
+                self.jitter,
+                seed,
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_clamps_zero_attempts_to_one() {
+        assert_eq!(RetryPolicy::new(0).max_attempts, 1);
+    }
+
+    #[test]
+    fn defaults_are_sane() {
+        let policy = RetryPolicy::new(3);
+        assert_eq!(policy.max_attempts, 3);
+        assert_eq!(policy.base_delay, Duration::from_millis(500));
+        assert_eq!(policy.multiplier, 2.0);
+        assert_eq!(policy.jitter, 0.2);
+        assert_eq!(policy.max_delay, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn jitter_is_clamped() {
+        assert_eq!(RetryPolicy::new(1).jitter(5.0).jitter, 1.0);
+        assert_eq!(RetryPolicy::new(1).jitter(-5.0).jitter, 0.0);
+    }
+
+    #[test]
+    fn explicit_retry_after_is_honored_verbatim_ignoring_max_delay() {
+        let policy = RetryPolicy::new(3).max_delay(Duration::from_secs(1));
+        let mut seed = 42;
+        let delay = policy.delay_for(5, Some(Duration::from_secs(999)), &mut seed);
+        assert_eq!(delay, Duration::from_secs(999));
+    }
+
+    #[test]
+    fn falls_back_to_exponential_backoff_when_no_retry_after() {
+        let policy = RetryPolicy::new(5)
+            .base_delay(Duration::from_secs(1))
+            .multiplier(2.0)
+            .jitter(0.0)
+            .max_delay(Duration::from_secs(10));
+        let mut seed = 1;
+        assert_eq!(policy.delay_for(0, None, &mut seed), Duration::from_secs(1));
+        assert_eq!(policy.delay_for(1, None, &mut seed), Duration::from_secs(2));
+        assert_eq!(policy.delay_for(2, None, &mut seed), Duration::from_secs(4));
+        // Capped.
+        assert_eq!(
+            policy.delay_for(10, None, &mut seed),
+            Duration::from_secs(10)
+        );
+    }
+}

--- a/src/providers/retry.rs
+++ b/src/providers/retry.rs
@@ -7,10 +7,11 @@ use std::time::Duration;
 ///
 /// When configured, a candidate provider that returns
 /// [`FinanceError::RateLimited`](crate::error::FinanceError::RateLimited) is
-/// retried in place — honoring the error's `retry_after` hint verbatim when
-/// present, or this policy's own exponential-backoff-plus-jitter delay
-/// otherwise — up to `max_attempts` times before dispatch falls through to
-/// the next routed provider (or fails, if it was the last).
+/// retried in place — honoring the error's `retry_after` hint when present
+/// (capped by `max_retry_after`), or this policy's own
+/// exponential-backoff-plus-jitter delay otherwise — up to `max_attempts`
+/// times before dispatch falls through to the next routed provider (or
+/// fails, if it was the last).
 ///
 /// Other error kinds are never retried by this policy: a `RateLimited` is the
 /// one error a policy-level retry can reliably fix by waiting; anything else
@@ -49,9 +50,13 @@ pub struct RetryPolicy {
     /// Jitter fraction (`0.0..=1.0`) applied to the computed delay so many
     /// concurrent callers don't retry in lockstep. Default: `0.2`.
     pub jitter: f64,
-    /// Upper bound on the computed delay. Never applied to an explicit
-    /// `retry_after` hint — that value is honored verbatim. Default: 30s.
+    /// Upper bound on the computed backoff delay. Default: 30s.
     pub max_delay: Duration,
+    /// Upper bound on an explicit `retry_after` hint. Separate from
+    /// `max_delay` so a legitimate multi-minute hint is honored, while a
+    /// hostile or buggy upstream can't park the caller indefinitely.
+    /// Default: 5 minutes.
+    pub max_retry_after: Duration,
 }
 
 impl RetryPolicy {
@@ -65,6 +70,7 @@ impl RetryPolicy {
             multiplier: 2.0,
             jitter: 0.2,
             max_delay: Duration::from_secs(30),
+            max_retry_after: Duration::from_secs(300),
         }
     }
 
@@ -92,9 +98,16 @@ impl RetryPolicy {
         self
     }
 
+    /// Override the cap on an explicit `retry_after` hint
+    /// (see [`RetryPolicy::max_retry_after`] field docs).
+    pub fn max_retry_after(mut self, max_retry_after: Duration) -> Self {
+        self.max_retry_after = max_retry_after;
+        self
+    }
+
     /// Delay before the retry numbered `attempt` (0-indexed: `0` is the delay
-    /// before the first retry), honoring an explicit `retry_after` hint
-    /// verbatim when present.
+    /// before the first retry), honoring an explicit `retry_after` hint when
+    /// present, capped at [`max_retry_after`](Self::max_retry_after).
     pub(crate) fn delay_for(
         &self,
         attempt: u32,
@@ -102,17 +115,14 @@ impl RetryPolicy {
         seed: &mut u64,
     ) -> Duration {
         match retry_after {
-            Some(explicit) => explicit,
-            None => crate::backoff::with_jitter(
-                crate::backoff::exponential_delay(
-                    attempt,
-                    self.base_delay,
-                    self.multiplier,
-                    self.max_delay,
-                ),
-                self.jitter,
-                seed,
-            ),
+            Some(explicit) => explicit.min(self.max_retry_after),
+            None => crate::backoff::BackoffParams {
+                base: self.base_delay,
+                max: self.max_delay,
+                multiplier: self.multiplier,
+                jitter: self.jitter,
+            }
+            .delay_for(attempt, seed),
         }
     }
 }
@@ -134,6 +144,7 @@ mod tests {
         assert_eq!(policy.multiplier, 2.0);
         assert_eq!(policy.jitter, 0.2);
         assert_eq!(policy.max_delay, Duration::from_secs(30));
+        assert_eq!(policy.max_retry_after, Duration::from_secs(300));
     }
 
     #[test]
@@ -143,11 +154,21 @@ mod tests {
     }
 
     #[test]
-    fn explicit_retry_after_is_honored_verbatim_ignoring_max_delay() {
+    fn explicit_retry_after_is_honored_independently_of_max_delay() {
+        // max_delay bounds the computed backoff, not the hint.
         let policy = RetryPolicy::new(3).max_delay(Duration::from_secs(1));
         let mut seed = 42;
-        let delay = policy.delay_for(5, Some(Duration::from_secs(999)), &mut seed);
-        assert_eq!(delay, Duration::from_secs(999));
+        let delay = policy.delay_for(5, Some(Duration::from_secs(120)), &mut seed);
+        assert_eq!(delay, Duration::from_secs(120));
+    }
+
+    #[test]
+    fn an_absurd_retry_after_hint_is_capped() {
+        // A hostile or buggy upstream must not park the caller for a day.
+        let policy = RetryPolicy::new(3);
+        let mut seed = 42;
+        let delay = policy.delay_for(0, Some(Duration::from_secs(86_400)), &mut seed);
+        assert_eq!(delay, Duration::from_secs(300));
     }
 
     #[test]

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -67,7 +67,7 @@ impl RateLimiter {
     /// Best-effort peek at the estimated number of tokens currently
     /// available, without consuming one.
     ///
-    /// For provider health/budget introspection (issue #276). Refills the
+    /// For provider health/budget introspection. Refills the
     /// estimate against elapsed time exactly like [`acquire`](Self::acquire),
     /// but never mutates `last_refill` or consumes a token — a health check
     /// must not itself spend rate-limit budget. Uses `try_lock` rather than

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -63,6 +63,24 @@ impl RateLimiter {
             tokio::time::sleep(sleep_duration).await;
         }
     }
+
+    /// Best-effort peek at the estimated number of tokens currently
+    /// available, without consuming one.
+    ///
+    /// For provider health/budget introspection (issue #276). Refills the
+    /// estimate against elapsed time exactly like [`acquire`](Self::acquire),
+    /// but never mutates `last_refill` or consumes a token — a health check
+    /// must not itself spend rate-limit budget. Uses `try_lock` rather than
+    /// blocking: a momentary contention with a concurrent `acquire` just
+    /// yields `None` instead of stalling a synchronous health snapshot.
+    #[allow(dead_code)] // used by fmp/alphavantage/polygon/fred feature-gated providers
+    pub(crate) fn available_estimate(&self) -> Option<f64> {
+        let state = self.state.try_lock().ok()?;
+        let elapsed = Instant::now()
+            .duration_since(state.last_refill)
+            .as_secs_f64();
+        Some((state.available + elapsed * state.refill_rate).min(state.max_tokens))
+    }
 }
 
 #[cfg(test)]
@@ -111,5 +129,32 @@ mod tests {
 
         assert!(elapsed >= Duration::from_millis(1900));
         assert!(elapsed <= Duration::from_millis(2100));
+    }
+
+    #[tokio::test]
+    async fn available_estimate_reflects_consumption_without_consuming() {
+        let limiter = RateLimiter::new(4.0);
+        assert_eq!(limiter.available_estimate(), Some(4.0));
+
+        limiter.acquire().await;
+        let after_one = limiter.available_estimate().unwrap();
+        assert!((after_one - 3.0).abs() < 0.01);
+
+        // Peeking again immediately must not consume a second token.
+        let peeked_again = limiter.available_estimate().unwrap();
+        assert!((peeked_again - after_one).abs() < 0.01);
+    }
+
+    #[tokio::test]
+    async fn available_estimate_refills_over_time() {
+        tokio::time::pause();
+        let limiter = RateLimiter::new(2.0);
+        limiter.acquire().await;
+        limiter.acquire().await;
+        assert!(limiter.available_estimate().unwrap() < 0.01);
+
+        tokio::time::advance(Duration::from_millis(500)).await;
+        let refilled = limiter.available_estimate().unwrap();
+        assert!(refilled > 0.9, "expected ~1 token refilled, got {refilled}");
     }
 }

--- a/src/streaming/book.rs
+++ b/src/streaming/book.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use super::client::StreamResult;
 use super::handle::{RECONNECT_BACKOFF, SourceStream, stream_builder, stream_handle};
 use super::polygon::PolygonBookSource;
+use super::source::ReconnectConfig;
 
 /// Channel capacity — book updates are large but less frequent than prints.
 const CHANNEL_CAPACITY: usize = 1024;
@@ -115,6 +116,7 @@ impl DepthStream {
 pub struct DepthStreamBuilder {
     pairs: Vec<String>,
     retry_delay: Duration,
+    max_reconnect_attempts: Option<u32>,
 }
 
 impl DepthStreamBuilder {
@@ -123,16 +125,19 @@ impl DepthStreamBuilder {
         Self {
             pairs: Vec::new(),
             retry_delay: RECONNECT_BACKOFF,
+            max_reconnect_attempts: None,
         }
     }
 
     /// Build and start the stream.
     pub async fn build(self) -> StreamResult<DepthStream> {
+        let reconnect =
+            ReconnectConfig::new(self.retry_delay).max_attempts(self.max_reconnect_attempts);
         Ok(DepthStream {
             inner: SourceStream::start(
                 Arc::new(PolygonBookSource),
                 self.pairs,
-                self.retry_delay,
+                reconnect,
                 CHANNEL_CAPACITY,
             ),
         })

--- a/src/streaming/client.rs
+++ b/src/streaming/client.rs
@@ -280,8 +280,7 @@ impl PriceStreamBuilder {
     }
 
     /// Cap the number of consecutive reconnect attempts before the stream
-    /// gives up and ends (default: unlimited, i.e. retry forever like before
-    /// issue #276).
+    /// gives up and ends (default: unlimited, i.e. retry forever).
     pub fn max_reconnect_attempts(mut self, max: u32) -> Self {
         self.max_reconnect_attempts = Some(max);
         self

--- a/src/streaming/client.rs
+++ b/src/streaming/client.rs
@@ -13,7 +13,7 @@ use futures::stream::Stream;
 
 use super::handle::SourceStream;
 use super::pricing::PriceUpdate;
-use super::source::StreamSource;
+use super::source::{ReconnectConfig, StreamSource};
 use super::yahoo::YahooStreamSource;
 use crate::error::FinanceError;
 
@@ -113,7 +113,7 @@ impl PriceStream {
         Self::subscribe_with_source(
             Arc::new(YahooStreamSource),
             symbols,
-            Duration::from_secs(RECONNECT_BACKOFF_SECS),
+            ReconnectConfig::new(Duration::from_secs(RECONNECT_BACKOFF_SECS)),
         )
         .await
     }
@@ -125,7 +125,7 @@ impl PriceStream {
     pub(crate) async fn subscribe_with_source<S, I>(
         source: Arc<dyn StreamSource<PriceUpdate>>,
         symbols: I,
-        retry_delay: Duration,
+        reconnect: ReconnectConfig,
     ) -> StreamResult<Self>
     where
         S: Into<String>,
@@ -134,7 +134,7 @@ impl PriceStream {
         let initial_symbols: Vec<String> = symbols.into_iter().map(Into::into).collect();
 
         Ok(PriceStream {
-            inner: SourceStream::start(source, initial_symbols, retry_delay, CHANNEL_CAPACITY),
+            inner: SourceStream::start(source, initial_symbols, reconnect, CHANNEL_CAPACITY),
         })
     }
 
@@ -223,6 +223,7 @@ pub enum PriceSource {
 pub struct PriceStreamBuilder {
     symbols: Vec<String>,
     retry_delay: Duration,
+    max_reconnect_attempts: Option<u32>,
     source: PriceSource,
 }
 
@@ -232,6 +233,7 @@ impl PriceStreamBuilder {
         Self {
             symbols: Vec::new(),
             retry_delay: Duration::from_secs(RECONNECT_BACKOFF_SECS),
+            max_reconnect_attempts: None,
             source: PriceSource::Yahoo,
         }
     }
@@ -268,9 +270,20 @@ impl PriceStreamBuilder {
         self
     }
 
-    /// Set the delay between reconnection attempts (default: 3s)
+    /// Set the base delay before the first reconnection attempt (default:
+    /// 3s). Later attempts grow exponentially from this, capped and
+    /// jittered — see [`Self::max_reconnect_attempts`] to also cap how many
+    /// attempts are made.
     pub fn retry(mut self, delay: Duration) -> Self {
         self.retry_delay = delay;
+        self
+    }
+
+    /// Cap the number of consecutive reconnect attempts before the stream
+    /// gives up and ends (default: unlimited, i.e. retry forever like before
+    /// issue #276).
+    pub fn max_reconnect_attempts(mut self, max: u32) -> Self {
+        self.max_reconnect_attempts = Some(max);
         self
     }
 
@@ -281,7 +294,9 @@ impl PriceStreamBuilder {
             #[cfg(feature = "polygon")]
             PriceSource::Polygon(class) => Arc::new(super::polygon::PolygonPriceSource::new(class)),
         };
-        PriceStream::subscribe_with_source(source, self.symbols, self.retry_delay).await
+        let reconnect =
+            ReconnectConfig::new(self.retry_delay).max_attempts(self.max_reconnect_attempts);
+        PriceStream::subscribe_with_source(source, self.symbols, reconnect).await
     }
 }
 

--- a/src/streaming/handle.rs
+++ b/src/streaming/handle.rs
@@ -205,7 +205,7 @@ macro_rules! stream_builder {
 
             /// Cap the number of consecutive reconnect attempts before the
             /// stream gives up and ends (default: unlimited, i.e. retry
-            /// forever like before issue #276).
+            /// forever).
             pub fn max_reconnect_attempts(mut self, max: u32) -> Self {
                 self.max_reconnect_attempts = Some(max);
                 self

--- a/src/streaming/handle.rs
+++ b/src/streaming/handle.rs
@@ -12,12 +12,13 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
+#[cfg(feature = "polygon")]
 use std::time::Duration;
 
 use futures::stream::Stream;
 use tokio::sync::{broadcast, mpsc};
 
-use super::source::{StreamCommand, StreamSource, run_stream_loop};
+use super::source::{ReconnectConfig, StreamCommand, StreamSource, run_stream_loop};
 use super::subscription::Subscription;
 
 /// Command-channel depth: control messages are rare compared to data.
@@ -43,11 +44,11 @@ where
     pub(crate) fn start(
         source: Arc<dyn StreamSource<T>>,
         symbols: Vec<String>,
-        retry_delay: Duration,
+        reconnect: ReconnectConfig,
         capacity: usize,
     ) -> Self {
         Self::spawn(capacity, move |broadcast_tx, command_rx| async move {
-            let _ = run_stream_loop(source, symbols, broadcast_tx, command_rx, retry_delay).await;
+            let _ = run_stream_loop(source, symbols, broadcast_tx, command_rx, reconnect).await;
         })
     }
 
@@ -176,8 +177,9 @@ macro_rules! stream_handle {
     };
 }
 
-/// Emit the symbol-accumulating setter, `retry` and `Default` for a builder
-/// whose fields are `$field: Vec<String>` and `retry_delay: Duration`.
+/// Emit the symbol-accumulating setter, `retry`, `max_reconnect_attempts` and
+/// `Default` for a builder whose fields are `$field: Vec<String>`,
+/// `retry_delay: Duration` and `max_reconnect_attempts: Option<u32>`.
 #[cfg(feature = "polygon")]
 macro_rules! stream_builder {
     ($builder:ident, $field:ident = $doc:literal) => {
@@ -192,9 +194,20 @@ macro_rules! stream_builder {
                 self
             }
 
-            /// Set the delay between reconnection attempts (default: 3s).
+            /// Set the base delay before the first reconnection attempt
+            /// (default: 3s). Later attempts grow exponentially from this,
+            /// capped and jittered — see [`Self::max_reconnect_attempts`] to
+            /// also cap how many attempts are made.
             pub fn retry(mut self, delay: ::std::time::Duration) -> Self {
                 self.retry_delay = delay;
+                self
+            }
+
+            /// Cap the number of consecutive reconnect attempts before the
+            /// stream gives up and ends (default: unlimited, i.e. retry
+            /// forever like before issue #276).
+            pub fn max_reconnect_attempts(mut self, max: u32) -> Self {
+                self.max_reconnect_attempts = Some(max);
                 self
             }
         }

--- a/src/streaming/options.rs
+++ b/src/streaming/options.rs
@@ -13,6 +13,7 @@ use super::client::StreamResult;
 use super::handle::{RECONNECT_BACKOFF, SourceStream, stream_builder, stream_handle};
 use super::polygon::PolygonOptionsSource;
 use super::pricing::OptionType;
+use super::source::ReconnectConfig;
 
 /// Channel capacity — a wide chain fans out many contracts per tick.
 const CHANNEL_CAPACITY: usize = 2048;
@@ -184,6 +185,7 @@ impl OptionsChainStream {
 pub struct OptionsChainStreamBuilder {
     underlyings: Vec<String>,
     retry_delay: Duration,
+    max_reconnect_attempts: Option<u32>,
     greeks_refresh: Option<Duration>,
 }
 
@@ -193,6 +195,7 @@ impl OptionsChainStreamBuilder {
         Self {
             underlyings: Vec::new(),
             retry_delay: RECONNECT_BACKOFF,
+            max_reconnect_attempts: None,
             greeks_refresh: Some(DEFAULT_GREEKS_REFRESH),
         }
     }
@@ -209,13 +212,10 @@ impl OptionsChainStreamBuilder {
     /// Build and start the stream.
     pub async fn build(self) -> StreamResult<OptionsChainStream> {
         let source = Arc::new(PolygonOptionsSource::new(self.greeks_refresh));
+        let reconnect =
+            ReconnectConfig::new(self.retry_delay).max_attempts(self.max_reconnect_attempts);
         Ok(OptionsChainStream {
-            inner: SourceStream::start(
-                source,
-                self.underlyings,
-                self.retry_delay,
-                CHANNEL_CAPACITY,
-            ),
+            inner: SourceStream::start(source, self.underlyings, reconnect, CHANNEL_CAPACITY),
         })
     }
 }

--- a/src/streaming/source.rs
+++ b/src/streaming/source.rs
@@ -54,7 +54,7 @@ where
 }
 
 /// Exponential-backoff-with-jitter configuration for [`run_stream_loop`]'s
-/// reconnect delay (issue #276).
+/// reconnect delay.
 ///
 /// `base_delay` is the same knob every builder's `.retry(Duration)` method has
 /// always exposed — the delay before the first reconnect attempt. Later
@@ -70,6 +70,7 @@ pub(crate) struct ReconnectConfig {
     multiplier: f64,
     jitter: f64,
     max_attempts: Option<u32>,
+    healthy_after: Duration,
 }
 
 impl ReconnectConfig {
@@ -80,6 +81,7 @@ impl ReconnectConfig {
             multiplier: 2.0,
             jitter: 0.2,
             max_attempts: None,
+            healthy_after: Duration::from_secs(60),
         }
     }
 
@@ -90,29 +92,37 @@ impl ReconnectConfig {
         self
     }
 
+    /// How long a session must stay up before its failure resets the attempt
+    /// counter. Test hook — production uses the 60s default.
+    #[cfg(test)]
+    pub(crate) fn healthy_after(mut self, healthy_after: Duration) -> Self {
+        self.healthy_after = healthy_after;
+        self
+    }
+
     /// Delay before the reconnect attempt numbered `attempt` (0-indexed).
     fn delay_for(&self, attempt: u32, seed: &mut u64) -> Duration {
-        crate::backoff::with_jitter(
-            crate::backoff::exponential_delay(
-                attempt,
-                self.base_delay,
-                self.multiplier,
-                self.max_delay,
-            ),
-            self.jitter,
-            seed,
-        )
+        crate::backoff::BackoffParams {
+            base: self.base_delay,
+            max: self.max_delay,
+            multiplier: self.multiplier,
+            jitter: self.jitter,
+        }
+        .delay_for(attempt, seed)
     }
 }
 
 /// Drive a [`StreamSource`] with automatic reconnection until it shuts down.
 ///
 /// `reconnect` is supplied by the caller rather than hard-coded so builders
-/// can tune the base delay and attempt cap without touching sources (see
-/// issue #276). A session that stays connected for at least one `base_delay`
-/// interval is treated as healthy — its disconnect resets the backoff, so a
-/// single brief blip doesn't inherit a long delay accumulated from an earlier
-/// outage.
+/// can tune the base delay and attempt cap without touching sources. A session
+/// that stays connected for `healthy_after` is treated as healthy — its
+/// disconnect resets the backoff, so a single brief blip doesn't inherit a
+/// long delay accumulated from an earlier outage. That threshold is
+/// deliberately independent of `base_delay`: keying it to the (short) base
+/// delay would let a source that accepts the connection and then fails a few
+/// seconds in — auth rejection, subscription error, idle kill — reset the
+/// counter every cycle and reconnect forever despite `max_attempts`.
 pub(crate) async fn run_stream_loop<T>(
     source: Arc<dyn StreamSource<T>>,
     initial_symbols: Vec<String>,
@@ -138,7 +148,7 @@ where
                 break;
             }
             Err(e) => {
-                if session_start.elapsed() >= reconnect.base_delay {
+                if session_start.elapsed() >= reconnect.healthy_after {
                     attempt = 0;
                 }
                 if let Some(max) = reconnect.max_attempts
@@ -304,6 +314,51 @@ mod tests {
                 "boom".to_string(),
             ))
         }
+    }
+
+    /// A source whose session survives briefly, then fails — the shape that
+    /// used to defeat `max_attempts` by resetting the counter every cycle.
+    struct BrieflyUpThenFailSource;
+
+    #[async_trait::async_trait]
+    impl StreamSource<PriceUpdate> for BrieflyUpThenFailSource {
+        fn id(&self) -> &'static str {
+            "briefly-up"
+        }
+
+        async fn run_session(
+            &self,
+            _subscriptions: &Arc<RwLock<HashSet<String>>>,
+            _broadcast_tx: &broadcast::Sender<PriceUpdate>,
+            _command_rx: &mut mpsc::Receiver<StreamCommand>,
+        ) -> StreamResult<()> {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            Err(super::super::client::StreamError::ConnectionFailed(
+                "dropped".to_string(),
+            ))
+        }
+    }
+
+    #[tokio::test]
+    async fn a_session_shorter_than_healthy_after_still_counts_toward_max_attempts() {
+        // Sessions last ~20ms — longer than base_delay but well short of
+        // healthy_after, so the attempt counter must keep climbing.
+        let reconnect = ReconnectConfig::new(Duration::from_millis(1))
+            .max_attempts(Some(2))
+            .healthy_after(Duration::from_secs(60));
+        let mut stream = PriceStream::subscribe_with_source(
+            Arc::new(BrieflyUpThenFailSource),
+            Vec::<String>::new(),
+            reconnect,
+        )
+        .await
+        .unwrap();
+
+        let ended = tokio::time::timeout(Duration::from_secs(5), stream.next()).await;
+        assert!(
+            matches!(ended, Ok(None)),
+            "stream should have given up, not reconnected forever"
+        );
     }
 
     #[tokio::test]

--- a/src/streaming/source.rs
+++ b/src/streaming/source.rs
@@ -53,23 +53,82 @@ where
     ) -> StreamResult<()>;
 }
 
+/// Exponential-backoff-with-jitter configuration for [`run_stream_loop`]'s
+/// reconnect delay (issue #276).
+///
+/// `base_delay` is the same knob every builder's `.retry(Duration)` method has
+/// always exposed — the delay before the first reconnect attempt. Later
+/// attempts grow by `multiplier` each time (capped at `max_delay`), with
+/// jitter applied so many concurrently-reconnecting streams don't retry in
+/// lockstep. `max_attempts` optionally stops the loop from reconnecting
+/// forever; `None` (the default) preserves the original "retry forever"
+/// behavior.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ReconnectConfig {
+    base_delay: Duration,
+    max_delay: Duration,
+    multiplier: f64,
+    jitter: f64,
+    max_attempts: Option<u32>,
+}
+
+impl ReconnectConfig {
+    pub(crate) fn new(base_delay: Duration) -> Self {
+        Self {
+            base_delay,
+            max_delay: Duration::from_secs(60),
+            multiplier: 2.0,
+            jitter: 0.2,
+            max_attempts: None,
+        }
+    }
+
+    /// Cap the number of consecutive reconnect attempts before the loop gives
+    /// up and ends. `None` (the default) retries forever.
+    pub(crate) fn max_attempts(mut self, max: Option<u32>) -> Self {
+        self.max_attempts = max;
+        self
+    }
+
+    /// Delay before the reconnect attempt numbered `attempt` (0-indexed).
+    fn delay_for(&self, attempt: u32, seed: &mut u64) -> Duration {
+        crate::backoff::with_jitter(
+            crate::backoff::exponential_delay(
+                attempt,
+                self.base_delay,
+                self.multiplier,
+                self.max_delay,
+            ),
+            self.jitter,
+            seed,
+        )
+    }
+}
+
 /// Drive a [`StreamSource`] with automatic reconnection until it shuts down.
 ///
-/// `retry_delay` is supplied by the caller rather than hard-coded so a smarter
-/// policy can be swapped in without touching sources.
+/// `reconnect` is supplied by the caller rather than hard-coded so builders
+/// can tune the base delay and attempt cap without touching sources (see
+/// issue #276). A session that stays connected for at least one `base_delay`
+/// interval is treated as healthy — its disconnect resets the backoff, so a
+/// single brief blip doesn't inherit a long delay accumulated from an earlier
+/// outage.
 pub(crate) async fn run_stream_loop<T>(
     source: Arc<dyn StreamSource<T>>,
     initial_symbols: Vec<String>,
     broadcast_tx: broadcast::Sender<T>,
     mut command_rx: mpsc::Receiver<StreamCommand>,
-    retry_delay: Duration,
+    reconnect: ReconnectConfig,
 ) -> StreamResult<()>
 where
     T: Clone + Send + 'static,
 {
     let subscriptions = Arc::new(RwLock::new(HashSet::<String>::from_iter(initial_symbols)));
+    let mut attempt: u32 = 0;
+    let mut seed = crate::backoff::seed_from_time();
 
     loop {
+        let session_start = tokio::time::Instant::now();
         match source
             .run_session(&subscriptions, &broadcast_tx, &mut command_rx)
             .await
@@ -79,13 +138,30 @@ where
                 break;
             }
             Err(e) => {
+                if session_start.elapsed() >= reconnect.base_delay {
+                    attempt = 0;
+                }
+                if let Some(max) = reconnect.max_attempts
+                    && attempt >= max
+                {
+                    error!(
+                        "{} stream error: {}, giving up after {} reconnect attempts",
+                        source.id(),
+                        e,
+                        max
+                    );
+                    break;
+                }
+                let delay = reconnect.delay_for(attempt, &mut seed);
                 error!(
-                    "{} stream error: {}, reconnecting in {:.1}s...",
+                    "{} stream error: {}, reconnecting in {:.1}s (attempt {})...",
                     source.id(),
                     e,
-                    retry_delay.as_secs_f32()
+                    delay.as_secs_f32(),
+                    attempt + 1
                 );
-                tokio::time::sleep(retry_delay).await;
+                tokio::time::sleep(delay).await;
+                attempt += 1;
             }
         }
     }
@@ -172,7 +248,7 @@ mod tests {
         let mut stream = PriceStream::subscribe_with_source(
             Arc::new(MockSource),
             ["AAPL"],
-            Duration::from_millis(50),
+            ReconnectConfig::new(Duration::from_millis(50)),
         )
         .await
         .unwrap();
@@ -206,5 +282,65 @@ mod tests {
         assert_eq!(removed, Some(vec!["NVDA".to_string()]));
 
         assert!(apply_command(&StreamCommand::Close, &subs).await.is_none());
+    }
+
+    /// A source whose session always fails immediately — for exercising the
+    /// reconnect loop's `max_attempts` cap without waiting on real timeouts.
+    struct AlwaysFailSource;
+
+    #[async_trait::async_trait]
+    impl StreamSource<PriceUpdate> for AlwaysFailSource {
+        fn id(&self) -> &'static str {
+            "always-fail"
+        }
+
+        async fn run_session(
+            &self,
+            _subscriptions: &Arc<RwLock<HashSet<String>>>,
+            _broadcast_tx: &broadcast::Sender<PriceUpdate>,
+            _command_rx: &mut mpsc::Receiver<StreamCommand>,
+        ) -> StreamResult<()> {
+            Err(super::super::client::StreamError::ConnectionFailed(
+                "boom".to_string(),
+            ))
+        }
+    }
+
+    #[tokio::test]
+    async fn reconnect_loop_gives_up_after_max_attempts() {
+        let reconnect = ReconnectConfig::new(Duration::from_millis(1)).max_attempts(Some(2));
+        let mut stream = PriceStream::subscribe_with_source(
+            Arc::new(AlwaysFailSource),
+            Vec::<String>::new(),
+            reconnect,
+        )
+        .await
+        .unwrap();
+
+        // The loop must stop retrying and end the stream rather than
+        // reconnecting forever.
+        let ended = tokio::time::timeout(Duration::from_secs(5), stream.next()).await;
+        assert!(matches!(ended, Ok(None)), "stream should have ended");
+    }
+
+    #[test]
+    fn reconnect_config_delay_grows_and_caps() {
+        let reconnect = ReconnectConfig::new(Duration::from_secs(1));
+        let mut seed = 1u64;
+        // Default max_delay is 60s with 20% jitter: no sample may exceed 72s.
+        for attempt in 0..12 {
+            let delay = reconnect.delay_for(attempt, &mut seed);
+            assert!(
+                delay <= Duration::from_secs(72),
+                "attempt {attempt}: {delay:?}"
+            );
+        }
+        // Deep into the attempt sequence the delay must be pinned near the
+        // cap (>= 60s * 0.8), not still climbing toward it from the 1s base.
+        let late = reconnect.delay_for(20, &mut seed);
+        assert!(
+            late >= Duration::from_secs(48),
+            "expected the delay capped near max_delay, got {late:?}"
+        );
     }
 }

--- a/src/streaming/trades.rs
+++ b/src/streaming/trades.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use super::client::StreamResult;
 use super::handle::{RECONNECT_BACKOFF, SourceStream, stream_builder, stream_handle};
 use super::polygon::{AssetClass, PolygonTradeSource};
+use super::source::ReconnectConfig;
 
 /// Channel capacity — trade prints are the highest-volume feed here.
 const CHANNEL_CAPACITY: usize = 4096;
@@ -87,6 +88,7 @@ pub struct TradeStreamBuilder {
     symbols: Vec<String>,
     asset_class: AssetClass,
     retry_delay: Duration,
+    max_reconnect_attempts: Option<u32>,
 }
 
 impl TradeStreamBuilder {
@@ -96,6 +98,7 @@ impl TradeStreamBuilder {
             symbols: Vec::new(),
             asset_class: AssetClass::Stocks,
             retry_delay: RECONNECT_BACKOFF,
+            max_reconnect_attempts: None,
         }
     }
 
@@ -116,8 +119,10 @@ impl TradeStreamBuilder {
     /// when the chosen asset class has no trade feed.
     pub async fn build(self) -> StreamResult<TradeStream> {
         let source = Arc::new(PolygonTradeSource::new(self.asset_class)?);
+        let reconnect =
+            ReconnectConfig::new(self.retry_delay).max_attempts(self.max_reconnect_attempts);
         Ok(TradeStream {
-            inner: SourceStream::start(source, self.symbols, self.retry_delay, CHANNEL_CAPACITY),
+            inner: SourceStream::start(source, self.symbols, reconnect, CHANNEL_CAPACITY),
         })
     }
 }


### PR DESCRIPTION
## Description
Provider dispatch had no answer for a rate-limited response except failing over to the next provider immediately, and the streaming reconnect loop retried a dead connection every 3 seconds forever. This PR adds opt-in retry with backoff and jitter to provider dispatch, a per-provider health snapshot (success/failure counts, last error, rate-limit budget), and exponential reconnect backoff for streaming. All three share one delay implementation instead of two hand-rolled copies.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Added `RetryPolicy` (`Providers::builder().retry(RetryPolicy::new(3))`). A candidate that returns `RateLimited` is retried in place before falling through to the next routed provider, honoring the error's `retry_after` hint when present and backing off exponentially otherwise.
- Added `max_retry_after` (default 5 minutes) to bound a hostile or buggy `retry_after` hint, kept separate from `max_delay` so a legitimate multi-minute hint still applies.
- Omitting `.retry(..)` leaves one attempt per candidate, unchanged from current behavior.
- Added `Providers::health()`, returning a `ProviderHealth` per configured provider: success/failure counts over the last 20 dispatches, the most recent error, and a rate-limit budget estimate where the adapter exposes one. Health tracking is observational and does not affect routing.
- `NotSupported` is excluded from health accounting, since it means try the next candidate, not a provider failure.
- Streaming reconnect delay now grows exponentially from the builder's existing `.retry(Duration)` base, capped at 60s and jittered so concurrent streams don't reconnect in lockstep.
- Added `.max_reconnect_attempts(n)` to cap consecutive reconnect attempts. Default stays unlimited.
- Added a `healthy_after` threshold (60s), separate from the base delay: the old behavior keyed that threshold to the short base delay, so a stream that connected and failed a few seconds in reset its attempt counter every cycle and reconnected forever despite the cap.
- Fixed a zero base delay producing `max_delay` instead of zero at high attempt counts (`0.0 * inf` is NaN, and `f64::min` returns the other operand).
- `RetryPolicy` and `ReconnectConfig` now share one `BackoffParams` delay implementation instead of two separate copies.

## Breaking Changes
None. `RetryPolicy` is opt-in, `health()` is additive, and streaming reconnects keep their previous first-attempt delay and unlimited-retry default unless `.max_reconnect_attempts()` is set.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] All tests pass (`cargo test`)

`cargo test --lib --features full`: 1162 passed, 0 failed.

## Documentation
- [x] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [x] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy`)
- [x] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues
Closes #276