### PR TITLE
feat: scrape S&P 500 constituent changes from Wikipedia

### DIFF
--- a/src/adapters/wikipedia/indices.rs
+++ b/src/adapters/wikipedia/indices.rs
@@ -7,15 +7,16 @@
 //! by sector, no headquarters/CIK/founding-year columns), a meaningfully
 //! different and thinner shape not worth a bespoke parser for. Both stay
 //! `NotSupported` here rather than shipping a fragile navbox scrape.
-//! Likewise, no Wikipedia article in this set currently carries a
-//! constituent-changes history table, so `IndexConstituentChanges` is
-//! unrouted for every index.
+//! Constituent changes are similarly S&P-500-only, scraped from a separate
+//! article ("Historical components of the S&P 500") whose `table#changes`
+//! tracks additions/removals.
 
 use crate::error::{FinanceError, Result};
-use crate::models::indices::{IndexConstituent, MajorIndex};
+use crate::models::indices::{IndexConstituent, IndexConstituentChange, MajorIndex};
 use crate::scrapers::html;
 
 const SP500_ARTICLE: &str = "List_of_S%26P_500_companies";
+const SP500_CHANGES_ARTICLE: &str = "Historical_components_of_the_S%26P_500";
 
 pub(crate) async fn fetch_index_constituents_response(
     index: MajorIndex,
@@ -27,6 +28,21 @@ pub(crate) async fn fetch_index_constituents_response(
         }
         MajorIndex::Nasdaq100 | MajorIndex::DowJones => {
             Err(crate::providers::Operation::IndexConstituents
+                .not_supported(crate::Provider::Wikipedia))
+        }
+    }
+}
+
+pub(crate) async fn fetch_index_constituent_changes_response(
+    index: MajorIndex,
+) -> Result<Vec<IndexConstituentChange>> {
+    match index {
+        MajorIndex::Sp500 => {
+            let page = super::client()?.page_html(SP500_CHANGES_ARTICLE).await?;
+            parse_sp500_changes(&page)
+        }
+        MajorIndex::Nasdaq100 | MajorIndex::DowJones => {
+            Err(crate::providers::Operation::IndexConstituentChanges
                 .not_supported(crate::Provider::Wikipedia))
         }
     }
@@ -66,6 +82,65 @@ fn parse_sp500_constituents(page: &str) -> Result<Vec<IndexConstituent>> {
         });
     }
     Ok(constituents)
+}
+
+fn parse_sp500_changes(page: &str) -> Result<Vec<IndexConstituentChange>> {
+    let table = html::find_all(page, "table")
+        .into_iter()
+        .find(|t| t.attr("id").as_deref() == Some("changes"))
+        .ok_or_else(|| FinanceError::ResponseStructureError {
+            field: "table#changes".to_string(),
+            context: "no constituent-changes table found on the historical S&P 500 Wikipedia page"
+                .to_string(),
+        })?;
+
+    let changes: Vec<IndexConstituentChange> = html::find_all(table.inner, "tr")
+        .into_iter()
+        .filter_map(|row| {
+            let cells = html::find_all(row.inner, "td");
+            (cells.len() >= 6).then(|| {
+                let text: Vec<String> = cells.iter().map(|c| c.text().trim().to_string()).collect();
+                IndexConstituentChange {
+                    date: parse_wiki_date(&text[0]),
+                    symbol: non_empty(&text[1]),
+                    added_security: non_empty(&text[2]),
+                    removed_ticker: non_empty(&text[3]),
+                    removed_security: non_empty(&text[4]),
+                    reason: non_empty(&text[5]),
+                }
+            })
+        })
+        .collect();
+
+    if changes.is_empty() {
+        return Err(FinanceError::ResponseStructureError {
+            field: "table#changes.rows".to_string(),
+            context: "S&P 500 changes table had no data rows".to_string(),
+        });
+    }
+    Ok(changes)
+}
+
+/// Parse a `"Month D, YYYY"` date (e.g. `"August 5, 2026"`) into `YYYY-MM-DD`.
+fn parse_wiki_date(s: &str) -> Option<String> {
+    let (month_day, year) = s.trim().rsplit_once(',')?;
+    let (month, day) = month_day.trim().split_once(' ')?;
+    let month_num = match month {
+        "January" => "01",
+        "February" => "02",
+        "March" => "03",
+        "April" => "04",
+        "May" => "05",
+        "June" => "06",
+        "July" => "07",
+        "August" => "08",
+        "September" => "09",
+        "October" => "10",
+        "November" => "11",
+        "December" => "12",
+        _ => return None,
+    };
+    Some(format!("{}-{month_num}-{:0>2}", year.trim(), day.trim()))
 }
 
 fn non_empty(s: &str) -> Option<String> {
@@ -120,5 +195,99 @@ mod tests {
     fn a_page_with_no_table_errors() {
         let err = parse_sp500_constituents("<html><body>no tables here</body></html>").unwrap_err();
         assert!(matches!(err, FinanceError::ResponseStructureError { .. }));
+    }
+
+    fn changes_fixture_page(row: &str) -> String {
+        format!(
+            r#"<html><body>
+            <table><tr><td>unrelated</td></tr></table>
+            <table class="wikitable sortable" id="changes">
+            <tbody><tr>
+            <th rowspan="2">Effective Date</th><th colspan="2">Added</th><th colspan="2">Removed</th>
+            <th rowspan="2">Reason</th><th rowspan="2">Refs</th></tr>
+            <tr><th>Ticker</th><th>Security</th><th>Ticker</th><th>Security</th></tr>
+            {row}
+            </tbody></table>
+            </body></html>"#
+        )
+    }
+
+    #[test]
+    fn changes_table_parses_a_full_row() {
+        let page = changes_fixture_page(
+            r#"<tr>
+            <td>August 18, 2026</td>
+            <td>RDDT</td>
+            <td><a href="/wiki/Reddit">Reddit</a></td>
+            <td>AVB</td>
+            <td><a href="/wiki/AvalonBay">AvalonBay Communities</a></td>
+            <td>Equity Residential acquired AvalonBay Communities.</td>
+            <td>[2]</td>
+            </tr>"#,
+        );
+
+        let changes = parse_sp500_changes(&page).unwrap();
+        assert_eq!(changes.len(), 1);
+        let change = &changes[0];
+        assert_eq!(change.date.as_deref(), Some("2026-08-18"));
+        assert_eq!(change.symbol.as_deref(), Some("RDDT"));
+        assert_eq!(change.added_security.as_deref(), Some("Reddit"));
+        assert_eq!(change.removed_ticker.as_deref(), Some("AVB"));
+        assert_eq!(
+            change.removed_security.as_deref(),
+            Some("AvalonBay Communities")
+        );
+        assert_eq!(
+            change.reason.as_deref(),
+            Some("Equity Residential acquired AvalonBay Communities.")
+        );
+    }
+
+    #[test]
+    fn changes_table_row_without_refs_column_still_parses() {
+        let page = changes_fixture_page(
+            r#"<tr>
+            <td>March 23, 2015</td>
+            <td>SLG</td>
+            <td>SL Green Realty</td>
+            <td>NBR</td>
+            <td>Nabors Industries</td>
+            <td>Index rebalancing.</td>
+            </tr>"#,
+        );
+
+        let changes = parse_sp500_changes(&page).unwrap();
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].date.as_deref(), Some("2015-03-23"));
+    }
+
+    #[test]
+    fn a_changes_page_with_no_changes_table_errors() {
+        let err =
+            parse_sp500_changes("<html><body><table><tr><td>x</td></tr></table></body></html>")
+                .unwrap_err();
+        assert!(matches!(err, FinanceError::ResponseStructureError { .. }));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires network access"]
+    async fn fetches_changes_from_the_live_wikipedia_article() {
+        let changes = fetch_index_constituent_changes_response(MajorIndex::Sp500)
+            .await
+            .unwrap();
+        assert!(changes.len() > 100);
+        assert!(changes[0].date.as_deref().unwrap() >= "2015-01-01");
+    }
+
+    #[test]
+    fn wiki_dates_parse_single_and_double_digit_days() {
+        assert_eq!(
+            parse_wiki_date("August 5, 2026"),
+            Some("2026-08-05".to_string())
+        );
+        assert_eq!(
+            parse_wiki_date("August 18, 2026"),
+            Some("2026-08-18".to_string())
+        );
     }
 }

--- a/src/adapters/wikipedia/mod.rs
+++ b/src/adapters/wikipedia/mod.rs
@@ -2,11 +2,12 @@
 //!
 //! Requires the **`wikipedia`** feature flag.
 //!
-//! Table-scrapes "List of S&P 500 companies", the only tracked index article
-//! that still carries an inline constituents table (see `indices` for why
-//! Nasdaq-100/Dow Jones stay unrouted). Reuses the crate's dependency-free
-//! HTML element matcher (`crate::scrapers::html`), the same one
-//! `scrapers::yahoo_exchanges` already scrapes a table with.
+//! Table-scrapes "List of S&P 500 companies" for current constituents and
+//! "Historical components of the S&P 500" for constituent-change history —
+//! the only tracked index with inline tables for either (see `indices` for
+//! why Nasdaq-100/Dow Jones stay unrouted). Reuses the crate's
+//! dependency-free HTML element matcher (`crate::scrapers::html`), the same
+//! one `scrapers::yahoo_exchanges` already scrapes a table with.
 
 pub(crate) mod client;
 pub(crate) mod indices;
@@ -30,4 +31,6 @@ fn client() -> Result<WikipediaClient> {
     WikipediaClient::new(DEFAULT_TIMEOUT, shared_limiter(), client::WIKIPEDIA_BASE)
 }
 
-pub(crate) use indices::fetch_index_constituents_response;
+pub(crate) use indices::{
+    fetch_index_constituent_changes_response, fetch_index_constituents_response,
+};

--- a/src/providers/wikipedia.rs
+++ b/src/providers/wikipedia.rs
@@ -26,6 +26,13 @@ impl IndicesProvider for WikipediaProvider {
     ) -> Result<Vec<crate::models::indices::IndexConstituent>> {
         crate::adapters::wikipedia::fetch_index_constituents_response(index).await
     }
+
+    async fn fetch_index_constituent_changes(
+        &self,
+        index: crate::models::indices::MajorIndex,
+    ) -> Result<Vec<crate::models::indices::IndexConstituentChange>> {
+        crate::adapters::wikipedia::fetch_index_constituent_changes_response(index).await
+    }
 }
 
 #[async_trait::async_trait]


### PR DESCRIPTION
## Description
The Wikipedia adapter already scrapes current S&P 500 constituents, but constituent-change history had no keyless source — FMP was the only provider. A second Wikipedia article, "Historical components of the S&P 500," turns out to carry exactly the table needed (`table#changes`), confirmed against the live page rather than assumed from the article's existence. Adds a second scrape target and parser alongside the existing one.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Added `parse_sp500_changes` and `fetch_index_constituent_changes_response` to `src/adapters/wikipedia/indices.rs`, targeting the `Historical_components_of_the_S%26P_500` article's `table#changes`.
- Wired `fetch_index_constituent_changes` into `WikipediaProvider`'s `IndicesProvider` impl.
- Corrected the module's doc comment, which previously stated no Wikipedia article carried this table.

## Breaking Changes
None.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All tests pass (`cargo test`)

6 unit tests + 1 live-network test (`fetches_changes_from_the_live_wikipedia_article`, 100+ real changes), verified against the live page. Full workspace suite passes at the tip of this stack; clippy clean.

## Documentation
- [x] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues
N/A
