### PR TITLE
feat: route active listing status through EDGAR

### DIFF
--- a/src/adapters/edgar/client.rs
+++ b/src/adapters/edgar/client.rs
@@ -9,11 +9,27 @@ use crate::models::filings::{
     CompanyFacts, EdgarFilingIndex, EdgarSearchResults, EdgarSubmissions,
 };
 use crate::rate_limiter::RateLimiter;
+use serde::Deserialize;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
 use tracing::{debug, info};
+
+/// One row of SEC's ticker reference file.
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct CompanyTickerEntry {
+    #[serde(rename = "cik_str")]
+    pub cik: u64,
+    pub ticker: String,
+    pub title: String,
+}
+
+/// SEC's ticker-exchange file: `{"fields": [...], "data": [[cik, name, ticker, exchange], ...]}`.
+#[derive(Debug, Deserialize)]
+struct CompanyTickersExchangeResponse {
+    data: Vec<(u64, String, String, Option<String>)>,
+}
 
 /// Builder for constructing an [`EdgarClient`].
 ///
@@ -239,6 +255,32 @@ impl EdgarClient {
         info!("Loaded {} ticker-to-CIK mappings from SEC EDGAR", map.len());
         *cache = Some(map);
         Ok(())
+    }
+
+    // ========================================================================
+    // Ticker Reference Data
+    // ========================================================================
+
+    /// Fetch SEC's full ticker-to-company reference list.
+    ///
+    /// This is the same file [`resolve_cik`](Self::resolve_cik) caches from,
+    /// fetched fresh here since this is a rare bulk-listing call rather than
+    /// the per-symbol hot path.
+    pub async fn company_tickers(&self) -> Result<Vec<CompanyTickerEntry>> {
+        let response = self.get(urls::COMPANY_TICKERS).await?;
+        let json: HashMap<String, CompanyTickerEntry> = response.json().await?;
+        Ok(json.into_values().collect())
+    }
+
+    /// Fetch SEC's ticker-to-listing-exchange reference list.
+    pub async fn company_tickers_exchange(&self) -> Result<HashMap<String, String>> {
+        let response = self.get(urls::COMPANY_TICKERS_EXCHANGE).await?;
+        let body: CompanyTickersExchangeResponse = response.json().await?;
+        Ok(body
+            .data
+            .into_iter()
+            .filter_map(|(_, _, ticker, exchange)| exchange.map(|e| (ticker, e)))
+            .collect())
     }
 
     // ========================================================================

--- a/src/adapters/edgar/discovery/mod.rs
+++ b/src/adapters/edgar/discovery/mod.rs
@@ -89,6 +89,7 @@ mod tests {
     #[tokio::test]
     #[ignore = "requires network access"]
     async fn fetches_the_full_listing_from_live_edgar() {
+        let _ = crate::adapters::edgar::init("test@example.com");
         let out = fetch_listing_status_response(true).await.unwrap();
         assert!(out.len() > 5000);
         let aapl = out.iter().find(|s| s.symbol == "AAPL").unwrap();

--- a/src/adapters/edgar/discovery/mod.rs
+++ b/src/adapters/edgar/discovery/mod.rs
@@ -1,0 +1,98 @@
+//! DISCOVERY capability: SEC's active-listing universe.
+//!
+//! `company_tickers.json` has no delisted-securities history, so this only
+//! ever answers `active = true` queries.
+
+use crate::adapters::edgar::build_client;
+use crate::adapters::edgar::client::CompanyTickerEntry;
+use crate::error::Result;
+use crate::models::discovery::reference::SymbolMatch;
+use crate::providers::{Operation, Provider};
+
+fn to_symbol_match(entry: CompanyTickerEntry, exchange: Option<&String>) -> SymbolMatch {
+    SymbolMatch {
+        symbol: entry.ticker,
+        id: Some(entry.cik.to_string()),
+        name: Some(entry.title),
+        exchange: exchange.cloned(),
+        asset_type: None,
+        currency: None,
+        active: Some(true),
+        market_cap_rank: None,
+        thumbnail: None,
+        image: None,
+    }
+}
+
+/// Fetch canonical listing status. `active = false` is not supported — SEC's
+/// bulk ticker files carry no delisted-securities history.
+pub async fn fetch_listing_status_response(active: bool) -> Result<Vec<SymbolMatch>> {
+    if !active {
+        return Err(Operation::ListingStatus.not_supported(Provider::Edgar));
+    }
+
+    let client = build_client()?;
+    let (tickers, exchanges) =
+        tokio::try_join!(client.company_tickers(), client.company_tickers_exchange())?;
+
+    Ok(tickers
+        .into_iter()
+        .map(|entry| {
+            let exchange = exchanges.get(&entry.ticker);
+            to_symbol_match(entry, exchange)
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_a_ticker_row_with_its_exchange() {
+        let entry = CompanyTickerEntry {
+            cik: 320193,
+            ticker: "AAPL".to_string(),
+            title: "Apple Inc.".to_string(),
+        };
+        let exchange = "Nasdaq".to_string();
+
+        let out = to_symbol_match(entry, Some(&exchange));
+        assert_eq!(out.symbol, "AAPL");
+        assert_eq!(out.id.as_deref(), Some("320193"));
+        assert_eq!(out.name.as_deref(), Some("Apple Inc."));
+        assert_eq!(out.exchange.as_deref(), Some("Nasdaq"));
+        assert_eq!(out.active, Some(true));
+    }
+
+    #[test]
+    fn missing_exchange_row_leaves_exchange_none() {
+        let entry = CompanyTickerEntry {
+            cik: 1,
+            ticker: "ZZZ".to_string(),
+            title: "Unmatched Inc.".to_string(),
+        };
+
+        let out = to_symbol_match(entry, None);
+        assert_eq!(out.exchange, None);
+    }
+
+    #[tokio::test]
+    async fn delisted_query_is_not_supported() {
+        let err = fetch_listing_status_response(false).await.unwrap_err();
+        assert!(matches!(
+            err,
+            crate::error::FinanceError::NotSupported { .. }
+        ));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires network access"]
+    async fn fetches_the_full_listing_from_live_edgar() {
+        let out = fetch_listing_status_response(true).await.unwrap();
+        assert!(out.len() > 5000);
+        let aapl = out.iter().find(|s| s.symbol == "AAPL").unwrap();
+        assert_eq!(aapl.name.as_deref(), Some("Apple Inc."));
+        assert_eq!(aapl.exchange.as_deref(), Some("Nasdaq"));
+    }
+}

--- a/src/adapters/edgar/endpoints.rs
+++ b/src/adapters/edgar/endpoints.rs
@@ -6,6 +6,11 @@
 /// All ticker-to-CIK mappings (JSON, ~2MB).
 pub const COMPANY_TICKERS: &str = "https://www.sec.gov/files/company_tickers.json";
 
+/// Ticker-to-listing-exchange mappings (JSON, ~1MB). Covers active listings
+/// only — SEC keeps no delisted-securities file.
+pub const COMPANY_TICKERS_EXCHANGE: &str =
+    "https://www.sec.gov/files/company_tickers_exchange.json";
+
 /// Build the submissions URL for a CIK (filing history + company metadata).
 ///
 /// CIK is zero-padded to 10 digits as required by the EDGAR API.

--- a/src/adapters/edgar/mod.rs
+++ b/src/adapters/edgar/mod.rs
@@ -36,6 +36,7 @@
 //! ```
 
 mod client;
+pub(crate) mod discovery; // DISCOVERY
 mod endpoints;
 pub(crate) mod filings; // FILINGS
 

--- a/src/domains/discovery.rs
+++ b/src/domains/discovery.rs
@@ -96,7 +96,9 @@ impl Discovery {
     /// `active = false` asks for delisted securities instead. This is an
     /// unfiltered dump — expect thousands of rows in one response — so prefer
     /// [`search`](Self::search) when you have a query. Cached per `active`.
-    /// Currently Alpha Vantage only.
+    /// EDGAR serves `active = true` keylessly from SEC's bulk ticker files
+    /// (no exchange-listing history, so `active = false` isn't supported
+    /// there); Alpha Vantage and FMP serve both.
     pub async fn listing_status(&self, active: bool) -> Result<Vec<SymbolMatch>> {
         let providers = Arc::clone(&self.providers);
         self.cache

--- a/src/providers/edgar.rs
+++ b/src/providers/edgar.rs
@@ -4,7 +4,9 @@
 //! Always available — no API key required (needs `EDGAR_EMAIL` env var
 //! or an `edgar::init()` call before use).
 
-use super::{CorporateProvider, FilingsProvider, Operation, ProviderAdapter, ProviderCore};
+use super::{
+    CorporateProvider, DiscoveryProvider, FilingsProvider, Operation, ProviderAdapter, ProviderCore,
+};
 use crate::error::Result;
 use crate::models::filings::ProviderFilings;
 
@@ -112,6 +114,25 @@ impl CorporateProvider for EdgarProvider {
     }
 }
 
+/// EDGAR has no free-text symbol search — only the bulk ticker listing.
+#[async_trait::async_trait]
+impl DiscoveryProvider for EdgarProvider {
+    async fn fetch_symbol_search(
+        &self,
+        _query: &str,
+        _limit: u32,
+    ) -> Result<Vec<crate::models::discovery::reference::SymbolMatch>> {
+        Err(self.not_supported(Operation::SymbolSearch))
+    }
+
+    async fn fetch_listing_status(
+        &self,
+        active: bool,
+    ) -> Result<Vec<crate::models::discovery::reference::SymbolMatch>> {
+        crate::adapters::edgar::discovery::fetch_listing_status_response(active).await
+    }
+}
+
 #[async_trait::async_trait]
 impl ProviderAdapter for EdgarProvider {
     fn as_filings(&self) -> Option<&dyn FilingsProvider> {
@@ -119,6 +140,10 @@ impl ProviderAdapter for EdgarProvider {
     }
 
     fn as_corporate(&self) -> Option<&dyn CorporateProvider> {
+        Some(self)
+    }
+
+    fn as_discovery(&self) -> Option<&dyn DiscoveryProvider> {
         Some(self)
     }
 }


### PR DESCRIPTION
## Description
SEC's bulk `company_tickers.json` file is already fetched internally for CIK resolution, but only the ticker-to-CIK reduction, not the full row data listing status needs. Adds a second bulk fetch plus `company_tickers_exchange.json` for the exchange field, and routes `active=true` listing-status queries through EDGAR, keyless. `active=false` stays FMP/Alpha Vantage-only, since SEC's files carry no delisted-securities history to serve it from.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Added `company_tickers`/`company_tickers_exchange` client methods to `EdgarClient`, and a `COMPANY_TICKERS_EXCHANGE` endpoint constant.
- Added `src/adapters/edgar/discovery/mod.rs`, mapping the joined ticker/exchange rows to `SymbolMatch`.
- Wired a `DiscoveryProvider` impl into `EdgarProvider`, returning `NotSupported` for `active=false` and for free-text symbol search, since EDGAR has neither.

## Breaking Changes
None.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All tests pass (`cargo test`)

3 unit tests + 1 live-network test (`fetches_the_full_listing_from_live_edgar`, 10k+ symbols), verified against real EDGAR data. Full workspace suite passes at the tip of this stack; clippy clean.

## Documentation
- [x] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues
N/A
