### PR TITLE
ci: fix trend-append loop, stale soothfast installs, baseline reuse

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -45,7 +45,11 @@ jobs:
         with:
           tool: cargo-binstall
       - name: Install cargo-soothfast
-        run: cargo binstall cargo-soothfast --locked --no-confirm
+        # rust-cache can restore binstall's install record without the
+        # binary itself; --force reinstalls past the stale record.
+        run: |
+          command -v cargo-soothfast >/dev/null || FORCE=--force
+          cargo binstall cargo-soothfast --locked --no-confirm ${FORCE:-}
       # Without a bench on the reference side there are no deterministic
       # metrics to diff, so the perf table falls back to a full snapshot and
       # walltime jitter rewrites every row on every push.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -143,7 +143,8 @@ jobs:
           git config user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
 
       # soothfast.yml's paths filter and [bot] exclusion let no-code commits
-      # reach master, where gating them can only report noise.
+      # reach master, where gating them can only report noise. Also gates the
+      # trend append
       - name: Detect benchmarkable changes
         id: bench_changes
         run: |
@@ -171,11 +172,13 @@ jobs:
           fi
 
       - name: Append performance trend point
+        if: steps.bench_changes.outputs.changed == 'true'
         run: cargo soothfast trend append -p finance-query --from-baseline base
 
       # Direct pushes to master are blocked by the branch ruleset, so the bot
       # opens a PR and squash-merges it itself instead.
       - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        if: steps.bench_changes.outputs.changed == 'true'
         id: cpr
         with:
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -130,9 +130,12 @@ jobs:
         with:
           tool: cargo-binstall
       - name: Install cargo-soothfast
+        # rust-cache can restore binstall's install record without the
+        # binary itself; --force reinstalls past the stale record.
         run: |
           RUNNER=$(grep -A1 '^name = "soothfast"$' Cargo.lock | grep '^version' | cut -d'"' -f2)
-          cargo binstall cargo-soothfast --version "$RUNNER" --locked --no-confirm
+          command -v cargo-soothfast >/dev/null || FORCE=--force
+          cargo binstall cargo-soothfast --version "$RUNNER" --locked --no-confirm ${FORCE:-}
 
       - name: Configure git identity for the gh-pages commit
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -158,6 +158,14 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
+      # Instruction counts are deterministic for identical benchmarked code,
+      # so a hit lets the measure step below skip via its [ ! -f ] guard.
+      - name: Restore measured baseline
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .soothfast/baselines/base.json
+          key: soothfast-baseline-${{ hashFiles('src/**', 'benches/**', 'Cargo.toml', 'Cargo.lock', 'finance-query-derive/**') }}
+
       # Writes .soothfast/gate-status.json, which `report render` reads to
       # color the gate badge. HEAD~1 is well-defined: master is linear.
       - name: Gate against previous commit

--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -34,6 +34,10 @@ jobs:
         with:
           tool: cargo-binstall
       - name: Install cargo-soothfast
-        run: cargo binstall cargo-soothfast --locked --no-confirm
+        # rust-cache can restore binstall's install record without the
+        # binary itself; --force reinstalls past the stale record.
+        run: |
+          command -v cargo-soothfast >/dev/null || FORCE=--force
+          cargo binstall cargo-soothfast --locked --no-confirm ${FORCE:-}
       - name: Publish
         run: cargo soothfast sdk publish -p finance-query-server --target soothfast-routes --only python

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -85,7 +85,11 @@ jobs:
         with:
           tool: cargo-binstall
       - name: Install cargo-soothfast
-        run: cargo binstall cargo-soothfast --locked --no-confirm
+        # rust-cache can restore binstall's install record without the
+        # binary itself; --force reinstalls past the stale record.
+        run: |
+          command -v cargo-soothfast >/dev/null || FORCE=--force
+          cargo binstall cargo-soothfast --locked --no-confirm ${FORCE:-}
       - name: Regenerate
         run: |
           cargo soothfast spec gen -p finance-query-server --target soothfast-routes

--- a/.github/workflows/soothfast.yml
+++ b/.github/workflows/soothfast.yml
@@ -79,9 +79,12 @@ jobs:
         with:
           tool: cargo-binstall
       - name: Install cargo-soothfast
+        # rust-cache can restore binstall's install record without the
+        # binary itself; --force reinstalls past the stale record.
         run: |
           RUNNER=$(grep -A1 '^name = "soothfast"$' Cargo.lock | grep '^version' | cut -d'"' -f2)
-          cargo binstall cargo-soothfast --version "$RUNNER" --locked --no-confirm
+          command -v cargo-soothfast >/dev/null || FORCE=--force
+          cargo binstall cargo-soothfast --version "$RUNNER" --locked --no-confirm ${FORCE:-}
       - name: Gate against merge-base
         run: |
           set -euo pipefail
@@ -132,9 +135,12 @@ jobs:
         with:
           tool: cargo-binstall
       - name: Install cargo-soothfast
+        # rust-cache can restore binstall's install record without the
+        # binary itself; --force reinstalls past the stale record.
         run: |
           RUNNER=$(grep -A1 '^name = "soothfast"$' Cargo.lock | grep '^version' | cut -d'"' -f2)
-          cargo binstall cargo-soothfast --version "$RUNNER" --locked --no-confirm
+          command -v cargo-soothfast >/dev/null || FORCE=--force
+          cargo binstall cargo-soothfast --version "$RUNNER" --locked --no-confirm ${FORCE:-}
       - name: Measure baseline
         run: cargo soothfast measure -p finance-query --features bench-gate --save-baseline base
       - name: Upload baseline
@@ -172,9 +178,12 @@ jobs:
         with:
           tool: cargo-binstall
       - name: Install cargo-soothfast
+        # rust-cache can restore binstall's install record without the
+        # binary itself; --force reinstalls past the stale record.
         run: |
           RUNNER=$(grep -A1 '^name = "soothfast"$' Cargo.lock | grep '^version' | cut -d'"' -f2)
-          cargo binstall cargo-soothfast --version "$RUNNER" --locked --no-confirm
+          command -v cargo-soothfast >/dev/null || FORCE=--force
+          cargo binstall cargo-soothfast --version "$RUNNER" --locked --no-confirm ${FORCE:-}
       - name: Download measured baseline
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -231,9 +240,12 @@ jobs:
         with:
           tool: cargo-binstall
       - name: Install cargo-soothfast
+        # rust-cache can restore binstall's install record without the
+        # binary itself; --force reinstalls past the stale record.
         run: |
           RUNNER=$(grep -A1 '^name = "soothfast"$' Cargo.lock | grep '^version' | cut -d'"' -f2)
-          cargo binstall cargo-soothfast --version "$RUNNER" --locked --no-confirm
+          command -v cargo-soothfast >/dev/null || FORCE=--force
+          cargo binstall cargo-soothfast --version "$RUNNER" --locked --no-confirm ${FORCE:-}
       - name: Reconcile OpenAPI/AsyncAPI/GraphQL routes against handlers
         run: cargo soothfast spec check -p finance-query-server --target soothfast-routes
       - name: Generated openapi.yaml/asyncapi.yaml are fresh
@@ -285,9 +297,12 @@ jobs:
         with:
           tool: cargo-binstall
       - name: Install cargo-soothfast
+        # rust-cache can restore binstall's install record without the
+        # binary itself; --force reinstalls past the stale record.
         run: |
           RUNNER=$(grep -A1 '^name = "soothfast"$' Cargo.lock | grep '^version' | cut -d'"' -f2)
-          cargo binstall cargo-soothfast --version "$RUNNER" --locked --no-confirm
+          command -v cargo-soothfast >/dev/null || FORCE=--force
+          cargo binstall cargo-soothfast --version "$RUNNER" --locked --no-confirm ${FORCE:-}
       - name: Reconcile MCP tool routes against mcp-tools.json
         run: cargo soothfast spec check -p finance-query-mcp --target soothfast-routes
       - name: Generated mcp-tools.json is fresh
@@ -325,9 +340,12 @@ jobs:
         with:
           tool: cargo-binstall
       - name: Install cargo-soothfast
+        # rust-cache can restore binstall's install record without the
+        # binary itself; --force reinstalls past the stale record.
         run: |
           RUNNER=$(grep -A1 '^name = "soothfast"$' Cargo.lock | grep '^version' | cut -d'"' -f2)
-          cargo binstall cargo-soothfast --version "$RUNNER" --locked --no-confirm
+          command -v cargo-soothfast >/dev/null || FORCE=--force
+          cargo binstall cargo-soothfast --version "$RUNNER" --locked --no-confirm ${FORCE:-}
       - name: Reconcile pricing.proto against PricingData
         run: |
           cargo soothfast spec check-proto -p finance-query --proto proto/pricing.proto \
@@ -356,9 +374,12 @@ jobs:
         with:
           tool: cargo-binstall
       - name: Install cargo-soothfast
+        # rust-cache can restore binstall's install record without the
+        # binary itself; --force reinstalls past the stale record.
         run: |
           RUNNER=$(grep -A1 '^name = "soothfast"$' Cargo.lock | grep '^version' | cut -d'"' -f2)
-          cargo binstall cargo-soothfast --version "$RUNNER" --locked --no-confirm
+          command -v cargo-soothfast >/dev/null || FORCE=--force
+          cargo binstall cargo-soothfast --version "$RUNNER" --locked --no-confirm ${FORCE:-}
       - name: Download measured baseline
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:


### PR DESCRIPTION
## Description

deploy-docs appends a trend point and auto-merges it as a bot PR, and that merge is itself a master push, so the workflow retriggered itself every ~8 minutes overnight (#336 through #340), each round with its own Docker builds and VPS deploy. The chain only stopped when a run died on `no such command: soothfast`, which turned out to be rust-cache restoring binstall's install record without the binary it describes. This PR gates the trend append on benchmarked changes, force-reinstalls the binary when it's missing, and caches the measured baseline so unchanged code skips the measure step.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement

## Changes

- Gated the trend append, PR creation, and auto-merge in `deploy.yml` on the existing `bench_changes` check, so a bot trend merge deploys once and appends nothing.
- Force-reinstalled `cargo-soothfast` when the binary is absent despite binstall's cached install record, in `deploy.yml`, `soothfast.yml`, `sdk.yml`, `sdk-publish.yml`, and `changelog.yml`.
- Added an `actions/cache` step for `.soothfast/baselines/base.json` keyed on `hashFiles` of the benchmarked paths. A hit lets the existing `[ ! -f ]` guard skip the measure step.

## Breaking Changes

None.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] All tests pass (`cargo test`)

Workflow YAML parses cleanly and `zizmor` reports no findings on the edited workflows. No Rust code is touched.

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [ ] Code compiles without warnings (`cargo check`)
- [ ] Tests pass (`cargo test`)
- [ ] Code formatted (`cargo fmt`)
- [ ] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

None.