### PR TITLE
docs: fix a broken link to Providers::ticker

### DIFF
--- a/src/ticker/core.rs
+++ b/src/ticker/core.rs
@@ -122,7 +122,7 @@ impl TickerBuilder {
         self.config = c;
         self
     }
-    /// Pre-inject a shared provider set (used by [`Providers::stock`](crate::Providers::stock)).
+    /// Pre-inject a shared provider set (used by [`Providers::ticker`](crate::Providers::ticker)).
     ///
     /// Not part of the stable public API — see [`ProviderAdapter`](crate::ProviderAdapter).
     #[doc(hidden)]


### PR DESCRIPTION
## Description

`TickerBuilder::with_provider_set` pointed its reader at `Providers::stock`, which does not exist. The method is `ticker`. The same sentence on `Tickers` already had it right.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Pointed the `with_provider_set` doc link at `Providers::ticker` in `src/ticker/core.rs`.

## Breaking Changes

None.

## Testing

`cargo doc` with `RUSTDOCFLAGS=-D rustdoc::broken_intra_doc_links`: 0 errors.

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] All tests pass (`cargo test`)

## Documentation
- [x] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy`)
- [x] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

None.
