### PR TITLE
fix: stop the perf gate reporting noise as regressions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -130,12 +130,22 @@ jobs:
           git config user.name "${APP_SLUG}[bot]"
           git config user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
 
-      # Writes .soothfast/gate-status.json, which `report render` below
-      # reads to color the "soothfast gate" badge — without this the badge
-      # is stuck at "unknown" forever. Gates against the immediately prior
-      # commit (master requires linear history, so HEAD~1 is well-defined)
-      # since the PR that landed this commit was already gated pre-merge.
+      # soothfast.yml's paths filter and [bot] exclusion let no-code commits
+      # reach master, where gating them can only report noise.
+      - name: Detect benchmarkable changes
+        id: bench_changes
+        run: |
+          if git diff --quiet HEAD~1 HEAD -- src benches Cargo.toml Cargo.lock finance-query-derive; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No benchmarked code changed since HEAD~1 — skipping the perf gate."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Writes .soothfast/gate-status.json, which `report render` reads to
+      # color the gate badge. HEAD~1 is well-defined: master is linear.
       - name: Gate against previous commit
+        if: steps.bench_changes.outputs.changed == 'true'
         run: cargo soothfast gate -p finance-query --features bench-gate --against-ref HEAD~1
 
       - name: Measure baseline for claims

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -119,8 +119,12 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y valgrind
+      # Pinned to the locked runner: soothfast-measure builds into the bench
+      # binary from Cargo.lock, so an unpinned CLI silently outruns it.
       - name: Install cargo-soothfast
-        run: cargo install cargo-soothfast --locked
+        run: |
+          RUNNER=$(grep -A1 '^name = "soothfast"$' Cargo.lock | grep '^version' | cut -d'"' -f2)
+          cargo install cargo-soothfast --locked --version "$RUNNER"
 
       - name: Configure git identity for the gh-pages commit
         env:

--- a/.github/workflows/soothfast.yml
+++ b/.github/workflows/soothfast.yml
@@ -70,8 +70,12 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y valgrind
+      # Pinned to the locked runner: soothfast-measure builds into the bench
+      # binary from Cargo.lock, so an unpinned CLI silently outruns it.
       - name: Install cargo-soothfast
-        run: cargo install cargo-soothfast --locked
+        run: |
+          RUNNER=$(grep -A1 '^name = "soothfast"$' Cargo.lock | grep '^version' | cut -d'"' -f2)
+          cargo install cargo-soothfast --locked --version "$RUNNER"
       - name: Gate against merge-base
         run: |
           set -euo pipefail
@@ -113,8 +117,12 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y valgrind
+      # Pinned to the locked runner: soothfast-measure builds into the bench
+      # binary from Cargo.lock, so an unpinned CLI silently outruns it.
       - name: Install cargo-soothfast
-        run: cargo install cargo-soothfast --locked
+        run: |
+          RUNNER=$(grep -A1 '^name = "soothfast"$' Cargo.lock | grep '^version' | cut -d'"' -f2)
+          cargo install cargo-soothfast --locked --version "$RUNNER"
       - name: Measure baseline
         run: cargo soothfast measure -p finance-query --features bench-gate --save-baseline base
       - name: Upload baseline
@@ -145,8 +153,12 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: test-suite
+      # Pinned to the locked runner: soothfast-measure builds into the bench
+      # binary from Cargo.lock, so an unpinned CLI silently outruns it.
       - name: Install cargo-soothfast
-        run: cargo install cargo-soothfast --locked
+        run: |
+          RUNNER=$(grep -A1 '^name = "soothfast"$' Cargo.lock | grep '^version' | cut -d'"' -f2)
+          cargo install cargo-soothfast --locked --version "$RUNNER"
       - name: Download measured baseline
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -196,8 +208,12 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: spec
+      # Pinned to the locked runner: soothfast-measure builds into the bench
+      # binary from Cargo.lock, so an unpinned CLI silently outruns it.
       - name: Install cargo-soothfast
-        run: cargo install cargo-soothfast --locked
+        run: |
+          RUNNER=$(grep -A1 '^name = "soothfast"$' Cargo.lock | grep '^version' | cut -d'"' -f2)
+          cargo install cargo-soothfast --locked --version "$RUNNER"
       - name: Reconcile OpenAPI/AsyncAPI/GraphQL routes against handlers
         run: cargo soothfast spec check -p finance-query-server --target soothfast-routes
       - name: Generated openapi.yaml/asyncapi.yaml are fresh
@@ -242,8 +258,12 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: spec
+      # Pinned to the locked runner: soothfast-measure builds into the bench
+      # binary from Cargo.lock, so an unpinned CLI silently outruns it.
       - name: Install cargo-soothfast
-        run: cargo install cargo-soothfast --locked
+        run: |
+          RUNNER=$(grep -A1 '^name = "soothfast"$' Cargo.lock | grep '^version' | cut -d'"' -f2)
+          cargo install cargo-soothfast --locked --version "$RUNNER"
       - name: Reconcile MCP tool routes against mcp-tools.json
         run: cargo soothfast spec check -p finance-query-mcp --target soothfast-routes
       - name: Generated mcp-tools.json is fresh
@@ -274,8 +294,12 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: spec
+      # Pinned to the locked runner: soothfast-measure builds into the bench
+      # binary from Cargo.lock, so an unpinned CLI silently outruns it.
       - name: Install cargo-soothfast
-        run: cargo install cargo-soothfast --locked
+        run: |
+          RUNNER=$(grep -A1 '^name = "soothfast"$' Cargo.lock | grep '^version' | cut -d'"' -f2)
+          cargo install cargo-soothfast --locked --version "$RUNNER"
       - name: Reconcile pricing.proto against PricingData
         run: |
           cargo soothfast spec check-proto -p finance-query --proto proto/pricing.proto \
@@ -297,8 +321,12 @@ jobs:
       - name: Install nightly (rustdoc JSON)
         run: rustup toolchain install nightly --profile minimal
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      # Pinned to the locked runner: soothfast-measure builds into the bench
+      # binary from Cargo.lock, so an unpinned CLI silently outruns it.
       - name: Install cargo-soothfast
-        run: cargo install cargo-soothfast --locked
+        run: |
+          RUNNER=$(grep -A1 '^name = "soothfast"$' Cargo.lock | grep '^version' | cut -d'"' -f2)
+          cargo install cargo-soothfast --locked --version "$RUNNER"
       - name: Download measured baseline
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5176,9 +5176,9 @@ dependencies = [
 
 [[package]]
 name = "soothfast"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95e3c885ee5ab63c26a8a6d6aaaaa3306efe5cdb03840f4ba077b5aef1f8ad7"
+checksum = "49f57affe570f46e65f375214c6012e1e82f9238ad2b11a2d06c659d767ea615"
 dependencies = [
  "soothfast-macros",
  "soothfast-measure",
@@ -5187,9 +5187,9 @@ dependencies = [
 
 [[package]]
 name = "soothfast-macros"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4efb854f9d757bd14fd34ed98563667ad5e0e937b944e2aeaa03d0df38362f32"
+checksum = "1aba71cd439ced607289200c07ab2bc3181eaf5b20be3d41ff20ff839b7decc3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5198,9 +5198,9 @@ dependencies = [
 
 [[package]]
 name = "soothfast-measure"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "408e4372de63b25250f0ba93e540faac85b7f9033a00fbc2ad2d73766270195d"
+checksum = "8b01a1a7a8b444e495bf122cb7e85cd14cb4d059d35d558c3543b423a652332c"
 dependencies = [
  "libc",
  "soothfast-registry",
@@ -5208,9 +5208,9 @@ dependencies = [
 
 [[package]]
 name = "soothfast-registry"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2139bb3134928485a95e95f97287be58d9e0628ec7aa1e63dc75101298f4d35b"
+checksum = "1f264ad14db3e97ffb0c56ba7384076fc25aab2e34ecb2ed8671e96294cac0a4"
 dependencies = [
  "linkme",
 ]


### PR DESCRIPTION
## Description

`de_edgar_submissions` failed the gate at +7.6% three times between commits whose only difference was three workflow YAML files. Three separate defects had to line up for that, and this fixes all three.

`deploy.yml` gated every master push against `HEAD~1`, including commits that changed no benchmarked code. Those comparisons have no regression to find, so the only thing they can report is measurement noise. `soothfast.yml` does gate pre-merge, but its paths filter covers `src/**`, `benches/**`, `Cargo.toml` and only `soothfast.yml` among workflows, and its `[bot]` exclusion skips bot PRs entirely, so such commits reach master ungated and get gated there instead.

soothfast 0.1.7 fixed the underlying measurement, which reported a single unaveraged iteration where individual iterations vary 9.4%. That fix did not take effect. `measure` lives in `soothfast-measure`, which compiles into the bench binary from `Cargo.lock`, while CI installed `cargo-soothfast` unpinned. The CLI moved to 0.1.7 and the runner stayed at 0.1.5, so a verification rerun returned byte-identical numbers.

## Changes

- Added a `Detect benchmarkable changes` step to the docs job that diffs `HEAD~1..HEAD` against `src`, `benches`, `Cargo.toml`, `Cargo.lock`, and `finance-query-derive`, and made the gate step conditional on it.
- Bumped `soothfast`, `soothfast-macros`, `soothfast-measure`, and `soothfast-registry` from 0.1.5 to 0.1.7 in `Cargo.lock`.
- Pinned `cargo install cargo-soothfast` to the version `Cargo.lock` resolves for the runner, at all eight install sites across `deploy.yml` and `soothfast.yml`. The CLI and the runner can no longer drift.
- Trimmed the comment above the gate step. It claimed the landing PR was already gated pre-merge, which the paths filter and bot exclusion do not guarantee.

## Test Plan

- [x] Verified the guard against real master history. `58ca06fe` and `cea2e620` gate, `a8da7818` and `490dcb38` skip. `490dcb38` is the commit whose gate failed three times.
- [x] `cargo check --benches --features bench-gate` passes on the bumped lockfile.
- [x] Version extraction from `Cargo.lock` yields `0.1.7`.
- [x] `zizmor` clean on both workflows.
- [ ] Next code-bearing push to master gates and reports averaged numbers rather than 5296445.
- [ ] Next no-code push to master skips the gate.

## Breaking Changes

None.