### PR TITLE
ci: fix fuzz profile mismatch and job scheduling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ env:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   # Decide which downstream jobs this change set actually needs, so
   # docs-only / single-crate PRs don't pay for work that can't have broken.
@@ -289,7 +293,7 @@ jobs:
   docker:
     name: Docker Build
     runs-on: ubuntu-latest
-    needs: [changes, fmt, clippy]
+    needs: changes
     if: needs.changes.outputs.server_docker == 'true'
     permissions:
       contents: read
@@ -343,7 +347,7 @@ jobs:
   docker-mcp:
     name: MCP Docker Build
     runs-on: ubuntu-latest
-    needs: [changes, fmt, clippy]
+    needs: changes
     if: needs.changes.outputs.mcp_docker == 'true'
     permissions:
       contents: read
@@ -414,38 +418,39 @@ jobs:
         with:
           workspaces: fuzz -> target
           save-if: ${{ github.ref == 'refs/heads/master' }}
-      - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz
+      - uses: taiki-e/install-action@ace6ebe54a6a0c86dfb5f7764b17f793b6925bc3 # v2.82.3
+        with:
+          tool: cargo-fuzz
       - name: Build fuzz targets
         run: cargo fuzz build --dev
         working-directory: fuzz
       - name: Run fuzz_quote (30 s)
-        run: cargo fuzz run fuzz_quote -- -max_total_time=30
+        run: cargo fuzz run fuzz_quote --dev -- -max_total_time=30
         working-directory: fuzz
       - name: Run fuzz_chart (30 s)
-        run: cargo fuzz run fuzz_chart -- -max_total_time=30
+        run: cargo fuzz run fuzz_chart --dev -- -max_total_time=30
         working-directory: fuzz
       - name: Run fuzz_atr (30 s)
-        run: cargo fuzz run fuzz_atr -- -max_total_time=30
+        run: cargo fuzz run fuzz_atr --dev -- -max_total_time=30
         working-directory: fuzz
       - name: Run fuzz_indicators_series (30 s)
-        run: cargo fuzz run fuzz_indicators_series -- -max_total_time=30
+        run: cargo fuzz run fuzz_indicators_series --dev -- -max_total_time=30
         working-directory: fuzz
       - name: Run fuzz_indicators_ohlcv (30 s)
-        run: cargo fuzz run fuzz_indicators_ohlcv -- -max_total_time=30
+        run: cargo fuzz run fuzz_indicators_ohlcv --dev -- -max_total_time=30
         working-directory: fuzz
       - name: Run fuzz_patterns (30 s)
-        run: cargo fuzz run fuzz_patterns -- -max_total_time=30
+        run: cargo fuzz run fuzz_patterns --dev -- -max_total_time=30
         working-directory: fuzz
       - name: Run fuzz_options (30 s)
-        run: cargo fuzz run fuzz_options -- -max_total_time=30
+        run: cargo fuzz run fuzz_options --dev -- -max_total_time=30
         working-directory: fuzz
       - name: Run fuzz_financials (30 s)
-        run: cargo fuzz run fuzz_financials -- -max_total_time=30
+        run: cargo fuzz run fuzz_financials --dev -- -max_total_time=30
         working-directory: fuzz
       - name: Run fuzz_edgar (30 s)
-        run: cargo fuzz run fuzz_edgar -- -max_total_time=30
+        run: cargo fuzz run fuzz_edgar --dev -- -max_total_time=30
         working-directory: fuzz
       - name: Run fuzz_discovery (30 s)
-        run: cargo fuzz run fuzz_discovery -- -max_total_time=30
+        run: cargo fuzz run fuzz_discovery --dev -- -max_total_time=30
         working-directory: fuzz

--- a/.github/workflows/soothfast.yml
+++ b/.github/workflows/soothfast.yml
@@ -19,8 +19,7 @@ env:
   CARGO_PROFILE_TEST_DEBUG: "0"
 
 concurrency:
-  # Scoped to the commit, not just the PR
-  group: soothfast-${{ github.event.pull_request.number }}-${{ github.sha }}
+  group: soothfast-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Description

Three scheduling fixes. The fuzz job built targets with `--dev` but ran them without it, so the first run step silently rebuilt all 189 crates in release with ASan, 5.2 minutes on a recent run. The Docker jobs waited on fmt and clippy for no build reason, adding ~3.5 minutes to the CI critical path. And neither workflow cancelled superseded runs, so every force-push paid for two.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement

## Changes

- Ran fuzz targets with `--dev` to match the build step. Dev-profile 30-second bursts still catch the malformed-input panics these smoke runs exist for; release-speed coverage belongs in a longer scheduled run.
- Installed `cargo-fuzz` via `taiki-e/install-action` instead of compiling it with `cargo install`.
- Dropped `fmt`/`clippy` from the Docker jobs' `needs`; both remain required checks on their own.
- Added `cancel-in-progress` concurrency groups to ci.yml and simplified soothfast.yml's to stop keying on the commit SHA.

## Breaking Changes

None.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] All tests pass (`cargo test`)

Workflow YAML parses cleanly and `zizmor` reports no findings on the edited workflows.

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [ ] Code compiles without warnings (`cargo check`)
- [ ] Tests pass (`cargo test`)
- [ ] Code formatted (`cargo fmt`)
- [ ] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

None.