### PR TITLE
perf: run library docs regen in parallel with spec jobs

### DIFF
--- a/.github/workflows/soothfast.yml
+++ b/.github/workflows/soothfast.yml
@@ -334,11 +334,54 @@ jobs:
           cargo soothfast spec check-proto -p finance-query --proto proto/pricing.proto \
             --message PricingData --source src/streaming/pricing.rs --struct PricingData
 
+  docs-lib:
+    name: Docs pages (lib)
+    runs-on: ubuntu-latest
+    needs: baseline
+    if: always() && needs.baseline.result == 'success'
+    env:
+      SOOTHFAST_BENCH_TOOLCHAIN: nightly
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+        with:
+          toolchain: nightly
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: docs-binds
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+      - name: Install cargo-soothfast
+        uses: Verdenroz/soothfast@1b87d6d12cf78fcd1bc3d1141d6088b4ed772f29 # v0.1.17
+      - name: Download measured baseline
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: soothfast-baseline
+          path: .soothfast/baselines
+      - name: Regenerate library docs pages
+        run: make docs-pages PAGES=lib
+      - name: Upload library docs pages
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: docs-pages-lib
+          path: |
+            docs/reference
+            docs/perf
+            docs/coverage.md
+            docs/llms.txt
+            llms.txt
+          if-no-files-found: error
+
   site-build:
     name: Docs site build
     runs-on: ubuntu-latest
-    needs: [baseline, spec-server, spec-mcp]
-    if: always() && needs.baseline.result == 'success' && needs.spec-server.result == 'success' && needs.spec-mcp.result == 'success'
+    needs: [baseline, docs-lib, spec-server, spec-mcp]
+    if: always() && needs.baseline.result == 'success' && needs.docs-lib.result == 'success' && needs.spec-server.result == 'success' && needs.spec-mcp.result == 'success'
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
@@ -364,8 +407,10 @@ jobs:
           pattern: docs-pages-*
           merge-multiple: true
           path: docs/server
-      - name: Regenerate library docs pages
-        run: make docs-pages PAGES=lib
+      - name: Download library docs pages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: docs-pages-lib
       - name: Docs site builds cleanly
         # Static build only (not gh-deploy)
         run: cargo soothfast docs build --baseline base --out target/site-check


### PR DESCRIPTION
## Description
`site-build` waited on `baseline`, `spec-server`, and `spec-mcp` before starting, but its dominant step — regenerating the library's rustdoc-JSON docs pages, 2m38s of the job's ~2m39s — never reads anything spec-server or spec-mcp produce. Only the final 1-second assembly step does. Split the job in two: `docs-lib` needs only `baseline` and runs alongside spec-server/spec-mcp instead of after them; a thin `site-build` downloads all three artifacts and just runs the assembly check.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement

## Changes
- Split `site-build` into `docs-lib` (library docs regen, needs only `baseline`) and a thinned `site-build` (needs `baseline`, `docs-lib`, `spec-server`, `spec-mcp`; downloads all three artifacts and runs the assembly check).
- `docs-lib` uploads `docs/reference`, `docs/perf`, `docs/coverage.md`, `docs/llms.txt`, and `llms.txt` as a `docs-pages-lib` artifact for `site-build` to download.

## Breaking Changes
None. CI-only change.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] All tests pass (`cargo test`)

Ran the full sequence locally: `make docs-pages PAGES=lib`, `PAGES=server`, `PAGES=mcp`, then `cargo soothfast docs build --baseline base --out target/site-check` against the combined output — assembled cleanly (54 pages, 16 assets), confirming the split artifacts are exactly what the final assembly step needs.

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [ ] Code compiles without warnings (`cargo check`)
- [ ] Tests pass (`cargo test`)
- [ ] Code formatted (`cargo fmt`)
- [ ] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues
None.