### PR TITLE
fix: force HTTP/1.1 for the Yahoo earnings-calls scraper

### DIFF
--- a/src/scrapers/yahoo_earnings.rs
+++ b/src/scrapers/yahoo_earnings.rs
@@ -76,6 +76,7 @@ pub(crate) async fn scrape_earnings_calls(symbol: &str) -> Result<Vec<EarningsCa
 
     let client = reqwest::Client::builder()
         .user_agent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36")
+        .http1_only()
         .build()?;
 
     let response = client.get(&url).send().await?;


### PR DESCRIPTION
## Description
`test_fetch_for_symbol_latest` has been failing intermittently in CI, exhausting nextest's 3 retries. Reproduced locally: reqwest negotiates HTTP/2 by default against `finance.yahoo.com`'s edge (Apache Traffic Server), which reset the stream with `PROTOCOL_ERROR` on 6 of 8 back-to-back requests. `curl` against the same URL never failed on HTTP/1.1 or HTTP/2, so this isn't Yahoo blocking the client — it's a real interop issue between this stack's HTTP/2 implementation and that edge. Forcing this one scraper's client to HTTP/1.1 was 8 for 8 clean in the same test.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Added `.http1_only()` to `scrapers::yahoo_earnings::scrape_earnings_calls`'s `reqwest::Client` builder.

## Breaking Changes
None.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] All tests pass (`cargo test`)

Ran the real network test (`test_fetch_for_symbol_latest`, `--ignored`) 4 times after the fix: 4/4 passed. Isolated repro against the live endpoint: default HTTP/2 client failed 6/8 attempts, HTTP/1.1-forced client passed 8/8. `cargo test -p finance-query --lib scrapers::yahoo_earnings::` (existing unit tests, unaffected): 7 passed, 1 ignored (network).

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [ ] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [ ] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues
None.