### PR TITLE
chore: bump soothfast crates to 0.1.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5176,9 +5176,9 @@ dependencies = [
 
 [[package]]
 name = "soothfast"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494e2ff1a0ae1bb321d418ccc7f5023c39b3a90f2fd561406dd50264c9db1e57"
+checksum = "e536fb82d2b270d05e2567dae9b27cb703551bfd6f8c840b02765bf311ab09f1"
 dependencies = [
  "soothfast-macros",
  "soothfast-measure",
@@ -5187,9 +5187,9 @@ dependencies = [
 
 [[package]]
 name = "soothfast-macros"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dca29ccfc4ca66b440f92354466055d8c4d871abbceb70522c8170fda836033"
+checksum = "4092725b6b5aed27541a8aa967db07a13fc54d6514112a4887c454c65bb3affa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5198,9 +5198,9 @@ dependencies = [
 
 [[package]]
 name = "soothfast-measure"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd810d1801e9e9199a7c395466abd85021f647c4e2634389e823bd03cc93e25"
+checksum = "f3859dbaa79b8805e4b65f9fda8e840bdc18dae16cd7722fe8909142ff70312c"
 dependencies = [
  "libc",
  "soothfast-registry",
@@ -5208,9 +5208,9 @@ dependencies = [
 
 [[package]]
 name = "soothfast-registry"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ebcfe1c05cda21373b695d4977bd7baa02bc3318cc509497304ef606eaf7f41"
+checksum = "ad71f9019275a82a088f7c24623e4aabb56b661b1e5f99afb4b649abb34990d7"
 dependencies = [
  "linkme",
 ]


### PR DESCRIPTION
## Description

Bumps the four soothfast crates from 0.1.11 to 0.1.12, the release with the fleet-scale trend chart redesign. The deploy workflow installs `cargo-soothfast` pinned to whatever this lockfile says, so the next master deploy renders the perf page's trend charts as a p10-p90 band with named movers instead of 176 overlapping polylines.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes

- Bumped `soothfast`, `soothfast-macros`, `soothfast-measure`, and `soothfast-registry` from 0.1.11 to 0.1.12 in `Cargo.lock`. No manifest change; the dev-dependency requirement is already `0.1`.

## Breaking Changes

None.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] All tests pass (`cargo test`)

`cargo test --lib --features full`: 1216 passed, 0 failed, 61 ignored (network tests). `cargo check --benches --features bench-gate` compiles the harness against 0.1.12 cleanly; the gate on this PR runs it for real. The chart output was verified against this repo's actual trend series before the release.

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [ ] Tests pass (`cargo test`)
- [ ] Code formatted (`cargo fmt`)
- [ ] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

None.