### PR TITLE
ci: split workspace build, unify spec cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,9 +245,11 @@ jobs:
           done
 
   # Check compilation
-  # Build release binary
-  build:
-    name: Build Release
+  # Per-crate release-profile check, no linking. Nothing downstream consumes
+  # a PR's binaries (docker/docker-mcp and deploy.yml all build from source
+  # independently), so PRs get compile-correctness without paying for LTO.
+  build-check-server:
+    name: Build Check (server)
     runs-on: ubuntu-latest
     needs: [fmt, clippy]
     steps:
@@ -264,44 +266,99 @@ jobs:
           sudo rm -rf /opt/ghc
           sudo rm -rf /opt/hostedtoolcache/CodeQL
           df -h /
-      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          # Cargo fingerprints LTO flags, so the thin PR profile and the fat
-          # master profile need separate caches or PRs rebuild every dep
-          shared-key: build-${{ github.event_name == 'pull_request' && 'thin' || 'fat' }}
-          # PR-ref saves are invisible to other PRs and evict master caches
-          save-if: ${{ github.ref == 'refs/heads/master' }}
-      # cargo-auditable embeds the dependency manifest into each binary so the
-      # shipped artifacts can be scanned later with `cargo audit bin`.
-      - uses: taiki-e/install-action@ace6ebe54a6a0c86dfb5f7764b17f793b6925bc3 # v2.82.3
-        with:
-          tool: cargo-auditable
-      # The root crate is a library; the shippable binaries live in the
-      # workspace members, so build the whole workspace.
-      - name: Build release binaries
-        # PRs validate with thin LTO; master builds the shipped fat-LTO profile
-        env:
-          CARGO_PROFILE_RELEASE_LTO: ${{ github.event_name == 'pull_request' && 'thin' || 'true' }}
-          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: ${{ github.event_name == 'pull_request' && '16' || '1' }}
-        run: cargo auditable build --workspace --release --verbose
-      - name: Upload binaries
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: finance-query-linux-x86_64
-          path: |
-            target/release/finance-query-server
-            target/release/fq
-            target/release/fq-mcp
-          if-no-files-found: error
+          shared-key: check-server
+      - name: Check server (release profile)
+        run: cargo check --release -p finance-query-server --verbose
 
-  # Master-side warm for the thin-LTO cache the PR build job restores; a
-  # PR-side save would land on the merge ref where no other PR can see it.
-  build-thin-warm:
-    name: Warm thin build cache
-    if: github.event_name == 'push'
+  build-check-mcp:
+    name: Build Check (mcp)
     runs-on: ubuntu-latest
+    needs: [fmt, clippy]
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          df -h /
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: check-mcp
+      # mcp path-deps on server for its in-process GraphQL schema, so this
+      # also compiles finance-query-server as a library dependency.
+      - name: Check mcp (release profile)
+        run: cargo check --release -p finance-query-mcp --verbose
+
+  build-check-cli:
+    name: Build Check (cli)
+    runs-on: ubuntu-latest
+    needs: [fmt, clippy]
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          df -h /
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: check-cli
+      - name: Check cli (release profile)
+        run: cargo check --release -p finance-query-cli --verbose
+
+  # Validates the lib's real published default-feature build; clippy and the
+  # test jobs all force `--features finance-query/full` and never cover this.
+  build-check-lib:
+    name: Build Check (lib)
+    runs-on: ubuntu-latest
+    needs: [fmt, clippy]
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          df -h /
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: check-lib-default
+      - name: Check lib (default features)
+        run: cargo check --release -p finance-query --verbose
+
+  # Build release binary
+  # Master only: fat LTO matches the shipped [profile.release] unmodified.
+  build-release:
+    name: Build Release (binaries)
+    runs-on: ubuntu-latest
+    needs: [fmt, clippy]
+    if: github.event_name == 'push' && needs.fmt.result == 'success' && needs.clippy.result == 'success'
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
@@ -320,12 +377,49 @@ jobs:
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          shared-key: build-thin
-      - name: Build with the PR profile
-        env:
-          CARGO_PROFILE_RELEASE_LTO: thin
-          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"
-        run: cargo build --workspace --release
+          shared-key: build-fat
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+      # cargo-auditable embeds the dependency manifest into each binary so the
+      # shipped artifacts can be scanned later with `cargo audit bin`.
+      - uses: taiki-e/install-action@ace6ebe54a6a0c86dfb5f7764b17f793b6925bc3 # v2.82.3
+        with:
+          tool: cargo-auditable
+      # The root crate is a library; the shippable binaries live in the
+      # workspace members, so build the whole workspace.
+      - name: Build release binaries
+        run: cargo auditable build --workspace --release --verbose
+      - name: Upload binaries
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: finance-query-linux-x86_64
+          path: |
+            target/release/finance-query-server
+            target/release/fq
+            target/release/fq-mcp
+          if-no-files-found: error
+
+  # Required-status-check name preserved as "Build Release" (branch
+  # protection references this exact context) even though the real work now
+  # runs as parallel check jobs plus a master-only release build above.
+  build:
+    name: Build Release
+    runs-on: ubuntu-latest
+    needs: [changes, build-check-server, build-check-mcp, build-check-cli, build-check-lib, build-release]
+    if: always() && needs.changes.outputs.rust == 'true'
+    steps:
+      - name: Check build results
+        run: |
+          for result in "${{ needs.build-check-server.result }}" "${{ needs.build-check-mcp.result }}" "${{ needs.build-check-cli.result }}" "${{ needs.build-check-lib.result }}"; do
+            if [ "$result" != "success" ]; then
+              echo "A build check did not succeed: $result"
+              exit 1
+            fi
+          done
+          release_result="${{ needs.build-release.result }}"
+          if [ "$release_result" != "success" ] && [ "$release_result" != "skipped" ]; then
+            echo "Build Release (binaries) did not succeed: $release_result"
+            exit 1
+          fi
 
   # Build and test Docker image
   docker:

--- a/.github/workflows/soothfast.yml
+++ b/.github/workflows/soothfast.yml
@@ -241,7 +241,7 @@ jobs:
           toolchain: nightly
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          shared-key: spec-server
+          shared-key: spec
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Install cargo-soothfast
         uses: Verdenroz/soothfast@1b87d6d12cf78fcd1bc3d1141d6088b4ed772f29 # v0.1.17
@@ -291,7 +291,7 @@ jobs:
           toolchain: nightly
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          shared-key: spec-mcp
+          shared-key: spec
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Install cargo-soothfast
         uses: Verdenroz/soothfast@1b87d6d12cf78fcd1bc3d1141d6088b4ed772f29 # v0.1.17
@@ -328,8 +328,8 @@ jobs:
           toolchain: nightly
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          shared-key: spec-mcp
-          # near-empty target; saving would poison the spec-mcp key
+          shared-key: spec
+          # near-empty target; saving would poison the shared spec key
           save-if: false
       - name: Install cargo-soothfast
         uses: Verdenroz/soothfast@1b87d6d12cf78fcd1bc3d1141d6088b4ed772f29 # v0.1.17


### PR DESCRIPTION
## Description
CI's `build` job ran one serial `--workspace --release` build producing all three binaries, but nothing in PR-time CI ever consumed them: docker/docker-mcp and deploy.yml all build from source independently. This splits it into parallel per-crate `cargo check` jobs for PRs, with the linked release build running only on master push. It also drops `build-thin-warm`, which existed solely to keep a cache warm for a profile only PRs used, and unifies `spec-server`/`spec-mcp`'s cache key in soothfast.yml, since mcp's compile graph is a strict superset of server's.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement

## Changes
- Split `ci.yml`'s `build` job into `build-check-server`, `build-check-mcp`, `build-check-cli`, and `build-check-lib` (`cargo check --release`, run on both `push` and `pull_request`).
- Added `build-check-lib`, checking the library's actual default-feature build for the first time (clippy/test jobs all force `--features finance-query/full`).
- Moved the linked, artifact-uploading build into `build-release`, gated to `push` only.
- Added a `build` aggregator job so the "Build Release" required-status-check name stays stable across the new topology.
- Removed `build-thin-warm`, which only existed to warm a thin-LTO cache no job restores anymore.
- Unified `spec-server`/`spec-mcp`'s `rust-cache` `shared-key` to `spec` in `soothfast.yml`.

## Breaking Changes
None to library functionality. PR runs no longer produce a downloadable `finance-query-linux-x86_64` artifact (server/fq/fq-mcp binaries); the master-only `build-release` job still produces it.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] All tests pass (`cargo test`)

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [ ] Code compiles without warnings (`cargo check`)
- [ ] Tests pass (`cargo test`)
- [ ] Code formatted (`cargo fmt`)
- [ ] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues
Closes #