### PR TITLE
feat: route SEC fails-to-deliver via keyless EDGAR

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ full = [
     "defi",
     "gdelt",
     "cftc",
+    "secftd",
 ]
 # Enable DataFrame conversions with polars
 dataframe = ["dep:polars"]
@@ -153,6 +154,8 @@ defi = []
 gdelt = []
 # Enable CFTC Commitments of Traders futures positioning data (keyless)
 cftc = []
+# Enable SEC fails-to-deliver flat-file data on the EDGAR adapter (keyless)
+secftd = ["dep:zip"]
 # Enable offline VADER lexicon-based news/transcript sentiment scoring
 sentiment = ["dep:vader_sentiment"]
 # Enable Alpha Vantage financial data API
@@ -204,6 +207,7 @@ features = [
     "defi",
     "gdelt",
     "cftc",
+    "secftd",
 ]
 rustdoc-args = ["--cfg", "docsrs"]
 

--- a/finance-query-mcp/src/tools/mod.rs
+++ b/finance-query-mcp/src/tools/mod.rs
@@ -789,7 +789,7 @@ impl FinanceTools {
     }
 
     #[tool(
-        description = "Get fails-to-deliver records for a symbol (currently FMP only, requires FMP_API_KEY)."
+        description = "Get fails-to-deliver records for a symbol. Uses FMP when FMP_API_KEY is set, keyless EDGAR otherwise."
     )]
     async fn get_fails_to_deliver(
         &self,

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Finance library (our own)
-finance-query = { path = "..", features = ["indicators", "fred", "crypto", "risk", "sentiment", "gdelt", "cftc", "alphavantage", "fmp", "worldbank", "fiscaldata", "frankfurter", "binance", "kraken"] }
+finance-query = { path = "..", features = ["indicators", "fred", "crypto", "risk", "sentiment", "gdelt", "cftc", "alphavantage", "fmp", "worldbank", "fiscaldata", "frankfurter", "binance", "kraken", "secftd"] }
 
 # GraphQL
 async-graphql = { version = "7", features = ["graphiql"] }

--- a/server/schema.graphql
+++ b/server/schema.graphql
@@ -3091,8 +3091,8 @@ type GqlTicker {
 		after: String
 	): GqlCongressionalTradeConnection!
 	"""
-	Fails-to-deliver records for this symbol (currently FMP only,
-	requires `FMP_API_KEY`).
+	Fails-to-deliver records for this symbol. Routes through FMP when
+	`FMP_API_KEY` is set, EDGAR otherwise (keyless).
 	"""
 	failsToDeliver(
 		"""

--- a/server/src/graphql/query/ticker_filings.rs
+++ b/server/src/graphql/query/ticker_filings.rs
@@ -1,7 +1,8 @@
-//! Per-symbol FMP-routed filings/disclosure fields: congressional trading
-//! and fails-to-deliver. Distinct from Yahoo's `insiderTransactions`/
-//! `secFilings` (`TickerHoldersQuery`/`TickerCoreQuery`) and SEC EDGAR
-//! (`TickerAnalysisQuery`).
+//! Per-symbol filings/disclosure fields routed via `Capability::FILINGS`:
+//! congressional trading (FMP only) and fails-to-deliver (FMP, falling back
+//! to keyless EDGAR). Distinct from Yahoo's `insiderTransactions`/
+//! `secFilings` (`TickerHoldersQuery`/`TickerCoreQuery`) and SEC EDGAR's own
+//! submissions/facts fields (`TickerAnalysisQuery`).
 
 use async_graphql::{Context, Object, Result};
 
@@ -38,8 +39,8 @@ impl TickerFilingsQuery {
         pagination::paginate(&entries, first, after).await
     }
 
-    /// Fails-to-deliver records for this symbol (currently FMP only,
-    /// requires `FMP_API_KEY`).
+    /// Fails-to-deliver records for this symbol. Routes through FMP when
+    /// `FMP_API_KEY` is set, EDGAR otherwise (keyless).
     async fn fails_to_deliver(
         &self,
         ctx: &Context<'_>,

--- a/server/src/handlers/filings.rs
+++ b/server/src/handlers/filings.rs
@@ -57,8 +57,8 @@ pub(crate) async fn get_congressional_trades(
 
 /// GET /v2/filings/{symbol}/fails-to-deliver
 ///
-/// Fails-to-deliver records for a symbol. Currently FMP only — requires
-/// `FMP_API_KEY`.
+/// Fails-to-deliver records for a symbol. Routes through FMP when
+/// `FMP_API_KEY` is set, EDGAR otherwise (keyless).
 pub(crate) async fn get_fails_to_deliver(
     Extension(schema): Extension<graphql::FinanceSchema>,
     Path(symbol): Path<String>,

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -121,7 +121,7 @@ pub(crate) fn api_routes() -> Router {
             "/filings/{symbol}/congressional-trades",
             get(filings::get_congressional_trades),
         )
-        // GET /v2/filings/{symbol}/fails-to-deliver (currently FMP only)
+        // GET /v2/filings/{symbol}/fails-to-deliver
         .route(
             "/filings/{symbol}/fails-to-deliver",
             get(filings::get_fails_to_deliver),

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -141,12 +141,13 @@ fn route_table(
     forex.push(Provider::Frankfurter);
     routes.push((Capability::FOREX, forex));
 
+    let mut filings = Vec::new();
     if flags.fmp {
-        routes.push((
-            Capability::FILINGS,
-            vec![Provider::Fmp, Provider::Edgar, Provider::Yahoo],
-        ));
+        filings.push(Provider::Fmp);
     }
+    filings.push(Provider::Edgar);
+    filings.push(Provider::Yahoo);
+    routes.push((Capability::FILINGS, filings));
 
     routes
 }
@@ -229,7 +230,10 @@ mod provider_routing_tests {
         );
         assert_eq!(route(&routes, Capability::DISCOVERY), None);
         assert_eq!(route(&routes, Capability::INDICES), None);
-        assert_eq!(route(&routes, Capability::FILINGS), None);
+        assert_eq!(
+            route(&routes, Capability::FILINGS),
+            Some(&[Provider::Edgar, Provider::Yahoo][..])
+        );
     }
 
     #[test]

--- a/src/adapters/edgar/filings/fails_to_deliver.rs
+++ b/src/adapters/edgar/filings/fails_to_deliver.rs
@@ -1,0 +1,267 @@
+//! SEC fails-to-deliver flat files (`sec.gov/data/foiadocsfailsdatahtm`).
+//!
+//! SEC publishes consolidated fails-to-deliver data as bi-monthly pipe-delimited
+//! text archives, one ZIP per settlement half-month (`cnsfails{YYYYMM}{a|b}.zip`,
+//! `a` = 1st-15th, `b` = 16th-end). There is no per-symbol query endpoint, so each
+//! period's archive is downloaded whole and filtered locally. The archive for the
+//! most recent half-month is typically published with a few weeks' lag, so lookup
+//! walks backward from the current period until it collects enough periods.
+
+use std::io::{Cursor, Read};
+
+use chrono::{Datelike, NaiveDate, Utc};
+
+use crate::adapters::edgar::build_client;
+use crate::error::{FinanceError, Result};
+use crate::models::filings::FailToDeliver;
+
+const SEC_WWW_BASE: &str = "https://www.sec.gov";
+
+/// Bi-monthly periods to collect. Three periods cover roughly six weeks.
+const LOOKBACK_PERIODS: usize = 3;
+
+/// Caps walk-back so an unpublished current period doesn't loop forever.
+const MAX_ATTEMPTS: usize = 8;
+
+/// Descending bi-monthly period ids (`YYYYMMa`/`YYYYMMb`) starting at `from`.
+fn periods_desc(from: NaiveDate) -> impl Iterator<Item = String> {
+    let mut year = from.year();
+    let mut month = from.month();
+    let mut half = if from.day() <= 15 { 'a' } else { 'b' };
+    std::iter::from_fn(move || {
+        let period = format!("{year:04}{month:02}{half}");
+        if half == 'b' {
+            half = 'a';
+        } else {
+            half = 'b';
+            month -= 1;
+            if month == 0 {
+                month = 12;
+                year -= 1;
+            }
+        }
+        Some(period)
+    })
+}
+
+fn zip_url(base: &str, period: &str) -> String {
+    format!("{base}/files/data/fails-deliver-data/cnsfails{period}.zip")
+}
+
+/// `SETTLEMENT DATE` (`YYYYMMDD`) to `YYYY-MM-DD`; malformed values pass through as `None`.
+fn format_settlement_date(raw: &str) -> Option<String> {
+    (raw.len() == 8).then(|| format!("{}-{}-{}", &raw[0..4], &raw[4..6], &raw[6..8]))
+}
+
+/// Parse one period's `SETTLEMENT DATE|CUSIP|SYMBOL|QUANTITY (FAILS)|DESCRIPTION|PRICE`
+/// rows, keeping only those matching `symbol` (already uppercased).
+fn parse_rows(text: &str, symbol: &str) -> Vec<FailToDeliver> {
+    text.lines()
+        .skip(1)
+        .filter_map(|line| {
+            let mut cols = line.split('|');
+            let date = cols.next()?;
+            let _cusip = cols.next()?;
+            let sym = cols.next()?;
+            if sym != symbol {
+                return None;
+            }
+            let quantity = cols.next()?;
+            let description = cols.next()?;
+            let price = cols.next()?;
+            let name = description.trim();
+            Some(FailToDeliver {
+                symbol: Some(sym.to_string()),
+                date: format_settlement_date(date),
+                quantity: quantity.trim().parse().ok(),
+                price: price.trim().parse().ok(),
+                name: (!name.is_empty()).then(|| name.to_string()),
+                description: None,
+            })
+        })
+        .collect()
+}
+
+fn parse_period(bytes: &[u8], symbol: &str) -> Result<Vec<FailToDeliver>> {
+    let mut archive = zip::ZipArchive::new(Cursor::new(bytes)).map_err(|e| {
+        FinanceError::ResponseStructureError {
+            field: "secftd.zip".to_string(),
+            context: format!("failed to open fails-to-deliver archive: {e}"),
+        }
+    })?;
+    let mut entry = archive
+        .by_index(0)
+        .map_err(|e| FinanceError::ResponseStructureError {
+            field: "secftd.zip".to_string(),
+            context: format!("empty fails-to-deliver archive: {e}"),
+        })?;
+    let mut text = String::new();
+    entry
+        .read_to_string(&mut text)
+        .map_err(|e| FinanceError::ResponseStructureError {
+            field: "secftd.zip".to_string(),
+            context: format!("non-UTF8 fails-to-deliver data: {e}"),
+        })?;
+    Ok(parse_rows(&text, symbol))
+}
+
+async fn fetch_fails_to_deliver_with(
+    base: &str,
+    symbol: &str,
+    lookback_periods: usize,
+    max_attempts: usize,
+) -> Result<Vec<FailToDeliver>> {
+    let client = build_client()?;
+    let symbol = symbol.to_uppercase();
+    let mut records = Vec::new();
+    let mut periods_found = 0;
+
+    for period in periods_desc(Utc::now().date_naive()).take(max_attempts) {
+        if periods_found >= lookback_periods {
+            break;
+        }
+        let bytes = match client.get_document(&zip_url(base, &period)).await {
+            Ok(bytes) => bytes,
+            // Not yet published for this half-month; walk further back.
+            Err(FinanceError::SymbolNotFound { .. }) => continue,
+            Err(e) => return Err(e),
+        };
+        records.extend(parse_period(&bytes, &symbol)?);
+        periods_found += 1;
+    }
+
+    records.sort_by(|a, b| a.date.cmp(&b.date));
+    Ok(records)
+}
+
+/// Fetch fails-to-deliver records for a symbol across the most recent
+/// available bi-monthly periods, oldest first.
+pub(crate) async fn fetch_fails_to_deliver_response(symbol: &str) -> Result<Vec<FailToDeliver>> {
+    fetch_fails_to_deliver_with(SEC_WWW_BASE, symbol, LOOKBACK_PERIODS, MAX_ATTEMPTS).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn periods_walk_back_across_year_and_half_boundaries() {
+        let start = NaiveDate::from_ymd_opt(2026, 1, 10).unwrap();
+        let periods: Vec<String> = periods_desc(start).take(4).collect();
+        assert_eq!(periods, vec!["202601a", "202512b", "202512a", "202511b"]);
+    }
+
+    #[test]
+    fn periods_split_on_the_15th() {
+        let first_half = NaiveDate::from_ymd_opt(2026, 3, 15).unwrap();
+        let second_half = NaiveDate::from_ymd_opt(2026, 3, 16).unwrap();
+        assert_eq!(periods_desc(first_half).next().unwrap(), "202603a");
+        assert_eq!(periods_desc(second_half).next().unwrap(), "202603b");
+    }
+
+    #[test]
+    fn rows_are_filtered_by_symbol_and_mapped() {
+        let text = "SETTLEMENT DATE|CUSIP|SYMBOL|QUANTITY (FAILS)|DESCRIPTION|PRICE\n\
+                     20250602|037833100|AAPL|69|APPLE INC;COM NPV|201.70\n\
+                     20250602|B38564108|CMBT|51003|CMB.TECH NV (BEL)|8.83\n";
+
+        let rows = parse_rows(text, "AAPL");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].symbol.as_deref(), Some("AAPL"));
+        assert_eq!(rows[0].date.as_deref(), Some("2025-06-02"));
+        assert_eq!(rows[0].quantity, Some(69.0));
+        assert!((rows[0].price.unwrap() - 201.70).abs() < 1e-9);
+        assert_eq!(rows[0].name.as_deref(), Some("APPLE INC;COM NPV"));
+    }
+
+    #[test]
+    fn a_symbol_absent_from_the_period_yields_no_rows() {
+        let text = "SETTLEMENT DATE|CUSIP|SYMBOL|QUANTITY (FAILS)|DESCRIPTION|PRICE\n\
+                     20250602|B38564108|CMBT|51003|CMB.TECH NV (BEL)|8.83\n";
+        assert!(parse_rows(text, "AAPL").is_empty());
+    }
+
+    fn zip_bytes(inner_name: &str, contents: &str) -> Vec<u8> {
+        let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
+        let options = zip::write::SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Stored);
+        writer.start_file(inner_name, options).unwrap();
+        writer.write_all(contents.as_bytes()).unwrap();
+        writer.finish().unwrap().into_inner()
+    }
+
+    #[tokio::test]
+    async fn fetches_the_current_period_when_it_is_already_published() {
+        let _ = crate::adapters::edgar::init("test@example.com");
+        let mut server = mockito::Server::new_async().await;
+        let period = periods_desc(Utc::now().date_naive()).next().unwrap();
+        let body = zip_bytes(
+            &format!("cnsfails{period}"),
+            "SETTLEMENT DATE|CUSIP|SYMBOL|QUANTITY (FAILS)|DESCRIPTION|PRICE\n\
+             20250602|037833100|AAPL|69|APPLE INC;COM NPV|201.70\n",
+        );
+        let _m = server
+            .mock(
+                "GET",
+                format!("/files/data/fails-deliver-data/cnsfails{period}.zip").as_str(),
+            )
+            .with_status(200)
+            .with_header("content-type", "application/octet-stream")
+            .with_body(body)
+            .create_async()
+            .await;
+
+        let records = fetch_fails_to_deliver_with(&server.url(), "AAPL", 1, 1)
+            .await
+            .unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].symbol.as_deref(), Some("AAPL"));
+    }
+
+    #[tokio::test]
+    async fn walks_back_one_period_when_the_current_one_is_unpublished() {
+        let _ = crate::adapters::edgar::init("test@example.com");
+        let mut server = mockito::Server::new_async().await;
+        let mut periods = periods_desc(Utc::now().date_naive());
+        let current = periods.next().unwrap();
+        let previous = periods.next().unwrap();
+
+        let _missing = server
+            .mock(
+                "GET",
+                format!("/files/data/fails-deliver-data/cnsfails{current}.zip").as_str(),
+            )
+            .with_status(404)
+            .create_async()
+            .await;
+        let body = zip_bytes(
+            &format!("cnsfails{previous}"),
+            "SETTLEMENT DATE|CUSIP|SYMBOL|QUANTITY (FAILS)|DESCRIPTION|PRICE\n\
+             20250602|037833100|AAPL|69|APPLE INC;COM NPV|201.70\n",
+        );
+        let _m = server
+            .mock(
+                "GET",
+                format!("/files/data/fails-deliver-data/cnsfails{previous}.zip").as_str(),
+            )
+            .with_status(200)
+            .with_header("content-type", "application/octet-stream")
+            .with_body(body)
+            .create_async()
+            .await;
+
+        let records = fetch_fails_to_deliver_with(&server.url(), "AAPL", 1, 4)
+            .await
+            .unwrap();
+        assert_eq!(records.len(), 1);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires network access"]
+    async fn test_live_fails_to_deliver() {
+        let _ = crate::adapters::edgar::init("test@example.com");
+        let records = fetch_fails_to_deliver_response("AAPL").await.unwrap();
+        assert!(!records.is_empty());
+    }
+}

--- a/src/adapters/edgar/filings/mod.rs
+++ b/src/adapters/edgar/filings/mod.rs
@@ -3,6 +3,8 @@
 //! The submissions / company-facts / filing-index calls predate this directory
 //! and still live in the parent module; new routed operations land here.
 
+#[cfg(feature = "secftd")]
+pub mod fails_to_deliver;
 pub mod full_text;
 pub mod insider;
 pub mod thirteen_f;

--- a/src/domains/filings.rs
+++ b/src/domains/filings.rs
@@ -197,7 +197,7 @@ impl Filings {
     }
 
     /// SEC fails-to-deliver data for this symbol, via the FILINGS route
-    /// (currently FMP only). Not cached.
+    /// (FMP, or keyless EDGAR when FMP isn't routed). Not cached.
     pub async fn fails_to_deliver(&self) -> Result<Vec<crate::models::filings::FailToDeliver>> {
         let symbol: String = self.symbol().to_string();
         self.providers

--- a/src/models/filings/ownership.rs
+++ b/src/models/filings/ownership.rs
@@ -6,8 +6,8 @@
 //! come straight from the filed XML — Forms 3/4/5 for insider activity and
 //! 13F-HR information tables for institutional positions. EDGAR is the only
 //! source for [`InstitutionalHolding`]; [`InsiderTrade`] also has Alpha
-//! Vantage and FMP fallbacks. Congressional trades and fails-to-deliver are
-//! FMP-only for now.
+//! Vantage and FMP fallbacks. Congressional trades is FMP-only for now;
+//! fails-to-deliver also has a keyless EDGAR fallback (feature `secftd`).
 
 use serde::{Deserialize, Serialize};
 

--- a/src/providers/edgar.rs
+++ b/src/providers/edgar.rs
@@ -49,6 +49,15 @@ impl FilingsProvider for EdgarProvider {
         crate::adapters::edgar::filings::thirteen_f::fetch_institutional_holdings_response(symbol)
             .await
     }
+
+    #[cfg(feature = "secftd")]
+    async fn fetch_fails_to_deliver(
+        &self,
+        symbol: &str,
+    ) -> Result<Vec<crate::models::filings::FailToDeliver>> {
+        crate::adapters::edgar::filings::fails_to_deliver::fetch_fails_to_deliver_response(symbol)
+            .await
+    }
 }
 
 #[async_trait::async_trait]


### PR DESCRIPTION
## Description
SEC fails-to-deliver data is published as free bi-monthly flat files at sec.gov/files/data/fails-deliver-data, keyless like the rest of EDGAR, so this extends the existing EDGAR adapter instead of standing up a new provider. Gated behind a new `secftd` feature. FILINGS now routes `Edgar`+`Yahoo` unconditionally in the server instead of only when `FMP_API_KEY` is set. Congressional trades stays FMP-only: senate-stock-watcher and house-stock-watcher, the well-known free aggregators, have been dead since 2021 (S3 buckets now 403), and the one live keyless alternative found reports 82 days of data staleness despite advertising a 6-hour refresh, which isn't solid enough to build a library feature against.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Added `src/adapters/edgar/filings/fails_to_deliver.rs`: period math, walk-back to the latest published bi-monthly report, zip download, row parsing/filtering.
- Added a new `secftd` Cargo feature (pulls in the `zip` dependency already used by `translation-offline`).
- Implemented `FilingsProvider::fetch_fails_to_deliver` for EDGAR behind `#[cfg(feature = "secftd")]`.
- Changed `route_table()`'s `FILINGS` route to include `Edgar`+`Yahoo` unconditionally instead of only when `FMP_API_KEY` is set.
- Fixed stale "currently FMP only" doc comments across the REST handler, GraphQL resolver, MCP tool description, and domain handle for `fails_to_deliver` (found while manually verifying the endpoint); regenerated `server/schema.graphql`.
- Congressional trades intentionally left FMP-only after researching available free alternatives and finding none reliable enough.

## Breaking Changes
None. `FILINGS` gains an always-present keyless fallback; no existing candidate is removed.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All tests pass (`cargo test`)

Ran locally against the live SEC endpoint, not just the test suite:
- `cargo test -p finance-query --features full --lib fails_to_deliver`: 6 passed, 0 failed, 1 ignored
- `cargo test -p finance-query --features full --lib -- --ignored fails_to_deliver`: 1 passed (live SEC network call)
- `cargo test -p finance-query-server --features finance-query/full --lib`: 38 passed, 0 failed
- Started the server locally with `FMP_API_KEY` unset and `EDGAR_EMAIL` set, then `curl localhost:8091/v2/filings/GME/fails-to-deliver` and `.../AAPL/fails-to-deliver` — both returned real SEC fails-to-deliver records with `HTTP 200`. Confirmed `.../GME/congressional-trades` still correctly returns `501` without `FMP_API_KEY`, unaffected by this change.

## Documentation
- [x] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues
Closes #