### PR TITLE
ci: stop parallel deploys racing the trend PR

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,6 +79,10 @@ jobs:
   deploy-docs:
     name: Deploy docs site to GitHub Pages
     runs-on: ubuntu-latest
+    # Parallel runs from rapid merges each branch trend.jsonl off their own
+    # checkout; the second trend PR then conflicts on master and hangs
+    concurrency:
+      group: deploy-docs
     permissions: {} # all repo access comes from the minted App token below
 
     steps:
@@ -184,7 +188,10 @@ jobs:
 
       - name: Append performance trend point
         if: steps.bench_changes.outputs.changed == 'true'
-        run: cargo soothfast trend append -p finance-query --from-baseline base
+        run: |
+          git fetch origin master
+          git checkout origin/master -- .soothfast/trend.jsonl
+          cargo soothfast trend append -p finance-query --from-baseline base
 
       # Direct pushes to master are blocked by the branch ruleset, so the bot
       # opens a PR and squash-merges it itself instead.


### PR DESCRIPTION
## Description

The stack merge produced two trend PRs from parallel deploy runs. The first merged; the second had branched `trend.jsonl` off a checkout that predated that merge, so it conflicted with master permanently. A conflicting PR gets no test merge commit, which means no `pull_request` workflow runs, which means required checks sit expected forever and auto-merge never fires (that was #353). The deploy-docs job now serializes on a concurrency group and re-reads master's `trend.jsonl` right before appending, so each trend PR is built on the current history.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes

- Added a `deploy-docs` concurrency group so rapid merges queue instead of interleaving.
- Fetched master's `.soothfast/trend.jsonl` before `trend append`, so the bot PR carries the full history plus one line.

## Breaking Changes

None.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] All tests pass (`cargo test`)

Workflow YAML parses cleanly and `zizmor` reports no findings. Reproduced the failure mode on #353: `mergeable: CONFLICTING`, zero check runs on its head SHA.

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [ ] Code compiles without warnings (`cargo check`)
- [ ] Tests pass (`cargo test`)
- [ ] Code formatted (`cargo fmt`)
- [ ] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

None.