### PR TITLE
feat: route employee count through EDGAR

### DIFF
--- a/src/adapters/edgar/filings/employee_count.rs
+++ b/src/adapters/edgar/filings/employee_count.rs
@@ -137,6 +137,7 @@ mod tests {
     #[tokio::test]
     #[ignore = "requires network access"]
     async fn fetches_hii_employee_count_from_live_edgar() {
+        let _ = crate::adapters::edgar::init("test@example.com");
         let out = fetch_employee_count_response("HII").await.unwrap();
         assert!(!out.is_empty());
         assert!(out[0].employee_count.unwrap() > 0);

--- a/src/adapters/edgar/filings/employee_count.rs
+++ b/src/adapters/edgar/filings/employee_count.rs
@@ -1,0 +1,144 @@
+//! Employee headcount extracted from EDGAR's XBRL company facts.
+//!
+//! `dei:EntityNumberOfEmployees` is a voluntary cover-page tag that most
+//! filers, including large caps like Apple, don't use — absence here is a
+//! real "not reported" result, not a parsing failure.
+
+use crate::adapters::edgar::company_facts_for_symbol;
+use crate::error::{FinanceError, Result};
+use crate::models::corporate::governance::EmployeeCount;
+use crate::models::filings::{CompanyFacts, FactUnit};
+
+fn to_employee_count(
+    unit: &FactUnit,
+    symbol: &str,
+    cik: Option<u64>,
+    company_name: &Option<String>,
+) -> EmployeeCount {
+    EmployeeCount {
+        symbol: Some(symbol.to_string()),
+        cik: cik.map(|c| c.to_string()),
+        company_name: company_name.clone(),
+        employee_count: unit.val.map(|v| v as i64),
+        period_of_report: unit.end.clone(),
+        form_type: unit.form.clone(),
+        filing_date: unit.filed.clone(),
+        source: match (cik, &unit.accn) {
+            (Some(cik), Some(accn)) => Some(format!(
+                "https://www.sec.gov/Archives/edgar/data/{cik}/{}/",
+                accn.replace('-', "")
+            )),
+            _ => None,
+        },
+    }
+}
+
+fn dei_employee_counts(facts: &CompanyFacts, symbol: &str) -> Result<Vec<EmployeeCount>> {
+    let units = facts
+        .dei()
+        .and_then(|dei| dei.0.get("EntityNumberOfEmployees"))
+        .and_then(|concept| concept.units.get("pure"))
+        .ok_or_else(|| FinanceError::ResponseStructureError {
+            field: "facts.dei.EntityNumberOfEmployees".to_string(),
+            context: format!("{symbol} does not report this tag"),
+        })?;
+
+    let mut out: Vec<EmployeeCount> = units
+        .iter()
+        .map(|unit| to_employee_count(unit, symbol, facts.cik, &facts.entity_name))
+        .collect();
+    out.sort_by(|a, b| b.period_of_report.cmp(&a.period_of_report));
+    Ok(out)
+}
+
+/// Fetch canonical employee headcount history, most recent period first.
+pub async fn fetch_employee_count_response(symbol: &str) -> Result<Vec<EmployeeCount>> {
+    let facts = company_facts_for_symbol(symbol).await?;
+    dei_employee_counts(&facts, symbol)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn facts_with_employees(entries: serde_json::Value) -> CompanyFacts {
+        serde_json::from_value(serde_json::json!({
+            "cik": 320193,
+            "entityName": "Apple Inc.",
+            "facts": {
+                "dei": {
+                    "EntityNumberOfEmployees": {
+                        "label": "Entity Number of Employees",
+                        "units": { "pure": entries }
+                    }
+                }
+            }
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn maps_filing_metadata_and_builds_source_url() {
+        let facts = facts_with_employees(serde_json::json!([{
+            "end": "2023-09-30",
+            "val": 161_000,
+            "accn": "0000320193-23-000106",
+            "form": "10-K",
+            "filed": "2023-11-03"
+        }]));
+
+        let out = dei_employee_counts(&facts, "AAPL").unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].employee_count, Some(161_000));
+        assert_eq!(out[0].period_of_report.as_deref(), Some("2023-09-30"));
+        assert_eq!(out[0].form_type.as_deref(), Some("10-K"));
+        assert_eq!(out[0].cik.as_deref(), Some("320193"));
+        assert_eq!(
+            out[0].source.as_deref(),
+            Some("https://www.sec.gov/Archives/edgar/data/320193/000032019323000106/")
+        );
+    }
+
+    #[test]
+    fn sorts_most_recent_period_first() {
+        let facts = facts_with_employees(serde_json::json!([
+            { "end": "2021-09-30", "val": 100_000, "form": "10-K" },
+            { "end": "2023-09-30", "val": 161_000, "form": "10-K" },
+            { "end": "2022-09-30", "val": 150_000, "form": "10-K" }
+        ]));
+
+        let out = dei_employee_counts(&facts, "AAPL").unwrap();
+        assert_eq!(
+            out.iter()
+                .map(|e| e.period_of_report.clone())
+                .collect::<Vec<_>>(),
+            vec![
+                Some("2023-09-30".to_string()),
+                Some("2022-09-30".to_string()),
+                Some("2021-09-30".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn missing_tag_errors_instead_of_returning_empty() {
+        let facts: CompanyFacts = serde_json::from_value(serde_json::json!({
+            "cik": 320193,
+            "entityName": "Apple Inc.",
+            "facts": { "us-gaap": {} }
+        }))
+        .unwrap();
+
+        assert!(dei_employee_counts(&facts, "AAPL").is_err());
+    }
+
+    /// HII tags `dei:EntityNumberOfEmployees`; most filers (including AAPL)
+    /// don't, so this is one of the few reliable live fixtures.
+    #[tokio::test]
+    #[ignore = "requires network access"]
+    async fn fetches_hii_employee_count_from_live_edgar() {
+        let out = fetch_employee_count_response("HII").await.unwrap();
+        assert!(!out.is_empty());
+        assert!(out[0].employee_count.unwrap() > 0);
+    }
+}

--- a/src/adapters/edgar/filings/mod.rs
+++ b/src/adapters/edgar/filings/mod.rs
@@ -3,6 +3,7 @@
 //! The submissions / company-facts / filing-index calls predate this directory
 //! and still live in the parent module; new routed operations land here.
 
+pub mod employee_count;
 #[cfg(feature = "secftd")]
 pub mod fails_to_deliver;
 pub mod full_text;

--- a/src/models/corporate/governance.rs
+++ b/src/models/corporate/governance.rs
@@ -1,9 +1,11 @@
 //! Corporate governance models: executive compensation and employee headcount.
 //!
 //! Served through the [`Capability::CORPORATE`](crate::Capability::CORPORATE)
-//! route; FMP is currently the only provider. Both are derived from the
-//! company's own SEC filings (DEF 14A proxy statements and 10-K cover pages
-//! respectively), so figures are annual and lag the filing date.
+//! route. Both are derived from the company's own SEC filings (DEF 14A proxy
+//! statements and 10-K/10-Q cover pages respectively), so figures are annual
+//! and lag the filing date. EDGAR serves employee counts filed under the
+//! voluntary `dei:EntityNumberOfEmployees` tag, which most filers don't use;
+//! FMP remains the more complete source.
 
 use serde::{Deserialize, Serialize};
 

--- a/src/providers/edgar.rs
+++ b/src/providers/edgar.rs
@@ -103,6 +103,13 @@ impl CorporateProvider for EdgarProvider {
         )
         .await
     }
+
+    async fn fetch_employee_count(
+        &self,
+        symbol: &str,
+    ) -> Result<Vec<crate::models::corporate::governance::EmployeeCount>> {
+        crate::adapters::edgar::filings::employee_count::fetch_employee_count_response(symbol).await
+    }
 }
 
 #[async_trait::async_trait]


### PR DESCRIPTION
## Description
EDGAR's XBRL company facts already carry `dei:EntityNumberOfEmployees`, a voluntary cover-page tag that only FMP served until now. Wires it into `EdgarProvider` so employee-count history routes there first, keyless, falling back to FMP when the tag isn't present. Verified live against real EDGAR data: Huntington Ingalls reports the tag, Apple and most large caps don't, so this closes the gap only partially rather than fully replacing FMP.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Added `dei_employee_counts` in `src/adapters/edgar/filings/employee_count.rs`, mapping `CompanyFacts.dei()`'s `EntityNumberOfEmployees` fact to `EmployeeCount`, sorted most-recent-first.
- Wired `fetch_employee_count` into `EdgarProvider`'s existing `CorporateProvider` impl.
- Returns an error rather than an empty list when the tag is absent, so `Fetch::Sequential` routing falls through to FMP instead of reporting a false "zero history."

## Breaking Changes
None.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All tests pass (`cargo test`)

3 unit tests + 1 live-network test (`fetches_hii_employee_count_from_live_edgar`), verified against real EDGAR data. Full workspace suite (1351 tests) passes at the tip of this stack; clippy clean.

## Documentation
- [x] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues
N/A
