### PR TITLE
ci: reuse gate measurements and speed up soothfast installs

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -40,8 +40,12 @@ jobs:
       - name: Install nightly (rustdoc JSON for the surface diff)
         run: rustup toolchain install nightly --profile minimal
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2.85.13
+        with:
+          tool: cargo-binstall
       - name: Install cargo-soothfast
-        run: cargo install cargo-soothfast --locked
+        run: cargo binstall cargo-soothfast --locked --no-confirm
       # Without a bench on the reference side there are no deterministic
       # metrics to diff, so the perf table falls back to a full snapshot and
       # walltime jitter rewrites every row on every push.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,6 +113,10 @@ jobs:
       - name: Install nightly (rustdoc JSON for the docs engine)
         run: rustup toolchain install nightly --profile minimal
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          # A failing gate must not throw away the warm build state the
+          # retry (and the docs-regen steps) would otherwise reuse.
+          cache-on-failure: true
       - name: Install valgrind
         # CI VMs often expose no PMU, in which case
         # the auto backend gates on callgrind instruction counts instead.
@@ -195,9 +199,17 @@ jobs:
         run: gh pr merge --auto --squash --delete-branch "$PR_NUMBER"
 
       - name: Regenerate endpoint reference pages
+        # The two extractions are independent; run them concurrently and
+        # fail if either failed (a bare `wait` would mask the exit codes).
         run: |
-          cargo soothfast docs routes -p finance-query-server --target soothfast-routes --out docs/server
-          cargo soothfast docs routes -p finance-query-mcp --target soothfast-routes --out docs/server
+          cargo soothfast docs routes -p finance-query-server --target soothfast-routes --out docs/server &
+          server=$!
+          cargo soothfast docs routes -p finance-query-mcp --target soothfast-routes --out docs/server &
+          mcp=$!
+          status=0
+          wait "$server" || status=1
+          wait "$mcp" || status=1
+          [ "$status" -eq 0 ] || exit "$status"
           cargo soothfast spec html -p finance-query-server --target soothfast-routes --out docs/server/api
           cargo soothfast spec html -p finance-query-mcp --target soothfast-routes --out docs/server/api
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,10 +121,14 @@ jobs:
           sudo apt-get install -y valgrind
       # Pinned to the locked runner: soothfast-measure builds into the bench
       # binary from Cargo.lock, so an unpinned CLI silently outruns it.
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2.85.13
+        with:
+          tool: cargo-binstall
       - name: Install cargo-soothfast
         run: |
           RUNNER=$(grep -A1 '^name = "soothfast"$' Cargo.lock | grep '^version' | cut -d'"' -f2)
-          cargo install cargo-soothfast --locked --version "$RUNNER"
+          cargo binstall cargo-soothfast --version "$RUNNER" --locked --no-confirm
 
       - name: Configure git identity for the gh-pages commit
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -162,14 +162,11 @@ jobs:
           cargo soothfast gate -p finance-query --features bench-gate \
             --against-ref HEAD~1 --save-baseline base
 
-      # A passing gate saved the baseline above; measure only when the gate
-      # was skipped or short-circuited without saving, so the docs-regen
-      # steps below never run without one.
+      # A passing gate already saved the baseline; measure only fills in
+      # when the gate was skipped, so docs regen never runs without one.
       - name: Measure baseline for claims
         run: |
-          if [ -f .soothfast/baselines/base.json ]; then
-            echo "Reusing the baseline the gate saved."
-          else
+          if [ ! -f .soothfast/baselines/base.json ]; then
             cargo soothfast measure -p finance-query --features bench-gate --save-baseline base
           fi
 
@@ -199,8 +196,7 @@ jobs:
         run: gh pr merge --auto --squash --delete-branch "$PR_NUMBER"
 
       - name: Regenerate endpoint reference pages
-        # The two extractions are independent; run them concurrently and
-        # fail if either failed (a bare `wait` would mask the exit codes).
+        # A bare `wait` after backgrounding both would mask their exit codes.
         run: |
           cargo soothfast docs routes -p finance-query-server --target soothfast-routes --out docs/server &
           server=$!

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -154,13 +154,23 @@ jobs:
       # color the gate badge. HEAD~1 is well-defined: master is linear.
       - name: Gate against previous commit
         if: steps.bench_changes.outputs.changed == 'true'
-        run: cargo soothfast gate -p finance-query --features bench-gate --against-ref HEAD~1
+        run: |
+          cargo soothfast gate -p finance-query --features bench-gate \
+            --against-ref HEAD~1 --save-baseline base
 
+      # A passing gate saved the baseline above; measure only when the gate
+      # was skipped or short-circuited without saving, so the docs-regen
+      # steps below never run without one.
       - name: Measure baseline for claims
-        run: cargo soothfast measure -p finance-query --features bench-gate --save-baseline base
+        run: |
+          if [ -f .soothfast/baselines/base.json ]; then
+            echo "Reusing the baseline the gate saved."
+          else
+            cargo soothfast measure -p finance-query --features bench-gate --save-baseline base
+          fi
 
       - name: Append performance trend point
-        run: cargo soothfast trend append -p finance-query --features bench-gate
+        run: cargo soothfast trend append -p finance-query --from-baseline base
 
       # Direct pushes to master are blocked by the branch ruleset, so the bot
       # opens a PR and squash-merges it itself instead.

--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -29,7 +29,11 @@ jobs:
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: false
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2.85.13
+        with:
+          tool: cargo-binstall
       - name: Install cargo-soothfast
-        run: cargo install cargo-soothfast --locked
+        run: cargo binstall cargo-soothfast --locked --no-confirm
       - name: Publish
         run: cargo soothfast sdk publish -p finance-query-server --target soothfast-routes --only python

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -80,8 +80,12 @@ jobs:
       - name: Install nightly (rustdoc JSON)
         run: rustup toolchain install nightly --profile minimal
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2.85.13
+        with:
+          tool: cargo-binstall
       - name: Install cargo-soothfast
-        run: cargo install cargo-soothfast --locked
+        run: cargo binstall cargo-soothfast --locked --no-confirm
       - name: Regenerate
         run: |
           cargo soothfast spec gen -p finance-query-server --target soothfast-routes

--- a/.github/workflows/soothfast.yml
+++ b/.github/workflows/soothfast.yml
@@ -72,10 +72,14 @@ jobs:
           sudo apt-get install -y valgrind
       # Pinned to the locked runner: soothfast-measure builds into the bench
       # binary from Cargo.lock, so an unpinned CLI silently outruns it.
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2.85.13
+        with:
+          tool: cargo-binstall
       - name: Install cargo-soothfast
         run: |
           RUNNER=$(grep -A1 '^name = "soothfast"$' Cargo.lock | grep '^version' | cut -d'"' -f2)
-          cargo install cargo-soothfast --locked --version "$RUNNER"
+          cargo binstall cargo-soothfast --version "$RUNNER" --locked --no-confirm
       - name: Gate against merge-base
         run: |
           set -euo pipefail
@@ -119,10 +123,14 @@ jobs:
           sudo apt-get install -y valgrind
       # Pinned to the locked runner: soothfast-measure builds into the bench
       # binary from Cargo.lock, so an unpinned CLI silently outruns it.
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2.85.13
+        with:
+          tool: cargo-binstall
       - name: Install cargo-soothfast
         run: |
           RUNNER=$(grep -A1 '^name = "soothfast"$' Cargo.lock | grep '^version' | cut -d'"' -f2)
-          cargo install cargo-soothfast --locked --version "$RUNNER"
+          cargo binstall cargo-soothfast --version "$RUNNER" --locked --no-confirm
       - name: Measure baseline
         run: cargo soothfast measure -p finance-query --features bench-gate --save-baseline base
       - name: Upload baseline
@@ -155,10 +163,14 @@ jobs:
           shared-key: test-suite
       # Pinned to the locked runner: soothfast-measure builds into the bench
       # binary from Cargo.lock, so an unpinned CLI silently outruns it.
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2.85.13
+        with:
+          tool: cargo-binstall
       - name: Install cargo-soothfast
         run: |
           RUNNER=$(grep -A1 '^name = "soothfast"$' Cargo.lock | grep '^version' | cut -d'"' -f2)
-          cargo install cargo-soothfast --locked --version "$RUNNER"
+          cargo binstall cargo-soothfast --version "$RUNNER" --locked --no-confirm
       - name: Download measured baseline
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -210,10 +222,14 @@ jobs:
           shared-key: spec
       # Pinned to the locked runner: soothfast-measure builds into the bench
       # binary from Cargo.lock, so an unpinned CLI silently outruns it.
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2.85.13
+        with:
+          tool: cargo-binstall
       - name: Install cargo-soothfast
         run: |
           RUNNER=$(grep -A1 '^name = "soothfast"$' Cargo.lock | grep '^version' | cut -d'"' -f2)
-          cargo install cargo-soothfast --locked --version "$RUNNER"
+          cargo binstall cargo-soothfast --version "$RUNNER" --locked --no-confirm
       - name: Reconcile OpenAPI/AsyncAPI/GraphQL routes against handlers
         run: cargo soothfast spec check -p finance-query-server --target soothfast-routes
       - name: Generated openapi.yaml/asyncapi.yaml are fresh
@@ -260,10 +276,14 @@ jobs:
           shared-key: spec
       # Pinned to the locked runner: soothfast-measure builds into the bench
       # binary from Cargo.lock, so an unpinned CLI silently outruns it.
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2.85.13
+        with:
+          tool: cargo-binstall
       - name: Install cargo-soothfast
         run: |
           RUNNER=$(grep -A1 '^name = "soothfast"$' Cargo.lock | grep '^version' | cut -d'"' -f2)
-          cargo install cargo-soothfast --locked --version "$RUNNER"
+          cargo binstall cargo-soothfast --version "$RUNNER" --locked --no-confirm
       - name: Reconcile MCP tool routes against mcp-tools.json
         run: cargo soothfast spec check -p finance-query-mcp --target soothfast-routes
       - name: Generated mcp-tools.json is fresh
@@ -296,10 +316,14 @@ jobs:
           shared-key: spec
       # Pinned to the locked runner: soothfast-measure builds into the bench
       # binary from Cargo.lock, so an unpinned CLI silently outruns it.
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2.85.13
+        with:
+          tool: cargo-binstall
       - name: Install cargo-soothfast
         run: |
           RUNNER=$(grep -A1 '^name = "soothfast"$' Cargo.lock | grep '^version' | cut -d'"' -f2)
-          cargo install cargo-soothfast --locked --version "$RUNNER"
+          cargo binstall cargo-soothfast --version "$RUNNER" --locked --no-confirm
       - name: Reconcile pricing.proto against PricingData
         run: |
           cargo soothfast spec check-proto -p finance-query --proto proto/pricing.proto \
@@ -323,10 +347,14 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       # Pinned to the locked runner: soothfast-measure builds into the bench
       # binary from Cargo.lock, so an unpinned CLI silently outruns it.
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2.85.13
+        with:
+          tool: cargo-binstall
       - name: Install cargo-soothfast
         run: |
           RUNNER=$(grep -A1 '^name = "soothfast"$' Cargo.lock | grep '^version' | cut -d'"' -f2)
-          cargo install cargo-soothfast --locked --version "$RUNNER"
+          cargo binstall cargo-soothfast --version "$RUNNER" --locked --no-confirm
       - name: Download measured baseline
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/soothfast.yml
+++ b/.github/workflows/soothfast.yml
@@ -64,6 +64,8 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: bench-gate
+          # A failing measured run must not cost the retry its warm cache.
+          cache-on-failure: true
       - name: Install valgrind
         # Fallback gating backend: CI VMs often expose no PMU, in which case
         # the auto backend gates on callgrind instruction counts instead.
@@ -117,6 +119,8 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: bench-gate
+          # A failing measured run must not cost the retry its warm cache.
+          cache-on-failure: true
       - name: Install valgrind
         run: |
           sudo apt-get update


### PR DESCRIPTION
## Description

Cuts the deploy job's wall time by measuring the bench suite once instead of three times, installing `cargo-soothfast` from a prebuilt binary instead of compiling it, keeping warm caches when a measured run fails, and running the two independent route-page extractions concurrently. The last full deploy run spent roughly 32m gating, 6m re-measuring the baseline, 6m re-measuring the trend point, and 15-20m of cold docs regen; the three measurement steps collapse into the gate, and the retry-after-failure path stays warm.

Ordering note: the `--save-baseline` / `--from-baseline` flags and the prebuilt release asset ship in the next soothfast release; this PR should land after that release and a `Cargo.lock` bump to it. The binstall switch is safe immediately since binstall falls back to a source build while no prebuilt asset exists.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement

## Changes
- Replaced all eleven `cargo install cargo-soothfast` steps (deploy.yml, soothfast.yml, changelog.yml, sdk-publish.yml, sdk.yml) with cargo-binstall via `taiki-e/install-action` pinned to a full commit SHA. The runner-version pin from `Cargo.lock` is preserved where it existed.
- Changed deploy.yml's gate to run with `--save-baseline base`. The `Measure baseline for claims` step now measures only when `.soothfast/baselines/base.json` is absent, so the docs-regen steps never run without a baseline. `trend append` reads `--from-baseline base` instead of re-measuring.
- Set `cache-on-failure: true` on `Swatinem/rust-cache` in deploy.yml and soothfast.yml's gate and baseline jobs. A failing measured run no longer discards the warm build state its retry needs.
- Ran the server and MCP `docs routes` extractions concurrently in deploy.yml, with both exit codes checked so a failure is never masked.

## Breaking Changes

None. Workflow-only changes.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] All tests pass (`cargo test`)

`zizmor` (v1.25.2) reports no findings on all five changed workflows, `git diff --check` is clean, and the YAML passes the repo's pre-commit yaml hook. The new soothfast flags were exercised end-to-end in the soothfast repo: a passing gate saved a baseline, and `trend append --from-baseline` appended a full-metric point without re-measuring. The Rust test suite was not run; no Rust files changed.

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [ ] Code compiles without warnings (`cargo check`)
- [ ] Tests pass (`cargo test`)
- [ ] Code formatted (`cargo fmt`)
- [ ] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

None. Depends on the next soothfast release carrying `gate --save-baseline`, `trend append --from-baseline`, and the prebuilt release asset, plus a `Cargo.lock` bump to that runner version.
