### PR TITLE
ci: pin fuzz target to gnu triple

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,35 +426,35 @@ jobs:
         with:
           tool: cargo-fuzz
       - name: Build fuzz targets
-        run: cargo fuzz build --dev
+        run: cargo fuzz build --dev --target x86_64-unknown-linux-gnu
         working-directory: fuzz
       - name: Run fuzz_quote (30 s)
-        run: cargo fuzz run fuzz_quote --dev -- -max_total_time=30
+        run: cargo fuzz run fuzz_quote --dev --target x86_64-unknown-linux-gnu -- -max_total_time=30
         working-directory: fuzz
       - name: Run fuzz_chart (30 s)
-        run: cargo fuzz run fuzz_chart --dev -- -max_total_time=30
+        run: cargo fuzz run fuzz_chart --dev --target x86_64-unknown-linux-gnu -- -max_total_time=30
         working-directory: fuzz
       - name: Run fuzz_atr (30 s)
-        run: cargo fuzz run fuzz_atr --dev -- -max_total_time=30
+        run: cargo fuzz run fuzz_atr --dev --target x86_64-unknown-linux-gnu -- -max_total_time=30
         working-directory: fuzz
       - name: Run fuzz_indicators_series (30 s)
-        run: cargo fuzz run fuzz_indicators_series --dev -- -max_total_time=30
+        run: cargo fuzz run fuzz_indicators_series --dev --target x86_64-unknown-linux-gnu -- -max_total_time=30
         working-directory: fuzz
       - name: Run fuzz_indicators_ohlcv (30 s)
-        run: cargo fuzz run fuzz_indicators_ohlcv --dev -- -max_total_time=30
+        run: cargo fuzz run fuzz_indicators_ohlcv --dev --target x86_64-unknown-linux-gnu -- -max_total_time=30
         working-directory: fuzz
       - name: Run fuzz_patterns (30 s)
-        run: cargo fuzz run fuzz_patterns --dev -- -max_total_time=30
+        run: cargo fuzz run fuzz_patterns --dev --target x86_64-unknown-linux-gnu -- -max_total_time=30
         working-directory: fuzz
       - name: Run fuzz_options (30 s)
-        run: cargo fuzz run fuzz_options --dev -- -max_total_time=30
+        run: cargo fuzz run fuzz_options --dev --target x86_64-unknown-linux-gnu -- -max_total_time=30
         working-directory: fuzz
       - name: Run fuzz_financials (30 s)
-        run: cargo fuzz run fuzz_financials --dev -- -max_total_time=30
+        run: cargo fuzz run fuzz_financials --dev --target x86_64-unknown-linux-gnu -- -max_total_time=30
         working-directory: fuzz
       - name: Run fuzz_edgar (30 s)
-        run: cargo fuzz run fuzz_edgar --dev -- -max_total_time=30
+        run: cargo fuzz run fuzz_edgar --dev --target x86_64-unknown-linux-gnu -- -max_total_time=30
         working-directory: fuzz
       - name: Run fuzz_discovery (30 s)
-        run: cargo fuzz run fuzz_discovery --dev -- -max_total_time=30
+        run: cargo fuzz run fuzz_discovery --dev --target x86_64-unknown-linux-gnu -- -max_total_time=30
         working-directory: fuzz


### PR DESCRIPTION
## Description

The switch to a prebuilt `cargo-fuzz` broke the Fuzz job: the binstall artifact is musl-linked, and cargo-fuzz uses its own compiled-in host triple as the default `--target`, so builds went to `x86_64-unknown-linux-musl`, where the sanitizer cannot link against statically linked libc. Pinning `--target x86_64-unknown-linux-gnu` on the build and every run restores the old behavior while keeping the prebuilt install.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes

- Added `--target x86_64-unknown-linux-gnu` to `cargo fuzz build` and all ten `cargo fuzz run` steps.

## Breaking Changes

None.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] All tests pass (`cargo test`)

Workflow YAML parses cleanly and `zizmor` reports no findings. Reproduced the failure in the PR #357 run logs: `error: sanitizer is incompatible with statically linked libc`.

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [ ] Code compiles without warnings (`cargo check`)
- [ ] Tests pass (`cargo test`)
- [ ] Code formatted (`cargo fmt`)
- [ ] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

None.