### PR TITLE
feat: ungate the capability layer from provider flags

### DIFF
--- a/src/domains/mod.rs
+++ b/src/domains/mod.rs
@@ -539,80 +539,28 @@ macro_rules! impl_chartable_analytics {
 // ── Modules ─────────────────────────────────────────────────────────
 
 pub(crate) mod commodities;
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "binance",
-    feature = "crypto",
-    feature = "defi",
-    feature = "fmp",
-    feature = "gdelt",
-    feature = "kraken",
-    feature = "polygon"
-))]
 pub(crate) mod crypto;
 pub(crate) mod discovery;
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "bls",
-    feature = "fiscaldata",
-    feature = "fred",
-    feature = "polygon",
-    feature = "worldbank"
-))]
 pub(crate) mod economic;
 pub(crate) mod filings;
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "fmp",
-    feature = "frankfurter",
-    feature = "gdelt",
-    feature = "polygon"
-))]
 pub(crate) mod forex;
 pub(crate) mod futures;
 pub(crate) mod indices;
 pub(crate) mod market;
-#[cfg(feature = "polygon")]
 pub(crate) mod snapshot;
 
 // ── Re-exports ──────────────────────────────────────────────────────
 
 pub use commodities::Commodity;
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "binance",
-    feature = "crypto",
-    feature = "defi",
-    feature = "fmp",
-    feature = "gdelt",
-    feature = "kraken",
-    feature = "polygon"
-))]
 pub use crypto::CryptoCoin;
 pub use discovery::Discovery;
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "bls",
-    feature = "fiscaldata",
-    feature = "fred",
-    feature = "polygon",
-    feature = "worldbank"
-))]
 pub use economic::{EconomicCatalog, EconomicIndicator};
 pub use filings::Filings;
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "fmp",
-    feature = "frankfurter",
-    feature = "gdelt",
-    feature = "polygon"
-))]
 pub use forex::ForexPair;
 pub use futures::FuturesContract;
 pub use indices::Index;
 pub use market::Market;
 pub use market::MarketCalendar;
-#[cfg(feature = "polygon")]
 pub use snapshot::Snapshot;
 
 // ── Tests ───────────────────────────────────────────────────────────

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -309,33 +309,8 @@ pub mod quote {
     pub use crate::models::quote::price::Price;
     pub use crate::models::quote::quote_type::QuoteTypeData;
 }
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "binance",
-    feature = "crypto",
-    feature = "defi",
-    feature = "fmp",
-    feature = "gdelt",
-    feature = "kraken",
-    feature = "polygon"
-))]
 pub use providers::CryptoProvider;
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "bls",
-    feature = "fiscaldata",
-    feature = "fred",
-    feature = "polygon",
-    feature = "worldbank"
-))]
 pub use providers::EconomicProvider;
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "fmp",
-    feature = "frankfurter",
-    feature = "gdelt",
-    feature = "polygon"
-))]
 pub use providers::ForexProvider;
 pub use providers::config::{Providers, ProvidersBuilder};
 pub use providers::{
@@ -355,33 +330,8 @@ pub use async_trait::async_trait;
 pub use ticker::{ClientHandle, Ticker, TickerBuilder};
 
 // Domain-specific query handles — constructable via Providers factory methods.
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "binance",
-    feature = "crypto",
-    feature = "defi",
-    feature = "fmp",
-    feature = "gdelt",
-    feature = "kraken",
-    feature = "polygon"
-))]
 pub use domains::CryptoCoin;
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "fmp",
-    feature = "frankfurter",
-    feature = "gdelt",
-    feature = "polygon"
-))]
 pub use domains::ForexPair;
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "bls",
-    feature = "fiscaldata",
-    feature = "fred",
-    feature = "polygon",
-    feature = "worldbank"
-))]
 pub use domains::{EconomicCatalog, EconomicIndicator};
 
 // Remaining Capability handles — indices, futures, commodities, filings, discovery
@@ -390,7 +340,6 @@ pub use domains::Discovery;
 pub use domains::Filings;
 pub use domains::FuturesContract;
 pub use domains::Index;
-#[cfg(feature = "polygon")]
 pub use domains::Snapshot;
 // `Market` is unconditional — its grouped-daily/crypto methods route through
 // CHART/CRYPTO, which have their own (broader) per-method gating rather than
@@ -490,41 +439,15 @@ pub use models::{
 pub use models::sentiment::{Sentiment, SentimentLabel, analyze as analyze_sentiment};
 // Multi-provider capability response types (feature-gated)
 pub use models::commodities::CommodityQuote;
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "binance",
-    feature = "crypto",
-    feature = "defi",
-    feature = "fmp",
-    feature = "gdelt",
-    feature = "kraken",
-    feature = "polygon"
-))]
 pub use models::crypto::CryptoQuote;
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "bls",
-    feature = "fiscaldata",
-    feature = "fred",
-    feature = "polygon",
-    feature = "worldbank"
-))]
 pub use models::economic::{
     EconomicCategory, EconomicRelease, EconomicSeries, EconomicSeriesMatch,
 };
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "fmp",
-    feature = "frankfurter",
-    feature = "gdelt",
-    feature = "polygon"
-))]
 pub use models::forex::ForexQuote;
 pub use models::futures::FuturesQuote;
 #[cfg(feature = "cftc")]
 pub use models::futures::cot::{CommitmentsOfTraders, CotObservation};
 pub use models::indices::{IndexConstituent, IndexConstituentChange, IndexQuote, MajorIndex};
-#[cfg(feature = "polygon")]
 pub use models::quote::snapshot::{AssetClass, MarketSnapshot};
 
 // ============================================================================

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -36,35 +36,10 @@ pub mod sentiment;
 /// Commodities market data (gold, silver, oil, etc.) — Yahoo / FMP / Alpha Vantage.
 pub mod commodities;
 /// Cryptocurrency market data — CoinGecko, Alpha Vantage, FMP, Polygon.
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "binance",
-    feature = "crypto",
-    feature = "defi",
-    feature = "fmp",
-    feature = "gdelt",
-    feature = "kraken",
-    feature = "polygon"
-))]
 pub mod crypto;
 /// Macro-economic data — FRED, Alpha Vantage, Polygon.
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "bls",
-    feature = "fiscaldata",
-    feature = "fred",
-    feature = "polygon",
-    feature = "worldbank"
-))]
 pub mod economic;
 /// Forex (foreign exchange) data models — Polygon / FMP / Alpha Vantage.
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "fmp",
-    feature = "frankfurter",
-    feature = "gdelt",
-    feature = "polygon"
-))]
 pub mod forex;
 /// Futures market data models — Yahoo / Polygon / CFTC.
 pub mod futures;

--- a/src/models/quote/mod.rs
+++ b/src/models/quote/mod.rs
@@ -12,7 +12,6 @@ pub mod data;
 /// Formatted value wrapper for Yahoo Finance numeric fields.
 pub mod formatted_value;
 /// Cross-market snapshot models (provider-routed; Polygon-only).
-#[cfg(feature = "polygon")]
 pub mod snapshot;
 
 // Re-export only the final flattened Quote struct and FormattedValue (used in Quote's public fields)

--- a/src/providers/adapter/dispatch.rs
+++ b/src/providers/adapter/dispatch.rs
@@ -68,39 +68,14 @@ pub trait ProviderAdapter: ProviderCore {
     fn as_market(&self) -> Option<&dyn MarketProvider> {
         None
     }
-    #[cfg(any(
-        feature = "alphavantage",
-        feature = "binance",
-        feature = "crypto",
-        feature = "defi",
-        feature = "fmp",
-        feature = "gdelt",
-        feature = "kraken",
-        feature = "polygon"
-    ))]
     /// Override to `Some(self)` to serve [`crate::Capability::CRYPTO`].
     fn as_crypto(&self) -> Option<&dyn CryptoProvider> {
         None
     }
-    #[cfg(any(
-        feature = "alphavantage",
-        feature = "bls",
-        feature = "fiscaldata",
-        feature = "fred",
-        feature = "polygon",
-        feature = "worldbank"
-    ))]
     /// Override to `Some(self)` to serve [`crate::Capability::ECONOMIC`].
     fn as_economic(&self) -> Option<&dyn EconomicProvider> {
         None
     }
-    #[cfg(any(
-        feature = "alphavantage",
-        feature = "fmp",
-        feature = "frankfurter",
-        feature = "gdelt",
-        feature = "polygon"
-    ))]
     /// Override to `Some(self)` to serve [`crate::Capability::FOREX`].
     fn as_forex(&self) -> Option<&dyn ForexProvider> {
         None

--- a/src/providers/adapter/equity.rs
+++ b/src/providers/adapter/equity.rs
@@ -22,7 +22,6 @@ pub trait QuoteProvider: ProviderCore {
     /// Fetch a snapshot for symbols spanning several asset classes in one
     /// request. Rows the provider could not resolve are returned with
     /// `error` set rather than dropped.
-    #[cfg(feature = "polygon")]
     async fn fetch_unified_snapshot(
         &self,
         _symbols: &[&str],

--- a/src/providers/adapter/markets.rs
+++ b/src/providers/adapter/markets.rs
@@ -110,16 +110,6 @@ pub trait MarketProvider: ProviderCore {
 }
 
 /// [`crate::Capability::CRYPTO`] — cryptocurrency quotes.
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "binance",
-    feature = "crypto",
-    feature = "defi",
-    feature = "fmp",
-    feature = "gdelt",
-    feature = "kraken",
-    feature = "polygon"
-))]
 #[async_trait::async_trait]
 pub trait CryptoProvider: ProviderCore {
     /// Fetch a quote for one coin, priced in `vs_currency`.
@@ -169,14 +159,6 @@ pub trait CryptoProvider: ProviderCore {
 }
 
 /// [`crate::Capability::ECONOMIC`] — macro-economic data series.
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "bls",
-    feature = "fiscaldata",
-    feature = "fred",
-    feature = "polygon",
-    feature = "worldbank"
-))]
 #[async_trait::async_trait]
 pub trait EconomicProvider: ProviderCore {
     /// Fetch observations for one macro-economic series.
@@ -237,13 +219,6 @@ pub trait EconomicProvider: ProviderCore {
 }
 
 /// [`crate::Capability::FOREX`] — currency-pair quotes.
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "fmp",
-    feature = "frankfurter",
-    feature = "gdelt",
-    feature = "polygon"
-))]
 #[async_trait::async_trait]
 pub trait ForexProvider: ProviderCore {
     /// Fetch the exchange rate for one currency pair.

--- a/src/providers/adapter/mod.rs
+++ b/src/providers/adapter/mod.rs
@@ -36,33 +36,8 @@ pub use equity::{
     ChartProvider, CorporateProvider, FilingsProvider, FundamentalsProvider, OptionsProvider,
     QuoteProvider,
 };
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "binance",
-    feature = "crypto",
-    feature = "defi",
-    feature = "fmp",
-    feature = "gdelt",
-    feature = "kraken",
-    feature = "polygon"
-))]
 pub use markets::CryptoProvider;
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "bls",
-    feature = "fiscaldata",
-    feature = "fred",
-    feature = "polygon",
-    feature = "worldbank"
-))]
 pub use markets::EconomicProvider;
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "fmp",
-    feature = "frankfurter",
-    feature = "gdelt",
-    feature = "polygon"
-))]
 pub use markets::ForexProvider;
 pub use markets::{
     CalendarProvider, CommoditiesProvider, DiscoveryProvider, FuturesProvider, IndicesProvider,

--- a/src/providers/config.rs
+++ b/src/providers/config.rs
@@ -110,28 +110,11 @@ impl Providers {
     }
 
     /// Create a [`CryptoCoin`](crate::CryptoCoin) handle backed by this provider set.
-    #[cfg(any(
-        feature = "alphavantage",
-        feature = "binance",
-        feature = "crypto",
-        feature = "defi",
-        feature = "fmp",
-        feature = "gdelt",
-        feature = "kraken",
-        feature = "polygon"
-    ))]
     pub fn crypto(&self, id: impl Into<String>) -> crate::domains::CryptoCoin {
         crate::domains::CryptoCoin::with_providers(id.into().into(), Arc::clone(&self.set))
     }
 
     /// Create a [`ForexPair`](crate::ForexPair) handle backed by this provider set.
-    #[cfg(any(
-        feature = "alphavantage",
-        feature = "fmp",
-        feature = "frankfurter",
-        feature = "gdelt",
-        feature = "polygon"
-    ))]
     pub fn forex(
         &self,
         from: impl Into<String>,
@@ -145,14 +128,6 @@ impl Providers {
     }
 
     /// Create an [`EconomicIndicator`](crate::EconomicIndicator) handle backed by this provider set.
-    #[cfg(any(
-        feature = "alphavantage",
-        feature = "bls",
-        feature = "fiscaldata",
-        feature = "fred",
-        feature = "polygon",
-        feature = "worldbank"
-    ))]
     pub fn economic(&self, series_id: impl Into<String>) -> crate::domains::EconomicIndicator {
         crate::domains::EconomicIndicator::with_providers(
             series_id.into().into(),
@@ -209,7 +184,6 @@ impl Providers {
     /// [`Capability::ECONOMIC`](crate::Capability::ECONOMIC). Unlike
     /// [`economic`](Self::economic) it takes no series id — it is how you find
     /// one.
-    #[cfg(any(feature = "fred", feature = "alphavantage", feature = "polygon"))]
     pub fn economic_catalog(&self) -> crate::domains::EconomicCatalog {
         crate::domains::EconomicCatalog::with_providers(Arc::clone(&self.set))
     }
@@ -220,7 +194,6 @@ impl Providers {
     /// [`Capability::QUOTE`](crate::Capability::QUOTE). Needs a provider whose
     /// snapshot endpoint spans asset classes — currently Polygon only, which is
     /// why the handle is gated on that feature.
-    #[cfg(feature = "polygon")]
     pub fn snapshot(&self) -> crate::domains::Snapshot {
         crate::domains::Snapshot::with_providers(Arc::clone(&self.set))
     }

--- a/src/providers/config.rs
+++ b/src/providers/config.rs
@@ -110,11 +110,19 @@ impl Providers {
     }
 
     /// Create a [`CryptoCoin`](crate::CryptoCoin) handle backed by this provider set.
+    ///
+    /// Compiled in unconditionally. With no built-in provider for this
+    /// capability, register one with [`ProvidersBuilder::with_adapter`] or
+    /// enable its feature, or these calls return `NoProviderAvailable`.
     pub fn crypto(&self, id: impl Into<String>) -> crate::domains::CryptoCoin {
         crate::domains::CryptoCoin::with_providers(id.into().into(), Arc::clone(&self.set))
     }
 
     /// Create a [`ForexPair`](crate::ForexPair) handle backed by this provider set.
+    ///
+    /// Compiled in unconditionally. With no built-in provider for this
+    /// capability, register one with [`ProvidersBuilder::with_adapter`] or
+    /// enable its feature, or these calls return `NoProviderAvailable`.
     pub fn forex(
         &self,
         from: impl Into<String>,
@@ -128,6 +136,10 @@ impl Providers {
     }
 
     /// Create an [`EconomicIndicator`](crate::EconomicIndicator) handle backed by this provider set.
+    ///
+    /// Compiled in unconditionally. With no built-in provider for this
+    /// capability, register one with [`ProvidersBuilder::with_adapter`] or
+    /// enable its feature, or these calls return `NoProviderAvailable`.
     pub fn economic(&self, series_id: impl Into<String>) -> crate::domains::EconomicIndicator {
         crate::domains::EconomicIndicator::with_providers(
             series_id.into().into(),
@@ -184,6 +196,10 @@ impl Providers {
     /// [`Capability::ECONOMIC`](crate::Capability::ECONOMIC). Unlike
     /// [`economic`](Self::economic) it takes no series id — it is how you find
     /// one.
+    ///
+    /// Compiled in unconditionally. With no built-in provider for this
+    /// capability, register one with [`ProvidersBuilder::with_adapter`] or
+    /// enable its feature, or these calls return `NoProviderAvailable`.
     pub fn economic_catalog(&self) -> crate::domains::EconomicCatalog {
         crate::domains::EconomicCatalog::with_providers(Arc::clone(&self.set))
     }
@@ -192,8 +208,11 @@ impl Providers {
     ///
     /// Routes cross-market snapshots through
     /// [`Capability::QUOTE`](crate::Capability::QUOTE). Needs a provider whose
-    /// snapshot endpoint spans asset classes — currently Polygon only, which is
-    /// why the handle is gated on that feature.
+    /// snapshot endpoint spans asset classes, currently Polygon alone.
+    ///
+    /// Compiled in unconditionally. With no built-in provider for this
+    /// capability, register one with [`ProvidersBuilder::with_adapter`] or
+    /// enable its feature, or these calls return `NoProviderAvailable`.
     pub fn snapshot(&self) -> crate::domains::Snapshot {
         crate::domains::Snapshot::with_providers(Arc::clone(&self.set))
     }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -51,33 +51,8 @@ pub(crate) mod worldbank;
 pub(crate) mod yahoo;
 mod yahoo_ttm;
 
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "binance",
-    feature = "crypto",
-    feature = "defi",
-    feature = "fmp",
-    feature = "gdelt",
-    feature = "kraken",
-    feature = "polygon"
-))]
 pub use adapter::CryptoProvider;
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "bls",
-    feature = "fiscaldata",
-    feature = "fred",
-    feature = "polygon",
-    feature = "worldbank"
-))]
 pub use adapter::EconomicProvider;
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "fmp",
-    feature = "frankfurter",
-    feature = "gdelt",
-    feature = "polygon"
-))]
 pub use adapter::ForexProvider;
 /// Not part of the stable public API — see [`ProviderAdapter`].
 #[doc(hidden)]

--- a/tests/custom_provider.rs
+++ b/tests/custom_provider.rs
@@ -161,3 +161,53 @@ fn routes_report_what_they_carry() {
     );
     assert_eq!(routes.providers_for(Capability::QUOTE), None);
 }
+
+struct CannedForex;
+
+impl ProviderCore for CannedForex {
+    fn id(&self) -> Provider {
+        Provider::custom("canned-forex")
+    }
+}
+
+#[finance_query::async_trait]
+impl finance_query::ForexProvider for CannedForex {
+    async fn fetch_forex_quote(
+        &self,
+        from: &str,
+        to: &str,
+    ) -> finance_query::Result<finance_query::ForexQuote> {
+        serde_json::from_value(serde_json::json!({
+            "symbol": format!("{from}{to}=X"),
+            "price": 1.25,
+        }))
+        .map_err(|e| FinanceError::ResponseStructureError {
+            field: "forex".to_string(),
+            context: e.to_string(),
+        })
+    }
+}
+
+impl ProviderAdapter for CannedForex {
+    fn as_forex(&self) -> Option<&dyn finance_query::ForexProvider> {
+        Some(self)
+    }
+}
+
+#[tokio::test]
+async fn forex_handle_reachable_with_no_builtin_forex_feature() {
+    let providers = Providers::builder()
+        .with_adapter(Arc::new(CannedForex))
+        .route(Capability::FOREX, [Provider::custom("canned-forex")])
+        .build()
+        .await
+        .expect("builds");
+
+    let quote = providers
+        .forex("EUR", "USD")
+        .quote()
+        .await
+        .expect("the custom adapter serves FOREX");
+    assert_eq!(quote.price, Some(1.25));
+    assert_eq!(quote.symbol, "EURUSD=X");
+}


### PR DESCRIPTION
## Description

A custom FOREX provider could not reach `Providers::forex()`. The factory method was cfg-gated on built-in provider features, so it did not exist unless a built-in forex provider happened to be compiled in. That defeats the extensibility the Providers API just gained. The gates turned out to run the whole vertical rather than just the factory: models, capability traits, `as_*` accessors, domain handles, and three separate re-export layers. This ungates the capability layer and leaves adapters and `Provider` variants gated, which is what the feature flags are for.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Removed 38 `cfg` attributes across the CRYPTO, ECONOMIC, FOREX and snapshot verticals.
- Made `CryptoProvider`, `EconomicProvider` and `ForexProvider` unconditional, along with their models and their `as_*` accessors on `ProviderAdapter`.
- Made `Providers::crypto`, `forex`, `economic`, `economic_catalog` and `snapshot` always available.
- Documented on each ungated factory that its calls return `NoProviderAvailable` when no provider serves the capability. The compiler used to carry that information.
- Corrected the `Providers::snapshot` docs, which described a feature gate that no longer exists.
- Added `forex_handle_reachable_with_no_builtin_forex_feature` to `tests/custom_provider.rs`, which exercises FOREX on default features.

## Breaking Changes

None. Methods and types become available on more feature combinations than before; nothing is removed or renamed. Net diff is -233 lines.

## Testing

`cargo test --workspace --features finance-query/full`: 2065 passed, 0 failed. Single-feature builds checked for `polygon`, `crypto`, `fred`, `frankfurter`, `defi`, `worldbank`, `alphavantage` and `full`.

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [x] All tests pass (`cargo test`)

## Documentation
- [x] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy`)
- [x] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

None.
