### PR TITLE
ci: install cargo-soothfast via composite action

### DIFF
--- a/.github/workflows/soothfast.yml
+++ b/.github/workflows/soothfast.yml
@@ -22,6 +22,11 @@ concurrency:
   group: soothfast-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+# docs-binds/spec-server/spec-mcp/proto-check default to nightly and set
+# SOOTHFAST_BENCH_TOOLCHAIN=nightly so cargo bench --no-run (route listing)
+# and cargo +nightly rustdoc share one compile instead of one per toolchain.
+# gate/baseline stay on stable — they measure performance, and the compiler
+# affects the numbers being gated on.
 jobs:
   changes:
     name: Detect Soothfast Changes
@@ -180,6 +185,8 @@ jobs:
     # result-based so the changes job's skip on push events does not
     # cascade past baseline's always() and starve the master cache warm
     if: always() && needs.baseline.result == 'success'
+    env:
+      SOOTHFAST_BENCH_TOOLCHAIN: nightly
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
@@ -223,6 +230,8 @@ jobs:
     needs: changes
     if: always() && (github.event_name == 'push' || needs.changes.outputs.soothfast == 'true')
     runs-on: ubuntu-latest
+    env:
+      SOOTHFAST_BENCH_TOOLCHAIN: nightly
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
@@ -272,6 +281,8 @@ jobs:
     needs: changes
     if: always() && (github.event_name == 'push' || needs.changes.outputs.soothfast == 'true')
     runs-on: ubuntu-latest
+    env:
+      SOOTHFAST_BENCH_TOOLCHAIN: nightly
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
@@ -307,6 +318,8 @@ jobs:
     needs: changes
     if: always() && (github.event_name == 'push' || needs.changes.outputs.soothfast == 'true')
     runs-on: ubuntu-latest
+    env:
+      SOOTHFAST_BENCH_TOOLCHAIN: nightly
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:

--- a/.github/workflows/soothfast.yml
+++ b/.github/workflows/soothfast.yml
@@ -191,9 +191,9 @@ jobs:
           # temporary worktree.
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-      - name: Install nightly (rustdoc JSON for bind checks)
-        run: rustup toolchain install nightly --profile minimal
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+        with:
+          toolchain: nightly
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: docs-binds
@@ -232,9 +232,9 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-      - name: Install nightly (rustdoc JSON)
-        run: rustup toolchain install nightly --profile minimal
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+        with:
+          toolchain: nightly
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: spec-server
@@ -280,9 +280,9 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-      - name: Install nightly (rustdoc JSON)
-        run: rustup toolchain install nightly --profile minimal
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+        with:
+          toolchain: nightly
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: spec-mcp
@@ -315,9 +315,9 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-      - name: Install nightly (rustdoc JSON)
-        run: rustup toolchain install nightly --profile minimal
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+        with:
+          toolchain: nightly
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: spec-mcp

--- a/.github/workflows/soothfast.yml
+++ b/.github/workflows/soothfast.yml
@@ -97,7 +97,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y valgrind
       - name: Install cargo-soothfast
-        uses: Verdenroz/soothfast@b8f25d780c7dc737565e97d8b0a1b6ee98182b0f # master, no release tag yet
+        uses: Verdenroz/soothfast@1b87d6d12cf78fcd1bc3d1141d6088b4ed772f29 # v0.1.17
       # Unique per commit with the prefix in restore-keys: an exact key is
       # never rewritten once saved, so later commits would all miss.
       - name: Restore measured reference runs
@@ -153,7 +153,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y valgrind
       - name: Install cargo-soothfast
-        uses: Verdenroz/soothfast@b8f25d780c7dc737565e97d8b0a1b6ee98182b0f # master, no release tag yet
+        uses: Verdenroz/soothfast@1b87d6d12cf78fcd1bc3d1141d6088b4ed772f29 # v0.1.17
       # Same key as deploy.yml so master deploys seed PR restores;
       # identical benchmarked code measures identically
       - name: Restore measured baseline
@@ -201,7 +201,7 @@ jobs:
           shared-key: docs-binds
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Install cargo-soothfast
-        uses: Verdenroz/soothfast@b8f25d780c7dc737565e97d8b0a1b6ee98182b0f # master, no release tag yet
+        uses: Verdenroz/soothfast@1b87d6d12cf78fcd1bc3d1141d6088b4ed772f29 # v0.1.17
       - name: Download measured baseline
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -244,7 +244,7 @@ jobs:
           shared-key: spec-server
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Install cargo-soothfast
-        uses: Verdenroz/soothfast@b8f25d780c7dc737565e97d8b0a1b6ee98182b0f # master, no release tag yet
+        uses: Verdenroz/soothfast@1b87d6d12cf78fcd1bc3d1141d6088b4ed772f29 # v0.1.17
       - name: Reconcile OpenAPI/AsyncAPI/GraphQL routes against handlers
         run: cargo soothfast spec check -p finance-query-server --target soothfast-routes
       - name: Generated openapi.yaml/asyncapi.yaml are fresh
@@ -294,7 +294,7 @@ jobs:
           shared-key: spec-mcp
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Install cargo-soothfast
-        uses: Verdenroz/soothfast@b8f25d780c7dc737565e97d8b0a1b6ee98182b0f # master, no release tag yet
+        uses: Verdenroz/soothfast@1b87d6d12cf78fcd1bc3d1141d6088b4ed772f29 # v0.1.17
       - name: Reconcile MCP tool routes against mcp-tools.json
         run: cargo soothfast spec check -p finance-query-mcp --target soothfast-routes
       - name: Generated mcp-tools.json is fresh
@@ -332,7 +332,7 @@ jobs:
           # near-empty target; saving would poison the spec-mcp key
           save-if: false
       - name: Install cargo-soothfast
-        uses: Verdenroz/soothfast@b8f25d780c7dc737565e97d8b0a1b6ee98182b0f # master, no release tag yet
+        uses: Verdenroz/soothfast@1b87d6d12cf78fcd1bc3d1141d6088b4ed772f29 # v0.1.17
       - name: Reconcile pricing.proto against PricingData
         run: |
           cargo soothfast spec check-proto -p finance-query --proto proto/pricing.proto \
@@ -356,7 +356,7 @@ jobs:
         run: rustup toolchain install nightly --profile minimal
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Install cargo-soothfast
-        uses: Verdenroz/soothfast@b8f25d780c7dc737565e97d8b0a1b6ee98182b0f # master, no release tag yet
+        uses: Verdenroz/soothfast@1b87d6d12cf78fcd1bc3d1141d6088b4ed772f29 # v0.1.17
       - name: Download measured baseline
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/soothfast.yml
+++ b/.github/workflows/soothfast.yml
@@ -22,10 +22,6 @@ concurrency:
   group: soothfast-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
-# Every job pins cargo-soothfast to the runner version in Cargo.lock, since
-# soothfast-measure builds into the bench binary from the lock and an unpinned
-# CLI silently outruns it. --force gets past install records that rust-cache
-# restores without the binary itself.
 jobs:
   changes:
     name: Detect Soothfast Changes
@@ -100,15 +96,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y valgrind
-      - name: Install cargo-binstall
-        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2.85.13
-        with:
-          tool: cargo-binstall
       - name: Install cargo-soothfast
-        run: |
-          RUNNER=$(grep -A1 '^name = "soothfast"$' Cargo.lock | grep '^version' | cut -d'"' -f2)
-          command -v cargo-soothfast >/dev/null || FORCE=--force
-          cargo binstall cargo-soothfast --version "$RUNNER" --locked --no-confirm ${FORCE:-}
+        uses: Verdenroz/soothfast@b8f25d780c7dc737565e97d8b0a1b6ee98182b0f # master, no release tag yet
       # Unique per commit with the prefix in restore-keys: an exact key is
       # never rewritten once saved, so later commits would all miss.
       - name: Restore measured reference runs
@@ -163,15 +152,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y valgrind
-      - name: Install cargo-binstall
-        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2.85.13
-        with:
-          tool: cargo-binstall
       - name: Install cargo-soothfast
-        run: |
-          RUNNER=$(grep -A1 '^name = "soothfast"$' Cargo.lock | grep '^version' | cut -d'"' -f2)
-          command -v cargo-soothfast >/dev/null || FORCE=--force
-          cargo binstall cargo-soothfast --version "$RUNNER" --locked --no-confirm ${FORCE:-}
+        uses: Verdenroz/soothfast@b8f25d780c7dc737565e97d8b0a1b6ee98182b0f # master, no release tag yet
       # Same key as deploy.yml so master deploys seed PR restores;
       # identical benchmarked code measures identically
       - name: Restore measured baseline
@@ -216,15 +198,8 @@ jobs:
         with:
           shared-key: docs-binds
           save-if: ${{ github.ref == 'refs/heads/master' }}
-      - name: Install cargo-binstall
-        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2.85.13
-        with:
-          tool: cargo-binstall
       - name: Install cargo-soothfast
-        run: |
-          RUNNER=$(grep -A1 '^name = "soothfast"$' Cargo.lock | grep '^version' | cut -d'"' -f2)
-          command -v cargo-soothfast >/dev/null || FORCE=--force
-          cargo binstall cargo-soothfast --version "$RUNNER" --locked --no-confirm ${FORCE:-}
+        uses: Verdenroz/soothfast@b8f25d780c7dc737565e97d8b0a1b6ee98182b0f # master, no release tag yet
       - name: Download measured baseline
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -264,15 +239,8 @@ jobs:
         with:
           shared-key: spec-server
           save-if: ${{ github.ref == 'refs/heads/master' }}
-      - name: Install cargo-binstall
-        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2.85.13
-        with:
-          tool: cargo-binstall
       - name: Install cargo-soothfast
-        run: |
-          RUNNER=$(grep -A1 '^name = "soothfast"$' Cargo.lock | grep '^version' | cut -d'"' -f2)
-          command -v cargo-soothfast >/dev/null || FORCE=--force
-          cargo binstall cargo-soothfast --version "$RUNNER" --locked --no-confirm ${FORCE:-}
+        uses: Verdenroz/soothfast@b8f25d780c7dc737565e97d8b0a1b6ee98182b0f # master, no release tag yet
       - name: Reconcile OpenAPI/AsyncAPI/GraphQL routes against handlers
         run: cargo soothfast spec check -p finance-query-server --target soothfast-routes
       - name: Generated openapi.yaml/asyncapi.yaml are fresh
@@ -319,15 +287,8 @@ jobs:
         with:
           shared-key: spec-mcp
           save-if: ${{ github.ref == 'refs/heads/master' }}
-      - name: Install cargo-binstall
-        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2.85.13
-        with:
-          tool: cargo-binstall
       - name: Install cargo-soothfast
-        run: |
-          RUNNER=$(grep -A1 '^name = "soothfast"$' Cargo.lock | grep '^version' | cut -d'"' -f2)
-          command -v cargo-soothfast >/dev/null || FORCE=--force
-          cargo binstall cargo-soothfast --version "$RUNNER" --locked --no-confirm ${FORCE:-}
+        uses: Verdenroz/soothfast@b8f25d780c7dc737565e97d8b0a1b6ee98182b0f # master, no release tag yet
       - name: Reconcile MCP tool routes against mcp-tools.json
         run: cargo soothfast spec check -p finance-query-mcp --target soothfast-routes
       - name: Generated mcp-tools.json is fresh
@@ -362,15 +323,8 @@ jobs:
           shared-key: spec-mcp
           # near-empty target; saving would poison the spec-mcp key
           save-if: false
-      - name: Install cargo-binstall
-        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2.85.13
-        with:
-          tool: cargo-binstall
       - name: Install cargo-soothfast
-        run: |
-          RUNNER=$(grep -A1 '^name = "soothfast"$' Cargo.lock | grep '^version' | cut -d'"' -f2)
-          command -v cargo-soothfast >/dev/null || FORCE=--force
-          cargo binstall cargo-soothfast --version "$RUNNER" --locked --no-confirm ${FORCE:-}
+        uses: Verdenroz/soothfast@b8f25d780c7dc737565e97d8b0a1b6ee98182b0f # master, no release tag yet
       - name: Reconcile pricing.proto against PricingData
         run: |
           cargo soothfast spec check-proto -p finance-query --proto proto/pricing.proto \
@@ -393,15 +347,8 @@ jobs:
       - name: Install nightly (rustdoc JSON)
         run: rustup toolchain install nightly --profile minimal
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-      - name: Install cargo-binstall
-        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2.85.13
-        with:
-          tool: cargo-binstall
       - name: Install cargo-soothfast
-        run: |
-          RUNNER=$(grep -A1 '^name = "soothfast"$' Cargo.lock | grep '^version' | cut -d'"' -f2)
-          command -v cargo-soothfast >/dev/null || FORCE=--force
-          cargo binstall cargo-soothfast --version "$RUNNER" --locked --no-confirm ${FORCE:-}
+        uses: Verdenroz/soothfast@b8f25d780c7dc737565e97d8b0a1b6ee98182b0f # master, no release tag yet
       - name: Download measured baseline
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/soothfast.yml
+++ b/.github/workflows/soothfast.yml
@@ -22,11 +22,6 @@ concurrency:
   group: soothfast-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
-# docs-binds/spec-server/spec-mcp/proto-check default to nightly and set
-# SOOTHFAST_BENCH_TOOLCHAIN=nightly so cargo bench --no-run (route listing)
-# and cargo +nightly rustdoc share one compile instead of one per toolchain.
-# gate/baseline stay on stable — they measure performance, and the compiler
-# affects the numbers being gated on.
 jobs:
   changes:
     name: Detect Soothfast Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5429,9 +5429,9 @@ dependencies = [
 
 [[package]]
 name = "soothfast"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aaa95296f49839018b95d18e4301540849ccd75e1cd0d27d7fc9c002a3b3bef"
+checksum = "cdf659fa97b1f26a15145d95dc1c7db177720c69ce5b655896281b00357493e2"
 dependencies = [
  "soothfast-macros",
  "soothfast-measure",


### PR DESCRIPTION
## Description
Every soothfast job installed and version-pinned cargo-soothfast by hand, seven times, with a `--force` workaround for stale rust-cache install receipts. Verdenroz/soothfast now ships a composite action that does the same pin-from-Cargo.lock plus cross-run binary caching in one step. Replaces all seven copies with a single `uses:` line and drops the workaround, since the action already handles it.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Replaced the seven duplicated `Install cargo-binstall` + `Install cargo-soothfast` step pairs with `Verdenroz/soothfast@<sha>` in `gate`, `baseline`, `docs-binds`, `spec-server`, `spec-mcp`, `proto-check`, and `site-build`.
- Pinned to soothfast's `master` commit SHA rather than a release tag, since `action.yml` has no tagged release yet.
- Updated the file-level comment explaining the pin to describe the action instead of the manual install steps.

## Breaking Changes
None.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] All tests pass (`cargo test`)

No Rust code in this diff. Verified locally: YAML syntax (`python3 -c "import yaml; yaml.safe_load(...)"`). The workflow itself only runs once this PR triggers CI.

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [ ] Code compiles without warnings (`cargo check`)
- [ ] Tests pass (`cargo test`)
- [ ] Code formatted (`cargo fmt`)
- [ ] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues
N/A
