### PR TITLE
test: pin the Provider wire format before changing it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,9 +319,10 @@ jobs:
         run: cargo check -p finance-query --features full --verbose
       # The test job runs with `full`, so a test that assumes a feature-gated
       # item exists passes there and fails for anyone running the documented
-      # `cargo test -p finance-query`.
+      # `cargo test -p finance-query`. Covers tests/ too: the wire-format pin
+      # is an integration test, so --lib would leave it unguarded.
       - name: Test lib (default features)
-        run: cargo test -p finance-query --lib --verbose
+        run: cargo test -p finance-query --lib --tests --verbose
 
   build-release:
     name: Build Release (binaries)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,7 +322,7 @@ jobs:
       # `cargo test -p finance-query`. Covers tests/ too: the wire-format pin
       # is an integration test, so --lib would leave it unguarded.
       - name: Test lib (default features)
-        run: cargo test -p finance-query --lib --tests --verbose
+        run: cargo test -p finance-query --tests --verbose
 
   build-release:
     name: Build Release (binaries)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,6 +317,11 @@ jobs:
       # crates.io consumer would need.
       - name: Check lib (full features, no workspace unification)
         run: cargo check -p finance-query --features full --verbose
+      # The test job runs with `full`, so a test that assumes a feature-gated
+      # item exists passes there and fails for anyone running the documented
+      # `cargo test -p finance-query`.
+      - name: Test lib (default features)
+        run: cargo test -p finance-query --lib --verbose
 
   build-release:
     name: Build Release (binaries)

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1824,74 +1824,64 @@ mod tests {
     }
 
     /// Companion to `tests/provider_wire_format.rs`, which can only name the
-    /// variants it hard-codes. `all()` is `pub(crate)`, so only an in-crate
-    /// test can prove no variant escapes the pin.
+    /// variants it hard-codes. The match has no wildcard, so a new variant
+    /// fails to compile until it is pinned here.
+    fn pin_for(provider: Provider) -> (&'static str, &'static str) {
+        match provider {
+            Provider::Yahoo => ("\"Yahoo\"", "yahoo"),
+            #[cfg(feature = "polygon")]
+            Provider::Polygon => ("\"Polygon\"", "polygon"),
+            #[cfg(feature = "fmp")]
+            Provider::Fmp => ("\"Fmp\"", "fmp"),
+            #[cfg(feature = "alphavantage")]
+            Provider::AlphaVantage => ("\"AlphaVantage\"", "alphavantage"),
+            #[cfg(feature = "crypto")]
+            Provider::CoinGecko => ("\"CoinGecko\"", "coingecko"),
+            #[cfg(feature = "fred")]
+            Provider::Fred => ("\"Fred\"", "fred"),
+            #[cfg(feature = "worldbank")]
+            Provider::WorldBank => ("\"WorldBank\"", "worldbank"),
+            #[cfg(feature = "fiscaldata")]
+            Provider::FiscalData => ("\"FiscalData\"", "fiscaldata"),
+            #[cfg(feature = "bls")]
+            Provider::Bls => ("\"Bls\"", "bls"),
+            #[cfg(feature = "frankfurter")]
+            Provider::Frankfurter => ("\"Frankfurter\"", "frankfurter"),
+            #[cfg(feature = "binance")]
+            Provider::Binance => ("\"Binance\"", "binance"),
+            #[cfg(feature = "kraken")]
+            Provider::Kraken => ("\"Kraken\"", "kraken"),
+            #[cfg(feature = "finra")]
+            Provider::Finra => ("\"Finra\"", "finra"),
+            #[cfg(feature = "defi")]
+            Provider::DefiLlama => ("\"DefiLlama\"", "defillama"),
+            #[cfg(feature = "gdelt")]
+            Provider::Gdelt => ("\"Gdelt\"", "gdelt"),
+            #[cfg(feature = "cftc")]
+            Provider::Cftc => ("\"Cftc\"", "cftc"),
+            #[cfg(feature = "nasdaq")]
+            Provider::Nasdaq => ("\"Nasdaq\"", "nasdaq"),
+            #[cfg(feature = "wikipedia")]
+            Provider::Wikipedia => ("\"Wikipedia\"", "wikipedia"),
+            #[cfg(any(feature = "housetrades", feature = "senatetrades"))]
+            Provider::CongressTrades => ("\"CongressTrades\"", "congresstrades"),
+            Provider::Edgar => ("\"Edgar\"", "edgar"),
+            Provider::LocalMarketCalendar => ("\"LocalMarketCalendar\"", "local_market_calendar"),
+            Provider::LocalExchange => ("\"LocalExchange\"", "local_exchange"),
+        }
+    }
+
+    /// The match in `pin_for` catches a variant missing from the pin; this
+    /// catches one missing from `all()`, which is a hand-maintained list.
     #[test]
     fn every_variant_has_its_serialized_form_pinned() {
-        let expected: &[(Provider, &str, &str)] = &[
-            (Provider::Yahoo, "\"Yahoo\"", "yahoo"),
-            #[cfg(feature = "polygon")]
-            (Provider::Polygon, "\"Polygon\"", "polygon"),
-            #[cfg(feature = "fmp")]
-            (Provider::Fmp, "\"Fmp\"", "fmp"),
-            #[cfg(feature = "alphavantage")]
-            (Provider::AlphaVantage, "\"AlphaVantage\"", "alphavantage"),
-            #[cfg(feature = "crypto")]
-            (Provider::CoinGecko, "\"CoinGecko\"", "coingecko"),
-            #[cfg(feature = "fred")]
-            (Provider::Fred, "\"Fred\"", "fred"),
-            #[cfg(feature = "worldbank")]
-            (Provider::WorldBank, "\"WorldBank\"", "worldbank"),
-            #[cfg(feature = "fiscaldata")]
-            (Provider::FiscalData, "\"FiscalData\"", "fiscaldata"),
-            #[cfg(feature = "bls")]
-            (Provider::Bls, "\"Bls\"", "bls"),
-            #[cfg(feature = "frankfurter")]
-            (Provider::Frankfurter, "\"Frankfurter\"", "frankfurter"),
-            #[cfg(feature = "binance")]
-            (Provider::Binance, "\"Binance\"", "binance"),
-            #[cfg(feature = "kraken")]
-            (Provider::Kraken, "\"Kraken\"", "kraken"),
-            #[cfg(feature = "finra")]
-            (Provider::Finra, "\"Finra\"", "finra"),
-            #[cfg(feature = "defi")]
-            (Provider::DefiLlama, "\"DefiLlama\"", "defillama"),
-            #[cfg(feature = "gdelt")]
-            (Provider::Gdelt, "\"Gdelt\"", "gdelt"),
-            #[cfg(feature = "cftc")]
-            (Provider::Cftc, "\"Cftc\"", "cftc"),
-            #[cfg(feature = "nasdaq")]
-            (Provider::Nasdaq, "\"Nasdaq\"", "nasdaq"),
-            #[cfg(feature = "wikipedia")]
-            (Provider::Wikipedia, "\"Wikipedia\"", "wikipedia"),
-            #[cfg(any(feature = "housetrades", feature = "senatetrades"))]
-            (
-                Provider::CongressTrades,
-                "\"CongressTrades\"",
-                "congresstrades",
-            ),
-            (Provider::Edgar, "\"Edgar\"", "edgar"),
-            (
-                Provider::LocalMarketCalendar,
-                "\"LocalMarketCalendar\"",
-                "local_market_calendar",
-            ),
-            (
-                Provider::LocalExchange,
-                "\"LocalExchange\"",
-                "local_exchange",
-            ),
-        ];
-
-        assert_eq!(
-            expected.len(),
-            Provider::all().len(),
-            "a Provider variant is missing from the wire-format pin"
-        );
-        for (provider, serialized, id) in expected {
-            assert_eq!(&serde_json::to_string(provider).unwrap(), serialized);
-            assert_eq!(&provider.as_str(), id);
-            assert_eq!(Provider::from_id_str(id), Some(*provider));
+        let all = Provider::all();
+        assert_eq!(all.len(), 22, "Provider::all() is missing a variant");
+        for provider in all {
+            let (serialized, id) = pin_for(provider);
+            assert_eq!(serde_json::to_string(&provider).unwrap(), serialized);
+            assert_eq!(provider.as_str(), id);
+            assert_eq!(Provider::from_id_str(id), Some(provider));
         }
     }
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1822,4 +1822,76 @@ mod tests {
         assert_eq!(health[0].recent_failures, 0);
         assert!(health[0].last_error.is_none());
     }
+
+    /// Companion to `tests/provider_wire_format.rs`, which can only name the
+    /// variants it hard-codes. `all()` is `pub(crate)`, so only an in-crate
+    /// test can prove no variant escapes the pin.
+    #[test]
+    fn every_variant_has_its_serialized_form_pinned() {
+        let expected: &[(Provider, &str, &str)] = &[
+            (Provider::Yahoo, "\"Yahoo\"", "yahoo"),
+            #[cfg(feature = "polygon")]
+            (Provider::Polygon, "\"Polygon\"", "polygon"),
+            #[cfg(feature = "fmp")]
+            (Provider::Fmp, "\"Fmp\"", "fmp"),
+            #[cfg(feature = "alphavantage")]
+            (Provider::AlphaVantage, "\"AlphaVantage\"", "alphavantage"),
+            #[cfg(feature = "crypto")]
+            (Provider::CoinGecko, "\"CoinGecko\"", "coingecko"),
+            #[cfg(feature = "fred")]
+            (Provider::Fred, "\"Fred\"", "fred"),
+            #[cfg(feature = "worldbank")]
+            (Provider::WorldBank, "\"WorldBank\"", "worldbank"),
+            #[cfg(feature = "fiscaldata")]
+            (Provider::FiscalData, "\"FiscalData\"", "fiscaldata"),
+            #[cfg(feature = "bls")]
+            (Provider::Bls, "\"Bls\"", "bls"),
+            #[cfg(feature = "frankfurter")]
+            (Provider::Frankfurter, "\"Frankfurter\"", "frankfurter"),
+            #[cfg(feature = "binance")]
+            (Provider::Binance, "\"Binance\"", "binance"),
+            #[cfg(feature = "kraken")]
+            (Provider::Kraken, "\"Kraken\"", "kraken"),
+            #[cfg(feature = "finra")]
+            (Provider::Finra, "\"Finra\"", "finra"),
+            #[cfg(feature = "defi")]
+            (Provider::DefiLlama, "\"DefiLlama\"", "defillama"),
+            #[cfg(feature = "gdelt")]
+            (Provider::Gdelt, "\"Gdelt\"", "gdelt"),
+            #[cfg(feature = "cftc")]
+            (Provider::Cftc, "\"Cftc\"", "cftc"),
+            #[cfg(feature = "nasdaq")]
+            (Provider::Nasdaq, "\"Nasdaq\"", "nasdaq"),
+            #[cfg(feature = "wikipedia")]
+            (Provider::Wikipedia, "\"Wikipedia\"", "wikipedia"),
+            #[cfg(any(feature = "housetrades", feature = "senatetrades"))]
+            (
+                Provider::CongressTrades,
+                "\"CongressTrades\"",
+                "congresstrades",
+            ),
+            (Provider::Edgar, "\"Edgar\"", "edgar"),
+            (
+                Provider::LocalMarketCalendar,
+                "\"LocalMarketCalendar\"",
+                "local_market_calendar",
+            ),
+            (
+                Provider::LocalExchange,
+                "\"LocalExchange\"",
+                "local_exchange",
+            ),
+        ];
+
+        assert_eq!(
+            expected.len(),
+            Provider::all().len(),
+            "a Provider variant is missing from the wire-format pin"
+        );
+        for (provider, serialized, id) in expected {
+            assert_eq!(&serde_json::to_string(provider).unwrap(), serialized);
+            assert_eq!(&provider.as_str(), id);
+            assert_eq!(Provider::from_id_str(id), Some(*provider));
+        }
+    }
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1875,8 +1875,28 @@ mod tests {
     /// catches one missing from `all()`, which is a hand-maintained list.
     #[test]
     fn every_variant_has_its_serialized_form_pinned() {
+        const EXPECTED: usize = 4
+            + cfg!(feature = "polygon") as usize
+            + cfg!(feature = "fmp") as usize
+            + cfg!(feature = "alphavantage") as usize
+            + cfg!(feature = "crypto") as usize
+            + cfg!(feature = "fred") as usize
+            + cfg!(feature = "worldbank") as usize
+            + cfg!(feature = "fiscaldata") as usize
+            + cfg!(feature = "bls") as usize
+            + cfg!(feature = "frankfurter") as usize
+            + cfg!(feature = "binance") as usize
+            + cfg!(feature = "kraken") as usize
+            + cfg!(feature = "finra") as usize
+            + cfg!(feature = "defi") as usize
+            + cfg!(feature = "gdelt") as usize
+            + cfg!(feature = "cftc") as usize
+            + cfg!(feature = "nasdaq") as usize
+            + cfg!(feature = "wikipedia") as usize
+            + cfg!(any(feature = "housetrades", feature = "senatetrades")) as usize;
+
         let all = Provider::all();
-        assert_eq!(all.len(), 22, "Provider::all() is missing a variant");
+        assert_eq!(all.len(), EXPECTED, "Provider::all() is missing a variant");
         for provider in all {
             let (serialized, id) = pin_for(provider);
             assert_eq!(serde_json::to_string(&provider).unwrap(), serialized);

--- a/tests/provider_wire_format.rs
+++ b/tests/provider_wire_format.rs
@@ -19,10 +19,6 @@ fn json(provider: Provider) -> String {
 fn serializes_as_the_variant_name() {
     assert_eq!(json(Provider::Yahoo), "\"Yahoo\"");
     assert_eq!(json(Provider::Edgar), "\"Edgar\"");
-    assert_eq!(
-        json(Provider::LocalMarketCalendar),
-        "\"LocalMarketCalendar\""
-    );
     assert_eq!(json(Provider::LocalExchange), "\"LocalExchange\"");
 }
 

--- a/tests/provider_wire_format.rs
+++ b/tests/provider_wire_format.rs
@@ -1,0 +1,94 @@
+//! Pins the serialized form of [`Provider`] from outside the crate.
+//!
+//! `provider_id` is a public field on ten models and reaches REST and GraphQL
+//! responses, so its serialized value is a wire contract. Nothing else in the
+//! tree asserts it: `openapi.yaml` types the field as a bare string, so
+//! `spec gen --check` cannot see the values move.
+//!
+//! These tests record what ships today, including the disagreement between
+//! `Serialize` and `as_str`. A change to either must fail here first and be
+//! re-recorded deliberately.
+
+use finance_query::Provider;
+
+fn json(provider: Provider) -> String {
+    serde_json::to_string(&provider).expect("Provider serializes")
+}
+
+#[test]
+fn serializes_as_the_variant_name() {
+    assert_eq!(json(Provider::Yahoo), "\"Yahoo\"");
+    assert_eq!(json(Provider::Edgar), "\"Edgar\"");
+    assert_eq!(
+        json(Provider::LocalMarketCalendar),
+        "\"LocalMarketCalendar\""
+    );
+    assert_eq!(json(Provider::LocalExchange), "\"LocalExchange\"");
+}
+
+#[cfg(any(feature = "housetrades", feature = "senatetrades"))]
+#[test]
+fn congress_trades_serializes_unlike_its_id() {
+    assert_eq!(json(Provider::CongressTrades), "\"CongressTrades\"");
+    assert_eq!(Provider::CongressTrades.as_str(), "congresstrades");
+}
+
+#[cfg(feature = "defi")]
+#[test]
+fn defillama_serializes_unlike_its_id() {
+    assert_eq!(json(Provider::DefiLlama), "\"DefiLlama\"");
+    assert_eq!(Provider::DefiLlama.as_str(), "defillama");
+}
+
+#[test]
+fn local_market_calendar_serializes_unlike_its_id() {
+    assert_eq!(
+        json(Provider::LocalMarketCalendar),
+        "\"LocalMarketCalendar\""
+    );
+    assert_eq!(
+        Provider::LocalMarketCalendar.as_str(),
+        "local_market_calendar"
+    );
+}
+
+#[test]
+fn display_agrees_with_as_str_not_with_serialize() {
+    assert_eq!(Provider::Yahoo.to_string(), Provider::Yahoo.as_str());
+    assert_ne!(format!("\"{}\"", Provider::Yahoo), json(Provider::Yahoo));
+}
+
+/// The documented id is what `from_id_str` accepts, and it is the one form
+/// `Deserialize` rejects.
+#[test]
+fn the_documented_id_does_not_deserialize() {
+    assert_eq!(Provider::from_id_str("yahoo"), Some(Provider::Yahoo));
+    assert!(serde_json::from_str::<Provider>("\"yahoo\"").is_err());
+    assert!(serde_json::from_str::<Provider>("\"Yahoo\"").is_ok());
+}
+
+#[test]
+fn serialized_form_round_trips_with_itself() {
+    for provider in [
+        Provider::Yahoo,
+        Provider::Edgar,
+        Provider::LocalMarketCalendar,
+        Provider::LocalExchange,
+    ] {
+        let encoded = json(provider);
+        let decoded: Provider = serde_json::from_str(&encoded).expect("round trips");
+        assert_eq!(decoded, provider);
+    }
+}
+
+#[test]
+fn every_id_is_accepted_by_from_id_str() {
+    for id in ["yahoo", "edgar", "local_market_calendar", "local_exchange"] {
+        assert_eq!(
+            Provider::from_id_str(id).map(Provider::as_str),
+            Some(id),
+            "{id} should round-trip through from_id_str"
+        );
+    }
+    assert_eq!(Provider::from_id_str("not-a-provider"), None);
+}


### PR DESCRIPTION
## Description

This adds a test and nothing else, and its whole value is that it merges before the change it exists to catch. `provider_id` is a public field on ten models and reaches REST and GraphQL responses, but `openapi.yaml` types it as a bare string, so `spec gen --check` cannot see its values move. The commit above this one rewrites `Provider`'s serialization, and without the pin landing first that arrives as a green diff. With it, the same change arrives as six failing assertions naming exactly which wire values moved, and the re-recording is the reviewable part.

Recording today's behaviour also documents a real inconsistency: `Serialize` emits the variant name (`"Yahoo"`), while `as_str`, `Display`, and `from_id_str` all use the lowercase id (`"yahoo"`). The documented id is therefore the one string that fails to deserialize.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

Test-only. None of the six categories fit; no library code changes in this PR.

## Changes
- Added `tests/provider_wire_format.rs`, pinning the serialized form of `Provider` from outside the crate.
- Added an in-crate companion in `src/providers/tests.rs` covering every variant. The external test can only name variants it hard-codes, and `Provider::all()` is `pub(crate)`.
- Built the companion's expectation from a wildcard-free `match`, so a new variant fails to compile until it is pinned, and kept a count check against `Provider::all()`, which is a hand-maintained list with no compiler behind it.
- Made that count a `cfg!` sum, since `all()` is feature-gated and a literal only held under `full`.
- Added a `Test lib (default features)` step to the `build-check-lib` CI job.

## Breaking Changes

None. Test and CI only.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [x] All tests pass (`cargo test`)

The two enforcement mechanisms cover opposite directions and both were verified rather than assumed. Deleting an arm from the `match` produces `error[E0004]: non-exhaustive patterns: Provider::Edgar not covered`; the count catches a variant missing from `all()`.

The `cfg!` sum was checked on three feature sets, not two: default gives 4 variants, `full` gives 22, and `--features defi,fmp` gives 6. The middle case matters because a `#[cfg(feature = "full")]` guard would have skipped it.

The CI step exists because this hole is why a broken test shipped green in the first place: `test-unit` runs with `--features finance-query/full`, and `build-check-lib` compiled the default build without testing it. `cargo test -p finance-query --tests` on default features now runs in that job.

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

None.
