### PR TITLE
ci: build PR release binaries with thin LTO

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,6 +278,10 @@ jobs:
       # The root crate is a library; the shippable binaries live in the
       # workspace members, so build the whole workspace.
       - name: Build release binaries
+        # PRs validate with thin LTO; master builds the shipped fat-LTO profile
+        env:
+          CARGO_PROFILE_RELEASE_LTO: ${{ github.event_name == 'pull_request' && 'thin' || 'true' }}
+          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: ${{ github.event_name == 'pull_request' && '16' || '1' }}
         run: cargo auditable build --workspace --release --verbose
       - name: Upload binaries
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Description

The release profile is fat LTO with one codegen unit, tuned for shipped binaries. PR validation only needs to prove the workspace builds release-clean, so PR runs of Build Release override to thin LTO with 16 codegen units through environment variables. Master pushes still build the exact shipped profile before anything deploys, so a fat-LTO-only failure surfaces there rather than never.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement

## Changes

- Set `CARGO_PROFILE_RELEASE_LTO=thin` and `CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16` on the Build Release step for pull_request events only; master keeps the Cargo.toml values.

## Breaking Changes

None.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] All tests pass (`cargo test`)

Workflow YAML parses cleanly and `zizmor` reports no findings on the edited workflows.

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [ ] Code compiles without warnings (`cargo check`)
- [ ] Tests pass (`cargo test`)
- [ ] Code formatted (`cargo fmt`)
- [ ] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

None.