### PR TITLE
chore: soothfast 0.1.11, spec gate from committed base

### DIFF
--- a/.github/workflows/soothfast.yml
+++ b/.github/workflows/soothfast.yml
@@ -305,7 +305,7 @@ jobs:
         run: |
           if git cat-file -e "${BASE_SHA}:server/spec/routes.rs" 2>/dev/null; then
             cargo soothfast spec gate -p finance-query-server --target soothfast-routes \
-              --base "$BASE_SHA"
+              --base "$BASE_SHA" --from-committed
           else
             echo "Merge-base has no soothfast-routes bench yet — nothing to gate against."
           fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5176,9 +5176,9 @@ dependencies = [
 
 [[package]]
 name = "soothfast"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c53f075f5b368a841c10de83812c9f81ef763ccd3e15cb78b4e652ac494411ce"
+checksum = "494e2ff1a0ae1bb321d418ccc7f5023c39b3a90f2fd561406dd50264c9db1e57"
 dependencies = [
  "soothfast-macros",
  "soothfast-measure",
@@ -5187,9 +5187,9 @@ dependencies = [
 
 [[package]]
 name = "soothfast-macros"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d78251868346a03c022a36c0caaa05f280ae7fd7b681668618c42070bca9052"
+checksum = "4dca29ccfc4ca66b440f92354466055d8c4d871abbceb70522c8170fda836033"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5198,9 +5198,9 @@ dependencies = [
 
 [[package]]
 name = "soothfast-measure"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f654dea69a5cd9957db8c002c696230a96126ab9721421d7c3d00fbe916e213"
+checksum = "0dd810d1801e9e9199a7c395466abd85021f647c4e2634389e823bd03cc93e25"
 dependencies = [
  "libc",
  "soothfast-registry",
@@ -5208,9 +5208,9 @@ dependencies = [
 
 [[package]]
 name = "soothfast-registry"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d5fbf5ab60ac03263b518f13af7abf234dabefb1e9c80986f53bec57ed81c00"
+checksum = "5ebcfe1c05cda21373b695d4977bd7baa02bc3318cc509497304ef606eaf7f41"
 dependencies = [
  "linkme",
 ]


### PR DESCRIPTION
## Description

The Spec & SDK (server) job spends ~15 of its ~24 minutes rebuilding the merge-base workspace to regenerate documents that are guaranteed byte-identical to the committed `openapi.yaml` and `asyncapi.yaml` at the base SHA, since the freshness check is required on every merge. soothfast 0.1.11 adds `spec gate --from-committed`, which reads those committed files instead and refuses any file that does not re-render byte-identically. This bumps the pin and switches the compat gate step over.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement

## Changes

- Bumped `soothfast`, `soothfast-macros`, `soothfast-measure`, and `soothfast-registry` from 0.1.10 to 0.1.11 in `Cargo.lock`. No manifest change; the dev-dependency requirement is already `0.1`.
- Added `--from-committed` to the spec compat gate step in `soothfast.yml`.

## Breaking Changes

None.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All tests pass (`cargo test`)

`cargo test --lib --features full`: 1216 passed, 0 failed, 61 ignored (network tests). `cargo check --benches --features bench-gate` compiles the harness against 0.1.11 cleanly. The committed-base mode was run locally against this repo's specs before 0.1.11 shipped: both files parsed, verified byte-identical, and diffed clean in seconds. This PR's own Spec & SDK (server) check exercises it in CI.

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [ ] Code formatted (`cargo fmt`)
- [ ] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

None.