### PR TITLE
fix: grant the deploy bot token workflows permission

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -98,6 +98,7 @@ jobs:
           private-key: ${{ secrets.CHANGELOG_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
+          permission-workflows: write
       - name: Get soothfast-bot user id
         id: app-user
         env:


### PR DESCRIPTION
## Description
`deploy.yml`'s "Deploy docs site" job has been failing to push its `bot/derived-artifacts` branch: "refusing to allow a GitHub App to create or update workflow `.github/workflows/soothfast.yml` without `workflows` permission." The bot's own commit never touches workflow files — it regenerates `trend.jsonl`/`llms.txt`/docs — but GitHub's App permission check evaluates the whole pushed ref, and master's recent history includes several commits that did touch `.github/workflows/**`. The token step only requested `contents`/`pull-requests` permission.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Added `permission-workflows: write` to the `actions/create-github-app-token` step in `deploy.yml`.

## Breaking Changes
None. The GitHub App installation's `Workflows: write` permission has already been granted and approved separately.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] All tests pass (`cargo test`)

Will be confirmed on the next `deploy-docs` run after this merges.

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [ ] Code compiles without warnings (`cargo check`)
- [ ] Tests pass (`cargo test`)
- [ ] Code formatted (`cargo fmt`)
- [ ] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues
None.