### PR TITLE
ci: give each cache profile its own shared key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,9 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          shared-key: test-suite
+          # check-only artifacts; sharing test-suite let this job's save
+          # starve the test jobs, which then recompiled everything
+          shared-key: clippy
       # `full` = all features except translation-offline, which compiles
       # CTranslate2 from source; the Docker jobs cover that build instead.
       - name: Run clippy
@@ -180,7 +182,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          shared-key: test-suite
+          # default features, unlike the full-features test-suite key
+          shared-key: test-network
       - uses: taiki-e/install-action@ace6ebe54a6a0c86dfb5f7764b17f793b6925bc3 # v2.82.3
         with:
           tool: nextest
@@ -260,6 +263,9 @@ jobs:
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          # PR-ref saves are invisible to other PRs and evict master caches
+          save-if: ${{ github.ref == 'refs/heads/master' }}
       # cargo-auditable embeds the dependency manifest into each binary so the
       # shipped artifacts can be scanned later with `cargo audit bin`.
       - uses: taiki-e/install-action@ace6ebe54a6a0c86dfb5f7764b17f793b6925bc3 # v2.82.3
@@ -407,6 +413,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: fuzz -> target
+          save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz
       - name: Build fuzz targets

--- a/.github/workflows/soothfast.yml
+++ b/.github/workflows/soothfast.yml
@@ -193,7 +193,7 @@ jobs:
         run: rustup toolchain install nightly --profile minimal
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          shared-key: test-suite
+          shared-key: docs-binds
       # Pinned to the locked runner: soothfast-measure builds into the bench
       # binary from Cargo.lock, so an unpinned CLI silently outruns it.
       - name: Install cargo-binstall
@@ -257,7 +257,7 @@ jobs:
         run: rustup toolchain install nightly --profile minimal
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          shared-key: spec
+          shared-key: spec-server
       # Pinned to the locked runner: soothfast-measure builds into the bench
       # binary from Cargo.lock, so an unpinned CLI silently outruns it.
       - name: Install cargo-binstall
@@ -316,7 +316,7 @@ jobs:
         run: rustup toolchain install nightly --profile minimal
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          shared-key: spec
+          shared-key: spec-mcp
       # Pinned to the locked runner: soothfast-measure builds into the bench
       # binary from Cargo.lock, so an unpinned CLI silently outruns it.
       - name: Install cargo-binstall
@@ -361,7 +361,9 @@ jobs:
         run: rustup toolchain install nightly --profile minimal
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          shared-key: spec
+          shared-key: spec-mcp
+          # near-empty target; saving would poison the spec-mcp key
+          save-if: false
       # Pinned to the locked runner: soothfast-measure builds into the bench
       # binary from Cargo.lock, so an unpinned CLI silently outruns it.
       - name: Install cargo-binstall


### PR DESCRIPTION
## Description

With a shared rust-cache key, the first job to finish is the one that saves. Three-minute Clippy saved check-only artifacts under `test-suite`, so the unit and doctest jobs recompiled 362 and 310 crates on every run, and near-empty proto-check did the same to the `spec` key. Each cache profile now has its own key, and the big low-reuse families only save from master, where every PR can actually restore them.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement

## Changes

- Gave Clippy its own `clippy` key and the network tests their own `test-network` key; unit and doctest keep sharing `test-suite` since both build full features under the test profile.
- Split `spec` into `spec-server` and `spec-mcp`; proto-check restores `spec-mcp` but saves nothing.
- Pointed docs-binds at its own `docs-binds` key. Its nightly toolchain made its old `test-suite` key unmatchable anyway.
- Limited Build Release and Fuzz cache saves to master.

## Breaking Changes

None.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] All tests pass (`cargo test`)

Workflow YAML parses cleanly and `zizmor` reports no findings on the edited workflows.

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [ ] Code compiles without warnings (`cargo check`)
- [ ] Tests pass (`cargo test`)
- [ ] Code formatted (`cargo fmt`)
- [ ] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

None.