### PR TITLE
docs: drop plan-numbered section markers

### DIFF
--- a/soothfast.lock
+++ b/soothfast.lock
@@ -4,7 +4,7 @@
     "finance_query::Tickers": "02e3b3cf7e934806",
     "finance_query::adapters::yahoo::discovery::lookup::LookupType": "bd43904ed5eb7ca3",
     "finance_query::adapters::yahoo::discovery::search::SearchOptions": "3b5c45b79fa73ec0",
-    "finance_query::backtesting::config::BacktestConfig": "be711817fbec6dfd",
+    "finance_query::backtesting::config::BacktestConfig": "c540598d16f6aa35",
     "finance_query::backtesting::engine::BacktestEngine": "de98e01c8b31704b",
     "finance_query::backtesting::strategy::prebuilt::SmaCrossover": "c8c0c46bfbbefe96",
     "finance_query::constants::enums::interval::Interval": "d18a25746f10f1c2",

--- a/src/backtesting/config/mod.rs
+++ b/src/backtesting/config/mod.rs
@@ -101,7 +101,7 @@ pub struct BacktestConfig {
     /// benchmark metrics.
     pub bars_per_year: f64,
 
-    // ── Phase 5: Enhanced Broker Simulation ──────────────────────────────────
+    // ── Broker simulation ────────────────────────────────────────────────────
     /// Symmetric bid-ask spread as a fraction of price (0.0 – 1.0).
     ///
     /// On each fill, **half** the spread widens the entry price adversely and

--- a/src/backtesting/engine/exits.rs
+++ b/src/backtesting/engine/exits.rs
@@ -340,7 +340,7 @@ mod tests {
         );
     }
 
-    // ── Per-trade bracket orders (Phase 11) ──────────────────────────────────
+    // ── Per-trade bracket orders ─────────────────────────────────────────────
 
     // Each bracket type is tested for both Long and Short sides.
     // Long:  SL fires on low breach; TP fires on high breach; trail tracks HWM (peak).

--- a/src/backtesting/optimizer/bayesian.rs
+++ b/src/backtesting/optimizer/bayesian.rs
@@ -255,7 +255,7 @@ impl BayesianSearch {
         let mut n_evaluations: usize = 0;
         let mut best_score: Option<f64> = None;
 
-        // ── Phase 1: Latin Hypercube initial sampling ──────────────────────────
+        // ── Latin Hypercube initial sampling ───────────────────────────────────
 
         for norm_point in latin_hypercube_sample(n_init, d, &mut rng) {
             n_evaluations += 1;
@@ -280,7 +280,7 @@ impl BayesianSearch {
             }
         }
 
-        // ── Phase 2: Sequential surrogate-guided search ────────────────────────
+        // ── Sequential surrogate-guided search ─────────────────────────────────
 
         for _ in 0..max_eval.saturating_sub(n_init) {
             let norm_point = if observations.len() < 2 {

--- a/src/backtesting/result/metrics.rs
+++ b/src/backtesting/result/metrics.rs
@@ -474,7 +474,7 @@ impl PerformanceMetrics {
         let time_in_market_pct = calculate_time_in_market(trades, equity_curve);
         let max_idle_period = calculate_max_idle_period(trades);
 
-        // Phase 1 — extended metrics
+        // Extended metrics
         let decisive_trades = stats.winning_trades + stats.losing_trades;
         let kelly_win_rate = if decisive_trades > 0 {
             stats.winning_trades as f64 / decisive_trades as f64

--- a/src/backtesting/result/rolling.rs
+++ b/src/backtesting/result/rolling.rs
@@ -2,7 +2,7 @@ use super::BacktestResult;
 use super::stats::{calculate_periodic_returns, calculate_risk_ratios};
 
 impl BacktestResult {
-    // ─── Phase 2 — Rolling & Temporal Analysis ───────────────────────────────
+    // ─── Rolling & temporal analysis ─────────────────────────────────────────
 
     /// Rolling Sharpe ratio over a sliding window of equity-curve bars.
     ///
@@ -93,7 +93,7 @@ mod tests {
     use super::super::fixtures::{equity_point, make_result, make_trade};
     use crate::backtesting::position::Trade;
 
-    // ─── Phase 2 — Rolling & Temporal Analysis ───────────────────────────────
+    // ─── Rolling & temporal analysis ─────────────────────────────────────────
 
     // ── rolling_sharpe ────────────────────────────────────────────────────────
 

--- a/src/backtesting/result/tags.rs
+++ b/src/backtesting/result/tags.rs
@@ -3,7 +3,7 @@ use super::{BacktestResult, EquityPoint, PerformanceMetrics};
 use crate::backtesting::position::Trade;
 
 impl BacktestResult {
-    // ─── Phase 3 — Trade Tagging & Subgroup Analysis ─────────────────────────
+    // ─── Trade tagging & subgroup analysis ───────────────────────────────────
 
     /// Return all trades that carry the given tag.
     ///
@@ -126,7 +126,7 @@ mod tests {
     use crate::backtesting::position::{Position, PositionSide};
     use crate::backtesting::signal::Signal;
 
-    // ─── Phase 3 — Trade Tagging & Subgroup Analysis ─────────────────────────
+    // ─── Trade tagging & subgroup analysis ───────────────────────────────────
 
     /// Create a tagged trade by going through the real `Position::close` path
     /// so that tag propagation is exercised end-to-end in tests.


### PR DESCRIPTION
## Description

Section markers like `// ── Phase 5: Enhanced Broker Simulation ──` name a development plan the reader cannot see. What each one labels is already clear from the code beneath it, so the number only dates the comment. This drops the numbering and keeps the label.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Renamed eight plan-numbered markers across `src/backtesting/`: `result/tags.rs`, `result/rolling.rs`, `result/metrics.rs`, `config/mod.rs`, `engine/exits.rs`, and `optimizer/bayesian.rs`.
- Left the descriptive uses alone. `bayesian.rs`'s "Exploration phase" and "Sequential phase", and `portfolio/engine/entries.rs`'s "Read phase" and "Write phase", name real stages of an algorithm rather than a plan, and are self-contained as written.

## Breaking Changes

None. Comment text only.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] All tests pass (`cargo test`)

No executable line changes; `cargo check -p finance-query --features full` is clean.

## Documentation
- [x] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

None.