### PR TITLE
ci: regenerate derived docs instead of failing PRs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -193,29 +193,6 @@ jobs:
           git checkout origin/master -- .soothfast/trend.jsonl
           cargo soothfast trend append -p finance-query --from-baseline base
 
-      # Direct pushes to master are blocked by the branch ruleset, so the bot
-      # opens a PR and squash-merges it itself instead.
-      - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
-        if: steps.bench_changes.outputs.changed == 'true'
-        id: cpr
-        with:
-          token: ${{ steps.app-token.outputs.token }}
-          add-paths: .soothfast/trend.jsonl
-          commit-message: "chore: append performance trend point"
-          title: "chore: append performance trend point"
-          body: Automated performance trend update.
-          branch: bot/trend-update
-          delete-branch: true
-          author: >-
-            ${{ steps.app-token.outputs.app-slug }}[bot]
-            <${{ steps.app-user.outputs.id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>
-      - name: Merge pull request
-        if: steps.cpr.outputs.pull-request-number
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
-        run: gh pr merge --auto --squash --delete-branch "$PR_NUMBER"
-
       - name: Regenerate endpoint reference pages
         # A bare `wait` after backgrounding both would mask their exit codes.
         run: |
@@ -242,6 +219,57 @@ jobs:
             cargo soothfast coverage docs -p finance-query --features full \
               --badge docs/perf/badges/coverage.json --badge docs/perf/badges/coverage.svg; \
             echo '```'; } > docs/coverage.md
+
+      - name: Regenerate captured doc output
+        # dataframe.md/finance.md/ticker.md/tickers.md capture live Yahoo
+        # Finance data (real prices/timestamps) so excluded here
+        run: |
+          cargo soothfast docs capture -p finance-query --features full \
+            docs/library/backtesting.md docs/library/commodities.md \
+            docs/library/configuration.md docs/library/crypto.md docs/library/economic.md \
+            docs/library/error-handling.md docs/library/feeds.md docs/library/filings.md \
+            docs/library/forex.md docs/library/futures.md docs/library/getting-started.md \
+            docs/library/indicators.md docs/library/indices.md docs/library/providers/alphavantage.md \
+            docs/library/providers/coingecko.md docs/library/providers/edgar.md \
+            docs/library/providers/fmp.md docs/library/providers/fred.md docs/library/providers/index.md \
+            docs/library/providers/polygon.md docs/library/risk.md docs/library/screeners.md \
+            docs/library/streaming.md docs/library/translation.md README.md
+
+      - name: Keep llms.txt only when the documented surface moved
+        # Measured lines change every run; committing them would make this
+        # job re-trigger itself off its own merges forever
+        run: |
+          if git diff --quiet -- llms.txt; then exit 0; fi
+          mkdir -p target/llms-churn
+          sed '/^\*\*Measured:\*\*/d' llms.txt > target/llms-churn/new.txt
+          git show HEAD:llms.txt | sed '/^\*\*Measured:\*\*/d' > target/llms-churn/old.txt
+          cmp -s target/llms-churn/old.txt target/llms-churn/new.txt && git checkout -- llms.txt || true
+
+      # Direct pushes to master are blocked by the branch ruleset, so the bot
+      # opens a PR and squash-merges it itself instead.
+      - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        id: cpr
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          add-paths: |
+            .soothfast/trend.jsonl
+            llms.txt
+            docs/library/**
+            README.md
+          commit-message: "chore: regenerate derived artifacts"
+          title: "chore: regenerate derived artifacts"
+          body: Automated trend, captured-output, and llms.txt regeneration.
+          branch: bot/derived-artifacts
+          delete-branch: true
+          author: >-
+            ${{ steps.app-token.outputs.app-slug }}[bot]
+            <${{ steps.app-user.outputs.id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>
+      - name: Merge pull request
+        if: steps.cpr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
+        run: gh pr merge --auto --squash --delete-branch "$PR_NUMBER"
 
       - name: Build and publish docs site
         run: cargo soothfast docs gh-deploy --baseline base

--- a/.github/workflows/soothfast.yml
+++ b/.github/workflows/soothfast.yml
@@ -233,20 +233,6 @@ jobs:
         run: |
           cargo soothfast docs check -p finance-query --features full --baseline base \
             docs/library README.md
-      - name: Verify captured doc example output is fresh
-        # dataframe.md/finance.md/ticker.md/tickers.md capture live Yahoo
-        # Finance data (real prices/timestamps) so excluded here
-        run: |
-          cargo soothfast docs capture -p finance-query --features full --check \
-            docs/library/backtesting.md docs/library/commodities.md \
-            docs/library/configuration.md docs/library/crypto.md docs/library/economic.md \
-            docs/library/error-handling.md docs/library/feeds.md docs/library/filings.md \
-            docs/library/forex.md docs/library/futures.md docs/library/getting-started.md \
-            docs/library/indicators.md docs/library/indices.md docs/library/providers/alphavantage.md \
-            docs/library/providers/coingecko.md docs/library/providers/edgar.md \
-            docs/library/providers/fmp.md docs/library/providers/fred.md docs/library/providers/index.md \
-            docs/library/providers/polygon.md docs/library/risk.md docs/library/screeners.md \
-            docs/library/streaming.md docs/library/translation.md README.md
       - name: Public API doc coverage (ratchet — currently 99%)
         run: cargo soothfast coverage docs -p finance-query --features full --min 95
       - name: Public API surface diff vs PR base
@@ -438,15 +424,6 @@ jobs:
         with:
           name: soothfast-baseline
           path: .soothfast/baselines
-      - name: Check llms.txt freshness
-        run: |
-          mkdir -p target/llms-check
-          cargo soothfast report render -p finance-query --baseline base --features full \
-            --out target/llms-check
-          sed '/^\*\*Measured:\*\*/d' llms.txt > target/llms-check/committed.txt
-          sed '/^\*\*Measured:\*\*/d' target/llms-check/llms.txt > target/llms-check/fresh.txt
-          diff -u target/llms-check/committed.txt target/llms-check/fresh.txt || \
-            (echo "::error::llms.txt is stale — run 'make docs-pages' and commit the result" && exit 1)
       - name: Download generated route pages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:


### PR DESCRIPTION
## Description

The trend point, specs, SDK, and CHANGELOG already regenerate through bot PRs on master, but llms.txt and the captured doc example output were still notify-style: a required PR check failing with an instruction to run make docs-pages by hand. Both are pure regenerations, so the deploy bot now produces them. The PR-side docs job keeps the checks that need a human: binds, claims, coverage, and the spec freshness check that the committed-base gate depends on.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes

- Extended deploy.yml's bot PR to carry `llms.txt`, the captured pages under `docs/library/`, and `README.md` alongside the trend point, regenerated after the docs build in the same job. The PR step moved below the regeneration steps it now depends on.
- Reverted `llms.txt` when only its `**Measured:**` lines changed, since those differ every run and would loop the bot off its own merges.
- Removed the llms.txt freshness check from Docs site build and the capture `--check` step from Docs binds & coverage.

## Breaking Changes

None.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] All tests pass (`cargo test`)

Workflow YAML parses cleanly and `zizmor` reports no findings on both edited workflows. The capture page list matches the removed check's exactly, live-data pages still excluded.

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [ ] Code compiles without warnings (`cargo check`)
- [ ] Tests pass (`cargo test`)
- [ ] Code formatted (`cargo fmt`)
- [ ] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

None.