### PR TITLE
chore: bump soothfast crates to 0.1.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5176,9 +5176,9 @@ dependencies = [
 
 [[package]]
 name = "soothfast"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e536fb82d2b270d05e2567dae9b27cb703551bfd6f8c840b02765bf311ab09f1"
+checksum = "a1441c7a8b78a6a19c39bf17d7c2e251222875169038aaf2b651c8f46b447f17"
 dependencies = [
  "soothfast-macros",
  "soothfast-measure",
@@ -5187,9 +5187,9 @@ dependencies = [
 
 [[package]]
 name = "soothfast-macros"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4092725b6b5aed27541a8aa967db07a13fc54d6514112a4887c454c65bb3affa"
+checksum = "a63a2f47a620909acc2e3f7e47463b74bb356bc10172d5e71961599ecc9c684b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5198,9 +5198,9 @@ dependencies = [
 
 [[package]]
 name = "soothfast-measure"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3859dbaa79b8805e4b65f9fda8e840bdc18dae16cd7722fe8909142ff70312c"
+checksum = "5529d3e920a34a9ab4739c2ff019a3fa83a141e97649102b36a2c6837b9093a5"
 dependencies = [
  "libc",
  "soothfast-registry",
@@ -5208,9 +5208,9 @@ dependencies = [
 
 [[package]]
 name = "soothfast-registry"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad71f9019275a82a088f7c24623e4aabb56b661b1e5f99afb4b649abb34990d7"
+checksum = "6cfdfae8184310cdc4641acae3a37e1b9d2da680202d69c17f0e2aba6ded4139"
 dependencies = [
  "linkme",
 ]


### PR DESCRIPTION
## Description

Bumps the four soothfast crates from 0.1.12 to 0.1.14, the release with the version-coupled spec gate and `spec probe`. CI installs `cargo-soothfast` pinned to this lockfile, so the spec gate starts acknowledging deliberate breaks by `info.version` bump and the data-quality probe command becomes available to workflows.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Updated `soothfast`, `soothfast-macros`, `soothfast-measure`, `soothfast-registry` to 0.1.14 in `Cargo.lock`.

## Breaking Changes

None.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] All tests pass (`cargo test`)

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [ ] Code compiles without warnings (`cargo check`)
- [ ] Tests pass (`cargo test`)
- [ ] Code formatted (`cargo fmt`)
- [ ] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

None.
