### PR TITLE
fix: auto-merge bot PRs instead of racing CI

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -42,11 +42,28 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Install cargo-soothfast
         run: cargo install cargo-soothfast --locked
-      - name: Measure baseline for claims
-        run: cargo soothfast measure -p finance-query --features bench-gate --save-baseline base
-      - name: Regenerate CHANGELOG.md
+      # Without a bench on the reference side there are no deterministic
+      # metrics to diff, so the perf table falls back to a full snapshot and
+      # walltime jitter rewrites every row on every push.
+      - name: Check the previous tag has a bench to compare against
+        id: prev
         run: |
           PREV=$(git describe --tags --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD)
+          echo "ref=$PREV" >> "$GITHUB_OUTPUT"
+          if git cat-file -e "$PREV:benches/soothfast.rs" 2>/dev/null; then
+            echo "comparable=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "comparable=false" >> "$GITHUB_OUTPUT"
+            echo "$PREV predates benches/soothfast.rs — skipping until the next release tag."
+          fi
+      - name: Measure baseline for claims
+        if: steps.prev.outputs.comparable == 'true'
+        run: cargo soothfast measure -p finance-query --features bench-gate --save-baseline base
+      - name: Regenerate CHANGELOG.md
+        if: steps.prev.outputs.comparable == 'true'
+        env:
+          PREV: ${{ steps.prev.outputs.ref }}
+        run: |
           cargo soothfast report changelog -p finance-query --baseline base \
             --against-ref "$PREV" --features full
       - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -67,4 +67,4 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
-        run: gh pr merge --squash --delete-branch "$PR_NUMBER"
+        run: gh pr merge --auto --squash --delete-branch "$PR_NUMBER"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -164,7 +164,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
-        run: gh pr merge --squash --delete-branch "$PR_NUMBER"
+        run: gh pr merge --auto --squash --delete-branch "$PR_NUMBER"
 
       - name: Regenerate endpoint reference pages
         run: |

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -106,4 +106,4 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
-        run: gh pr merge --squash --delete-branch "$PR_NUMBER"
+        run: gh pr merge --auto --squash --delete-branch "$PR_NUMBER"


### PR DESCRIPTION
## Description

Two bot-automation defects surfaced once #318 put these workflows on master.

**1. Bot PRs could not merge.**

```
GraphQL: Repository rule violations found
7 of 7 required status checks are expected.
```

`create-pull-request` is followed immediately by `gh pr merge` in the very next step, so the merge fires before CI has even been queued. With nothing reported yet, all seven required contexts read "expected" and the ruleset refuses. This is only a race — skipped checks *do* satisfy the ruleset (#323 reported `mergeable=MERGEABLE`, `mergeStateStatus=CLEAN` with every context SKIPPED). It hit `changelog.yml` and the docs-site job of `deploy.yml`; neither affected the VPS deploy or any image build, which all succeeded.

**2. The changelog rewrote all 176 perf rows on every push.**

`--against-ref` resolves to `v2.8.0`, which predates `benches/soothfast.rs`. With no bench on the reference side there are no deterministic metrics to diff, so the perf table falls back to a full snapshot and walltime jitter rewrites every row. The 0.1.5 deterministic-metrics fix is working — it just never engages without a comparable reference.

Both ship together deliberately: enabling auto-merge without the guard would turn that churn from open PRs into a stream of no-op commits on master.

## Changes

- `gh pr merge` → `gh pr merge --auto` in `changelog.yml`, `sdk.yml`, and `deploy.yml`, so GitHub merges once checks settle instead of at the instant the PR opens. Repo setting `allow_auto_merge` enabled, which `--auto` requires.
- `changelog.yml` skips regeneration when the previous tag has no `benches/soothfast.rs`, mirroring the guard `soothfast.yml`'s Gate job already uses. The baseline measurement is gated on the same condition, so a skipped run doesn't spend ~9 minutes measuring a baseline it won't use. Self-resolves once a release tag contains the bench.

## Test plan

- [x] Confirmed skipped checks satisfy the ruleset (#323 CLEAN/MERGEABLE)
- [x] Root-caused the churn to `v2.8.0` lacking `benches/soothfast.rs`
- [x] `zizmor` clean on both workflows
- [ ] Next master push produces no changelog PR
- [ ] Next bot PR merges itself without manual intervention