### PR TITLE
chore: bump soothfast crates to 0.1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5176,9 +5176,9 @@ dependencies = [
 
 [[package]]
 name = "soothfast"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f57affe570f46e65f375214c6012e1e82f9238ad2b11a2d06c659d767ea615"
+checksum = "7a4653c84fc0c0056ef11e5b9507ed7e28b4c71706f4f02872a69e80694d69c3"
 dependencies = [
  "soothfast-macros",
  "soothfast-measure",
@@ -5187,9 +5187,9 @@ dependencies = [
 
 [[package]]
 name = "soothfast-macros"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aba71cd439ced607289200c07ab2bc3181eaf5b20be3d41ff20ff839b7decc3"
+checksum = "88c4132a786c3822557efb3c60f543c7a361488f8d905ad60470ec9f5c19f5f6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5198,9 +5198,9 @@ dependencies = [
 
 [[package]]
 name = "soothfast-measure"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b01a1a7a8b444e495bf122cb7e85cd14cb4d059d35d558c3543b423a652332c"
+checksum = "40ca0cf432d15c9b5a70303ca7aa726d9b6dcc881f25e9b0114ea8a235470850"
 dependencies = [
  "libc",
  "soothfast-registry",
@@ -5208,9 +5208,9 @@ dependencies = [
 
 [[package]]
 name = "soothfast-registry"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f264ad14db3e97ffb0c56ba7384076fc25aab2e34ecb2ed8671e96294cac0a4"
+checksum = "ca65d7939ebb4502265480e26a90dd684f9b51547d56ccd64a4ceee5aba47d59"
 dependencies = [
  "linkme",
 ]


### PR DESCRIPTION
## Description
Bumps the four soothfast crates from 0.1.7 to 0.1.8, the release that fixes the deploy gate's false positives. The deploy workflow installs `cargo-soothfast` pinned to whatever this lockfile says, so the harness-pinning fix only reaches CI through this bump. It also serves as its own live test: the lockfile change makes the gate run, and the 0.1.8 CLI has to pin the base worktree's 0.1.7 harness up to 0.1.8 and compare clean, where the old CLI reported the protocol difference as +8.2% Ir.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Bumped `soothfast`, `soothfast-macros`, `soothfast-measure`, and `soothfast-registry` from 0.1.7 to 0.1.8 in `Cargo.lock`. No manifest change; the dev-dependency requirement is already `0.1`.

## Breaking Changes
None.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] All tests pass (`cargo test`)

`cargo check --benches --features bench-gate` passes on the bumped lockfile. The 0.1.8 gate behavior was validated by replaying the exact failing CI comparison (`e36a4daf` gated `--against-ref HEAD~1`): the CLI printed `pinning soothfast 0.1.5 -> 0.1.7` for the base worktree and `de_trending`, which failed CI at +18.5% instructions, measured -0.0%.

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [ ] Tests pass (`cargo test`)
- [ ] Code formatted (`cargo fmt`)
- [ ] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues
None.