### PR TITLE
ci: reuse measured baseline across identical code

### DIFF
--- a/.github/workflows/soothfast.yml
+++ b/.github/workflows/soothfast.yml
@@ -168,8 +168,18 @@ jobs:
           RUNNER=$(grep -A1 '^name = "soothfast"$' Cargo.lock | grep '^version' | cut -d'"' -f2)
           command -v cargo-soothfast >/dev/null || FORCE=--force
           cargo binstall cargo-soothfast --version "$RUNNER" --locked --no-confirm ${FORCE:-}
+      # Same key as deploy.yml so master deploys seed PR restores;
+      # identical benchmarked code measures identically
+      - name: Restore measured baseline
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .soothfast/baselines/base.json
+          key: soothfast-baseline-${{ hashFiles('src/**', 'benches/**', 'Cargo.toml', 'Cargo.lock', 'finance-query-derive/**') }}
       - name: Measure baseline
-        run: cargo soothfast measure -p finance-query --features bench-gate --save-baseline base
+        run: |
+          if [ ! -f .soothfast/baselines/base.json ]; then
+            cargo soothfast measure -p finance-query --features bench-gate --save-baseline base
+          fi
       - name: Upload baseline
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:


### PR DESCRIPTION
## Description

The Baseline job re-measured every PR from scratch, about eight minutes, even when no benchmarked path changed. deploy.yml already caches `base.json` keyed on a hash of the benchmarked paths; this restores the same key before measuring, so a PR that leaves benchmarked code untouched reuses the measurement master already made. Identical code measures identically, which is the premise the whole gate rests on.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement

## Changes

- Added an `actions/cache` step for `.soothfast/baselines/base.json` in the Baseline job, keyed identically to deploy.yml's.
- Skipped the measure run when the restore already produced `base.json`.

## Breaking Changes

None.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] All tests pass (`cargo test`)

Workflow YAML parses cleanly and `zizmor` reports no findings on the edited workflows.

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [ ] Code compiles without warnings (`cargo check`)
- [ ] Tests pass (`cargo test`)
- [ ] Code formatted (`cargo fmt`)
- [ ] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

None.