### PR TITLE
feat: serve exchanges from a local static table

### DIFF
--- a/soothfast.lock
+++ b/soothfast.lock
@@ -50,7 +50,7 @@
     "finance_query::models::sentiment::response::FearAndGreed": "9ff1c525f8b3de3d",
     "finance_query::providers::Capability": "2f58b918177f54e7",
     "finance_query::providers::Fetch": "716d0ecf6acde694",
-    "finance_query::providers::Provider": "b65bd092e2218214",
+    "finance_query::providers::Provider": "0695391e93fc2b1a",
     "finance_query::risk::RiskSummary": "ce95c5249016cb91",
     "finance_query::risk::beta::beta": "0dfd56b8cbadb56d",
     "finance_query::risk::ratios::sharpe_ratio": "25ed949fa65a8abe",

--- a/src/providers/local_exchanges.rs
+++ b/src/providers/local_exchanges.rs
@@ -1,0 +1,262 @@
+//! A static table of major global exchanges, computed locally rather than
+//! fetched. Unlike [`market_calendar`](super::market_calendar)'s holiday
+//! rules, MIC codes aren't derivable from a formula — this table needs
+//! occasional manual maintenance as venues merge or rebrand.
+
+use super::{DiscoveryProvider, Operation, ProviderAdapter, ProviderCore};
+use crate::error::Result;
+use crate::models::discovery::reference::{ExchangeInfo, SymbolMatch};
+
+pub(crate) struct LocalExchangeProvider;
+
+impl ProviderCore for LocalExchangeProvider {
+    fn id(&self) -> super::Provider {
+        super::Provider::LocalExchange
+    }
+}
+
+#[async_trait::async_trait]
+impl DiscoveryProvider for LocalExchangeProvider {
+    async fn fetch_symbol_search(&self, _query: &str, _limit: u32) -> Result<Vec<SymbolMatch>> {
+        Err(self.not_supported(Operation::SymbolSearch))
+    }
+
+    async fn fetch_exchanges(&self) -> Result<Vec<ExchangeInfo>> {
+        Ok(EXCHANGES.iter().map(|e| e.to_exchange_info()).collect())
+    }
+}
+
+#[async_trait::async_trait]
+impl ProviderAdapter for LocalExchangeProvider {
+    fn as_discovery(&self) -> Option<&dyn DiscoveryProvider> {
+        Some(self)
+    }
+}
+
+struct StaticExchange {
+    name: &'static str,
+    mic: &'static str,
+    operating_mic: &'static str,
+    asset_class: &'static str,
+    locale: &'static str,
+    exchange_type: &'static str,
+    url: &'static str,
+}
+
+impl StaticExchange {
+    fn to_exchange_info(&self) -> ExchangeInfo {
+        ExchangeInfo {
+            id: None,
+            name: Some(self.name.to_string()),
+            mic: Some(self.mic.to_string()),
+            operating_mic: Some(self.operating_mic.to_string()),
+            asset_class: Some(self.asset_class.to_string()),
+            locale: Some(self.locale.to_string()),
+            exchange_type: Some(self.exchange_type.to_string()),
+            url: Some(self.url.to_string()),
+        }
+    }
+}
+
+const EXCHANGES: &[StaticExchange] = &[
+    StaticExchange {
+        name: "New York Stock Exchange",
+        mic: "XNYS",
+        operating_mic: "XNYS",
+        asset_class: "stocks",
+        locale: "us",
+        exchange_type: "exchange",
+        url: "https://www.nyse.com",
+    },
+    StaticExchange {
+        name: "Nasdaq",
+        mic: "XNAS",
+        operating_mic: "XNAS",
+        asset_class: "stocks",
+        locale: "us",
+        exchange_type: "exchange",
+        url: "https://www.nasdaq.com",
+    },
+    StaticExchange {
+        name: "NYSE Arca",
+        mic: "ARCX",
+        operating_mic: "XNYS",
+        asset_class: "stocks",
+        locale: "us",
+        exchange_type: "exchange",
+        url: "https://www.nyse.com/markets/nyse-arca",
+    },
+    StaticExchange {
+        name: "Cboe BZX Exchange",
+        mic: "BATS",
+        operating_mic: "XCBO",
+        asset_class: "stocks",
+        locale: "us",
+        exchange_type: "exchange",
+        url: "https://www.cboe.com",
+    },
+    StaticExchange {
+        name: "IEX",
+        mic: "IEXG",
+        operating_mic: "IEXG",
+        asset_class: "stocks",
+        locale: "us",
+        exchange_type: "exchange",
+        url: "https://iextrading.com",
+    },
+    StaticExchange {
+        name: "OTC Markets",
+        mic: "OTCM",
+        operating_mic: "OTCM",
+        asset_class: "stocks",
+        locale: "us",
+        exchange_type: "TRF",
+        url: "https://www.otcmarkets.com",
+    },
+    StaticExchange {
+        name: "Toronto Stock Exchange",
+        mic: "XTSE",
+        operating_mic: "XTSE",
+        asset_class: "stocks",
+        locale: "ca",
+        exchange_type: "exchange",
+        url: "https://www.tsx.com",
+    },
+    StaticExchange {
+        name: "TSX Venture Exchange",
+        mic: "XTSX",
+        operating_mic: "XTSE",
+        asset_class: "stocks",
+        locale: "ca",
+        exchange_type: "exchange",
+        url: "https://www.tsx.com/tsxv",
+    },
+    StaticExchange {
+        name: "London Stock Exchange",
+        mic: "XLON",
+        operating_mic: "XLON",
+        asset_class: "stocks",
+        locale: "gb",
+        exchange_type: "exchange",
+        url: "https://www.londonstockexchange.com",
+    },
+    StaticExchange {
+        name: "Euronext Paris",
+        mic: "XPAR",
+        operating_mic: "XPAR",
+        asset_class: "stocks",
+        locale: "fr",
+        exchange_type: "exchange",
+        url: "https://www.euronext.com",
+    },
+    StaticExchange {
+        name: "Deutsche Börse Xetra",
+        mic: "XETR",
+        operating_mic: "XETR",
+        asset_class: "stocks",
+        locale: "de",
+        exchange_type: "exchange",
+        url: "https://www.xetra.com",
+    },
+    StaticExchange {
+        name: "SIX Swiss Exchange",
+        mic: "XSWX",
+        operating_mic: "XSWX",
+        asset_class: "stocks",
+        locale: "ch",
+        exchange_type: "exchange",
+        url: "https://www.six-group.com",
+    },
+    StaticExchange {
+        name: "Tokyo Stock Exchange",
+        mic: "XTKS",
+        operating_mic: "XTKS",
+        asset_class: "stocks",
+        locale: "jp",
+        exchange_type: "exchange",
+        url: "https://www.jpx.co.jp",
+    },
+    StaticExchange {
+        name: "Hong Kong Exchange",
+        mic: "XHKG",
+        operating_mic: "XHKG",
+        asset_class: "stocks",
+        locale: "hk",
+        exchange_type: "exchange",
+        url: "https://www.hkex.com.hk",
+    },
+    StaticExchange {
+        name: "Shanghai Stock Exchange",
+        mic: "XSHG",
+        operating_mic: "XSHG",
+        asset_class: "stocks",
+        locale: "cn",
+        exchange_type: "exchange",
+        url: "http://english.sse.com.cn",
+    },
+    StaticExchange {
+        name: "Shenzhen Stock Exchange",
+        mic: "XSHE",
+        operating_mic: "XSHE",
+        asset_class: "stocks",
+        locale: "cn",
+        exchange_type: "exchange",
+        url: "http://www.szse.cn",
+    },
+    StaticExchange {
+        name: "Australian Securities Exchange",
+        mic: "XASX",
+        operating_mic: "XASX",
+        asset_class: "stocks",
+        locale: "au",
+        exchange_type: "exchange",
+        url: "https://www.asx.com.au",
+    },
+    StaticExchange {
+        name: "National Stock Exchange of India",
+        mic: "XNSE",
+        operating_mic: "XNSE",
+        asset_class: "stocks",
+        locale: "in",
+        exchange_type: "exchange",
+        url: "https://www.nseindia.com",
+    },
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn returns_the_full_static_table() {
+        let out = LocalExchangeProvider.fetch_exchanges().await.unwrap();
+        assert_eq!(out.len(), EXCHANGES.len());
+    }
+
+    #[tokio::test]
+    async fn nyse_and_nasdaq_carry_their_known_mic_codes() {
+        let out = LocalExchangeProvider.fetch_exchanges().await.unwrap();
+        let nyse = out
+            .iter()
+            .find(|e| e.name.as_deref() == Some("New York Stock Exchange"))
+            .unwrap();
+        assert_eq!(nyse.mic.as_deref(), Some("XNYS"));
+        let nasdaq = out
+            .iter()
+            .find(|e| e.name.as_deref() == Some("Nasdaq"))
+            .unwrap();
+        assert_eq!(nasdaq.mic.as_deref(), Some("XNAS"));
+    }
+
+    #[tokio::test]
+    async fn symbol_search_is_not_supported() {
+        let err = LocalExchangeProvider
+            .fetch_symbol_search("aapl", 5)
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            crate::error::FinanceError::NotSupported { .. }
+        ));
+    }
+}

--- a/src/providers/local_exchanges.rs
+++ b/src/providers/local_exchanges.rs
@@ -22,7 +22,7 @@ impl DiscoveryProvider for LocalExchangeProvider {
     }
 
     async fn fetch_exchanges(&self) -> Result<Vec<ExchangeInfo>> {
-        Ok(EXCHANGES.iter().map(|e| e.to_exchange_info()).collect())
+        Ok(EXCHANGES.iter().map(to_exchange_info).collect())
     }
 }
 
@@ -33,195 +33,140 @@ impl ProviderAdapter for LocalExchangeProvider {
     }
 }
 
-struct StaticExchange {
-    name: &'static str,
-    mic: &'static str,
-    operating_mic: &'static str,
-    asset_class: &'static str,
-    locale: &'static str,
-    exchange_type: &'static str,
-    url: &'static str,
-}
+/// `(name, mic, operating_mic, locale, url)`. `asset_class` is always
+/// `"stocks"` and `exchange_type` is always `"exchange"` except OTC Markets
+/// (`"TRF"`), so both stay out of the table rather than repeating per row.
+const EXCHANGES: &[(&str, &str, &str, &str, &str)] = &[
+    (
+        "New York Stock Exchange",
+        "XNYS",
+        "XNYS",
+        "us",
+        "https://www.nyse.com",
+    ),
+    ("Nasdaq", "XNAS", "XNAS", "us", "https://www.nasdaq.com"),
+    (
+        "NYSE Arca",
+        "ARCX",
+        "XNYS",
+        "us",
+        "https://www.nyse.com/markets/nyse-arca",
+    ),
+    (
+        "Cboe BZX Exchange",
+        "BATS",
+        "XCBO",
+        "us",
+        "https://www.cboe.com",
+    ),
+    ("IEX", "IEXG", "IEXG", "us", "https://iextrading.com"),
+    (
+        "OTC Markets",
+        "OTCM",
+        "OTCM",
+        "us",
+        "https://www.otcmarkets.com",
+    ),
+    (
+        "Toronto Stock Exchange",
+        "XTSE",
+        "XTSE",
+        "ca",
+        "https://www.tsx.com",
+    ),
+    (
+        "TSX Venture Exchange",
+        "XTSX",
+        "XTSE",
+        "ca",
+        "https://www.tsx.com/tsxv",
+    ),
+    (
+        "London Stock Exchange",
+        "XLON",
+        "XLON",
+        "gb",
+        "https://www.londonstockexchange.com",
+    ),
+    (
+        "Euronext Paris",
+        "XPAR",
+        "XPAR",
+        "fr",
+        "https://www.euronext.com",
+    ),
+    (
+        "Deutsche Börse Xetra",
+        "XETR",
+        "XETR",
+        "de",
+        "https://www.xetra.com",
+    ),
+    (
+        "SIX Swiss Exchange",
+        "XSWX",
+        "XSWX",
+        "ch",
+        "https://www.six-group.com",
+    ),
+    (
+        "Tokyo Stock Exchange",
+        "XTKS",
+        "XTKS",
+        "jp",
+        "https://www.jpx.co.jp",
+    ),
+    (
+        "Hong Kong Exchange",
+        "XHKG",
+        "XHKG",
+        "hk",
+        "https://www.hkex.com.hk",
+    ),
+    (
+        "Shanghai Stock Exchange",
+        "XSHG",
+        "XSHG",
+        "cn",
+        "http://english.sse.com.cn",
+    ),
+    (
+        "Shenzhen Stock Exchange",
+        "XSHE",
+        "XSHE",
+        "cn",
+        "http://www.szse.cn",
+    ),
+    (
+        "Australian Securities Exchange",
+        "XASX",
+        "XASX",
+        "au",
+        "https://www.asx.com.au",
+    ),
+    (
+        "National Stock Exchange of India",
+        "XNSE",
+        "XNSE",
+        "in",
+        "https://www.nseindia.com",
+    ),
+];
 
-impl StaticExchange {
-    fn to_exchange_info(&self) -> ExchangeInfo {
-        ExchangeInfo {
-            id: None,
-            name: Some(self.name.to_string()),
-            mic: Some(self.mic.to_string()),
-            operating_mic: Some(self.operating_mic.to_string()),
-            asset_class: Some(self.asset_class.to_string()),
-            locale: Some(self.locale.to_string()),
-            exchange_type: Some(self.exchange_type.to_string()),
-            url: Some(self.url.to_string()),
-        }
+fn to_exchange_info(
+    &(name, mic, operating_mic, locale, url): &(&str, &str, &str, &str, &str),
+) -> ExchangeInfo {
+    ExchangeInfo {
+        id: None,
+        name: Some(name.to_string()),
+        mic: Some(mic.to_string()),
+        operating_mic: Some(operating_mic.to_string()),
+        asset_class: Some("stocks".to_string()),
+        locale: Some(locale.to_string()),
+        exchange_type: Some(if mic == "OTCM" { "TRF" } else { "exchange" }.to_string()),
+        url: Some(url.to_string()),
     }
 }
-
-const EXCHANGES: &[StaticExchange] = &[
-    StaticExchange {
-        name: "New York Stock Exchange",
-        mic: "XNYS",
-        operating_mic: "XNYS",
-        asset_class: "stocks",
-        locale: "us",
-        exchange_type: "exchange",
-        url: "https://www.nyse.com",
-    },
-    StaticExchange {
-        name: "Nasdaq",
-        mic: "XNAS",
-        operating_mic: "XNAS",
-        asset_class: "stocks",
-        locale: "us",
-        exchange_type: "exchange",
-        url: "https://www.nasdaq.com",
-    },
-    StaticExchange {
-        name: "NYSE Arca",
-        mic: "ARCX",
-        operating_mic: "XNYS",
-        asset_class: "stocks",
-        locale: "us",
-        exchange_type: "exchange",
-        url: "https://www.nyse.com/markets/nyse-arca",
-    },
-    StaticExchange {
-        name: "Cboe BZX Exchange",
-        mic: "BATS",
-        operating_mic: "XCBO",
-        asset_class: "stocks",
-        locale: "us",
-        exchange_type: "exchange",
-        url: "https://www.cboe.com",
-    },
-    StaticExchange {
-        name: "IEX",
-        mic: "IEXG",
-        operating_mic: "IEXG",
-        asset_class: "stocks",
-        locale: "us",
-        exchange_type: "exchange",
-        url: "https://iextrading.com",
-    },
-    StaticExchange {
-        name: "OTC Markets",
-        mic: "OTCM",
-        operating_mic: "OTCM",
-        asset_class: "stocks",
-        locale: "us",
-        exchange_type: "TRF",
-        url: "https://www.otcmarkets.com",
-    },
-    StaticExchange {
-        name: "Toronto Stock Exchange",
-        mic: "XTSE",
-        operating_mic: "XTSE",
-        asset_class: "stocks",
-        locale: "ca",
-        exchange_type: "exchange",
-        url: "https://www.tsx.com",
-    },
-    StaticExchange {
-        name: "TSX Venture Exchange",
-        mic: "XTSX",
-        operating_mic: "XTSE",
-        asset_class: "stocks",
-        locale: "ca",
-        exchange_type: "exchange",
-        url: "https://www.tsx.com/tsxv",
-    },
-    StaticExchange {
-        name: "London Stock Exchange",
-        mic: "XLON",
-        operating_mic: "XLON",
-        asset_class: "stocks",
-        locale: "gb",
-        exchange_type: "exchange",
-        url: "https://www.londonstockexchange.com",
-    },
-    StaticExchange {
-        name: "Euronext Paris",
-        mic: "XPAR",
-        operating_mic: "XPAR",
-        asset_class: "stocks",
-        locale: "fr",
-        exchange_type: "exchange",
-        url: "https://www.euronext.com",
-    },
-    StaticExchange {
-        name: "Deutsche Börse Xetra",
-        mic: "XETR",
-        operating_mic: "XETR",
-        asset_class: "stocks",
-        locale: "de",
-        exchange_type: "exchange",
-        url: "https://www.xetra.com",
-    },
-    StaticExchange {
-        name: "SIX Swiss Exchange",
-        mic: "XSWX",
-        operating_mic: "XSWX",
-        asset_class: "stocks",
-        locale: "ch",
-        exchange_type: "exchange",
-        url: "https://www.six-group.com",
-    },
-    StaticExchange {
-        name: "Tokyo Stock Exchange",
-        mic: "XTKS",
-        operating_mic: "XTKS",
-        asset_class: "stocks",
-        locale: "jp",
-        exchange_type: "exchange",
-        url: "https://www.jpx.co.jp",
-    },
-    StaticExchange {
-        name: "Hong Kong Exchange",
-        mic: "XHKG",
-        operating_mic: "XHKG",
-        asset_class: "stocks",
-        locale: "hk",
-        exchange_type: "exchange",
-        url: "https://www.hkex.com.hk",
-    },
-    StaticExchange {
-        name: "Shanghai Stock Exchange",
-        mic: "XSHG",
-        operating_mic: "XSHG",
-        asset_class: "stocks",
-        locale: "cn",
-        exchange_type: "exchange",
-        url: "http://english.sse.com.cn",
-    },
-    StaticExchange {
-        name: "Shenzhen Stock Exchange",
-        mic: "XSHE",
-        operating_mic: "XSHE",
-        asset_class: "stocks",
-        locale: "cn",
-        exchange_type: "exchange",
-        url: "http://www.szse.cn",
-    },
-    StaticExchange {
-        name: "Australian Securities Exchange",
-        mic: "XASX",
-        operating_mic: "XASX",
-        asset_class: "stocks",
-        locale: "au",
-        exchange_type: "exchange",
-        url: "https://www.asx.com.au",
-    },
-    StaticExchange {
-        name: "National Stock Exchange of India",
-        mic: "XNSE",
-        operating_mic: "XNSE",
-        asset_class: "stocks",
-        locale: "in",
-        exchange_type: "exchange",
-        url: "https://www.nseindia.com",
-    },
-];
 
 #[cfg(test)]
 mod tests {
@@ -246,6 +191,22 @@ mod tests {
             .find(|e| e.name.as_deref() == Some("Nasdaq"))
             .unwrap();
         assert_eq!(nasdaq.mic.as_deref(), Some("XNAS"));
+    }
+
+    #[tokio::test]
+    async fn otc_markets_is_the_only_trf_exchange_type() {
+        let out = LocalExchangeProvider.fetch_exchanges().await.unwrap();
+        let otc = out
+            .iter()
+            .find(|e| e.name.as_deref() == Some("OTC Markets"))
+            .unwrap();
+        assert_eq!(otc.exchange_type.as_deref(), Some("TRF"));
+        assert_eq!(
+            out.iter()
+                .filter(|e| e.exchange_type.as_deref() == Some("exchange"))
+                .count(),
+            EXCHANGES.len() - 1
+        );
     }
 
     #[tokio::test]

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -37,6 +37,7 @@ pub(crate) mod fred;
 pub(crate) mod gdelt;
 #[cfg(feature = "kraken")]
 pub(crate) mod kraken;
+pub(crate) mod local_exchanges;
 pub(crate) mod market_calendar;
 #[cfg(feature = "nasdaq")]
 pub(crate) mod nasdaq;
@@ -138,6 +139,9 @@ pub enum Provider {
     /// NYSE/NASDAQ market holidays, computed locally from federal-holiday
     /// rules rather than fetched (always available, no network call).
     LocalMarketCalendar,
+    /// A static table of major global exchanges (always available, no
+    /// network call).
+    LocalExchange,
 }
 
 impl Provider {
@@ -185,6 +189,7 @@ impl Provider {
             "congresstrades" => Some(Self::CongressTrades),
             "edgar" => Some(Self::Edgar),
             "local_market_calendar" => Some(Self::LocalMarketCalendar),
+            "local_exchange" => Some(Self::LocalExchange),
             _ => None,
         }
     }
@@ -231,6 +236,7 @@ impl Provider {
             Self::CongressTrades => "congresstrades",
             Self::Edgar => "edgar",
             Self::LocalMarketCalendar => "local_market_calendar",
+            Self::LocalExchange => "local_exchange",
         }
     }
 
@@ -278,6 +284,7 @@ impl Provider {
         v.push(Self::CongressTrades);
         v.push(Self::Edgar);
         v.push(Self::LocalMarketCalendar);
+        v.push(Self::LocalExchange);
         v
     }
 
@@ -332,6 +339,9 @@ impl Provider {
             Self::Edgar => ProviderAdapter::capabilities(&edgar::EdgarProvider),
             Self::LocalMarketCalendar => {
                 ProviderAdapter::capabilities(&market_calendar::LocalMarketCalendarProvider)
+            }
+            Self::LocalExchange => {
+                ProviderAdapter::capabilities(&local_exchanges::LocalExchangeProvider)
             }
         }
     }
@@ -1309,6 +1319,7 @@ pub(crate) async fn build_providers(
             Provider::CongressTrades => Arc::new(congresstrades::CongressTradesProvider),
             Provider::Edgar => Arc::new(edgar::EdgarProvider),
             Provider::LocalMarketCalendar => Arc::new(market_calendar::LocalMarketCalendarProvider),
+            Provider::LocalExchange => Arc::new(local_exchanges::LocalExchangeProvider),
         };
         adapter.initialize().await?;
         providers.push(adapter);
@@ -1453,6 +1464,15 @@ mod tests {
             Provider::LocalMarketCalendar
                 .capabilities()
                 .contains(Capability::CALENDAR)
+        );
+    }
+
+    #[test]
+    fn local_exchange_derives_discovery_capability() {
+        assert!(
+            Provider::LocalExchange
+                .capabilities()
+                .contains(Capability::DISCOVERY)
         );
     }
 


### PR DESCRIPTION
## Description
Exchange listings currently need Alpha Vantage or Polygon; there's no keyless route at all. Adds `LocalExchangeProvider`, a static table of 18 major global venues with MIC/operating-MIC/locale data, following the same always-on, no-network-call pattern `LocalMarketCalendarProvider` already uses for holidays. Unlike holiday rules, MIC codes aren't derivable from a formula, so this table needs occasional manual maintenance as venues merge or rebrand.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Added `src/providers/local_exchanges.rs` with `LocalExchangeProvider` and an 18-entry `(name, mic, operating_mic, locale, url)` tuple table; `asset_class` and `exchange_type` are computed rather than repeated per row, since they're constant across all but one venue.
- Added the `Provider::LocalExchange` variant, always compiled, no feature flag.

## Breaking Changes
None.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] All tests pass (`cargo test`)

5 unit tests, all local — static data, no network involved. Full workspace suite passes at the tip of this stack; clippy clean.

## Documentation
- [x] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues
N/A
