### PR TITLE
fix: dedup Ticker cache fetches, default to 60s TTL

### DIFF
--- a/src/domains/mod.rs
+++ b/src/domains/mod.rs
@@ -10,21 +10,20 @@
 // ── Caching ─────────────────────────────────────────────────────────
 
 use crate::error::Result;
-use crate::utils::{CacheEntry, CacheMode};
+use crate::utils::{CacheEntry, CacheMode, FetchGuards};
 use std::collections::HashMap;
-use std::sync::Arc;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::RwLock;
 
 /// Per-handle response cache with request deduplication.
 ///
 /// Keyed by a `String` so a handle can cache multiple variants (e.g. a
 /// crypto coin priced in different `vs_currency` values); single-result
-/// handles use the empty string. Caches for the handle's lifetime by
-/// default; `.cache(ttl)` bounds that and `.no_cache()` disables it.
+/// handles use the empty string. Caches for 60 seconds by default;
+/// `.cache(ttl)` changes that window and `.no_cache()` disables it.
 pub(crate) struct DomainCache<V> {
     mode: CacheMode,
     entries: RwLock<HashMap<String, CacheEntry<V>>>,
-    guards: RwLock<HashMap<String, Arc<Mutex<()>>>>,
+    guards: FetchGuards<String>,
 }
 
 impl<V: Clone> DomainCache<V> {
@@ -32,7 +31,7 @@ impl<V: Clone> DomainCache<V> {
         Self {
             mode,
             entries: RwLock::new(HashMap::new()),
-            guards: RwLock::new(HashMap::new()),
+            guards: FetchGuards::default(),
         }
     }
 
@@ -53,51 +52,25 @@ impl<V: Clone> DomainCache<V> {
             return Ok(entry.value.clone());
         }
 
-        // Dedup: hold a per-key guard so concurrent identical misses don't all
-        // fetch, while misses on different keys proceed in parallel.
-        let guard = {
-            let mut g = self.guards.write().await;
-            Arc::clone(g.entry(key.clone()).or_default())
-        };
-        let _g = guard.lock().await;
-        let result = async {
-            if let Some(entry) = self.entries.read().await.get(&key)
-                && entry.is_fresh(self.mode)
-            {
-                return Ok(entry.value.clone());
-            }
+        self.guards
+            .dedup(key.clone(), || async {
+                if let Some(entry) = self.entries.read().await.get(&key)
+                    && entry.is_fresh(self.mode)
+                {
+                    return Ok(entry.value.clone());
+                }
 
-            let value = f().await?;
-            crate::utils::cache_insert(
-                &mut *self.entries.write().await,
-                key.clone(),
-                value.clone(),
-                self.mode,
-                crate::utils::EVICTION_THRESHOLD,
-            );
-            Ok(value)
-        }
-        .await;
-
-        // Drop the guard entry on every exit, not just the success path — under
-        // `Ttl`, repeated expiry or error cycles would otherwise accumulate one
-        // `Arc<Mutex<_>>` per key that is never reclaimed.
-        //
-        // Only when nobody else holds it, though. Waiters clone the `Arc` before
-        // blocking on it, so an unconditional remove lets a waiter and a fresh
-        // arrival end up on two different mutexes and fetch the same key
-        // concurrently — the dedup this guard exists for.
-        drop(_g);
-        drop(guard);
-        {
-            let mut guards = self.guards.write().await;
-            // Our own clone is gone, so a count of 1 means the map is the only
-            // holder: no waiter is parked on this key and dropping it is safe.
-            if guards.get(&key).is_some_and(|g| Arc::strong_count(g) == 1) {
-                guards.remove(&key);
-            }
-        }
-        result
+                let value = f().await?;
+                crate::utils::cache_insert(
+                    &mut *self.entries.write().await,
+                    key.clone(),
+                    value.clone(),
+                    self.mode,
+                    crate::utils::EVICTION_THRESHOLD,
+                );
+                Ok(value)
+            })
+            .await
     }
 }
 
@@ -142,10 +115,23 @@ macro_rules! domain_handle {
                 }
             }
 
-            /// Cache responses for `ttl` instead of for the handle's lifetime,
+            /// Cache responses for `ttl` instead of the default 60 seconds,
             /// deduplicating concurrent identical requests.
             pub fn cache(mut self, ttl: std::time::Duration) -> Self {
                 let mode = crate::utils::CacheMode::Ttl(ttl);
+                self.cache = crate::domains::DomainCache::new(mode);
+                self.chart_cache = crate::domains::DomainCache::new(mode);
+                $($(
+                    $(#[$ecfg])*
+                    { self.$ecache = crate::domains::DomainCache::new(mode); }
+                )+)?
+                self
+            }
+
+            /// Cache responses for the handle's lifetime instead of the
+            /// default 60 seconds.
+            pub fn cache_forever(mut self) -> Self {
+                let mode = crate::utils::CacheMode::Lifetime;
                 self.cache = crate::domains::DomainCache::new(mode);
                 self.chart_cache = crate::domains::DomainCache::new(mode);
                 $($(
@@ -207,10 +193,19 @@ macro_rules! domain_handle {
                 }
             }
 
-            /// Cache responses for `ttl` instead of for the handle's lifetime,
+            /// Cache responses for `ttl` instead of the default 60 seconds,
             /// deduplicating concurrent identical requests.
             pub fn cache(mut self, ttl: std::time::Duration) -> Self {
                 let mode = crate::utils::CacheMode::Ttl(ttl);
+                self.cache = crate::domains::DomainCache::new(mode);
+                self.chart_cache = crate::domains::DomainCache::new(mode);
+                self
+            }
+
+            /// Cache responses for the handle's lifetime instead of the
+            /// default 60 seconds.
+            pub fn cache_forever(mut self) -> Self {
+                let mode = crate::utils::CacheMode::Lifetime;
                 self.cache = crate::domains::DomainCache::new(mode);
                 self.chart_cache = crate::domains::DomainCache::new(mode);
                 self
@@ -257,10 +252,17 @@ macro_rules! domain_handle {
                 }
             }
 
-            /// Cache responses for `ttl` instead of for the handle's lifetime,
+            /// Cache responses for `ttl` instead of the default 60 seconds,
             /// deduplicating concurrent identical requests.
             pub fn cache(mut self, ttl: std::time::Duration) -> Self {
                 self.cache = crate::domains::DomainCache::new(crate::utils::CacheMode::Ttl(ttl));
+                self
+            }
+
+            /// Cache responses for the handle's lifetime instead of the
+            /// default 60 seconds.
+            pub fn cache_forever(mut self) -> Self {
+                self.cache = crate::domains::DomainCache::new(crate::utils::CacheMode::Lifetime);
                 self
             }
 
@@ -308,10 +310,18 @@ macro_rules! domain_handle {
                 }
             }
 
-            /// Cache responses for `ttl` instead of for the handle's lifetime,
+            /// Cache responses for `ttl` instead of the default 60 seconds,
             /// deduplicating concurrent identical requests.
             pub fn cache(mut self, ttl: std::time::Duration) -> Self {
                 let mode = crate::utils::CacheMode::Ttl(ttl);
+                $(self.$cache = crate::domains::DomainCache::new(mode);)+
+                self
+            }
+
+            /// Cache responses for the handle's lifetime instead of the
+            /// default 60 seconds.
+            pub fn cache_forever(mut self) -> Self {
+                let mode = crate::utils::CacheMode::Lifetime;
                 $(self.$cache = crate::domains::DomainCache::new(mode);)+
                 self
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,8 +49,9 @@
 //! - **Chart data**: fetched and cached per (interval, range) combination
 //! - **Recommendations**: fetched once and cached
 //!
-//! A handle caches for as long as it lives. Use `.cache(ttl)` on the builder to
-//! bound that, or `.no_cache()` to fetch fresh on every call.
+//! A handle caches each response for 60 seconds by default. Use `.cache(ttl)`
+//! on the builder to change that window, or `.no_cache()` to fetch fresh on
+//! every call.
 
 #![warn(missing_docs)]
 #![warn(rustdoc::missing_crate_level_docs)]

--- a/src/providers/mock.rs
+++ b/src/providers/mock.rs
@@ -41,7 +41,6 @@ impl CountingProvider {
         self.chart_calls.load(Ordering::SeqCst)
     }
 
-    #[allow(dead_code)]
     pub(crate) fn news(&self) -> usize {
         self.news_calls.load(Ordering::SeqCst)
     }
@@ -78,6 +77,7 @@ impl ChartProvider for CountingProvider {
         _: crate::TimeRange,
     ) -> Result<Chart> {
         self.chart_calls.fetch_add(1, Ordering::SeqCst);
+        tokio::task::yield_now().await;
         Ok(Chart {
             symbol: symbol.to_string(),
             meta: ChartMeta::default(),
@@ -93,6 +93,7 @@ impl ChartProvider for CountingProvider {
 impl CorporateProvider for CountingProvider {
     async fn fetch_news(&self, _: &str) -> Result<Vec<News>> {
         self.news_calls.fetch_add(1, Ordering::SeqCst);
+        tokio::task::yield_now().await;
         Ok(Vec::new())
     }
 

--- a/src/ticker/core.rs
+++ b/src/ticker/core.rs
@@ -34,7 +34,7 @@ use crate::providers::{
 };
 #[cfg(feature = "risk")]
 use crate::risk;
-use crate::utils::{CacheEntry, CacheMode, filter_by_range};
+use crate::utils::{CacheEntry, CacheMode, FetchGuards, filter_by_range};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -141,15 +141,21 @@ impl TickerBuilder {
         self.shared_client = Some(handle);
         self
     }
-    /// Cache responses for `ttl` instead of for the handle's lifetime.
+    /// Cache responses for `ttl` instead of the default 60 seconds.
     pub fn cache(mut self, ttl: Duration) -> Self {
         self.cache_mode = CacheMode::Ttl(ttl);
         self
     }
+    /// Cache responses for the handle's lifetime instead of the default 60
+    /// seconds.
+    pub fn cache_forever(mut self) -> Self {
+        self.cache_mode = CacheMode::Lifetime;
+        self
+    }
     /// Disable caching — every call fetches fresh data.
     ///
-    /// By default a `Ticker` caches each response for as long as the handle
-    /// lives, so repeated accessor calls reuse one fetch.
+    /// By default a `Ticker` caches each response for 60 seconds, so
+    /// repeated accessor calls within that window reuse one fetch.
     pub fn no_cache(mut self) -> Self {
         self.cache_mode = CacheMode::Off;
         self
@@ -197,22 +203,31 @@ impl TickerBuilder {
             quote_cache: Default::default(),
             quote_fetch: Arc::new(tokio::sync::Mutex::new(())),
             chart_cache: Default::default(),
+            chart_guards: Default::default(),
             events_cache: Default::default(),
+            events_fetch: Arc::new(tokio::sync::Mutex::new(())),
             news_cache: Default::default(),
+            news_fetch: Arc::new(tokio::sync::Mutex::new(())),
             logo_cache: Default::default(),
             options_cache: Default::default(),
+            options_guards: Default::default(),
             financials_cache: Default::default(),
+            financials_guards: Default::default(),
             #[cfg(feature = "indicators")]
             indicators_cache: Default::default(),
+            #[cfg(feature = "indicators")]
+            indicators_guards: Default::default(),
             edgar_submissions_cache: Default::default(),
+            edgar_submissions_fetch: Arc::new(tokio::sync::Mutex::new(())),
             edgar_facts_cache: Default::default(),
+            edgar_facts_fetch: Arc::new(tokio::sync::Mutex::new(())),
         })
     }
 }
 
 /// The primary entry point for querying financial data for a single symbol.
 ///
-/// Data is fetched on first access and cached for the lifetime of the handle.
+/// Data is fetched on first access and cached for 60 seconds by default.
 /// Use the builder via [`Ticker::builder`] for custom configuration, including
 /// [`cache`](TickerBuilder::cache) and [`no_cache`](TickerBuilder::no_cache).
 pub struct Ticker {
@@ -225,15 +240,24 @@ pub struct Ticker {
     quote_cache: Cache<QuoteSummaryResponse>,
     quote_fetch: Arc<tokio::sync::Mutex<()>>,
     chart_cache: MapCache<(Interval, TimeRange), Chart>,
+    chart_guards: FetchGuards<(Interval, TimeRange)>,
     events_cache: Cache<ChartEvents>,
+    events_fetch: Arc<tokio::sync::Mutex<()>>,
     news_cache: Cache<Vec<News>>,
+    news_fetch: Arc<tokio::sync::Mutex<()>>,
     logo_cache: Cache<(Option<String>, Option<String>)>,
     options_cache: MapCache<Option<i64>, Options>,
+    options_guards: FetchGuards<Option<i64>>,
     financials_cache: MapCache<(StatementType, Frequency), FinancialStatement>,
+    financials_guards: FetchGuards<(StatementType, Frequency)>,
     #[cfg(feature = "indicators")]
     indicators_cache: MapCache<(Interval, TimeRange), indicators::IndicatorsSummary>,
+    #[cfg(feature = "indicators")]
+    indicators_guards: FetchGuards<(Interval, TimeRange)>,
     edgar_submissions_cache: Cache<EdgarSubmissions>,
+    edgar_submissions_fetch: Arc<tokio::sync::Mutex<()>>,
     edgar_facts_cache: Cache<CompanyFacts>,
+    edgar_facts_fetch: Arc<tokio::sync::Mutex<()>>,
 }
 
 impl Ticker {
@@ -367,21 +391,35 @@ impl Ticker {
 
     /// Get historical OHLCV chart data.
     pub async fn chart(&self, interval: Interval, range: TimeRange) -> Result<Chart> {
+        let key = (interval, range);
         {
             let cache = self.chart_cache.read().await;
-            if let Some(entry) = cache.get(&(interval, range))
+            if let Some(entry) = cache.get(&key)
                 && self.is_cache_fresh(Some(entry))
             {
                 return Ok(entry.value.clone());
             }
         }
-        let data = ticker_fetch!(self, CHART, as_chart, Chart, fetch_chart, interval, range)?;
-        let chart = Self::chart_from_provider_data(data, Some(interval), Some(range));
-        if self.cache_mode.enabled() {
-            let mut cache = self.chart_cache.write().await;
-            self.cache_insert(&mut cache, (interval, range), chart.clone());
-        }
-        Ok(chart)
+        self.chart_guards
+            .dedup(key, || async {
+                {
+                    let cache = self.chart_cache.read().await;
+                    if let Some(entry) = cache.get(&key)
+                        && self.is_cache_fresh(Some(entry))
+                    {
+                        return Ok(entry.value.clone());
+                    }
+                }
+                let data =
+                    ticker_fetch!(self, CHART, as_chart, Chart, fetch_chart, interval, range)?;
+                let chart = Self::chart_from_provider_data(data, Some(interval), Some(range));
+                if self.cache_mode.enabled() {
+                    let mut cache = self.chart_cache.write().await;
+                    self.cache_insert(&mut cache, key, chart.clone());
+                }
+                Ok(chart)
+            })
+            .await
     }
 
     /// Get chart data for a custom start/end timestamp range.
@@ -406,6 +444,13 @@ impl Ticker {
     }
 
     async fn ensure_events(&self) -> Result<()> {
+        {
+            let cache = self.events_cache.read().await;
+            if self.is_cache_fresh(cache.as_ref()) {
+                return Ok(());
+            }
+        }
+        let _guard = self.events_fetch.lock().await;
         {
             let cache = self.events_cache.read().await;
             if self.is_cache_fresh(cache.as_ref()) {
@@ -498,6 +543,15 @@ impl Ticker {
                 return Ok(e.value.clone());
             }
         }
+        let _guard = self.news_fetch.lock().await;
+        {
+            let cache = self.news_cache.read().await;
+            if let Some(e) = cache.as_ref()
+                && self.is_cache_fresh(Some(e))
+            {
+                return Ok(e.value.clone());
+            }
+        }
         let data = ticker_fetch!(self, CORPORATE, as_corporate, News, fetch_news)?;
         let news = data;
         // Score titles before translation — VADER is English-lexicon based.
@@ -549,12 +603,24 @@ impl Ticker {
                 return Ok(e.value.clone());
             }
         }
-        let opts = ticker_fetch!(self, OPTIONS, as_options, Options, fetch_options, date)?;
-        if self.cache_mode.enabled() {
-            let mut c = self.options_cache.write().await;
-            self.cache_insert(&mut c, date, opts.clone());
-        }
-        Ok(opts)
+        self.options_guards
+            .dedup(date, || async {
+                {
+                    let cache = self.options_cache.read().await;
+                    if let Some(e) = cache.get(&date)
+                        && self.is_cache_fresh(Some(e))
+                    {
+                        return Ok(e.value.clone());
+                    }
+                }
+                let opts = ticker_fetch!(self, OPTIONS, as_options, Options, fetch_options, date)?;
+                if self.cache_mode.enabled() {
+                    let mut c = self.options_cache.write().await;
+                    self.cache_insert(&mut c, date, opts.clone());
+                }
+                Ok(opts)
+            })
+            .await
     }
 
     /// Get financial statements.
@@ -572,20 +638,32 @@ impl Ticker {
                 return Ok(e.value.clone());
             }
         }
-        let stmt = ticker_fetch!(
-            self,
-            FUNDAMENTALS,
-            as_fundamentals,
-            Financials,
-            fetch_financials,
-            stmt_type,
-            frequency
-        )?;
-        if self.cache_mode.enabled() {
-            let mut c = self.financials_cache.write().await;
-            self.cache_insert(&mut c, key, stmt.clone());
-        }
-        Ok(stmt)
+        self.financials_guards
+            .dedup(key, || async {
+                {
+                    let cache = self.financials_cache.read().await;
+                    if let Some(e) = cache.get(&key)
+                        && self.is_cache_fresh(Some(e))
+                    {
+                        return Ok(e.value.clone());
+                    }
+                }
+                let stmt = ticker_fetch!(
+                    self,
+                    FUNDAMENTALS,
+                    as_fundamentals,
+                    Financials,
+                    fetch_financials,
+                    stmt_type,
+                    frequency
+                )?;
+                if self.cache_mode.enabled() {
+                    let mut c = self.financials_cache.write().await;
+                    self.cache_insert(&mut c, key, stmt.clone());
+                }
+                Ok(stmt)
+            })
+            .await
     }
 
     #[cfg(feature = "indicators")]
@@ -595,21 +673,34 @@ impl Ticker {
         interval: Interval,
         range: TimeRange,
     ) -> Result<indicators::IndicatorsSummary> {
+        let key = (interval, range);
         {
             let cache = self.indicators_cache.read().await;
-            if let Some(e) = cache.get(&(interval, range))
+            if let Some(e) = cache.get(&key)
                 && self.is_cache_fresh(Some(e))
             {
                 return Ok(e.value.clone());
             }
         }
-        let chart = self.chart(interval, range).await?;
-        let ind = indicators::summary::calculate_indicators(&chart.candles);
-        if self.cache_mode.enabled() {
-            let mut c = self.indicators_cache.write().await;
-            self.cache_insert(&mut c, (interval, range), ind.clone());
-        }
-        Ok(ind)
+        self.indicators_guards
+            .dedup(key, || async {
+                {
+                    let cache = self.indicators_cache.read().await;
+                    if let Some(e) = cache.get(&key)
+                        && self.is_cache_fresh(Some(e))
+                    {
+                        return Ok(e.value.clone());
+                    }
+                }
+                let chart = self.chart(interval, range).await?;
+                let ind = indicators::summary::calculate_indicators(&chart.candles);
+                if self.cache_mode.enabled() {
+                    let mut c = self.indicators_cache.write().await;
+                    self.cache_insert(&mut c, key, ind.clone());
+                }
+                Ok(ind)
+            })
+            .await
     }
 
     /// Get SEC EDGAR filing history for this symbol.
@@ -618,6 +709,15 @@ impl Ticker {
     /// history and XBRL company facts) that no other provider replicates. For routable
     /// provider-agnostic filing data use [`filings`](Self::filings) instead.
     pub async fn edgar_submissions(&self) -> Result<EdgarSubmissions> {
+        {
+            let cache = self.edgar_submissions_cache.read().await;
+            if let Some(e) = cache.as_ref()
+                && self.is_cache_fresh(Some(e))
+            {
+                return Ok(e.value.clone());
+            }
+        }
+        let _guard = self.edgar_submissions_fetch.lock().await;
         {
             let cache = self.edgar_submissions_cache.read().await;
             if let Some(e) = cache.as_ref()
@@ -639,6 +739,15 @@ impl Ticker {
     /// Always uses EDGAR directly — XBRL `us-gaap`/`ifrs`/`dei` fact data is unique
     /// to the SEC's EDGAR API. For routable filing data use [`filings`](Self::filings).
     pub async fn edgar_company_facts(&self) -> Result<CompanyFacts> {
+        {
+            let cache = self.edgar_facts_cache.read().await;
+            if let Some(e) = cache.as_ref()
+                && self.is_cache_fresh(Some(e))
+            {
+                return Ok(e.value.clone());
+            }
+        }
+        let _guard = self.edgar_facts_fetch.lock().await;
         {
             let cache = self.edgar_facts_cache.read().await;
             if let Some(e) = cache.as_ref()
@@ -1192,6 +1301,57 @@ mod tests {
             ticker.logo_cache.read().await.is_none(),
             "an unresolved logo must not be cached, or one blip is permanent"
         );
+    }
+
+    #[tokio::test]
+    async fn concurrent_chart_misses_dedup_to_one_fetch() {
+        let provider = CountingProvider::new();
+        let ticker = Arc::new(
+            Ticker::builder("AAPL")
+                .with_provider_set(provider_set(Arc::clone(&provider)))
+                .build()
+                .await
+                .unwrap(),
+        );
+
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let ticker = Arc::clone(&ticker);
+            handles.push(tokio::spawn(async move {
+                ticker
+                    .chart(Interval::OneDay, TimeRange::OneMonth)
+                    .await
+                    .unwrap()
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+
+        assert_eq!(provider.charts(), 1);
+    }
+
+    #[tokio::test]
+    async fn concurrent_news_misses_dedup_to_one_fetch() {
+        let provider = CountingProvider::new();
+        let ticker = Arc::new(
+            Ticker::builder("AAPL")
+                .with_provider_set(provider_set(Arc::clone(&provider)))
+                .build()
+                .await
+                .unwrap(),
+        );
+
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let ticker = Arc::clone(&ticker);
+            handles.push(tokio::spawn(async move { ticker.news().await.unwrap() }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+
+        assert_eq!(provider.news(), 1);
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/tickers/core/mod.rs
+++ b/src/tickers/core/mod.rs
@@ -193,7 +193,7 @@ impl TickersBuilder {
         self
     }
 
-    /// Cache responses for `ttl` instead of for the handle's lifetime.
+    /// Cache responses for `ttl` instead of the default 60 seconds.
     ///
     /// Responses are reused until the TTL expires; stale entries are evicted
     /// on a later write.
@@ -217,10 +217,17 @@ impl TickersBuilder {
         self
     }
 
+    /// Cache responses for the handle's lifetime instead of the default 60
+    /// seconds.
+    pub fn cache_forever(mut self) -> Self {
+        self.cache_mode = CacheMode::Lifetime;
+        self
+    }
+
     /// Disable caching — every call fetches fresh data.
     ///
-    /// By default a `Tickers` handle caches each response for as long as it
-    /// lives, so repeated calls reuse one fetch.
+    /// By default a `Tickers` handle caches each response for 60 seconds,
+    /// so repeated calls within that window reuse one fetch.
     pub fn no_cache(mut self) -> Self {
         self.cache_mode = CacheMode::Off;
         self

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,10 +4,57 @@ use crate::constants::TimeRange;
 use crate::models::chart::{CapitalGain, Dividend, Split};
 use std::collections::HashMap;
 use std::hash::Hash;
+use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::sync::{Mutex, RwLock};
 // tokio's Instant tracks the runtime clock, so TTL expiry is testable under
 // `tokio::time::pause`. Outside tests it is std::time::Instant.
 use tokio::time::Instant;
+
+/// Per-key mutex map that collapses concurrent identical cache misses into a
+/// single in-flight fetch, so N callers missing the same key don't each issue
+/// their own upstream request.
+pub(crate) struct FetchGuards<K> {
+    guards: RwLock<HashMap<K, Arc<Mutex<()>>>>,
+}
+
+impl<K: Eq + Hash + Clone> Default for FetchGuards<K> {
+    fn default() -> Self {
+        Self {
+            guards: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+impl<K: Eq + Hash + Clone> FetchGuards<K> {
+    /// Run `action` while holding the lock for `key`, so concurrent callers
+    /// with the same key serialize instead of each fetching independently.
+    /// `action` is expected to recheck the cache after acquiring the lock,
+    /// since a concurrent holder may have just populated it.
+    pub(crate) async fn dedup<T, Fut>(&self, key: K, action: impl FnOnce() -> Fut) -> T
+    where
+        Fut: std::future::Future<Output = T>,
+    {
+        let guard = {
+            let mut g = self.guards.write().await;
+            Arc::clone(g.entry(key.clone()).or_default())
+        };
+        let _g = guard.lock().await;
+        let result = action().await;
+
+        // Remove only when we're the last holder; a waiter that already
+        // cloned this Arc must still find it, not a fresh mutex.
+        drop(_g);
+        drop(guard);
+        {
+            let mut guards = self.guards.write().await;
+            if guards.get(&key).is_some_and(|g| Arc::strong_count(g) == 1) {
+                guards.remove(&key);
+            }
+        }
+        result
+    }
+}
 
 /// Returns the current time as Unix timestamp in seconds.
 #[inline]
@@ -40,16 +87,25 @@ pub(crate) fn eviction_threshold_for(working_set: usize) -> usize {
     EVICTION_THRESHOLD.max(working_set.saturating_mul(2))
 }
 
+/// Default TTL for handles that don't call `.cache(ttl)` explicitly, matching
+/// the server's own real-time quote TTL (`server/src/cache.rs::ttl::QUOTES`).
+pub(crate) const DEFAULT_CACHE_TTL: Duration = Duration::from_secs(60);
+
 /// How long a cached response stays usable.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CacheMode {
     /// Cache until the owning handle is dropped.
-    #[default]
     Lifetime,
     /// Cache for a bounded duration.
     Ttl(Duration),
     /// Never cache.
     Off,
+}
+
+impl Default for CacheMode {
+    fn default() -> Self {
+        Self::Ttl(DEFAULT_CACHE_TTL)
+    }
 }
 
 impl CacheMode {


### PR DESCRIPTION
## Description
Only `Ticker::quote()` had a fetch-guard against concurrent identical misses. Chart, financials, options, news, events, and both EDGAR accessors let every concurrent caller issue its own upstream fetch. Extracted the guard-map pattern into a shared `FetchGuards` primitive and applied it everywhere, which also let `DomainCache` drop its own duplicate copy of the same logic. Separately, `CacheMode::default()` was unbounded `Lifetime`, so a long-lived handle could serve arbitrarily stale data with no way out short of disabling caching entirely. Default is now a 60-second TTL matching the server's own quote TTL, with `.cache_forever()` added as the explicit opt-in for the old behavior.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Added `utils::FetchGuards<K>`, a per-key mutex-dedup primitive, and applied it to `Ticker`'s `chart`/`financials`/`options`/`news`/`events`/`edgar_submissions`/`edgar_facts` accessors.
- Refactored `DomainCache::get_or_try` to reuse `FetchGuards` instead of its own copy of the same guard-map logic.
- Changed `CacheMode::default()` from `Lifetime` to a 60-second `Ttl`.
- Added `.cache_forever()` to `TickerBuilder`, `TickersBuilder`, and every domain-handle macro arm.
- Added two concurrency tests (`concurrent_chart_misses_dedup_to_one_fetch`, `concurrent_news_misses_dedup_to_one_fetch`) and a `tokio::task::yield_now().await` in the mock provider so they can actually interleave.

## Breaking Changes
Default caching duration changes from unbounded (the handle's lifetime) to a 60-second TTL. Code relying on the old default to cache indefinitely needs the explicit opt-in.

**Migration Guide:**
```rust
// Before (implicit, cached for the handle's lifetime)
let ticker = Ticker::new("AAPL").await?;

// After (explicit, to keep the old behavior)
let ticker = Ticker::builder("AAPL").cache_forever().build().await?;
```

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] All tests pass (`cargo test`) — `cargo test -p finance-query --features full --lib`: 1238 passed, 0 failed, 63 ignored

## Documentation
- [x] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues
Closes #