### PR TITLE
ci: warm a thin-LTO cache for PR release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,6 +268,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
+          # Cargo fingerprints LTO flags, so the thin PR profile and the fat
+          # master profile need separate caches or PRs rebuild every dep
+          shared-key: build-${{ github.event_name == 'pull_request' && 'thin' || 'fat' }}
           # PR-ref saves are invisible to other PRs and evict master caches
           save-if: ${{ github.ref == 'refs/heads/master' }}
       # cargo-auditable embeds the dependency manifest into each binary so the
@@ -292,6 +295,37 @@ jobs:
             target/release/fq
             target/release/fq-mcp
           if-no-files-found: error
+
+  # Master-side warm for the thin-LTO cache the PR build job restores; a
+  # PR-side save would land on the merge ref where no other PR can see it.
+  build-thin-warm:
+    name: Warm thin build cache
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          df -h /
+      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: build-thin
+      - name: Build with the PR profile
+        env:
+          CARGO_PROFILE_RELEASE_LTO: thin
+          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"
+        run: cargo build --workspace --release
 
   # Build and test Docker image
   docker:


### PR DESCRIPTION
## Description

Build Release still took ~16 minutes on PRs after the thin-LTO switch, and the run data shows why: cargo fingerprints the LTO flags, so a thin-profile PR build reuses nothing from the cache that fat-profile master builds save. Every PR recompiled the whole dependency tree while unit tests on the same PR ran in under 4 minutes on their properly matched cache. The build job's cache key now splits by profile, and a master-side job warms the thin key, so PR builds only recompile workspace crates.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement

## Changes

- Keyed the Build Release cache by profile: `build-thin` on pull_request events, `build-fat` on master.
- Added a `build-thin-warm` job on master pushes that builds the workspace with the PR profile and saves the `build-thin` cache.

## Breaking Changes

None.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] All tests pass (`cargo test`)

Workflow YAML parses cleanly and `zizmor` reports no findings. Timings from the runs on PRs #357 and #358 ground the diagnosis.

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [ ] Code compiles without warnings (`cargo check`)
- [ ] Tests pass (`cargo test`)
- [ ] Code formatted (`cargo fmt`)
- [ ] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

None.