### PR TITLE
feat: export CustomId from the crate root

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,7 +318,9 @@ pub use providers::{
     FilingsProvider, FundamentalsProvider, FuturesProvider, IndicesProvider, MarketProvider,
     OptionsProvider, ProviderAdapter, ProviderCore, ProviderSet, QuoteProvider, Routes,
 };
-pub use providers::{Capability, Fetch, Operation, Provider, ProviderHealth, RetryPolicy};
+pub use providers::{
+    Capability, CustomId, Fetch, Operation, Provider, ProviderHealth, RetryPolicy,
+};
 
 /// The attribute every capability trait implementation needs.
 ///

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -77,7 +77,7 @@ pub use capability::Capability;
 #[allow(unused_imports)] // each is used only by a feature-gated provider bridge
 pub(crate) use convert::{build_financial_statement, build_options, range_to_dates};
 pub use operation::Operation;
-pub use provider::Provider;
+pub use provider::{CustomId, Provider};
 pub use routes::{Fetch, Routes};
 pub use set::ProviderSet;
 


### PR DESCRIPTION
## Description

`Provider::Custom(CustomId)` is a public variant whose payload type was not reachable. A downstream crate could match the variant but could not name its type in a signature or a struct field, and rustdoc flagged the public docs as linking to a private item.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Re-exported `CustomId` from `providers` and from the crate root, beside `Provider`.

## Breaking Changes

None. The export is additive.

## Testing

`cargo doc` with `RUSTDOCFLAGS=-D rustdoc::broken_intra_doc_links`: 0 errors, and the `private_intra_doc_links` warning on `Provider::Custom` is gone.

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] All tests pass (`cargo test`)

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy`)
- [x] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

None.
