### PR TITLE
ci: run docs jobs on master despite changes skip

### DIFF
--- a/.github/workflows/soothfast.yml
+++ b/.github/workflows/soothfast.yml
@@ -190,6 +190,9 @@ jobs:
     name: Docs binds & coverage
     runs-on: ubuntu-latest
     needs: baseline
+    # result-based so the changes job's skip on push events does not
+    # cascade past baseline's always() and starve the master cache warm
+    if: always() && needs.baseline.result == 'success'
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
@@ -404,6 +407,7 @@ jobs:
     name: Docs site build
     runs-on: ubuntu-latest
     needs: [baseline, spec-server, spec-mcp]
+    if: always() && needs.baseline.result == 'success' && needs.spec-server.result == 'success' && needs.spec-mcp.result == 'success'
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:


### PR DESCRIPTION
## Description

On the first master push run of the soothfast workflow, Docs binds & coverage and Docs site build were skipped even though Baseline succeeded. GitHub cascades a skipped job through the needs chain transitively, so Baseline's `always()` rescued only itself, and the two docs caches never got a master-scoped save. Result-based conditions on the two docs jobs stop the cascade; on PRs the behavior is unchanged since a skipped or failed parent still skips them.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes

- Gave `docs-binds` and `site-build` explicit `always() && needs.*.result == 'success'` conditions.

## Breaking Changes

None.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] All tests pass (`cargo test`)

Workflow YAML parses cleanly and `zizmor` reports no findings. Verified against push run 31877855207, where both jobs skipped after Baseline succeeded.

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [ ] Code compiles without warnings (`cargo check`)
- [ ] Tests pass (`cargo test`)
- [ ] Code formatted (`cargo fmt`)
- [ ] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

None.