### PR TITLE
deps: drop dead dependencies and narrow feature sets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,6 +312,11 @@ jobs:
           shared-key: check-lib-default
       - name: Check lib (default features)
         run: cargo check --release -p finance-query --verbose
+      # Deliberately not --workspace/--all-targets: those unify the server's and
+      # dev-deps' wider feature sets over the library's, hiding a feature a
+      # crates.io consumer would need.
+      - name: Check lib (full features, no workspace unification)
+        run: cargo check -p finance-query --features full --verbose
 
   build-release:
     name: Build Release (binaries)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,9 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
       - name: Run tests
-        run: cargo test --all-features --verbose
+        # Not --all-features: that pulls in `translation-offline`, which builds
+        # CTranslate2 from source and needs cmake + a C++ toolchain.
+        run: cargo test --features full --verbose
 
   publish:
     name: Publish to crates.io

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1589,7 +1589,6 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 name = "finance-query"
 version = "2.8.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "base64 0.22.1",
  "chromiumoxide",
@@ -1610,7 +1609,6 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serde_repr",
  "serial_test",
  "soothfast",
  "thiserror 2.0.20",
@@ -1619,7 +1617,6 @@ dependencies = [
  "tokio-test",
  "tokio-tungstenite 0.28.0",
  "tracing",
- "url",
  "vader_sentiment",
  "zip",
 ]
@@ -1660,7 +1657,6 @@ dependencies = [
 name = "finance-query-server"
 version = "2.8.0"
 dependencies = [
- "anyhow",
  "async-graphql",
  "async-graphql-axum",
  "axum",
@@ -1677,16 +1673,13 @@ dependencies = [
  "serde_json",
  "serial_test",
  "soothfast",
- "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tokio-test",
- "tokio-tungstenite 0.28.0",
  "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",
- "url",
  "uuid",
 ]
 
@@ -4276,17 +4269,6 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "serde_repr"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 3.0.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,25 +35,21 @@ path = "src/lib.rs"
 
 [dependencies]
 # HTTP client (core dependency)
-reqwest = { version = "0.13", features = ["json", "cookies", "gzip", "brotli", "blocking", "query"] }
+reqwest = { version = "0.13", features = ["json", "cookies", "gzip", "brotli", "query"] }
 
 # Async runtime
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "time", "macros", "net"] }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_repr = "0.1"
 
 # Error handling
 thiserror = "2.0.18"
-anyhow = "1"
 
 # Date and time
 chrono = { version = "0.4", features = ["serde"] }
 
-# URL parsing
-url = "2"
 percent-encoding = "2"
 
 # Regex for parsing
@@ -191,7 +187,7 @@ translation = []
 # models via CTranslate2, distributed as Argos packages). Heavy native build:
 # compiles CTranslate2 + SentencePiece from source (needs cmake + a C++
 # toolchain). Downloads a small (~80-210 MB) per-language model on first use.
-translation-offline = ["translation", "dep:ct2rs", "dep:zip"]
+translation-offline = ["translation", "dep:ct2rs", "dep:zip", "reqwest/blocking"]
 # Regression-gate aggregate: every feature whose representative work is pure-Rust
 # compute or serde. HTTP-only providers (alphavantage/polygon/fmp) hit the same
 # public models already covered; dataframe/translation-offline are too heavy for

--- a/deny.toml
+++ b/deny.toml
@@ -10,6 +10,8 @@ all-features = true
 # Fail on any crate with a known security advisory or that has been yanked.
 yanked = "deny"
 # Add advisory IDs here (with a justification) only to consciously accept a risk.
+# Gating a feature does not silence an advisory: `cargo audit` reads Cargo.lock
+# and `all-features` is on, so only dropping the optional dep clears an entry.
 ignore = [
     # `paste` is unmaintained (not vulnerable). Compile-time-only proc-macro
     # pulled in via ct2rs -> tokenizers -> macro_rules_attribute for the

--- a/finance-query-derive/Cargo.toml
+++ b/finance-query-derive/Cargo.toml
@@ -15,6 +15,6 @@ categories = ["development-tools::procedural-macro-helpers"]
 proc-macro = true
 
 [dependencies]
-syn = { version = "2", features = ["full", "parsing", "extra-traits"] }
+syn = { version = "2", features = ["full"] }
 quote = "1"
 proc-macro2 = "1"

--- a/finance-query-mcp/src/tools/mod.rs
+++ b/finance-query-mcp/src/tools/mod.rs
@@ -979,7 +979,7 @@ impl FinanceTools {
     }
 
     #[tool(
-        description = "Get congressional (House and Senate) trading disclosures for a symbol. Uses FMP when FMP_API_KEY is set, keyless House/Senate PTR filings otherwise."
+        description = "Get congressional trading disclosures for a symbol. Uses FMP when FMP_API_KEY is set, keyless House PTR filings otherwise."
     )]
     async fn get_congressional_trades(
         &self,

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -75,7 +75,7 @@ Those values win over the ambient environment; anything left out falls back to w
 - `get_commitments_of_traders` — `GET /v2/cftc/cot/{symbol}`: Weekly CFTC Commitments of Traders positioning (keyless)
 - `get_commodity` — `GET /v2/commodities/{symbol}`: Get a commodity's current quote
 - `get_company_profile` — `GET /v2/company-profile/{symbol}`: Get company profile
-- `get_congressional_trades` — `GET /v2/filings/{symbol}/congressional-trades`: Congressional (senate) trading disclosures for a symbol
+- `get_congressional_trades` — `GET /v2/filings/{symbol}/congressional-trades`: Congressional trading disclosures for a symbol
 - `get_crypto_coin` — `GET /v2/crypto/coins/{id}`: Single coin by CoinGecko ID
 - `get_crypto_coins` — `GET /v2/crypto/coins`: Top coins by market cap
 - `get_crypto_global` — `GET /v2/crypto/global`: Aggregate global cryptocurrency market statistics

--- a/sdks/python/src/finance_query/client.py
+++ b/sdks/python/src/finance_query/client.py
@@ -501,7 +501,7 @@ class Client:
         fields: str | None = None,
         limit: int | None = None,
     ) -> list[models.GqlCongressionalTrade]:
-        """Congressional (senate) trading disclosures for a symbol"""
+        """Congressional trading disclosures for a symbol"""
         return self._transport.request(
             "GET",
             f"/v2/filings/{path_seg(symbol)}/congressional-trades",
@@ -2108,7 +2108,7 @@ class AsyncClient:
         fields: str | None = None,
         limit: int | None = None,
     ) -> list[models.GqlCongressionalTrade]:
-        """Congressional (senate) trading disclosures for a symbol"""
+        """Congressional trading disclosures for a symbol"""
         return await self._transport.request(
             "GET",
             f"/v2/filings/{path_seg(symbol)}/congressional-trades",

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -79,7 +79,7 @@ Requires Node 18+.
 - `getCommitmentsOfTraders` — `GET /v2/cftc/cot/{symbol}`: Weekly CFTC Commitments of Traders positioning (keyless)
 - `getCommodity` — `GET /v2/commodities/{symbol}`: Get a commodity's current quote
 - `getCompanyProfile` — `GET /v2/company-profile/{symbol}`: Get company profile
-- `getCongressionalTrades` — `GET /v2/filings/{symbol}/congressional-trades`: Congressional (senate) trading disclosures for a symbol
+- `getCongressionalTrades` — `GET /v2/filings/{symbol}/congressional-trades`: Congressional trading disclosures for a symbol
 - `getCryptoCoin` — `GET /v2/crypto/coins/{id}`: Single coin by CoinGecko ID
 - `getCryptoCoins` — `GET /v2/crypto/coins`: Top coins by market cap
 - `getCryptoGlobal` — `GET /v2/crypto/global`: Aggregate global cryptocurrency market statistics

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -1168,7 +1168,7 @@ export class Client {
     });
   }
 
-  /** Congressional (senate) trading disclosures for a symbol */
+  /** Congressional trading disclosures for a symbol */
   getCongressionalTrades(symbol: string, options: GetCongressionalTradesOptions = {}): Promise<models.GqlCongressionalTrade[]> {
     return this.transport.request<models.GqlCongressionalTrade[]>("GET", `/v2/filings/${pathSeg(symbol)}/congressional-trades`, {
       query: queryOf(options),

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Finance library (our own)
-finance-query = { path = "..", features = ["indicators", "fred", "crypto", "risk", "sentiment", "gdelt", "cftc", "alphavantage", "fmp", "worldbank", "fiscaldata", "frankfurter", "binance", "kraken", "secftd", "housetrades", "senatetrades", "nasdaq", "wikipedia"] }
+finance-query = { path = "..", features = ["indicators", "fred", "crypto", "risk", "sentiment", "gdelt", "cftc", "alphavantage", "fmp", "worldbank", "fiscaldata", "frankfurter", "binance", "kraken", "secftd", "housetrades", "nasdaq", "wikipedia"] }
 
 # GraphQL
 async-graphql = { version = "7", features = ["graphiql"] }
@@ -30,7 +30,6 @@ async-graphql-axum = "7"
 # Web framework
 axum = { version = "0.8.9", features = ["ws", "macros"] }
 tokio = { version = "1", features = ["full"] }
-tower = "0.5"
 tower-http = { version = "0.6.11", features = ["fs", "trace", "cors", "timeout", "limit", "compression-full"] }
 
 # Serialization
@@ -41,17 +40,12 @@ serde_json = "1"
 redis = { version = "1.2.2", features = ["tokio-comp", "connection-manager"], optional = true }
 
 # WebSocket
-tokio-tungstenite = "0.28"
 tokio-stream = { version = "0.1", features = ["sync"] }
 futures-util = "0.3"
 
 # Logging and tracing
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
-
-# Error handling
-anyhow = "1"
-thiserror = "2.0.18"
 
 # Environment and configuration
 dotenvy = "0.15"
@@ -63,9 +57,6 @@ chrono-tz = "0.10"
 # UUID for request IDs
 uuid = { version = "1", features = ["v4", "serde"] }
 
-# URL parsing
-url = "2"
-
 # Metrics
 prometheus = "0.14"
 lazy_static = "1.5"
@@ -73,6 +64,7 @@ lazy_static = "1.5"
 [dev-dependencies]
 # Testing
 tokio-test = "0.4"
+tower = "0.5"
 mockito = "1"
 serial_test = "3"
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -1790,7 +1790,7 @@ paths:
   "/v2/filings/{symbol}/congressional-trades":
     get:
       operationId: getCongressionalTrades
-      summary: Congressional (senate) trading disclosures for a symbol
+      summary: Congressional trading disclosures for a symbol
       parameters:
         - name: cursor
           in: query

--- a/server/schema.graphql
+++ b/server/schema.graphql
@@ -3359,8 +3359,8 @@ type GqlTicker {
 	): [GqlTranscriptWithMeta!]!
 	"""
 	Congressional trading disclosures for this symbol (FMP when
-	`FMP_API_KEY` is set, falling back to keyless House/Senate PTR
-	disclosures otherwise).
+	`FMP_API_KEY` is set, falling back to keyless House PTR disclosures
+	otherwise).
 	"""
 	congressionalTrades(
 		"""

--- a/server/spec/routes.rs
+++ b/server/spec/routes.rs
@@ -145,7 +145,7 @@ fn route_forex_get_forex() {}
 )]
 fn route_analysis_get_company_profile() {}
 
-/// Congressional (senate) trading disclosures for a symbol
+/// Congressional trading disclosures for a symbol
 ///
 /// Implements `handlers::filings::get_congressional_trades`.
 #[allow(dead_code)]

--- a/server/src/graphql/query/ticker_filings.rs
+++ b/server/src/graphql/query/ticker_filings.rs
@@ -1,5 +1,5 @@
 //! Per-symbol filings/disclosure fields routed via `Capability::FILINGS`:
-//! congressional trading (FMP, falling back to keyless House/Senate PTR
+//! congressional trading (FMP, falling back to keyless House PTR
 //! disclosures) and fails-to-deliver (FMP, falling back to keyless EDGAR).
 //! Distinct from Yahoo's `insiderTransactions`/`secFilings`
 //! (`TickerHoldersQuery`/`TickerCoreQuery`) and SEC EDGAR's own
@@ -21,8 +21,8 @@ pub(super) struct TickerFilingsQuery {
 #[Object]
 impl TickerFilingsQuery {
     /// Congressional trading disclosures for this symbol (FMP when
-    /// `FMP_API_KEY` is set, falling back to keyless House/Senate PTR
-    /// disclosures otherwise).
+    /// `FMP_API_KEY` is set, falling back to keyless House PTR disclosures
+    /// otherwise).
     async fn congressional_trades(
         &self,
         ctx: &Context<'_>,

--- a/server/src/handlers/filings.rs
+++ b/server/src/handlers/filings.rs
@@ -21,9 +21,8 @@ use super::gql_bridge::{
 
 /// GET /v2/filings/{symbol}/congressional-trades
 ///
-/// Congressional (House and Senate) trading disclosures for a symbol. FMP
-/// when `FMP_API_KEY` is set; House and Senate PTR filings otherwise
-/// (keyless, merged when both are compiled in).
+/// Congressional trading disclosures for a symbol. FMP when `FMP_API_KEY`
+/// is set; keyless House PTR filings otherwise.
 pub(crate) async fn get_congressional_trades(
     Extension(schema): Extension<graphql::FinanceSchema>,
     Path(symbol): Path<String>,

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -125,7 +125,7 @@ pub(crate) fn api_routes() -> Router {
         // GET /v2/feeds/stream - WebSocket continuous RSS/Atom feed entries
         .route("/feeds/stream", get(feeds_stream::ws_feeds_stream_handler))
         // GET /v2/filings/{symbol}/congressional-trades (FMP, falling back
-        // to keyless House/Senate PTR disclosures)
+        // to keyless House PTR disclosures)
         .route(
             "/filings/{symbol}/congressional-trades",
             get(filings::get_congressional_trades),

--- a/server/src/services/filings.rs
+++ b/server/src/services/filings.rs
@@ -6,7 +6,7 @@ use finance_query::{FilingSectionForm, Providers};
 use super::{ServiceError, ServiceResult};
 
 /// Congressional trading disclosures for a symbol, via `Capability::FILINGS`
-/// (FMP, falling back to keyless House and Senate PTR disclosures).
+/// (FMP, falling back to keyless House PTR disclosures).
 pub async fn get_congressional_trades(
     cache: &Cache,
     providers: &Arc<Providers>,


### PR DESCRIPTION
## Description

Eight dependencies were declared and never used: `anyhow`, `serde_repr`, and `url` in the library, and `anyhow`, `thiserror`, `url`, and `tokio-tungstenite` in the server. `tokio` was on `full`, and `reqwest`'s `blocking` client compiled into every build to serve two call sites that only exist under `translation-offline`. The Senate eFD adapter also came out of the server image. It can't pass Akamai from a cloud IP, so the deployed binary was building a headless-Chromium stack for an adapter that returns nothing there, while the OpenAPI and MCP tool descriptions kept promising Senate data.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Removed `anyhow`, `serde_repr`, and `url` from the library manifest, and `anyhow`, `thiserror`, `url`, and `tokio-tungstenite` from the server manifest. None had a single use in `src/`, `tests/`, or `benches/`.
- Moved `tower` to `server/[dev-dependencies]`. Its only use is `ServiceExt` in `server/tests/common/mod.rs`.
- Narrowed `tokio` from `full` to `rt`, `rt-multi-thread`, `sync`, `time`, `macros`, and `net`. This drops `parking_lot`, `parking_lot_core`, `signal-hook-registry`, `errno`, `lock_api`, and `scopeguard` from the default tree.
- Gated `reqwest`'s `blocking` feature behind `translation-offline`, which holds its only two call sites in `src/translation/opusmt.rs`.
- Dropped `extra-traits` from `finance-query-derive`'s `syn` features.
- Removed `senatetrades` from the server's `finance-query` feature list, and corrected the six REST, GraphQL, and MCP descriptions that advertised Senate data.
- Changed `publish.yml` from `--all-features` to `--features full`. `--all-features` compiled CTranslate2 from source on every release tag.
- Added a `--features full` step to the `build-check-lib` CI job. It runs without `--workspace`, so the server's and dev-dependencies' wider feature sets cannot mask a feature a crates.io consumer needs.
- Documented in `deny.toml` that gating a feature cannot silence an advisory, because `cargo audit` reads `Cargo.lock` and `all-features` is on.
- Regenerated `server/openapi.yaml`, `server/schema.graphql`, and both SDK clients.

## Breaking Changes

The server and MCP binaries no longer return Senate PTR disclosures. `Provider::CongressTrades` degrades to House-only, which is what a cloud-hosted deployment already received, since the Senate eFD adapter is IP-reputation blocked from VPS addresses. The library is unaffected and still compiles `senatetrades` under `full`.

**Migration Guide:**
```rust
// Before: server built with senatetrades, House and Senate merged
// After: House only. To restore Senate coverage, re-add the feature
// and run the server from an IP that is not blocked by Akamai.
//
// server/Cargo.toml
// finance-query = { path = "..", features = [..., "housetrades", "senatetrades"] }
```

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All tests pass (`cargo test`)

`cargo test --workspace --features finance-query/full`: 1967 passed, 0 failed, 214 ignored.

Manual verification covered the dependency tree before and after (`cargo tree -e normal`, 177 to 170 crates on default features), that `translation-offline` still enables `reqwest/blocking` (`cargo tree -e features -i reqwest`), and a cold `cargo check -p finance-query --features full` outside workspace unification.

## Documentation
- [x] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy`)
- [x] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

None.
