### PR TITLE
feat: Pivot Points, Heikin-Ashi, ZigZag, Fibonacci, CVaR, Fear & Greed

### DIFF
--- a/benches/finance.rs
+++ b/benches/finance.rs
@@ -7,6 +7,8 @@ static SEARCH_JSON: &str = include_str!("fixtures/search.json");
 static MARKET_SUMMARY_JSON: &str = include_str!("fixtures/market_summary.json");
 static TRENDING_JSON: &str = include_str!("fixtures/trending.json");
 static FEAR_AND_GREED_JSON: &str = include_str!("fixtures/fear_and_greed.json");
+static FEAR_AND_GREED_CRYPTO_HISTORY_JSON: &str =
+    include_str!("fixtures/fear_and_greed_crypto_history.json");
 static HOURS_JSON: &str = include_str!("fixtures/hours.json");
 static NEWS_JSON: &str = include_str!("fixtures/news.json");
 static CURRENCIES_JSON: &str = include_str!("fixtures/currencies.json");
@@ -45,6 +47,16 @@ fn bench_fear_and_greed_deserialize(c: &mut Criterion) {
         b.iter(|| {
             let result: FearAndGreed =
                 serde_json::from_str(black_box(FEAR_AND_GREED_JSON)).unwrap();
+            black_box(result);
+        })
+    });
+}
+
+fn bench_fear_and_greed_crypto_history_deserialize(c: &mut Criterion) {
+    c.bench_function("fear_and_greed_crypto_history_deserialize_10_items", |b| {
+        b.iter(|| {
+            let result: Vec<FearAndGreed> =
+                serde_json::from_str(black_box(FEAR_AND_GREED_CRYPTO_HISTORY_JSON)).unwrap();
             black_box(result);
         })
     });
@@ -123,6 +135,7 @@ criterion_group!(
     bench_market_summary_deserialize,
     bench_trending_deserialize,
     bench_fear_and_greed_deserialize,
+    bench_fear_and_greed_crypto_history_deserialize,
     bench_hours_deserialize,
     bench_news_deserialize,
     bench_currencies_deserialize,

--- a/benches/fixtures/fear_and_greed_crypto_history.json
+++ b/benches/fixtures/fear_and_greed_crypto_history.json
@@ -1,0 +1,12 @@
+[
+  {"value":62,"classification":"Greed","timestamp":1774137600},
+  {"value":55,"classification":"Neutral","timestamp":1774051200},
+  {"value":48,"classification":"Neutral","timestamp":1773964800},
+  {"value":41,"classification":"Fear","timestamp":1773878400},
+  {"value":33,"classification":"Fear","timestamp":1773792000},
+  {"value":28,"classification":"Fear","timestamp":1773705600},
+  {"value":19,"classification":"Extreme Fear","timestamp":1773619200},
+  {"value":24,"classification":"Extreme Fear","timestamp":1773532800},
+  {"value":37,"classification":"Fear","timestamp":1773446400},
+  {"value":45,"classification":"Neutral","timestamp":1773360000}
+]

--- a/benches/indicators.rs
+++ b/benches/indicators.rs
@@ -3,9 +3,10 @@ use finance_query::Candle;
 use finance_query::indicators::{
     accumulation_distribution, adx, alma, aroon, atr, awesome_oscillator, balance_of_power,
     bollinger_bands, bull_bear_power, cci, chaikin_oscillator, choppiness_index, cmf, cmo,
-    coppock_curve, dema, donchian_channels, elder_ray, ema, hma, ichimoku, keltner_channels, macd,
-    mcginley_dynamic, mfi, momentum, obv, parabolic_sar, patterns, roc, rsi, sma, stochastic,
-    stochastic_rsi, supertrend, tema, true_range, vwap, vwma, williams_r, wma,
+    coppock_curve, dema, donchian_channels, elder_ray, ema, fibonacci_pivot_points,
+    fibonacci_retracement, heikin_ashi, hma, ichimoku, keltner_channels, macd, mcginley_dynamic,
+    mfi, momentum, obv, parabolic_sar, patterns, pivot_points, roc, rsi, sma, stochastic,
+    stochastic_rsi, supertrend, tema, true_range, vwap, vwma, williams_r, wma, zigzag,
 };
 use std::hint::black_box;
 
@@ -313,6 +314,35 @@ fn bench_patterns(c: &mut Criterion) {
     group.finish();
 }
 
+// ── Pivot Points, Heikin-Ashi, ZigZag, Fibonacci Retracement ────────────────
+
+fn bench_pivot_heikin_zigzag_fib(c: &mut Criterion) {
+    let candles = synthetic_candles(1000);
+    let closes: Vec<f64> = candles.iter().map(|c| c.close).collect();
+    let highs: Vec<f64> = candles.iter().map(|c| c.high).collect();
+    let lows: Vec<f64> = candles.iter().map(|c| c.low).collect();
+
+    let mut group = c.benchmark_group("pivot_heikin_zigzag_fib");
+
+    group.bench_function("pivot_points", |b| {
+        b.iter(|| pivot_points(black_box(&highs), black_box(&lows), black_box(&closes)))
+    });
+    group.bench_function("fibonacci_pivot_points", |b| {
+        b.iter(|| fibonacci_pivot_points(black_box(&highs), black_box(&lows), black_box(&closes)))
+    });
+    group.bench_function("heikin_ashi", |b| {
+        b.iter(|| heikin_ashi(black_box(&candles)))
+    });
+    group.bench_function("zigzag_5pct", |b| {
+        b.iter(|| zigzag(black_box(&highs), black_box(&lows), 5.0))
+    });
+    group.bench_function("fibonacci_retracement_50", |b| {
+        b.iter(|| fibonacci_retracement(black_box(&highs), black_box(&lows), 50))
+    });
+
+    group.finish();
+}
+
 // ── Full Indicator Suite (equivalent to IndicatorsSummary workload) ───────────
 
 fn bench_full_suite(c: &mut Criterion) {
@@ -397,6 +427,7 @@ criterion_group!(
     bench_volatility,
     bench_volume,
     bench_patterns,
+    bench_pivot_heikin_zigzag_fib,
     bench_full_suite,
 );
 criterion_main!(benches);

--- a/benches/regression.rs
+++ b/benches/regression.rs
@@ -54,8 +54,8 @@ use finance_query::risk::{
 use finance_query::streaming::{MarketHoursType, OptionType, PriceUpdate, QuoteType};
 use finance_query::translation::{Lang, translate_texts};
 use finance_query::{
-    Candle, Chart, CompanyFacts, Currency, EdgarSubmissions, FinancialStatement, News, Options,
-    Quote, ScreenerResults, SearchResults, Transcript, analyze_sentiment,
+    Candle, Chart, CompanyFacts, Currency, EdgarSubmissions, FearAndGreed, FinancialStatement,
+    News, Options, Quote, ScreenerResults, SearchResults, Transcript, analyze_sentiment,
 };
 use iai_callgrind::{
     Callgrind, EventKind, LibraryBenchmarkConfig, library_benchmark, library_benchmark_group, main,
@@ -599,6 +599,8 @@ library_benchmark_group!(
 static SEARCH_JSON: &str = include_str!("fixtures/search.json");
 static NEWS_JSON: &str = include_str!("fixtures/news.json");
 static CURRENCIES_JSON: &str = include_str!("fixtures/currencies.json");
+static FEAR_AND_GREED_CRYPTO_HISTORY_JSON: &str =
+    include_str!("fixtures/fear_and_greed_crypto_history.json");
 
 #[library_benchmark]
 fn de_search() -> SearchResults {
@@ -615,6 +617,11 @@ fn de_currencies() -> Vec<Currency> {
     black_box(serde_json::from_str(black_box(CURRENCIES_JSON)).unwrap())
 }
 
+#[library_benchmark]
+fn de_fear_and_greed_crypto_history() -> Vec<FearAndGreed> {
+    black_box(serde_json::from_str(black_box(FEAR_AND_GREED_CRYPTO_HISTORY_JSON)).unwrap())
+}
+
 fn parsed_currencies() -> Vec<Currency> {
     serde_json::from_str(CURRENCIES_JSON).unwrap()
 }
@@ -627,7 +634,7 @@ fn ser_currencies(currencies: Vec<Currency>) -> String {
 
 library_benchmark_group!(
     name = model_serde;
-    benchmarks = de_search, de_news, de_currencies, ser_currencies
+    benchmarks = de_search, de_news, de_currencies, ser_currencies, de_fear_and_greed_crypto_history
 );
 
 // ── Endpoint response (de)serialization (real captured server payloads) ──────

--- a/benches/regression.rs
+++ b/benches/regression.rs
@@ -47,7 +47,9 @@ use finance_query::indicators::{
     stochastic_rsi, supertrend, tema, true_range, vwap, vwma, williams_r, wma, zigzag,
 };
 use finance_query::risk::{
-    beta, historical_var, max_drawdown, parametric_var, sharpe_ratio, sortino_ratio,
+    beta, historical_cvar, historical_var, information_ratio, kelly_criterion, max_drawdown,
+    omega_ratio, parametric_cvar, parametric_var, sharpe_ratio, sortino_ratio, tracking_error,
+    ulcer_index, win_loss_stats,
 };
 use finance_query::streaming::{MarketHoursType, OptionType, PriceUpdate, QuoteType};
 use finance_query::translation::{Lang, translate_texts};
@@ -433,10 +435,63 @@ fn risk_beta(series: (Vec<f64>, Vec<f64>)) -> Option<f64> {
     black_box(beta(black_box(&series.0), black_box(&series.1)))
 }
 
+#[library_benchmark]
+#[bench::n1000(setup = returns_1000)]
+fn risk_historical_cvar(returns: Vec<f64>) -> Option<f64> {
+    black_box(historical_cvar(black_box(&returns), 0.95))
+}
+
+#[library_benchmark]
+#[bench::n1000(setup = returns_1000)]
+fn risk_parametric_cvar(returns: Vec<f64>) -> Option<f64> {
+    black_box(parametric_cvar(black_box(&returns), 0.95))
+}
+
+#[library_benchmark]
+#[bench::n1000(setup = returns_1000)]
+fn risk_omega_ratio(returns: Vec<f64>) -> f64 {
+    black_box(omega_ratio(black_box(&returns)))
+}
+
+#[library_benchmark]
+#[bench::n1000(setup = returns_1000)]
+fn risk_ulcer_index(returns: Vec<f64>) -> f64 {
+    black_box(ulcer_index(black_box(&returns)))
+}
+
+#[library_benchmark]
+#[bench::n1000(setup = returns_1000)]
+fn risk_kelly_criterion(returns: Vec<f64>) -> f64 {
+    let (win_rate, avg_win_pct, avg_loss_pct) = win_loss_stats(black_box(&returns));
+    black_box(kelly_criterion(win_rate, avg_win_pct, avg_loss_pct))
+}
+
+#[library_benchmark]
+#[bench::n1000(setup = returns_pair_1000)]
+fn risk_information_ratio(series: (Vec<f64>, Vec<f64>)) -> Option<f64> {
+    black_box(information_ratio(
+        black_box(&series.0),
+        black_box(&series.1),
+        252.0,
+    ))
+}
+
+#[library_benchmark]
+#[bench::n1000(setup = returns_pair_1000)]
+fn risk_tracking_error(series: (Vec<f64>, Vec<f64>)) -> Option<f64> {
+    black_box(tracking_error(
+        black_box(&series.0),
+        black_box(&series.1),
+        252.0,
+    ))
+}
+
 library_benchmark_group!(
     name = risk;
     benchmarks = risk_historical_var, risk_parametric_var, risk_sharpe, risk_sortino,
-        risk_max_drawdown, risk_beta
+        risk_max_drawdown, risk_beta, risk_historical_cvar, risk_parametric_cvar,
+        risk_omega_ratio, risk_ulcer_index, risk_kelly_criterion, risk_information_ratio,
+        risk_tracking_error
 );
 
 // ── Streaming (PriceUpdate serde — the per-tick hot path) ─────────────────────

--- a/benches/regression.rs
+++ b/benches/regression.rs
@@ -41,9 +41,10 @@ use finance_query::fred::{MacroSeries, TreasuryYield};
 use finance_query::indicators::{
     accumulation_distribution, adx, alma, aroon, atr, awesome_oscillator, balance_of_power,
     bollinger_bands, bull_bear_power, cci, chaikin_oscillator, choppiness_index, cmf, cmo,
-    coppock_curve, dema, donchian_channels, elder_ray, ema, hma, ichimoku, keltner_channels, macd,
-    mcginley_dynamic, mfi, momentum, obv, parabolic_sar, patterns, roc, rsi, sma, stochastic,
-    stochastic_rsi, supertrend, tema, true_range, vwap, vwma, williams_r, wma,
+    coppock_curve, dema, donchian_channels, elder_ray, ema, fibonacci_pivot_points,
+    fibonacci_retracement, heikin_ashi, hma, ichimoku, keltner_channels, macd, mcginley_dynamic,
+    mfi, momentum, obv, parabolic_sar, patterns, pivot_points, roc, rsi, sma, stochastic,
+    stochastic_rsi, supertrend, tema, true_range, vwap, vwma, williams_r, wma, zigzag,
 };
 use finance_query::risk::{
     beta, historical_var, max_drawdown, parametric_var, sharpe_ratio, sortino_ratio,
@@ -324,10 +325,46 @@ fn ind_patterns(candles: Vec<Candle>) {
     let _ = black_box(patterns(black_box(&candles)));
 }
 
+#[library_benchmark]
+#[bench::n1000(setup = series_1000)]
+fn ind_pivot_points(s: Series) {
+    let (_, highs, lows, closes, _) = &s;
+    let _ = black_box(pivot_points(
+        black_box(highs),
+        black_box(lows),
+        black_box(closes),
+    ));
+    let _ = black_box(fibonacci_pivot_points(
+        black_box(highs),
+        black_box(lows),
+        black_box(closes),
+    ));
+}
+
+#[library_benchmark]
+#[bench::n1000(setup = candles_1000)]
+fn ind_heikin_ashi(candles: Vec<Candle>) {
+    let _ = black_box(heikin_ashi(black_box(&candles)));
+}
+
+#[library_benchmark]
+#[bench::n1000(setup = series_1000)]
+fn ind_zigzag(s: Series) {
+    let (_, highs, lows, _, _) = &s;
+    let _ = black_box(zigzag(black_box(highs), black_box(lows), 5.0));
+}
+
+#[library_benchmark]
+#[bench::n1000(setup = series_1000)]
+fn ind_fibonacci_retracement(s: Series) {
+    let (_, highs, lows, _, _) = &s;
+    let _ = black_box(fibonacci_retracement(black_box(highs), black_box(lows), 50));
+}
+
 library_benchmark_group!(
     name = indicators;
     benchmarks = ind_moving_averages, ind_momentum, ind_trend, ind_volatility, ind_volume,
-        ind_patterns
+        ind_patterns, ind_pivot_points, ind_heikin_ashi, ind_zigzag, ind_fibonacci_retracement
 );
 
 // ── Backtesting engine ───────────────────────────────────────────────────────

--- a/benches/risk.rs
+++ b/benches/risk.rs
@@ -10,7 +10,9 @@
 
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use finance_query::risk::{
-    beta, calmar_ratio, historical_var, max_drawdown, parametric_var, sharpe_ratio, sortino_ratio,
+    beta, calmar_ratio, historical_cvar, historical_var, information_ratio, kelly_criterion,
+    max_drawdown, omega_ratio, parametric_cvar, parametric_var, sharpe_ratio, sortino_ratio,
+    tracking_error, ulcer_index, win_loss_stats,
 };
 
 /// Deterministic pseudo-random return series (seeded xorshift, no `rand` dep).
@@ -86,11 +88,62 @@ fn bench_beta(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_cvar(c: &mut Criterion) {
+    let mut group = c.benchmark_group("conditional_value_at_risk");
+    for n in [252usize, 1260, 2520] {
+        let returns = synthetic_returns(n);
+        group.bench_with_input(BenchmarkId::new("historical_95", n), &returns, |b, r| {
+            b.iter(|| historical_cvar(black_box(r), 0.95))
+        });
+        group.bench_with_input(BenchmarkId::new("parametric_95", n), &returns, |b, r| {
+            b.iter(|| parametric_cvar(black_box(r), 0.95))
+        });
+    }
+    group.finish();
+}
+
+fn bench_promoted_metrics(c: &mut Criterion) {
+    let mut group = c.benchmark_group("promoted_metrics");
+    for n in [252usize, 1260, 2520] {
+        let returns = synthetic_returns(n);
+        group.bench_with_input(BenchmarkId::new("omega_ratio", n), &returns, |b, r| {
+            b.iter(|| omega_ratio(black_box(r)))
+        });
+        group.bench_with_input(BenchmarkId::new("ulcer_index", n), &returns, |b, r| {
+            b.iter(|| ulcer_index(black_box(r)))
+        });
+        group.bench_with_input(BenchmarkId::new("win_loss_stats", n), &returns, |b, r| {
+            b.iter(|| win_loss_stats(black_box(r)))
+        });
+    }
+    group.bench_function("kelly_criterion", |b| {
+        b.iter(|| kelly_criterion(black_box(0.55), black_box(1.8), black_box(-1.2)))
+    });
+
+    for n in [252usize, 1260, 2520] {
+        let asset = synthetic_returns(n);
+        let benchmark = synthetic_returns(n + 1);
+        group.bench_with_input(
+            BenchmarkId::new("information_ratio", n),
+            &(asset.clone(), benchmark.clone()),
+            |b, (a, m)| b.iter(|| information_ratio(black_box(a), black_box(m), 252.0)),
+        );
+        group.bench_with_input(
+            BenchmarkId::new("tracking_error", n),
+            &(asset, benchmark),
+            |b, (a, m)| b.iter(|| tracking_error(black_box(a), black_box(m), 252.0)),
+        );
+    }
+    group.finish();
+}
+
 criterion_group!(
     risk_benches,
     bench_value_at_risk,
+    bench_cvar,
     bench_ratios,
     bench_drawdown,
     bench_beta,
+    bench_promoted_metrics,
 );
 criterion_main!(risk_benches);

--- a/src/adapters/yahoo/market/fear_and_greed.rs
+++ b/src/adapters/yahoo/market/fear_and_greed.rs
@@ -1,25 +1,42 @@
 //! Alternative.me Fear & Greed Index endpoint.
 //!
-//! No authentication required. Returns the current market sentiment index.
+//! No authentication required. Returns the current market sentiment index
+//! (Alternative.me's index specifically reflects crypto/Bitcoin sentiment).
 
 use std::time::Duration;
 
 use crate::error::{FinanceError, Result};
 use crate::models::sentiment::response::{FearAndGreed, FearAndGreedApiResponse};
 
-const API_URL: &str = "https://api.alternative.me/fng/?limit=1&format=json";
+const BASE_URL: &str = "https://api.alternative.me/fng";
 
 /// Fetch the current Fear & Greed Index from Alternative.me.
 pub(crate) async fn fetch() -> Result<FearAndGreed> {
+    let raw = fetch_raw(1, BASE_URL).await?;
+    FearAndGreed::from_response(raw)
+}
+
+/// Fetch `limit` historical entries (newest first) of the Fear & Greed Index
+/// from Alternative.me. Alternative.me's index specifically reflects crypto
+/// (Bitcoin) market sentiment.
+pub(crate) async fn fetch_history(limit: u32) -> Result<Vec<FearAndGreed>> {
+    let raw = fetch_raw(limit, BASE_URL).await?;
+    FearAndGreed::vec_from_response(raw)
+}
+
+/// `base_url` is injectable so tests can point at a mock server instead of
+/// the live API.
+async fn fetch_raw(limit: u32, base_url: &str) -> Result<FearAndGreedApiResponse> {
     // Per-call client construction is intentional: this endpoint is called at most once
     // per session, so connection-pool reuse provides no measurable benefit. A static
     // OnceLock<reqwest::Client> would bind the pool to whichever tokio runtime first
     // initialises it; if that runtime later drops (e.g. in tests, or on a server
     // restart with re-init), subsequent calls on a new runtime fail with DispatchGone.
+    let url = format!("{base_url}?limit={limit}&format=json");
     let response = reqwest::Client::builder()
         .timeout(Duration::from_secs(30))
         .build()?
-        .get(API_URL)
+        .get(url)
         .send()
         .await?;
 
@@ -31,7 +48,101 @@ pub(crate) async fn fetch() -> Result<FearAndGreed> {
         });
     }
 
-    let raw: FearAndGreedApiResponse = response.json().await?;
+    Ok(response.json().await?)
+}
 
-    FearAndGreed::from_response(raw)
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn single_entry_body(value: &str, classification: &str, timestamp: &str) -> String {
+        serde_json::json!({
+            "data": [
+                {
+                    "value": value,
+                    "value_classification": classification,
+                    "timestamp": timestamp,
+                }
+            ]
+        })
+        .to_string()
+    }
+
+    fn multi_entry_body() -> String {
+        serde_json::json!({
+            "data": [
+                { "value": "72", "value_classification": "Greed", "timestamp": "1700000200" },
+                { "value": "55", "value_classification": "Neutral", "timestamp": "1700000100" },
+                { "value": "20", "value_classification": "Extreme Fear", "timestamp": "1700000000" },
+            ]
+        })
+        .to_string()
+    }
+
+    #[tokio::test]
+    async fn fetch_raw_parses_single_entry() {
+        let mut server = mockito::Server::new_async().await;
+        let base = format!("{}/fng", server.url());
+        let _m = server
+            .mock("GET", "/fng")
+            .match_query(mockito::Matcher::UrlEncoded("limit".into(), "1".into()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(single_entry_body("20", "Extreme Fear", "1700000000"))
+            .create_async()
+            .await;
+
+        let raw = fetch_raw(1, &base).await.unwrap();
+        let fg = FearAndGreed::from_response(raw).unwrap();
+        assert_eq!(fg.value, 20);
+        assert_eq!(
+            fg.classification,
+            crate::models::sentiment::FearGreedLabel::ExtremeFear
+        );
+        assert_eq!(fg.timestamp, 1_700_000_000);
+    }
+
+    #[tokio::test]
+    async fn fetch_raw_parses_multiple_entries_newest_first() {
+        let mut server = mockito::Server::new_async().await;
+        let base = format!("{}/fng", server.url());
+        let _m = server
+            .mock("GET", "/fng")
+            .match_query(mockito::Matcher::UrlEncoded("limit".into(), "3".into()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(multi_entry_body())
+            .create_async()
+            .await;
+
+        let raw = fetch_raw(3, &base).await.unwrap();
+        let history = FearAndGreed::vec_from_response(raw).unwrap();
+
+        assert_eq!(history.len(), 3);
+        assert_eq!(history[0].value, 72);
+        assert_eq!(history[1].value, 55);
+        assert_eq!(history[2].value, 20);
+        assert!(history[0].timestamp > history[1].timestamp);
+        assert!(history[1].timestamp > history[2].timestamp);
+    }
+
+    #[tokio::test]
+    async fn fetch_raw_maps_http_error_status() {
+        let mut server = mockito::Server::new_async().await;
+        let base = format!("{}/fng", server.url());
+        let _m = server
+            .mock("GET", "/fng")
+            .match_query(mockito::Matcher::Any)
+            .with_status(500)
+            .with_header("content-type", "application/json")
+            .with_body("{}")
+            .create_async()
+            .await;
+
+        let err = fetch_raw(1, &base).await.unwrap_err();
+        assert!(matches!(
+            err,
+            FinanceError::ExternalApiError { status: 500, .. }
+        ));
+    }
 }

--- a/src/backtesting/engine.rs
+++ b/src/backtesting/engine.rs
@@ -1787,6 +1787,7 @@ fn compute_benchmark_metrics(
             alpha: 0.0,
             beta: 0.0,
             information_ratio: 0.0,
+            tracking_error: 0.0,
         };
     }
 
@@ -1836,27 +1837,18 @@ fn compute_benchmark_metrics(
     let rf_ann = risk_free_rate * 100.0;
     let alpha = strategy_ann - rf_ann - beta * (bench_ann - rf_ann);
 
-    // Information ratio: (excess returns mean / tracking error) * sqrt(bars_per_year)
-    // Uses sample standard deviation (n-1) for consistency with Sharpe/Sortino.
-    let excess: Vec<f64> = aligned_strategy
-        .iter()
-        .zip(aligned_benchmark.iter())
-        .map(|(si, bi)| si - bi)
-        .collect();
-    let ir = if excess.len() >= 2 {
-        let n = excess.len() as f64;
-        let mean = excess.iter().sum::<f64>() / n;
-        // Sample variance (n-1)
-        let variance = excess.iter().map(|e| (e - mean).powi(2)).sum::<f64>() / (n - 1.0);
-        let std_dev = variance.sqrt();
-        if std_dev > 0.0 {
-            (mean / std_dev) * bars_per_year.sqrt()
-        } else {
-            0.0
-        }
-    } else {
-        0.0
-    };
+    // Information ratio / tracking error: shared with the standalone `risk`
+    // module via `crate::perf_metrics` (see that module's doc comment for why
+    // the formula lives outside both `risk` and `backtesting`).
+    let ir = crate::perf_metrics::information_ratio(
+        &aligned_strategy,
+        &aligned_benchmark,
+        bars_per_year,
+    )
+    .unwrap_or(0.0);
+    let te =
+        crate::perf_metrics::tracking_error(&aligned_strategy, &aligned_benchmark, bars_per_year)
+            .unwrap_or(0.0);
 
     BenchmarkMetrics {
         symbol: benchmark_symbol.to_string(),
@@ -1865,6 +1857,7 @@ fn compute_benchmark_metrics(
         alpha,
         beta,
         information_ratio: ir,
+        tracking_error: te,
     }
 }
 

--- a/src/backtesting/engine.rs
+++ b/src/backtesting/engine.rs
@@ -48,6 +48,11 @@ fn needs_high_low(indicator: &Indicator) -> bool {
             | Indicator::BullBearPower(_)
             | Indicator::ElderRay(_)
             | Indicator::AwesomeOscillator { .. }
+            | Indicator::PivotPointsStandard
+            | Indicator::PivotPointsFibonacci
+            | Indicator::HeikinAshi
+            | Indicator::ZigZag(_)
+            | Indicator::FibonacciRetracement(_)
     )
 }
 
@@ -315,8 +320,111 @@ fn compute_one(
             out.push((format!("elder_bull_{period}"), er.bull_power));
             out.push((format!("elder_bear_{period}"), er.bear_power));
         }
+        Indicator::PivotPointsStandard => {
+            let pv = indicators::pivot_points(highs, lows, closes)?;
+            push_pivot_series(&mut out, "pivot", &pv);
+        }
+        Indicator::PivotPointsFibonacci => {
+            let pv = indicators::fibonacci_pivot_points(highs, lows, closes)?;
+            push_pivot_series(&mut out, "fib_pivot", &pv);
+        }
+        Indicator::HeikinAshi => {
+            let ha = indicators::heikin_ashi_raw(opens, highs, lows, closes)?;
+            out.push((
+                "ha_open".to_string(),
+                ha.open.into_iter().map(Some).collect(),
+            ));
+            out.push((
+                "ha_high".to_string(),
+                ha.high.into_iter().map(Some).collect(),
+            ));
+            out.push(("ha_low".to_string(), ha.low.into_iter().map(Some).collect()));
+            out.push((
+                "ha_close".to_string(),
+                ha.close.into_iter().map(Some).collect(),
+            ));
+        }
+        Indicator::ZigZag(deviation_pct) => {
+            let pivots = indicators::zigzag(highs, lows, deviation_pct)?;
+            let mut series = vec![None; closes.len()];
+            for p in &pivots {
+                if let Some(slot) = series.get_mut(p.index) {
+                    *slot = Some(p.price);
+                }
+            }
+            out.push((name, series));
+        }
+        Indicator::FibonacciRetracement(period) => {
+            let levels = indicators::fibonacci_retracement(highs, lows, period)?;
+            out.push((
+                "fib_swing_high".to_string(),
+                levels.iter().map(|o| o.map(|l| l.swing_high)).collect(),
+            ));
+            out.push((
+                "fib_swing_low".to_string(),
+                levels.iter().map(|o| o.map(|l| l.swing_low)).collect(),
+            ));
+            out.push((
+                "fib_23_6".to_string(),
+                levels.iter().map(|o| o.map(|l| l.level_23_6)).collect(),
+            ));
+            out.push((
+                "fib_38_2".to_string(),
+                levels.iter().map(|o| o.map(|l| l.level_38_2)).collect(),
+            ));
+            out.push((
+                "fib_50".to_string(),
+                levels.iter().map(|o| o.map(|l| l.level_50)).collect(),
+            ));
+            out.push((
+                "fib_61_8".to_string(),
+                levels.iter().map(|o| o.map(|l| l.level_61_8)).collect(),
+            ));
+            out.push((
+                "fib_78_6".to_string(),
+                levels.iter().map(|o| o.map(|l| l.level_78_6)).collect(),
+            ));
+        }
     }
     Ok(out)
+}
+
+/// Flatten a [`indicators::PivotPoints`] series into named scalar series
+/// (`{prefix}`, `{prefix}_r1`, ... `{prefix}_s3`) for the backtesting DSL,
+/// which only operates on flat `Vec<Option<f64>>` time series.
+fn push_pivot_series(
+    out: &mut Vec<(String, Vec<Option<f64>>)>,
+    prefix: &str,
+    pv: &[Option<indicators::PivotPoints>],
+) {
+    out.push((
+        prefix.to_string(),
+        pv.iter().map(|o| o.map(|p| p.pivot)).collect(),
+    ));
+    out.push((
+        format!("{prefix}_r1"),
+        pv.iter().map(|o| o.map(|p| p.r1)).collect(),
+    ));
+    out.push((
+        format!("{prefix}_r2"),
+        pv.iter().map(|o| o.map(|p| p.r2)).collect(),
+    ));
+    out.push((
+        format!("{prefix}_r3"),
+        pv.iter().map(|o| o.map(|p| p.r3)).collect(),
+    ));
+    out.push((
+        format!("{prefix}_s1"),
+        pv.iter().map(|o| o.map(|p| p.s1)).collect(),
+    ));
+    out.push((
+        format!("{prefix}_s2"),
+        pv.iter().map(|o| o.map(|p| p.s2)).collect(),
+    ));
+    out.push((
+        format!("{prefix}_s3"),
+        pv.iter().map(|o| o.map(|p| p.s3)).collect(),
+    ));
 }
 
 /// Pre-compute a set of indicators on the given candles.
@@ -360,7 +468,7 @@ pub(crate) fn compute_for_candles(
     let use_vol = required.iter().any(|(_, i)| needs_volumes(i));
     let use_open = required
         .iter()
-        .any(|(_, i)| matches!(i, Indicator::BalanceOfPower(_)));
+        .any(|(_, i)| matches!(i, Indicator::BalanceOfPower(_) | Indicator::HeikinAshi));
 
     // Extract price series upfront (single pass each, cache-friendly).
     let closes: Vec<f64> = candles.iter().map(|c| c.close).collect();

--- a/src/backtesting/result.rs
+++ b/src/backtesting/result.rs
@@ -585,18 +585,12 @@ fn analyze_trades(trades: &[Trade]) -> TradeStats {
 ///
 /// Returns `f64::MAX` when there are no losing trades and wins are positive
 /// (unbounded edge). Returns `0.0` when inputs are degenerate.
+///
+/// Delegates to `crate::perf_metrics::kelly_criterion`, shared with the
+/// standalone `risk` module so both compute the same formula without either
+/// feature depending on the other (see that module's doc comment).
 fn calculate_kelly(win_rate: f64, avg_win_pct: f64, avg_loss_pct: f64) -> f64 {
-    let abs_loss = avg_loss_pct.abs();
-    if abs_loss == 0.0 {
-        // No losing trades: edge is unbounded. Use f64::MAX to match the
-        // sentinel convention used by profit_factor and calmar_ratio.
-        return if avg_win_pct > 0.0 { f64::MAX } else { 0.0 };
-    }
-    if avg_win_pct == 0.0 {
-        return 0.0;
-    }
-    let r = avg_win_pct / abs_loss;
-    win_rate - (1.0 - win_rate) / r
+    crate::perf_metrics::kelly_criterion(win_rate, avg_win_pct, avg_loss_pct)
 }
 
 /// Van Tharp's System Quality Number.
@@ -621,14 +615,12 @@ fn calculate_sqn(returns: &[f64]) -> f64 {
 ///
 /// `Σ max(r, 0) / Σ max(-r, 0)`. Returns `f64::MAX` when the denominator
 /// is zero (no negative returns), `0.0` when the numerator is also zero.
+///
+/// Delegates to `crate::perf_metrics::omega_ratio` (see that module's doc
+/// comment for why the shared formula lives outside both `risk` and
+/// `backtesting`).
 fn calculate_omega_ratio(returns: &[f64]) -> f64 {
-    let gains: f64 = returns.iter().map(|&r| r.max(0.0)).sum();
-    let losses: f64 = returns.iter().map(|&r| (-r).max(0.0)).sum();
-    if losses == 0.0 {
-        if gains > 0.0 { f64::MAX } else { 0.0 }
-    } else {
-        gains / losses
-    }
+    crate::perf_metrics::omega_ratio(returns)
 }
 
 /// Tail Ratio: `abs(p95) / abs(p5)` of trade returns.
@@ -657,18 +649,13 @@ fn calculate_tail_ratio(returns: &[f64]) -> f64 {
 
 /// Ulcer Index: `sqrt(mean(drawdown_pct²))` across all equity curve points,
 /// returned in **percentage** units (0–100) to match standard tool output.
+///
+/// Delegates to `crate::perf_metrics::ulcer_index`, which takes plain
+/// drawdown fractions rather than `EquityPoint` so it stays usable from the
+/// standalone `risk` module too.
 fn calculate_ulcer_index(equity_curve: &[EquityPoint]) -> f64 {
-    if equity_curve.is_empty() {
-        return 0.0;
-    }
-    // drawdown_pct is a fraction (0–1); multiply by 100 before squaring so
-    // the result is in percentage units consistent with backtesting.py and
-    // Peter Martin's original definition.
-    let sum_sq: f64 = equity_curve
-        .iter()
-        .map(|p| (p.drawdown_pct * 100.0).powi(2))
-        .sum();
-    (sum_sq / equity_curve.len() as f64).sqrt()
+    let drawdowns: Vec<f64> = equity_curve.iter().map(|p| p.drawdown_pct).collect();
+    crate::perf_metrics::ulcer_index(&drawdowns)
 }
 
 /// Calculate maximum consecutive wins and losses
@@ -963,6 +950,10 @@ pub struct BenchmarkMetrics {
 
     /// Information ratio: excess return per unit of tracking error (annualised)
     pub information_ratio: f64,
+
+    /// Tracking error: annualised standard deviation of (strategy − benchmark)
+    /// periodic returns — the denominator of `information_ratio`.
+    pub tracking_error: f64,
 }
 
 /// Complete backtest result

--- a/src/finance.rs
+++ b/src/finance.rs
@@ -531,6 +531,36 @@ pub async fn fear_and_greed() -> Result<crate::models::sentiment::FearAndGreed> 
     crate::adapters::yahoo::market::fear_and_greed::fetch().await
 }
 
+/// Fetch the crypto Fear & Greed Index from Alternative.me — current value
+/// plus up to `limit - 1` historical readings (newest first).
+///
+/// Alternative.me's index specifically tracks crypto (Bitcoin) market
+/// sentiment from volatility, momentum, social media, dominance, and
+/// Google Trends signals. No API key required.
+///
+/// # Arguments
+///
+/// * `limit` - Number of readings to return, newest first (`1` for just the
+///   current value; e.g. `30` for the trailing month).
+///
+/// # Examples
+///
+/// ```no_run
+/// use finance_query::finance;
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let history = finance::fear_and_greed_crypto(7).await?;
+/// let latest = &history[0];
+/// println!("Crypto Fear & Greed: {} ({})", latest.value, latest.classification.as_str());
+/// # Ok(())
+/// # }
+/// ```
+pub async fn fear_and_greed_crypto(
+    limit: u32,
+) -> Result<Vec<crate::models::sentiment::FearAndGreed>> {
+    crate::adapters::yahoo::market::fear_and_greed::fetch_history(limit).await
+}
+
 // ── Financial Modeling Prep (FMP) ───────────────────────────────────
 
 /// Time period for analyst estimates.

--- a/src/indicators/fibonacci_retracement.rs
+++ b/src/indicators/fibonacci_retracement.rs
@@ -1,0 +1,173 @@
+//! Fibonacci Retracement indicator.
+//!
+//! Computes the standard Fibonacci retracement levels between the swing
+//! high and swing low of a rolling lookback window.
+
+use std::collections::VecDeque;
+
+use super::{IndicatorError, Result};
+use serde::{Deserialize, Serialize};
+
+/// Fibonacci retracement levels between a swing high and swing low.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct FibonacciLevels {
+    /// Swing high over the lookback window (0% retracement level)
+    pub swing_high: f64,
+    /// Swing low over the lookback window (100% retracement level)
+    pub swing_low: f64,
+    /// 23.6% retracement level
+    pub level_23_6: f64,
+    /// 38.2% retracement level
+    pub level_38_2: f64,
+    /// 50% retracement level
+    pub level_50: f64,
+    /// 61.8% retracement level
+    pub level_61_8: f64,
+    /// 78.6% retracement level
+    pub level_78_6: f64,
+}
+
+/// Calculate rolling Fibonacci retracement levels.
+///
+/// For each bar, the swing high/low are the highest high and lowest low over
+/// the trailing `period` bars (inclusive), and the standard retracement
+/// levels are interpolated between them (0% = swing high, 100% = swing low —
+/// the conventional orientation for retracing a preceding up-move).
+///
+/// # Arguments
+///
+/// * `highs` - High prices
+/// * `lows` - Low prices
+/// * `period` - Lookback window size (typically 50–100)
+///
+/// # Example
+///
+/// ```
+/// use finance_query::indicators::fibonacci_retracement;
+///
+/// let highs = vec![10.0, 12.0, 11.0, 9.0, 13.0];
+/// let lows = vec![8.0, 9.0, 8.5, 7.0, 10.0];
+/// let result = fibonacci_retracement(&highs, &lows, 3).unwrap();
+///
+/// assert!(result[0].is_none());
+/// assert!(result[2].is_some());
+/// ```
+pub fn fibonacci_retracement(
+    highs: &[f64],
+    lows: &[f64],
+    period: usize,
+) -> Result<Vec<Option<FibonacciLevels>>> {
+    if period == 0 {
+        return Err(IndicatorError::InvalidPeriod(
+            "Period must be greater than 0".to_string(),
+        ));
+    }
+    let len = highs.len();
+    if lows.len() != len {
+        return Err(IndicatorError::InvalidPeriod(
+            "highs and lows must have the same length".to_string(),
+        ));
+    }
+    if len < period {
+        return Err(IndicatorError::InsufficientData {
+            need: period,
+            got: len,
+        });
+    }
+
+    let mut result = vec![None; len];
+
+    // Monotonic deques for O(N) sliding window max/min (same technique as donchian_channels).
+    let mut max_deque: VecDeque<usize> = VecDeque::new();
+    let mut min_deque: VecDeque<usize> = VecDeque::new();
+
+    for i in 0..len {
+        while max_deque.front().is_some_and(|&j| j + period <= i) {
+            max_deque.pop_front();
+        }
+        while min_deque.front().is_some_and(|&j| j + period <= i) {
+            min_deque.pop_front();
+        }
+        while max_deque.back().is_some_and(|&j| highs[j] <= highs[i]) {
+            max_deque.pop_back();
+        }
+        while min_deque.back().is_some_and(|&j| lows[j] >= lows[i]) {
+            min_deque.pop_back();
+        }
+        max_deque.push_back(i);
+        min_deque.push_back(i);
+
+        if i + 1 >= period {
+            let swing_high = highs[*max_deque.front().unwrap()];
+            let swing_low = lows[*min_deque.front().unwrap()];
+            let range = swing_high - swing_low;
+            result[i] = Some(FibonacciLevels {
+                swing_high,
+                swing_low,
+                level_23_6: swing_high - range * 0.236,
+                level_38_2: swing_high - range * 0.382,
+                level_50: swing_high - range * 0.5,
+                level_61_8: swing_high - range * 0.618,
+                level_78_6: swing_high - range * 0.786,
+            });
+        }
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fibonacci_retracement_basic() {
+        let highs = vec![10.0, 12.0, 11.0, 9.0, 13.0];
+        let lows = vec![8.0, 9.0, 8.5, 7.0, 10.0];
+        let result = fibonacci_retracement(&highs, &lows, 3).unwrap();
+
+        assert!(result[0].is_none());
+        assert!(result[1].is_none());
+        assert!(result[2].is_some());
+
+        // Window [10,12,11]/[8,9,8.5] -> swing_high=12, swing_low=8, range=4
+        let l = result[2].unwrap();
+        assert!((l.swing_high - 12.0).abs() < 1e-9);
+        assert!((l.swing_low - 8.0).abs() < 1e-9);
+        assert!((l.level_50 - 10.0).abs() < 1e-9);
+        assert!((l.level_23_6 - (12.0 - 4.0 * 0.236)).abs() < 1e-9);
+        assert!((l.level_61_8 - (12.0 - 4.0 * 0.618)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_fibonacci_levels_ordering() {
+        let highs = vec![10.0, 12.0, 11.0, 9.0, 13.0];
+        let lows = vec![8.0, 9.0, 8.5, 7.0, 10.0];
+        let result = fibonacci_retracement(&highs, &lows, 3).unwrap();
+
+        for l in result.into_iter().flatten() {
+            assert!(l.swing_high >= l.level_23_6);
+            assert!(l.level_23_6 >= l.level_38_2);
+            assert!(l.level_38_2 >= l.level_50);
+            assert!(l.level_50 >= l.level_61_8);
+            assert!(l.level_61_8 >= l.level_78_6);
+            assert!(l.level_78_6 >= l.swing_low);
+        }
+    }
+
+    #[test]
+    fn test_fibonacci_retracement_insufficient_data() {
+        assert!(fibonacci_retracement(&[1.0, 2.0], &[1.0, 2.0], 5).is_err());
+    }
+
+    #[test]
+    fn test_fibonacci_retracement_invalid_period() {
+        assert!(fibonacci_retracement(&[1.0], &[1.0], 0).is_err());
+    }
+
+    #[test]
+    fn test_fibonacci_retracement_mismatched_lengths() {
+        assert!(fibonacci_retracement(&[1.0, 2.0], &[1.0], 1).is_err());
+    }
+}

--- a/src/indicators/heikin_ashi.rs
+++ b/src/indicators/heikin_ashi.rs
@@ -1,0 +1,178 @@
+//! Heikin-Ashi candle transform.
+//!
+//! Unlike the rest of `indicators`, this doesn't compute an oscillator or
+//! overlay value — it transforms OHLC candles into smoothed "average bar"
+//! candles that make the prevailing trend easier to read.
+
+use super::{IndicatorError, Result};
+use crate::Candle;
+
+/// Dense open/high/low/close series for a Heikin-Ashi transform.
+///
+/// Used internally where only price arrays are available (e.g. the
+/// backtesting engine's custom-strategy indicator dispatch), rather than
+/// full [`Candle`]s.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct HeikinAshiSeries {
+    pub open: Vec<f64>,
+    pub high: Vec<f64>,
+    pub low: Vec<f64>,
+    pub close: Vec<f64>,
+}
+
+/// Compute the Heikin-Ashi open/high/low/close series from raw price arrays.
+///
+/// # Formula
+///
+/// - `ha_close = (open + high + low + close) / 4`
+/// - `ha_open = (prev_ha_open + prev_ha_close) / 2` (first bar: `(open + close) / 2`)
+/// - `ha_high = max(high, ha_open, ha_close)`
+/// - `ha_low = min(low, ha_open, ha_close)`
+pub(crate) fn heikin_ashi_raw(
+    opens: &[f64],
+    highs: &[f64],
+    lows: &[f64],
+    closes: &[f64],
+) -> Result<HeikinAshiSeries> {
+    let len = opens.len();
+    if highs.len() != len || lows.len() != len || closes.len() != len {
+        return Err(IndicatorError::InvalidPeriod(
+            "opens, highs, lows, and closes must have the same length".to_string(),
+        ));
+    }
+    if len == 0 {
+        return Err(IndicatorError::InsufficientData { need: 1, got: 0 });
+    }
+
+    let mut ha_open = Vec::with_capacity(len);
+    let mut ha_high = Vec::with_capacity(len);
+    let mut ha_low = Vec::with_capacity(len);
+    let mut ha_close = Vec::with_capacity(len);
+
+    for i in 0..len {
+        let close = (opens[i] + highs[i] + lows[i] + closes[i]) / 4.0;
+        let open = if i == 0 {
+            (opens[i] + closes[i]) / 2.0
+        } else {
+            (ha_open[i - 1] + ha_close[i - 1]) / 2.0
+        };
+        let high = highs[i].max(open).max(close);
+        let low = lows[i].min(open).min(close);
+
+        ha_open.push(open);
+        ha_high.push(high);
+        ha_low.push(low);
+        ha_close.push(close);
+    }
+
+    Ok(HeikinAshiSeries {
+        open: ha_open,
+        high: ha_high,
+        low: ha_low,
+        close: ha_close,
+    })
+}
+
+/// Transform standard OHLC candles into Heikin-Ashi candles.
+///
+/// Volume, timestamp, adjusted close, and provider id pass through
+/// unchanged — only open/high/low/close are recomputed.
+///
+/// # Example
+///
+/// ```no_run
+/// use finance_query::{Ticker, Interval, TimeRange};
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let ticker = Ticker::new("AAPL").await?;
+/// let chart = ticker.chart(Interval::OneDay, TimeRange::ThreeMonths).await?;
+///
+/// let ha_candles = chart.heikin_ashi()?;
+/// # Ok(())
+/// # }
+/// ```
+pub fn heikin_ashi(candles: &[Candle]) -> Result<Vec<Candle>> {
+    if candles.is_empty() {
+        return Err(IndicatorError::InsufficientData { need: 1, got: 0 });
+    }
+    let opens: Vec<f64> = candles.iter().map(|c| c.open).collect();
+    let highs: Vec<f64> = candles.iter().map(|c| c.high).collect();
+    let lows: Vec<f64> = candles.iter().map(|c| c.low).collect();
+    let closes: Vec<f64> = candles.iter().map(|c| c.close).collect();
+
+    let series = heikin_ashi_raw(&opens, &highs, &lows, &closes)?;
+
+    Ok(candles
+        .iter()
+        .enumerate()
+        .map(|(i, c)| Candle {
+            timestamp: c.timestamp,
+            open: series.open[i],
+            high: series.high[i],
+            low: series.low[i],
+            close: series.close[i],
+            volume: c.volume,
+            adj_close: c.adj_close,
+            provider_id: c.provider_id,
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_candle(open: f64, high: f64, low: f64, close: f64) -> Candle {
+        serde_json::from_value(serde_json::json!({
+            "timestamp": 0,
+            "open": open,
+            "high": high,
+            "low": low,
+            "close": close,
+            "volume": 1_000_000,
+            "adjClose": close,
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn test_heikin_ashi_basic() {
+        let candles = vec![
+            make_candle(10.0, 12.0, 9.0, 11.0),
+            make_candle(11.0, 13.0, 10.5, 12.5),
+        ];
+        let ha = heikin_ashi(&candles).unwrap();
+        assert_eq!(ha.len(), 2);
+
+        // First bar: ha_close = (10+12+9+11)/4 = 10.5, ha_open = (10+11)/2 = 10.5
+        assert!((ha[0].close - 10.5).abs() < 1e-9);
+        assert!((ha[0].open - 10.5).abs() < 1e-9);
+        assert!(ha[0].high >= ha[0].open.max(ha[0].close));
+        assert!(ha[0].low <= ha[0].open.min(ha[0].close));
+
+        // Second bar's ha_open is the average of the first bar's ha_open/ha_close
+        let expected_open = (ha[0].open + ha[0].close) / 2.0;
+        assert!((ha[1].open - expected_open).abs() < 1e-9);
+
+        // Volume/timestamp pass through unchanged
+        assert_eq!(ha[0].volume, candles[0].volume);
+        assert_eq!(ha[1].timestamp, candles[1].timestamp);
+    }
+
+    #[test]
+    fn test_heikin_ashi_empty() {
+        assert!(heikin_ashi(&[]).is_err());
+    }
+
+    #[test]
+    fn test_heikin_ashi_smooths_gaps() {
+        // A single volatile bar shouldn't produce a HA high/low outside the real range.
+        let candles = vec![
+            make_candle(10.0, 10.0, 10.0, 10.0),
+            make_candle(10.0, 50.0, 5.0, 10.0),
+        ];
+        let ha = heikin_ashi(&candles).unwrap();
+        assert!(ha[1].high <= 50.0);
+        assert!(ha[1].low >= 5.0);
+    }
+}

--- a/src/indicators/mod.rs
+++ b/src/indicators/mod.rs
@@ -59,6 +59,8 @@ mod dema;
 mod donchian_channels;
 mod elder_ray;
 mod ema;
+mod fibonacci_retracement;
+mod heikin_ashi;
 mod hma;
 mod ichimoku;
 mod keltner_channels;
@@ -69,6 +71,7 @@ mod momentum;
 mod obv;
 mod parabolic_sar;
 mod patterns;
+mod pivot_points;
 mod roc;
 mod rsi;
 mod sma;
@@ -81,6 +84,7 @@ mod vwap;
 mod vwma;
 mod williams_r;
 mod wma;
+mod zigzag;
 
 // Summary module for batch indicator calculations
 pub mod summary;
@@ -105,6 +109,9 @@ pub use dema::dema;
 pub use donchian_channels::{DonchianChannelsResult, donchian_channels};
 pub use elder_ray::{ElderRayResult, elder_ray};
 pub use ema::ema;
+pub use fibonacci_retracement::{FibonacciLevels, fibonacci_retracement};
+pub use heikin_ashi::heikin_ashi;
+pub(crate) use heikin_ashi::heikin_ashi_raw;
 pub use hma::hma;
 pub use ichimoku::{IchimokuResult, ichimoku};
 pub use keltner_channels::{KeltnerChannelsResult, keltner_channels};
@@ -115,6 +122,7 @@ pub use momentum::momentum;
 pub use obv::obv;
 pub use parabolic_sar::parabolic_sar;
 pub use patterns::{CandlePattern, PatternSentiment, patterns};
+pub use pivot_points::{PivotPoints, fibonacci_pivot_points, pivot_points};
 pub use roc::roc;
 pub use rsi::rsi;
 pub use sma::sma;
@@ -127,6 +135,7 @@ pub use vwap::vwap;
 pub use vwma::vwma;
 pub use williams_r::williams_r;
 pub use wma::wma;
+pub use zigzag::{ZigZagPoint, zigzag};
 
 // Re-export summary types
 pub use summary::{
@@ -187,6 +196,14 @@ pub enum IndicatorResult {
     Keltner(KeltnerChannelsResult),
     /// Donchian Channels result
     Donchian(DonchianChannelsResult),
+    /// Pivot Points result (standard or Fibonacci variant)
+    PivotPoints(Vec<Option<PivotPoints>>),
+    /// Heikin-Ashi transformed candles
+    HeikinAshi(Vec<crate::Candle>),
+    /// ZigZag swing points
+    ZigZag(Vec<ZigZagPoint>),
+    /// Fibonacci Retracement levels
+    FibonacciRetracement(Vec<Option<FibonacciLevels>>),
 }
 
 /// Enum representing all available technical indicators.
@@ -349,6 +366,16 @@ pub enum Indicator {
     AccumulationDistribution,
     /// Balance of Power
     BalanceOfPower(Option<usize>),
+    /// Standard (classic) Pivot Points, derived from the previous bar's high/low/close
+    PivotPointsStandard,
+    /// Fibonacci Pivot Points, derived from the previous bar's high/low/close
+    PivotPointsFibonacci,
+    /// Heikin-Ashi candle transform
+    HeikinAshi,
+    /// ZigZag with a percentage reversal threshold
+    ZigZag(f64),
+    /// Fibonacci Retracement over a rolling lookback window
+    FibonacciRetracement(usize),
 }
 
 impl Indicator {
@@ -424,6 +451,11 @@ impl Indicator {
             Indicator::ChaikinOscillator => "Chaikin Oscillator",
             Indicator::AccumulationDistribution => "Accumulation/Distribution",
             Indicator::BalanceOfPower(_) => "Balance of Power",
+            Indicator::PivotPointsStandard => "Pivot Points (Standard)",
+            Indicator::PivotPointsFibonacci => "Pivot Points (Fibonacci)",
+            Indicator::HeikinAshi => "Heikin-Ashi",
+            Indicator::ZigZag(_) => "ZigZag",
+            Indicator::FibonacciRetracement(_) => "Fibonacci Retracement",
         }
     }
 
@@ -496,13 +528,18 @@ impl Indicator {
                 period, atr_period, ..
             } => *period.max(atr_period),
             Self::BalanceOfPower(Some(p)) => *p,
+            Self::FibonacciRetracement(p) => *p,
+            // Both pivot-point variants only need the single prior bar.
+            Self::PivotPointsStandard | Self::PivotPointsFibonacci => 2,
+            Self::ZigZag(_) => 2,
             // Volume/price indicators with no meaningful lookback
             Self::Obv
             | Self::Vwap
             | Self::TrueRange
             | Self::ChaikinOscillator
             | Self::AccumulationDistribution
-            | Self::BalanceOfPower(None) => 1,
+            | Self::BalanceOfPower(None)
+            | Self::HeikinAshi => 1,
         }
     }
 }
@@ -652,6 +689,21 @@ pub(crate) fn compute_indicator(
         Indicator::BalanceOfPower(p) => {
             IndicatorResult::Series(crate::indicators::balance_of_power(&o, &h, &l, &c, p)?)
         }
+        Indicator::PivotPointsStandard => {
+            IndicatorResult::PivotPoints(crate::indicators::pivot_points(&h, &l, &c)?)
+        }
+        Indicator::PivotPointsFibonacci => {
+            IndicatorResult::PivotPoints(crate::indicators::fibonacci_pivot_points(&h, &l, &c)?)
+        }
+        Indicator::HeikinAshi => {
+            IndicatorResult::HeikinAshi(crate::indicators::heikin_ashi(&chart.candles)?)
+        }
+        Indicator::ZigZag(deviation_pct) => {
+            IndicatorResult::ZigZag(crate::indicators::zigzag(&h, &l, deviation_pct)?)
+        }
+        Indicator::FibonacciRetracement(period) => IndicatorResult::FibonacciRetracement(
+            crate::indicators::fibonacci_retracement(&h, &l, period)?,
+        ),
     })
 }
 

--- a/src/indicators/pivot_points.rs
+++ b/src/indicators/pivot_points.rs
@@ -1,0 +1,192 @@
+//! Pivot Points indicator (Standard and Fibonacci variants).
+//!
+//! Pivot points are classic intraday/swing support-resistance levels derived
+//! from the *previous* bar's high/low/close and held for the current bar —
+//! the same convention floor traders have used since well before charting
+//! software existed.
+
+use super::{IndicatorError, Result};
+use serde::{Deserialize, Serialize};
+
+/// Pivot point support/resistance levels for a single bar.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct PivotPoints {
+    /// Central pivot point: `(high + low + close) / 3`
+    pub pivot: f64,
+    /// First resistance level
+    pub r1: f64,
+    /// Second resistance level
+    pub r2: f64,
+    /// Third resistance level
+    pub r3: f64,
+    /// First support level
+    pub s1: f64,
+    /// Second support level
+    pub s2: f64,
+    /// Third support level
+    pub s3: f64,
+}
+
+fn validate(highs: &[f64], lows: &[f64], closes: &[f64]) -> Result<()> {
+    if highs.len() != lows.len() || highs.len() != closes.len() {
+        return Err(IndicatorError::InvalidPeriod(
+            "highs, lows, and closes must have the same length".to_string(),
+        ));
+    }
+    if highs.len() < 2 {
+        return Err(IndicatorError::InsufficientData {
+            need: 2,
+            got: highs.len(),
+        });
+    }
+    Ok(())
+}
+
+/// Calculate classic (standard) pivot points.
+///
+/// Each bar's levels are derived from the **previous** bar's high/low/close;
+/// the first bar has no prior bar and is therefore `None`.
+///
+/// # Formula
+///
+/// - Pivot = (High + Low + Close) / 3
+/// - R1 = 2×Pivot − Low, S1 = 2×Pivot − High
+/// - R2 = Pivot + (High − Low), S2 = Pivot − (High − Low)
+/// - R3 = High + 2×(Pivot − Low), S3 = Low − 2×(High − Pivot)
+///
+/// # Example
+///
+/// ```
+/// use finance_query::indicators::pivot_points;
+///
+/// let highs = vec![10.0, 12.0, 11.0];
+/// let lows = vec![8.0, 9.0, 8.5];
+/// let closes = vec![9.0, 11.0, 10.0];
+/// let result = pivot_points(&highs, &lows, &closes).unwrap();
+///
+/// assert!(result[0].is_none());
+/// assert!(result[1].is_some());
+/// ```
+pub fn pivot_points(
+    highs: &[f64],
+    lows: &[f64],
+    closes: &[f64],
+) -> Result<Vec<Option<PivotPoints>>> {
+    validate(highs, lows, closes)?;
+    let mut result = vec![None; highs.len()];
+    for i in 1..highs.len() {
+        let (h, l, c) = (highs[i - 1], lows[i - 1], closes[i - 1]);
+        let pivot = (h + l + c) / 3.0;
+        let range = h - l;
+        result[i] = Some(PivotPoints {
+            pivot,
+            r1: 2.0 * pivot - l,
+            s1: 2.0 * pivot - h,
+            r2: pivot + range,
+            s2: pivot - range,
+            r3: h + 2.0 * (pivot - l),
+            s3: l - 2.0 * (h - pivot),
+        });
+    }
+    Ok(result)
+}
+
+/// Calculate Fibonacci pivot points.
+///
+/// Uses the same central pivot as the standard variant, but Fibonacci
+/// retracement ratios (38.2%, 61.8%, 100%) of the previous bar's range for
+/// the support/resistance levels instead of the classic multiples.
+///
+/// # Formula
+///
+/// - Pivot = (High + Low + Close) / 3
+/// - R1/S1 = Pivot ± 0.382×Range, R2/S2 = Pivot ± 0.618×Range, R3/S3 = Pivot ± 1.000×Range
+///
+/// # Example
+///
+/// ```
+/// use finance_query::indicators::fibonacci_pivot_points;
+///
+/// let highs = vec![10.0, 12.0, 11.0];
+/// let lows = vec![8.0, 9.0, 8.5];
+/// let closes = vec![9.0, 11.0, 10.0];
+/// let result = fibonacci_pivot_points(&highs, &lows, &closes).unwrap();
+///
+/// assert!(result[0].is_none());
+/// assert!(result[1].is_some());
+/// ```
+pub fn fibonacci_pivot_points(
+    highs: &[f64],
+    lows: &[f64],
+    closes: &[f64],
+) -> Result<Vec<Option<PivotPoints>>> {
+    validate(highs, lows, closes)?;
+    let mut result = vec![None; highs.len()];
+    for i in 1..highs.len() {
+        let (h, l, c) = (highs[i - 1], lows[i - 1], closes[i - 1]);
+        let pivot = (h + l + c) / 3.0;
+        let range = h - l;
+        result[i] = Some(PivotPoints {
+            pivot,
+            r1: pivot + 0.382 * range,
+            r2: pivot + 0.618 * range,
+            r3: pivot + 1.000 * range,
+            s1: pivot - 0.382 * range,
+            s2: pivot - 0.618 * range,
+            s3: pivot - 1.000 * range,
+        });
+    }
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pivot_points_basic() {
+        // Prior bar: H=12, L=8, C=10 -> pivot = 30/3 = 10.0
+        let highs = vec![12.0, 15.0];
+        let lows = vec![8.0, 9.0];
+        let closes = vec![10.0, 13.0];
+        let result = pivot_points(&highs, &lows, &closes).unwrap();
+
+        assert!(result[0].is_none());
+        let p = result[1].unwrap();
+        assert!((p.pivot - 10.0).abs() < 1e-9);
+        assert!((p.r1 - 12.0).abs() < 1e-9); // 2*10 - 8
+        assert!((p.s1 - 8.0).abs() < 1e-9); // 2*10 - 12
+        assert!((p.r2 - 14.0).abs() < 1e-9); // 10 + 4
+        assert!((p.s2 - 6.0).abs() < 1e-9); // 10 - 4
+        assert!(p.r3 > p.r2);
+        assert!(p.s3 < p.s2);
+    }
+
+    #[test]
+    fn test_fibonacci_pivot_points_basic() {
+        let highs = vec![12.0, 15.0];
+        let lows = vec![8.0, 9.0];
+        let closes = vec![10.0, 13.0];
+        let result = fibonacci_pivot_points(&highs, &lows, &closes).unwrap();
+
+        assert!(result[0].is_none());
+        let p = result[1].unwrap();
+        assert!((p.pivot - 10.0).abs() < 1e-9);
+        // range = 4.0
+        assert!((p.r1 - (10.0 + 0.382 * 4.0)).abs() < 1e-9);
+        assert!((p.s1 - (10.0 - 0.382 * 4.0)).abs() < 1e-9);
+        assert!((p.r3 - 14.0).abs() < 1e-9);
+        assert!((p.s3 - 6.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_pivot_points_insufficient_data() {
+        assert!(pivot_points(&[1.0], &[1.0], &[1.0]).is_err());
+    }
+
+    #[test]
+    fn test_pivot_points_mismatched_lengths() {
+        assert!(pivot_points(&[1.0, 2.0], &[1.0], &[1.0, 2.0]).is_err());
+    }
+}

--- a/src/indicators/summary.rs
+++ b/src/indicators/summary.rs
@@ -1,7 +1,7 @@
 //! Indicators summary module.
 //!
 //! Provides the `IndicatorsSummary` type which calculates and returns the latest
-//! values for all 52+ technical indicators at once.
+//! values for all 56+ technical indicators at once.
 //!
 //! This module reuses the main indicator implementations and extracts the last value,
 //! ensuring consistency and eliminating code duplication.
@@ -9,13 +9,14 @@
 use super::last_value;
 use crate::Candle;
 use crate::indicators::{
-    accumulation_distribution, adx, alma, aroon, atr, atr::atr_raw, awesome_oscillator,
-    balance_of_power, bollinger_bands, bull_bear_power, cci, chaikin_oscillator, choppiness_index,
-    cmf, cmo, coppock_curve, dema, donchian_channels, elder_ray, ema::ema_raw, hma, ichimoku,
-    keltner_channels::keltner_with_atr_dense, macd, mcginley_dynamic, mfi, momentum, obv,
-    parabolic_sar, roc, rsi::rsi_raw, sma::sma_raw, stochastic,
+    FibonacciLevels, PivotPoints, ZigZagPoint, accumulation_distribution, adx, alma, aroon, atr,
+    atr::atr_raw, awesome_oscillator, balance_of_power, bollinger_bands, bull_bear_power, cci,
+    chaikin_oscillator, choppiness_index, cmf, cmo, coppock_curve, dema, donchian_channels,
+    elder_ray, ema::ema_raw, fibonacci_pivot_points, fibonacci_retracement, heikin_ashi_raw, hma,
+    ichimoku, keltner_channels::keltner_with_atr_dense, macd, mcginley_dynamic, mfi, momentum, obv,
+    parabolic_sar, pivot_points, roc, rsi::rsi_raw, sma::sma_raw, stochastic,
     stochastic_rsi::stochastic_rsi_from_rsi_dense, supertrend::supertrend_with_atr_dense, tema,
-    true_range, vwap, vwma, williams_r, wma::wma_raw,
+    true_range, vwap, vwma, williams_r, wma::wma_raw, zigzag,
 };
 
 /// Helper to extract last value from Result-returning indicators
@@ -218,6 +219,36 @@ pub(crate) fn calculate_indicators(candles: &[Candle]) -> IndicatorsSummary {
         )),
         vwap: last_from_result(vwap(&highs, &lows, &closes, &volumes)),
         balance_of_power: last_from_result(balance_of_power(&opens, &highs, &lows, &closes, None)),
+
+        // === PIVOT POINTS, HEIKIN-ASHI, ZIGZAG, FIBONACCI ===
+        pivot_points: pivot_points(&highs, &lows, &closes)
+            .ok()
+            .and_then(|v| v.into_iter().rev().find_map(|p| p)),
+        fibonacci_pivot_points: fibonacci_pivot_points(&highs, &lows, &closes)
+            .ok()
+            .and_then(|v| v.into_iter().rev().find_map(|p| p)),
+        heikin_ashi: heikin_ashi_raw(&opens, &highs, &lows, &closes)
+            .ok()
+            .and_then(|series| {
+                let last = candles.last()?;
+                let i = series.close.len().checked_sub(1)?;
+                Some(Candle {
+                    timestamp: last.timestamp,
+                    open: series.open[i],
+                    high: series.high[i],
+                    low: series.low[i],
+                    close: series.close[i],
+                    volume: last.volume,
+                    adj_close: last.adj_close,
+                    provider_id: last.provider_id,
+                })
+            }),
+        zigzag_last_pivot: zigzag(&highs, &lows, 5.0)
+            .ok()
+            .and_then(|v| v.last().copied()),
+        fibonacci_retracement_50: fibonacci_retracement(&highs, &lows, 50)
+            .ok()
+            .and_then(|v| v.into_iter().rev().find_map(|p| p)),
     }
 }
 
@@ -398,6 +429,23 @@ pub struct IndicatorsSummary {
     /// Balance of Power
     #[serde(skip_serializing_if = "Option::is_none")]
     pub balance_of_power: Option<f64>,
+
+    // === PIVOT POINTS, HEIKIN-ASHI, ZIGZAG, FIBONACCI ===
+    /// Standard (classic) Pivot Points, derived from the previous bar's high/low/close
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pivot_points: Option<PivotPoints>,
+    /// Fibonacci Pivot Points, derived from the previous bar's high/low/close
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fibonacci_pivot_points: Option<PivotPoints>,
+    /// Latest Heikin-Ashi ("average bar") candle
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub heikin_ashi: Option<Candle>,
+    /// Most recent confirmed ZigZag swing point (5% reversal threshold)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub zigzag_last_pivot: Option<ZigZagPoint>,
+    /// Fibonacci Retracement levels (50-period rolling window)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fibonacci_retracement_50: Option<FibonacciLevels>,
 }
 
 /// Stochastic Oscillator data

--- a/src/indicators/zigzag.rs
+++ b/src/indicators/zigzag.rs
@@ -1,0 +1,210 @@
+//! ZigZag indicator: filters out price moves smaller than a percentage
+//! threshold, connecting only the significant swing highs and lows.
+
+use super::{IndicatorError, Result};
+use serde::{Deserialize, Serialize};
+
+/// A single confirmed ZigZag swing point.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ZigZagPoint {
+    /// Index into the original `highs`/`lows` slices where this swing occurred.
+    pub index: usize,
+    /// Price at the pivot (the high or low that qualified as a swing point).
+    pub price: f64,
+    /// `true` for a swing high, `false` for a swing low.
+    pub is_high: bool,
+}
+
+/// Calculate ZigZag swing points from high/low series using a percentage
+/// reversal threshold.
+///
+/// Starting from the first bar, price must move by at least `deviation_pct`
+/// (e.g. `5.0` for 5%) away from the running extreme before a reversal is
+/// confirmed and a pivot recorded. Consecutive pivots always alternate
+/// between highs and lows. The final unconfirmed extreme (the most recent
+/// swing-in-progress) is included as the last point.
+///
+/// # Arguments
+///
+/// * `highs` - High prices
+/// * `lows` - Low prices
+/// * `deviation_pct` - Minimum reversal size as a percentage (e.g. `5.0` = 5%)
+///
+/// # Example
+///
+/// ```
+/// use finance_query::indicators::zigzag;
+///
+/// let highs = vec![100.0, 110.0, 90.0, 120.0, 80.0];
+/// let lows = vec![100.0, 110.0, 90.0, 120.0, 80.0];
+/// let pivots = zigzag(&highs, &lows, 5.0).unwrap();
+///
+/// assert_eq!(pivots.len(), 4);
+/// assert!(pivots[0].is_high);
+/// assert!(!pivots[1].is_high);
+/// ```
+pub fn zigzag(highs: &[f64], lows: &[f64], deviation_pct: f64) -> Result<Vec<ZigZagPoint>> {
+    if deviation_pct <= 0.0 {
+        return Err(IndicatorError::InvalidPeriod(
+            "deviation_pct must be greater than 0".to_string(),
+        ));
+    }
+    if highs.len() != lows.len() {
+        return Err(IndicatorError::InvalidPeriod(
+            "highs and lows must have the same length".to_string(),
+        ));
+    }
+    if highs.is_empty() {
+        return Err(IndicatorError::InsufficientData {
+            need: 2,
+            got: highs.len(),
+        });
+    }
+
+    let threshold = deviation_pct / 100.0;
+    let mut pivots = Vec::new();
+
+    let start_price = (highs[0] + lows[0]) / 2.0;
+    let mut trend: Option<bool> = None; // Some(true) = uptrend (tracking a high), Some(false) = downtrend
+    let mut extreme_idx = 0usize;
+    let mut extreme_price = start_price;
+
+    for i in 1..highs.len() {
+        match trend {
+            None => {
+                if highs[i] >= start_price * (1.0 + threshold) {
+                    trend = Some(true);
+                    extreme_idx = i;
+                    extreme_price = highs[i];
+                } else if lows[i] <= start_price * (1.0 - threshold) {
+                    trend = Some(false);
+                    extreme_idx = i;
+                    extreme_price = lows[i];
+                }
+            }
+            Some(true) => {
+                if highs[i] > extreme_price {
+                    extreme_price = highs[i];
+                    extreme_idx = i;
+                } else if lows[i] <= extreme_price * (1.0 - threshold) {
+                    pivots.push(ZigZagPoint {
+                        index: extreme_idx,
+                        price: extreme_price,
+                        is_high: true,
+                    });
+                    trend = Some(false);
+                    extreme_price = lows[i];
+                    extreme_idx = i;
+                }
+            }
+            Some(false) => {
+                if lows[i] < extreme_price {
+                    extreme_price = lows[i];
+                    extreme_idx = i;
+                } else if highs[i] >= extreme_price * (1.0 + threshold) {
+                    pivots.push(ZigZagPoint {
+                        index: extreme_idx,
+                        price: extreme_price,
+                        is_high: false,
+                    });
+                    trend = Some(true);
+                    extreme_price = highs[i];
+                    extreme_idx = i;
+                }
+            }
+        }
+    }
+
+    if let Some(is_high) = trend {
+        pivots.push(ZigZagPoint {
+            index: extreme_idx,
+            price: extreme_price,
+            is_high,
+        });
+    }
+
+    Ok(pivots)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zigzag_basic() {
+        let highs = vec![100.0, 110.0, 90.0, 120.0, 80.0];
+        let lows = vec![100.0, 110.0, 90.0, 120.0, 80.0];
+        let pivots = zigzag(&highs, &lows, 5.0).unwrap();
+
+        assert_eq!(pivots.len(), 4);
+        assert_eq!(
+            pivots[0],
+            ZigZagPoint {
+                index: 1,
+                price: 110.0,
+                is_high: true
+            }
+        );
+        assert_eq!(
+            pivots[1],
+            ZigZagPoint {
+                index: 2,
+                price: 90.0,
+                is_high: false
+            }
+        );
+        assert_eq!(
+            pivots[2],
+            ZigZagPoint {
+                index: 3,
+                price: 120.0,
+                is_high: true
+            }
+        );
+        assert_eq!(
+            pivots[3],
+            ZigZagPoint {
+                index: 4,
+                price: 80.0,
+                is_high: false
+            }
+        );
+    }
+
+    #[test]
+    fn test_zigzag_alternates() {
+        let highs = vec![100.0, 110.0, 90.0, 120.0, 80.0];
+        let lows = vec![100.0, 110.0, 90.0, 120.0, 80.0];
+        let pivots = zigzag(&highs, &lows, 5.0).unwrap();
+        for w in pivots.windows(2) {
+            assert_ne!(w[0].is_high, w[1].is_high, "pivots must alternate");
+        }
+    }
+
+    #[test]
+    fn test_zigzag_small_moves_filtered() {
+        // Moves within the threshold shouldn't produce intermediate pivots.
+        let highs = vec![100.0, 101.0, 100.5, 101.5, 130.0];
+        let lows = vec![100.0, 100.5, 100.0, 101.0, 129.0];
+        let pivots = zigzag(&highs, &lows, 10.0).unwrap();
+        // Only the final large move to 130 should register (plus possibly the trend start).
+        assert!(pivots.len() <= 2);
+    }
+
+    #[test]
+    fn test_zigzag_invalid_deviation() {
+        assert!(zigzag(&[1.0, 2.0], &[1.0, 2.0], 0.0).is_err());
+        assert!(zigzag(&[1.0, 2.0], &[1.0, 2.0], -1.0).is_err());
+    }
+
+    #[test]
+    fn test_zigzag_mismatched_lengths() {
+        assert!(zigzag(&[1.0, 2.0], &[1.0], 5.0).is_err());
+    }
+
+    #[test]
+    fn test_zigzag_empty() {
+        assert!(zigzag(&[], &[], 5.0).is_err());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,8 @@ pub mod edgar {
 mod backoff;
 mod constants;
 mod models;
+#[cfg(any(feature = "risk", feature = "backtesting"))]
+mod perf_metrics;
 mod providers;
 pub(crate) mod rate_limiter;
 mod scrapers;

--- a/src/models/chart/candle.rs
+++ b/src/models/chart/candle.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// Note: This struct cannot be manually constructed - obtain via `Ticker::chart()`.
 #[non_exhaustive]
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "dataframe", derive(crate::ToDataFrame))]
 pub struct Candle {

--- a/src/models/chart/data.rs
+++ b/src/models/chart/data.rs
@@ -254,4 +254,62 @@ impl Chart {
     pub fn patterns(&self) -> Vec<Option<crate::indicators::CandlePattern>> {
         crate::indicators::patterns(&self.candles)
     }
+
+    /// Calculate classic (standard) Pivot Points.
+    ///
+    /// Each bar's levels are derived from the **previous** bar's
+    /// high/low/close; the first bar is `None`.
+    pub fn pivot_points(
+        &self,
+    ) -> crate::indicators::Result<Vec<Option<crate::indicators::PivotPoints>>> {
+        crate::indicators::pivot_points(
+            &self.high_prices(),
+            &self.low_prices(),
+            &self.close_prices(),
+        )
+    }
+
+    /// Calculate Fibonacci Pivot Points.
+    ///
+    /// Same central pivot as [`pivot_points`](Self::pivot_points), but uses
+    /// Fibonacci retracement ratios of the previous bar's range for the
+    /// support/resistance levels.
+    pub fn fibonacci_pivot_points(
+        &self,
+    ) -> crate::indicators::Result<Vec<Option<crate::indicators::PivotPoints>>> {
+        crate::indicators::fibonacci_pivot_points(
+            &self.high_prices(),
+            &self.low_prices(),
+            &self.close_prices(),
+        )
+    }
+
+    /// Transform candles into Heikin-Ashi ("average bar") candles.
+    ///
+    /// Smooths price action to make the prevailing trend easier to read.
+    /// Volume, timestamp, adjusted close, and provider id pass through
+    /// unchanged — only open/high/low/close are recomputed.
+    pub fn heikin_ashi(&self) -> crate::indicators::Result<Vec<crate::Candle>> {
+        crate::indicators::heikin_ashi(&self.candles)
+    }
+
+    /// Calculate ZigZag swing points using a percentage reversal threshold.
+    ///
+    /// `deviation_pct` is the minimum reversal size (e.g. `5.0` for 5%)
+    /// required before a swing high/low is confirmed.
+    pub fn zigzag(
+        &self,
+        deviation_pct: f64,
+    ) -> crate::indicators::Result<Vec<crate::indicators::ZigZagPoint>> {
+        crate::indicators::zigzag(&self.high_prices(), &self.low_prices(), deviation_pct)
+    }
+
+    /// Calculate rolling Fibonacci Retracement levels over a `period`-bar
+    /// lookback window.
+    pub fn fibonacci_retracement(
+        &self,
+        period: usize,
+    ) -> crate::indicators::Result<Vec<Option<crate::indicators::FibonacciLevels>>> {
+        crate::indicators::fibonacci_retracement(&self.high_prices(), &self.low_prices(), period)
+    }
 }

--- a/src/models/sentiment/response.rs
+++ b/src/models/sentiment/response.rs
@@ -74,6 +74,18 @@ impl FearAndGreed {
             }
         })?;
 
+        Self::from_entry(entry)
+    }
+
+    /// Parse every entry in the response (current + historical), newest
+    /// first — matching the API's own ordering. Used for `limit > 1` requests.
+    pub(crate) fn vec_from_response(
+        resp: FearAndGreedApiResponse,
+    ) -> Result<Vec<Self>, crate::error::FinanceError> {
+        resp.data.into_iter().map(Self::from_entry).collect()
+    }
+
+    fn from_entry(entry: FearAndGreedEntry) -> Result<Self, crate::error::FinanceError> {
         let value = entry.value.parse::<u8>().map_err(|_| {
             crate::error::FinanceError::ResponseStructureError {
                 field: "value".to_string(),

--- a/src/perf_metrics.rs
+++ b/src/perf_metrics.rs
@@ -1,0 +1,171 @@
+//! Shared performance-metric math for `risk` and `backtesting`.
+//!
+//! `risk` and `backtesting` are independent optional features — `backtesting`
+//! does not (and should not) depend on `risk` — but both already imply
+//! `indicators`. Formulas that both modules need (Omega Ratio, Kelly
+//! Criterion, Ulcer Index, Information Ratio, tracking error) live here,
+//! gated on `any(risk, backtesting)`, so extracting the duplication doesn't
+//! saddle either feature with a dependency on the other.
+//!
+//! Everything here is pure math over plain `f64` slices — no `Candle`,
+//! `EquityPoint`, or `Trade` types — so both call sites can adapt their own
+//! domain types to these signatures without this module depending on either.
+
+/// Kelly Criterion: optimal fraction of capital to risk, given a win rate and
+/// average win/loss magnitudes (in percent).
+///
+/// `W - (1 - W) / R` where `R = avg_win_pct / abs(avg_loss_pct)`.
+///
+/// Returns `f64::MAX` when there are no losses and wins are positive
+/// (unbounded edge), `0.0` for other degenerate inputs (no wins, or a zero
+/// win rate).
+pub(crate) fn kelly_criterion(win_rate: f64, avg_win_pct: f64, avg_loss_pct: f64) -> f64 {
+    let abs_loss = avg_loss_pct.abs();
+    if abs_loss == 0.0 {
+        return if avg_win_pct > 0.0 { f64::MAX } else { 0.0 };
+    }
+    if avg_win_pct == 0.0 {
+        return 0.0;
+    }
+    let r = avg_win_pct / abs_loss;
+    win_rate - (1.0 - win_rate) / r
+}
+
+/// Omega Ratio at a `0.0` threshold: `Σ max(r, 0) / Σ max(-r, 0)`.
+///
+/// More general than Sharpe — considers the full return distribution rather
+/// than only mean and standard deviation. Returns `f64::MAX` when there are
+/// no negative returns, `0.0` when there are also no positive returns.
+pub(crate) fn omega_ratio(returns: &[f64]) -> f64 {
+    let gains: f64 = returns.iter().map(|&r| r.max(0.0)).sum();
+    let losses: f64 = returns.iter().map(|&r| (-r).max(0.0)).sum();
+    if losses == 0.0 {
+        if gains > 0.0 { f64::MAX } else { 0.0 }
+    } else {
+        gains / losses
+    }
+}
+
+/// Ulcer Index: `sqrt(mean((drawdown_pct × 100)²))` given per-period drawdown
+/// fractions (0.0–1.0), returned in **percentage** units (0–100) to match
+/// backtesting.py and Peter Martin's original 1987 definition.
+///
+/// Unlike max drawdown, penalises both depth and duration — a long shallow
+/// drawdown scores higher than a brief deep one.
+pub(crate) fn ulcer_index(drawdown_pcts: &[f64]) -> f64 {
+    if drawdown_pcts.is_empty() {
+        return 0.0;
+    }
+    let sum_sq: f64 = drawdown_pcts.iter().map(|d| (d * 100.0).powi(2)).sum();
+    (sum_sq / drawdown_pcts.len() as f64).sqrt()
+}
+
+/// Mean and sample standard deviation (n-1) of the excess-return series
+/// (`strategy - benchmark`, aligned pairwise). `None` when the series differ
+/// in length or fewer than 2 observations are available.
+fn excess_stats(strategy_returns: &[f64], benchmark_returns: &[f64]) -> Option<(f64, f64)> {
+    let n = strategy_returns.len();
+    if n < 2 || n != benchmark_returns.len() {
+        return None;
+    }
+    let excess: Vec<f64> = strategy_returns
+        .iter()
+        .zip(benchmark_returns.iter())
+        .map(|(s, b)| s - b)
+        .collect();
+    let mean = excess.iter().sum::<f64>() / n as f64;
+    let variance = excess.iter().map(|e| (e - mean).powi(2)).sum::<f64>() / (n - 1) as f64;
+    Some((mean, variance.sqrt()))
+}
+
+/// Tracking error: annualised standard deviation of (strategy − benchmark)
+/// periodic returns.
+///
+/// `None` when the series differ in length or fewer than 2 aligned
+/// observations are available.
+pub(crate) fn tracking_error(
+    strategy_returns: &[f64],
+    benchmark_returns: &[f64],
+    periods_per_year: f64,
+) -> Option<f64> {
+    excess_stats(strategy_returns, benchmark_returns).map(|(_, std)| std * periods_per_year.sqrt())
+}
+
+/// Information Ratio: annualised mean excess return divided by tracking
+/// error (annualised standard deviation of excess returns).
+///
+/// `None` when the series differ in length, fewer than 2 aligned
+/// observations are available, or tracking error is zero.
+pub(crate) fn information_ratio(
+    strategy_returns: &[f64],
+    benchmark_returns: &[f64],
+    periods_per_year: f64,
+) -> Option<f64> {
+    let (mean, std) = excess_stats(strategy_returns, benchmark_returns)?;
+    if std > 0.0 {
+        Some((mean / std) * periods_per_year.sqrt())
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_kelly_criterion() {
+        // W=0.6, avg_win=10%, avg_loss=5% => R=2.0 => Kelly=0.6 - 0.4/2 = 0.4
+        let kelly = kelly_criterion(0.6, 10.0, -5.0);
+        assert!(
+            (kelly - 0.4).abs() < 1e-9,
+            "Kelly should be 0.4, got {kelly}"
+        );
+
+        // No losses, positive wins -> unbounded edge
+        assert_eq!(kelly_criterion(1.0, 10.0, 0.0), f64::MAX);
+        // No losses, no wins -> degenerate
+        assert_eq!(kelly_criterion(0.0, 0.0, 0.0), 0.0);
+    }
+
+    #[test]
+    fn test_omega_ratio() {
+        assert_eq!(omega_ratio(&[1.0, 2.0, 3.0]), f64::MAX);
+        assert_eq!(omega_ratio(&[-1.0, -2.0, -3.0]), 0.0);
+        let omega = omega_ratio(&[2.0, -1.0, 3.0, -2.0]);
+        assert!((omega - 5.0 / 3.0).abs() < 1e-9, "got {omega}");
+    }
+
+    #[test]
+    fn test_ulcer_index() {
+        assert_eq!(ulcer_index(&[]), 0.0);
+        assert_eq!(ulcer_index(&[0.0, 0.0, 0.0]), 0.0);
+        // drawdowns of 10% and 20% -> sqrt(mean(10^2, 20^2)) = sqrt(250) ≈ 15.81
+        let ui = ulcer_index(&[0.10, 0.20]);
+        assert!((ui - 250f64.sqrt()).abs() < 1e-9, "got {ui}");
+    }
+
+    #[test]
+    fn test_tracking_error_and_information_ratio() {
+        let strategy = vec![0.01, 0.02, -0.01, 0.03, 0.00];
+        let benchmark = vec![0.005, 0.01, -0.02, 0.02, 0.01];
+        let te = tracking_error(&strategy, &benchmark, 252.0).unwrap();
+        assert!(te > 0.0);
+        let ir = information_ratio(&strategy, &benchmark, 252.0).unwrap();
+        assert!(ir.is_finite());
+    }
+
+    #[test]
+    fn test_information_ratio_insufficient_data() {
+        assert!(information_ratio(&[0.01], &[0.01], 252.0).is_none());
+        assert!(information_ratio(&[0.01, 0.02], &[0.01], 252.0).is_none());
+    }
+
+    #[test]
+    fn test_information_ratio_zero_tracking_error() {
+        // Identical series -> zero excess std dev -> None
+        let r = vec![0.01, 0.02, 0.03, -0.01];
+        assert!(information_ratio(&r, &r, 252.0).is_none());
+        assert!(tracking_error(&r, &r, 252.0).unwrap() == 0.0);
+    }
+}

--- a/src/risk/cvar.rs
+++ b/src/risk/cvar.rs
@@ -1,0 +1,114 @@
+//! Conditional Value at Risk (CVaR / Expected Shortfall) calculations.
+//!
+//! CVaR is the average loss in the tail beyond the VaR threshold — a more
+//! conservative tail-risk measure than VaR, which only reports the
+//! threshold loss itself rather than the average loss beyond it.
+
+use super::var::normal_quantile;
+
+/// Compute historical CVaR (Expected Shortfall) at the given confidence level.
+///
+/// # Arguments
+///
+/// * `returns` - Daily log-returns or simple returns (as fractions, e.g. 0.02 = 2%)
+/// * `confidence` - Confidence level, e.g. 0.95 for 95% CVaR
+///
+/// Returns `None` when `returns` is empty.
+pub fn historical_cvar(returns: &[f64], confidence: f64) -> Option<f64> {
+    if returns.is_empty() {
+        return None;
+    }
+    let mut sorted = returns.to_vec();
+    sorted.sort_by(|a, b| a.total_cmp(b));
+    historical_cvar_sorted(&sorted, confidence)
+}
+
+/// `historical_cvar` over an already-sorted slice.
+pub(crate) fn historical_cvar_sorted(sorted: &[f64], confidence: f64) -> Option<f64> {
+    if sorted.is_empty() {
+        return None;
+    }
+    let n = sorted.len();
+    let idx = (((1.0 - confidence) * n as f64) as usize).min(n - 1);
+    // Average of the tail up to and including the VaR threshold index.
+    let tail = &sorted[..=idx];
+    let mean_tail = tail.iter().sum::<f64>() / tail.len() as f64;
+    Some(-mean_tail)
+}
+
+/// Compute parametric CVaR assuming normally distributed returns.
+///
+/// Uses the closed-form Expected Shortfall for a normal distribution:
+/// `ES = -(mean - std_dev * phi(z) / (1 - confidence))`, where `phi` is the
+/// standard normal density and `z` is the confidence level's quantile.
+///
+/// # Arguments
+///
+/// * `returns` - Daily returns as fractions
+/// * `confidence` - Confidence level (0.95 or 0.99 are common)
+///
+/// Returns `None` when fewer than 2 observations are provided.
+pub fn parametric_cvar(returns: &[f64], confidence: f64) -> Option<f64> {
+    let (mean, std_dev) = super::ratios::mean_and_std(returns)?;
+    Some(parametric_cvar_with_stats(mean, std_dev, confidence))
+}
+
+/// `parametric_cvar` given a precomputed mean and standard deviation.
+pub(crate) fn parametric_cvar_with_stats(mean: f64, std_dev: f64, confidence: f64) -> f64 {
+    let z = normal_quantile(confidence);
+    let phi_z = (-(z * z) / 2.0).exp() / (2.0 * std::f64::consts::PI).sqrt();
+    let es_factor = phi_z / (1.0 - confidence);
+    -(mean - es_factor * std_dev)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_historical_cvar_empty() {
+        assert!(historical_cvar(&[], 0.95).is_none());
+    }
+
+    #[test]
+    fn test_historical_cvar_simple() {
+        // sorted: [-0.10, -0.05, 0.0, 0.05, 0.10]; 95% VaR idx = 0 -> tail = [-0.10]
+        let returns = [-0.05_f64, 0.0, 0.05, 0.10, -0.10];
+        let cvar = historical_cvar(&returns, 0.95).unwrap();
+        assert!((cvar - 0.10).abs() < 1e-9, "got {cvar}");
+    }
+
+    #[test]
+    fn test_historical_cvar_worse_than_var() {
+        // CVaR (average of the tail) should be at least as large as VaR
+        // (the single threshold loss) for a fat left tail.
+        let returns: Vec<f64> = vec![
+            -0.30, -0.20, -0.15, -0.10, -0.05, 0.0, 0.02, 0.03, 0.04, 0.05,
+        ];
+        let cvar = historical_cvar(&returns, 0.90).unwrap();
+        let var = super::super::var::historical_var(&returns, 0.90).unwrap();
+        assert!(cvar >= var, "CVaR ({cvar}) should be >= VaR ({var})");
+    }
+
+    #[test]
+    fn test_parametric_cvar_positive_for_volatile_returns() {
+        let returns: Vec<f64> = (0..100)
+            .map(|i| if i % 2 == 0 { 0.01 } else { -0.01 })
+            .collect();
+        let cvar = parametric_cvar(&returns, 0.95).unwrap();
+        assert!(cvar > 0.0, "CVaR must be positive");
+    }
+
+    #[test]
+    fn test_parametric_cvar_worse_than_var() {
+        let returns: Vec<f64> = (0..100)
+            .map(|i| if i % 2 == 0 { 0.01 } else { -0.01 })
+            .collect();
+        let cvar = parametric_cvar(&returns, 0.95).unwrap();
+        let var = super::super::var::parametric_var(&returns, 0.95).unwrap();
+        assert!(
+            cvar >= var,
+            "parametric CVaR ({cvar}) should be >= VaR ({var})"
+        );
+    }
+}

--- a/src/risk/drawdown.rs
+++ b/src/risk/drawdown.rs
@@ -68,6 +68,35 @@ pub fn max_drawdown(returns: &[f64]) -> DrawdownResult {
     }
 }
 
+/// Per-period drawdown fraction (peak-to-current), built from the same
+/// synthetic cumulative-equity curve `max_drawdown` uses internally.
+///
+/// Returned length is `returns.len() + 1` (includes the starting point,
+/// always `0.0`). Used to feed `perf_metrics::ulcer_index` — kept separate
+/// from `max_drawdown` itself since that function also tracks peak/trough
+/// indices for recovery-period detection that ulcer index doesn't need.
+pub(crate) fn drawdown_series(returns: &[f64]) -> Vec<f64> {
+    if returns.is_empty() {
+        return Vec::new();
+    }
+    let mut equity = Vec::with_capacity(returns.len() + 1);
+    equity.push(1.0_f64);
+    for r in returns {
+        let last = *equity.last().unwrap();
+        equity.push(last * (1.0 + r));
+    }
+
+    let mut peak = equity[0];
+    let mut out = Vec::with_capacity(equity.len());
+    for &val in &equity {
+        if val > peak {
+            peak = val;
+        }
+        out.push((peak - val) / peak);
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/risk/mod.rs
+++ b/src/risk/mod.rs
@@ -2,8 +2,10 @@
 //!
 //! Requires the **`risk`** feature flag (which implies **`indicators`**).
 //!
-//! Provides Value at Risk, Sharpe/Sortino/Calmar ratios, beta, and max drawdown
-//! as standalone metrics — independent of the backtesting engine.
+//! Provides Value at Risk, Conditional VaR (Expected Shortfall),
+//! Sharpe/Sortino/Calmar ratios, Omega Ratio, Kelly Criterion, beta, max
+//! drawdown, Ulcer Index, Information Ratio, and tracking error as standalone
+//! metrics — independent of the backtesting engine.
 //!
 //! # Quick Start
 //!
@@ -24,13 +26,18 @@
 //! ```
 
 mod beta;
+mod cvar;
 mod drawdown;
 mod ratios;
 mod var;
 
 pub use self::beta::beta;
+pub use self::cvar::{historical_cvar, parametric_cvar};
 pub use self::drawdown::max_drawdown;
-pub use self::ratios::{calmar_ratio, sharpe_ratio, sortino_ratio};
+pub use self::ratios::{
+    calmar_ratio, information_ratio, kelly_criterion, omega_ratio, sharpe_ratio, sortino_ratio,
+    tracking_error, ulcer_index, win_loss_stats,
+};
 pub use self::var::{historical_var, parametric_var};
 
 use crate::models::chart::Candle;
@@ -48,6 +55,23 @@ pub struct RiskSummary {
     pub var_99: f64,
     /// 1-day parametric VaR at 95% confidence (assumes normally distributed returns)
     pub parametric_var_95: f64,
+    /// 1-day historical Conditional VaR (Expected Shortfall) at 95% confidence —
+    /// the average loss in the worst 5% of historical periods.
+    pub cvar_95: f64,
+    /// 1-day historical Conditional VaR at 99% confidence.
+    pub cvar_99: f64,
+    /// 1-day parametric Conditional VaR at 95% confidence (assumes normally
+    /// distributed returns).
+    pub parametric_cvar_95: f64,
+    /// Omega Ratio at a 0.0 threshold: probability-weighted ratio of gains to
+    /// losses over the full return distribution. `f64::MAX` when there are no
+    /// negative-return periods.
+    pub omega: f64,
+    /// Kelly Criterion: optimal fraction of capital to risk, treating each
+    /// positive-return period as a "win" and each negative-return period as a
+    /// "loss". `f64::MAX` when there are no losing periods and wins are
+    /// positive (unbounded edge).
+    pub kelly: f64,
     /// Annualised Sharpe Ratio (risk-free rate = 0, 252 trading days/year).
     /// `None` when fewer than 2 periods or zero volatility.
     pub sharpe: Option<f64>,
@@ -64,6 +88,17 @@ pub struct RiskSummary {
     /// Number of trading periods to recover from the maximum drawdown.
     /// `None` when no recovery occurred within the data window.
     pub max_drawdown_recovery_periods: Option<u64>,
+    /// Ulcer Index: root-mean-square of drawdown depth across all periods,
+    /// expressed as a percentage (0–100). Penalises both depth and duration of
+    /// drawdowns, unlike `max_drawdown` which only reports the worst single one.
+    pub ulcer_index: f64,
+    /// Information Ratio vs benchmark: annualised mean excess return divided by
+    /// tracking error. `None` when no benchmark is provided or data is insufficient.
+    pub information_ratio: Option<f64>,
+    /// Tracking error vs benchmark: annualised standard deviation of
+    /// (asset − benchmark) periodic returns. `None` when no benchmark is
+    /// provided or data is insufficient.
+    pub tracking_error: Option<f64>,
 }
 
 /// Compute returns from a slice of candles (simple daily returns: close-to-close).
@@ -90,6 +125,12 @@ pub(crate) enum TradingCalendar {
     Crypto,
 }
 
+// Only constructed/called by the domain-handle `risk()` macro in
+// `src/domains/mod.rs`, gated behind provider features (alphavantage, fmp,
+// polygon, crypto, ...) that may all be disabled under a narrower feature
+// set (e.g. `--features indicators,risk,backtesting` alone), same reasoning
+// as the `#[allow(dead_code)]` on `TradingCalendar` above.
+#[allow(dead_code)]
 impl TradingCalendar {
     fn trading_days(self) -> f64 {
         match self {
@@ -110,6 +151,7 @@ impl TradingCalendar {
 /// Number of `interval` periods in a trading year for the given calendar — the
 /// annualisation factor for Sharpe/Sortino/Calmar. Day/week/month/quarter are
 /// exact; intraday scales the daily count by the session length.
+#[allow(dead_code)]
 pub(crate) fn periods_per_year(interval: crate::Interval, cal: TradingCalendar) -> f64 {
     use crate::Interval;
     let days = cal.trading_days();
@@ -155,6 +197,16 @@ pub(crate) fn compute_risk_summary_with_periods(
         .map(|(m, s)| var::parametric_var_with_stats(m, s, 0.95))
         .unwrap_or(0.0);
 
+    let cvar_95 = cvar::historical_cvar_sorted(&sorted, 0.95).unwrap_or(0.0);
+    let cvar_99 = cvar::historical_cvar_sorted(&sorted, 0.99).unwrap_or(0.0);
+    let parametric_cvar_95 = stats
+        .map(|(m, s)| cvar::parametric_cvar_with_stats(m, s, 0.95))
+        .unwrap_or(0.0);
+
+    let omega = omega_ratio(&returns);
+    let (win_rate, avg_win_pct, avg_loss_pct) = win_loss_stats(&returns);
+    let kelly = kelly_criterion(win_rate, avg_win_pct, avg_loss_pct);
+
     let sharpe = stats.and_then(|(m, s)| ratios::sharpe_with_stats(m, s, 0.0, periods_per_year));
     let sortino = sortino_ratio(&returns, 0.0, periods_per_year);
 
@@ -162,19 +214,32 @@ pub(crate) fn compute_risk_summary_with_periods(
     let total_return = returns.iter().fold(1.0_f64, |acc, r| acc * (1.0 + r)) - 1.0;
     let years = returns.len() as f64 / periods_per_year;
     let calmar = calmar_ratio(total_return, years, dd.max_drawdown);
+    let ulcer_index_val = ulcer_index(&returns);
 
     let beta_val = benchmark_returns.and_then(|br| beta(&returns, br));
+    let information_ratio_val =
+        benchmark_returns.and_then(|br| information_ratio(&returns, br, periods_per_year));
+    let tracking_error_val =
+        benchmark_returns.and_then(|br| tracking_error(&returns, br, periods_per_year));
 
     RiskSummary {
         var_95,
         var_99,
         parametric_var_95,
+        cvar_95,
+        cvar_99,
+        parametric_cvar_95,
+        omega,
+        kelly,
         sharpe,
         sortino,
         calmar,
         beta: beta_val,
         max_drawdown: dd.max_drawdown,
         max_drawdown_recovery_periods: dd.recovery_periods,
+        ulcer_index: ulcer_index_val,
+        information_ratio: information_ratio_val,
+        tracking_error: tracking_error_val,
     }
 }
 
@@ -203,6 +268,60 @@ mod tests {
         assert_eq!(summary.var_95, 0.0);
         assert_eq!(summary.max_drawdown, 0.0);
         assert!(summary.sharpe.is_none());
+        // New metrics: degenerate for a flat (zero-return) series.
+        assert_eq!(summary.cvar_95, 0.0);
+        assert_eq!(summary.cvar_99, 0.0);
+        assert_eq!(summary.parametric_cvar_95, 0.0);
+        assert_eq!(summary.omega, 0.0);
+        assert_eq!(summary.kelly, 0.0);
+        assert_eq!(summary.ulcer_index, 0.0);
+        assert!(summary.information_ratio.is_none());
+        assert!(summary.tracking_error.is_none());
+    }
+
+    #[test]
+    fn test_cvar_at_least_as_severe_as_var() {
+        // A volatile, mostly-declining series should have CVaR >= VaR (CVaR
+        // averages the tail beyond the VaR threshold, so it's at least as bad).
+        let closes: Vec<f64> = (0..60)
+            .map(|i| 100.0 - i as f64 * 0.5 + if i % 5 == 0 { -8.0 } else { 0.0 })
+            .collect();
+        let candles: Vec<Candle> = closes.into_iter().map(make_candle).collect();
+        let summary = compute_risk_summary(&candles, None);
+        assert!(
+            summary.cvar_95 >= summary.var_95,
+            "cvar_95 ({}) should be >= var_95 ({})",
+            summary.cvar_95,
+            summary.var_95
+        );
+        assert!(summary.parametric_cvar_95 >= summary.parametric_var_95);
+    }
+
+    #[test]
+    fn test_drawdown_produces_positive_ulcer_index() {
+        // A single sharp drawdown followed by recovery should score a
+        // positive (nonzero) Ulcer Index.
+        let closes = [100.0, 110.0, 80.0, 85.0, 105.0, 115.0];
+        let candles: Vec<Candle> = closes.into_iter().map(make_candle).collect();
+        let summary = compute_risk_summary(&candles, None);
+        assert!(summary.ulcer_index > 0.0);
+        assert!(summary.max_drawdown > 0.0);
+    }
+
+    #[test]
+    fn test_information_ratio_and_tracking_error_with_benchmark() {
+        let asset_closes: Vec<f64> = (0..30).map(|i| 100.0 + i as f64 * 1.2).collect();
+        let bench_closes: Vec<f64> = (0..30).map(|i| 100.0 + i as f64 * 0.8).collect();
+        let candles: Vec<Candle> = asset_closes.into_iter().map(make_candle).collect();
+        let bench_candles: Vec<Candle> = bench_closes.into_iter().map(make_candle).collect();
+        let bench_returns = candles_to_returns(&bench_candles);
+
+        let summary = compute_risk_summary(&candles, Some(&bench_returns));
+        assert!(summary.information_ratio.is_some());
+        assert!(summary.tracking_error.is_some());
+        assert!(summary.tracking_error.unwrap() > 0.0);
+        // Asset outperforms the benchmark every period -> positive excess return.
+        assert!(summary.information_ratio.unwrap() > 0.0);
     }
 
     #[test]

--- a/src/risk/ratios.rs
+++ b/src/risk/ratios.rs
@@ -73,6 +73,99 @@ pub fn sortino_ratio(returns: &[f64], risk_free_rate: f64, periods_per_year: f64
     Some((mean - risk_free_rate) / downside_std * periods_per_year.sqrt())
 }
 
+/// Compute the Omega Ratio at a `0.0` threshold: probability-weighted ratio
+/// of gains to losses over the full return distribution.
+///
+/// `Σ max(r, 0) / Σ max(-r, 0)`. More general than Sharpe — considers the
+/// full return distribution rather than only mean and standard deviation.
+/// Returns `f64::MAX` when there are no negative returns, `0.0` when there
+/// are also no positive returns.
+pub fn omega_ratio(returns: &[f64]) -> f64 {
+    crate::perf_metrics::omega_ratio(returns)
+}
+
+/// Compute the Kelly Criterion: optimal fraction of capital to risk, given a
+/// win rate and average win/loss magnitudes (in percent).
+///
+/// `W - (1 - W) / R` where `R = avg_win_pct / abs(avg_loss_pct)`. Returns
+/// `f64::MAX` when there are no losses and wins are positive (unbounded
+/// edge), `0.0` for other degenerate inputs.
+///
+/// Use [`win_loss_stats`] to derive `win_rate`/`avg_win_pct`/`avg_loss_pct`
+/// from a plain return series (treating each positive-return period as a
+/// "win" and each negative-return period as a "loss").
+pub fn kelly_criterion(win_rate: f64, avg_win_pct: f64, avg_loss_pct: f64) -> f64 {
+    crate::perf_metrics::kelly_criterion(win_rate, avg_win_pct, avg_loss_pct)
+}
+
+/// Compute the Ulcer Index: root-mean-square of drawdown depth across a
+/// return series, expressed as a percentage (0–100).
+///
+/// Unlike [`max_drawdown`](super::max_drawdown), penalises both depth and
+/// duration of drawdowns — a long shallow drawdown scores higher than a
+/// brief deep one.
+pub fn ulcer_index(returns: &[f64]) -> f64 {
+    crate::perf_metrics::ulcer_index(&super::drawdown::drawdown_series(returns))
+}
+
+/// Compute the Information Ratio vs a benchmark: annualised mean excess
+/// return divided by tracking error.
+///
+/// Returns `None` when the series differ in length, fewer than 2 aligned
+/// observations are available, or tracking error is zero.
+pub fn information_ratio(
+    asset_returns: &[f64],
+    benchmark_returns: &[f64],
+    periods_per_year: f64,
+) -> Option<f64> {
+    crate::perf_metrics::information_ratio(asset_returns, benchmark_returns, periods_per_year)
+}
+
+/// Compute the tracking error vs a benchmark: annualised standard deviation
+/// of (asset − benchmark) periodic returns.
+///
+/// Returns `None` when the series differ in length or fewer than 2 aligned
+/// observations are available.
+pub fn tracking_error(
+    asset_returns: &[f64],
+    benchmark_returns: &[f64],
+    periods_per_year: f64,
+) -> Option<f64> {
+    crate::perf_metrics::tracking_error(asset_returns, benchmark_returns, periods_per_year)
+}
+
+/// Derive win-rate and average win/loss percentages from a return series,
+/// treating each period as if it were a discrete "trade" (a positive-return
+/// period is a win, a negative-return period is a loss) — the natural
+/// analogue of backtesting trade statistics for a plain returns series with
+/// no explicit trade log. Feeds [`kelly_criterion`].
+///
+/// Returns `(win_rate, avg_win_pct, avg_loss_pct)`, all `0.0` for an empty
+/// series.
+pub fn win_loss_stats(returns: &[f64]) -> (f64, f64, f64) {
+    let total = returns.len();
+    if total == 0 {
+        return (0.0, 0.0, 0.0);
+    }
+
+    let wins: Vec<f64> = returns.iter().copied().filter(|&r| r > 0.0).collect();
+    let losses: Vec<f64> = returns.iter().copied().filter(|&r| r < 0.0).collect();
+
+    let win_rate = wins.len() as f64 / total as f64;
+    let avg_win_pct = if wins.is_empty() {
+        0.0
+    } else {
+        wins.iter().sum::<f64>() / wins.len() as f64 * 100.0
+    };
+    let avg_loss_pct = if losses.is_empty() {
+        0.0
+    } else {
+        losses.iter().sum::<f64>() / losses.len() as f64 * 100.0
+    };
+
+    (win_rate, avg_win_pct, avg_loss_pct)
+}
+
 /// Compute the Calmar Ratio: annualised return divided by maximum drawdown.
 ///
 /// # Arguments

--- a/src/risk/var.rs
+++ b/src/risk/var.rs
@@ -54,7 +54,7 @@ pub(crate) fn parametric_var_with_stats(mean: f64, std_dev: f64, confidence: f64
 
 /// Approximate inverse normal CDF (quantile function) for confidence levels in [0.90, 0.999].
 /// Uses the Beasley-Springer-Moro approximation.
-fn normal_quantile(p: f64) -> f64 {
+pub(crate) fn normal_quantile(p: f64) -> f64 {
     // This covers the most common confidence levels (95%, 99%) with good accuracy.
     // For exact values, a statistics library would be needed.
     match p {


### PR DESCRIPTION
## Description
This branch closes out three related indicator/risk gaps. Pivot Points, Heikin-Ashi, ZigZag, and Fibonacci Retracement round out the technical indicator suite (#273), each wired through the standard recipe of computation function, `Indicator` enum dispatch, `Chart` extension method, and `IndicatorsSummary` field. CVaR joins `risk::`, and Omega Ratio, Kelly Criterion, Ulcer Index, and Information Ratio move from backtest-only metrics to fields on the standalone `risk::RiskSummary` (#272), sharing formulas through a new feature-independent `perf_metrics` module instead of duplicating them between `risk` and `backtesting`. Fear & Greed also picks up a crypto variant from Alternative.me (#271).

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Added Pivot Points, Heikin-Ashi, ZigZag, and Fibonacci Retracement indicators, each wired through `Indicator` enum dispatch, a `Chart` extension method, and `IndicatorsSummary`.
- Added historical and parametric Conditional VaR (CVaR / Expected Shortfall) to `src/risk/`.
- Promoted Omega Ratio, Kelly Criterion, Ulcer Index, Information Ratio, and tracking error from backtest-only metrics to fields on `risk::RiskSummary`.
- Extracted the shared metric formulas into a new `src/perf_metrics.rs`, gated on `any(risk, backtesting)`, so `risk` and `backtesting` no longer duplicate the math.
- Added `finance::fear_and_greed_crypto(limit)` for Alternative.me's crypto/Bitcoin sentiment index, alongside the existing `finance::fear_and_greed()`.
- Added an injectable base URL and a `limit` query parameter to the Alternative.me adapter, shared by both fetch paths.

## Breaking Changes
None.

## Testing
- [x] Unit tests added/updated (23 new `#[test]` functions, including mocked-HTTP coverage for `fear_and_greed_crypto` via `mockito`)
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] All tests pass (`cargo test --workspace --features full`: 1212 passed, 0 failed)

## Documentation
- [x] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues
Closes #273
Closes #272
Closes #271
