### PR TITLE
ci: generate spec api pages before docs deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -184,6 +184,8 @@ jobs:
         run: |
           cargo soothfast docs routes -p finance-query-server --target soothfast-routes --out docs/server
           cargo soothfast docs routes -p finance-query-mcp --target soothfast-routes --out docs/server
+          cargo soothfast spec html -p finance-query-server --target soothfast-routes --out docs/server/api
+          cargo soothfast spec html -p finance-query-mcp --target soothfast-routes --out docs/server/api
 
       - name: Regenerate API reference, perf report, coverage page, and llms.txt
         run: |


### PR DESCRIPTION
## Description

The first master push to clear the perf gate (run 31659825732) failed at `docs gh-deploy`: the site nav lists `server/api/openapi.md`, `asyncapi.md`, and `mcp-tools.md`, but `docs/server/api/` is gitignored and only ever generated by `make docs-pages`' `spec html` step, which deploy.yml never ran. Every earlier post-soothfast deploy died at the gate before reaching this step, so the gap was invisible until now.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Added the two `cargo soothfast spec html` extractions (server and MCP) to deploy.yml's endpoint-regen step, mirroring the Makefile's `docs-pages` target that generates these pages locally.

## Breaking Changes

None. Workflow-only change.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] All tests pass (`cargo test`)

The two commands are copied verbatim from `Makefile`'s `docs-pages` target, which generates exactly the three nav-listed pages. `zizmor` reports no findings on deploy.yml and `git diff --check` is clean. Ran both commands in a clean worktree where the pages did not exist: they generated exactly `openapi.md`, `asyncapi.md`, and `mcp-tools.md`.

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [ ] Code compiles without warnings (`cargo check`)
- [ ] Tests pass (`cargo test`)
- [ ] Code formatted (`cargo fmt`)
- [ ] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

None.
