### PR TITLE
ci: require approval before crates.io publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,7 @@ jobs:
     name: Publish to crates.io
     runs-on: ubuntu-latest
     needs: [test]
+    environment: release
     permissions:
       id-token: write # mint a short-lived crates.io token via OIDC
       contents: write # create the GitHub Release


### PR DESCRIPTION
## Description

A version tag push published to crates.io immediately, with no human between the tag and the registry. The publish job now runs in the `release` environment, whose required reviewer must approve the deployment before the OIDC exchange happens. The pre-publish tests still run first, so approval is the last step, not the only one.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes

- Added `environment: release` to the publish job in `publish.yml`. The environment exists with one required reviewer.

## Breaking Changes

None. The crates.io trusted publisher config does not pin an environment, so the OIDC exchange is unaffected; pinning `release` there too is an optional hardening step in the crates.io settings.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] All tests pass (`cargo test`)

Workflow YAML parses cleanly and `zizmor` reports no findings. The gate itself can only be exercised by the next tag push.

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [ ] Code compiles without warnings (`cargo check`)
- [ ] Tests pass (`cargo test`)
- [ ] Code formatted (`cargo fmt`)
- [ ] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

None.