### PR TITLE
chore: use line-tables-only debuginfo for benches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -263,7 +263,7 @@ opt-level = 2
 
 [profile.bench]
 inherits = "release"
-debug = true
+debug = "line-tables-only"
 strip = false
 lto = false
 codegen-units = 16


### PR DESCRIPTION
## Description

The bench profile carries full debuginfo on an optimized build, which typically adds 20-40% to compile time, and the soothfast gate builds that profile twice per PR (head and merge-base). Soothfast reads perf counters and the counting allocator, not DWARF, and debuginfo leaves `.text` unchanged, so counts and baselines are unaffected. Line tables stay so profiler stacks remain readable.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement

## Changes

- Changed `[profile.bench]` `debug = true` to `debug = "line-tables-only"` in `Cargo.toml`.

## Breaking Changes

None.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] All tests pass (`cargo test`)

The gate on this PR is the real test: it builds the bench profile with the new setting and compares measured counts against the merge-base built with the old one; identical counts confirm debuginfo has no measurement effect.

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [ ] Code compiles without warnings (`cargo check`)
- [ ] Tests pass (`cargo test`)
- [ ] Code formatted (`cargo fmt`)
- [ ] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

None.