### PR TITLE
feat: allow a Fetch mode per capability

### DIFF
--- a/src/providers/build.rs
+++ b/src/providers/build.rs
@@ -89,7 +89,7 @@ pub(crate) async fn build_providers(
         providers.push(Arc::new(edgar::EdgarProvider));
     }
     for routed in routes.map.values() {
-        for provider in routed {
+        for provider in &routed.providers {
             if !providers.iter().any(|p| p.id() == *provider) {
                 return Err(FinanceError::ProviderNotRegistered {
                     provider: *provider,

--- a/src/providers/config.rs
+++ b/src/providers/config.rs
@@ -301,9 +301,31 @@ impl ProvidersBuilder {
     /// initialisation list if not already present. If omitted for a capability,
     /// Yahoo is used as default.
     pub fn route(
+        self,
+        cap: crate::providers::Capability,
+        providers: impl IntoIterator<Item = Provider>,
+    ) -> Self {
+        self.insert_route(cap, providers, None)
+    }
+
+    /// Route a capability, overriding [`fetch`](Self::fetch) for it alone.
+    ///
+    /// Lets a quota-limited capability stay sequential while another races
+    /// its providers.
+    pub fn route_with(
+        self,
+        cap: crate::providers::Capability,
+        providers: impl IntoIterator<Item = Provider>,
+        fetch: Fetch,
+    ) -> Self {
+        self.insert_route(cap, providers, Some(fetch))
+    }
+
+    fn insert_route(
         mut self,
         cap: crate::providers::Capability,
         providers: impl IntoIterator<Item = Provider>,
+        fetch: Option<Fetch>,
     ) -> Self {
         let providers: Vec<Provider> = providers.into_iter().collect();
         for provider in &providers {
@@ -316,7 +338,9 @@ impl ProvidersBuilder {
                 self.provider_ids.push(*provider);
             }
         }
-        self.routes.map.insert(cap, providers);
+        self.routes
+            .map
+            .insert(cap, super::routes::Route { providers, fetch });
         self
     }
 

--- a/src/providers/routes.rs
+++ b/src/providers/routes.rs
@@ -14,15 +14,25 @@ pub enum Fetch {
     Parallel,
 }
 
+#[derive(Debug)]
+pub(crate) struct Route {
+    pub(crate) providers: Vec<Provider>,
+    pub(crate) fetch: Option<Fetch>,
+}
+
 /// Per-capability provider routing table.
 ///
 /// Maps each [`Capability`] to an ordered list of [`Provider`]s to try. A
 /// capability with no entry falls back to Yahoo, or to EDGAR then Yahoo for
 /// [`Capability::FILINGS`].
+///
+/// Each route may carry its own [`Fetch`] mode, so a quota-limited capability
+/// can stay sequential while another races its providers. Routes without one
+/// use the table default.
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct Routes {
-    pub(crate) map: HashMap<Capability, Vec<Provider>>,
+    pub(crate) map: HashMap<Capability, Route>,
     pub(crate) fetch: Fetch,
 }
 
@@ -41,18 +51,52 @@ impl Routes {
     /// Without this a hand-built table is empty and every capability falls
     /// back to its default, so a registered adapter would never be reached.
     #[must_use]
-    pub fn route(mut self, cap: Capability, providers: impl IntoIterator<Item = Provider>) -> Self {
-        self.map.insert(cap, providers.into_iter().collect());
+    pub fn route(self, cap: Capability, providers: impl IntoIterator<Item = Provider>) -> Self {
+        self.insert(cap, providers, None)
+    }
+
+    /// Route one capability, overriding the table's [`Fetch`] mode for it.
+    #[must_use]
+    pub fn route_with(
+        self,
+        cap: Capability,
+        providers: impl IntoIterator<Item = Provider>,
+        fetch: Fetch,
+    ) -> Self {
+        self.insert(cap, providers, Some(fetch))
+    }
+
+    fn insert(
+        mut self,
+        cap: Capability,
+        providers: impl IntoIterator<Item = Provider>,
+        fetch: Option<Fetch>,
+    ) -> Self {
+        self.map.insert(
+            cap,
+            Route {
+                providers: providers.into_iter().collect(),
+                fetch,
+            },
+        );
         self
     }
 
-    /// The concurrency mode this table was built with.
+    /// The default concurrency mode for capabilities that do not override it.
     pub fn fetch_mode(&self) -> Fetch {
         self.fetch
     }
 
+    /// The concurrency mode `cap` resolves to.
+    pub fn fetch_mode_for(&self, cap: Capability) -> Fetch {
+        self.map
+            .get(&cap)
+            .and_then(|r| r.fetch)
+            .unwrap_or(self.fetch)
+    }
+
     /// The providers routed to `cap`, or `None` when it falls back to the default.
     pub fn providers_for(&self, cap: Capability) -> Option<&[Provider]> {
-        self.map.get(&cap).map(Vec::as_slice)
+        self.map.get(&cap).map(|r| r.providers.as_slice())
     }
 }

--- a/src/providers/set.rs
+++ b/src/providers/set.rs
@@ -90,8 +90,9 @@ impl ProviderSet {
     /// explicit route configured via `.route()`. When no route is configured,
     /// defaults to Yahoo for all capabilities and EDGAR for filings.
     fn candidates_for(&self, cap: Capability) -> Vec<&Arc<dyn ProviderAdapter>> {
-        if let Some(provider_ids) = self.routes.map.get(&cap) {
-            provider_ids
+        if let Some(route) = self.routes.map.get(&cap) {
+            route
+                .providers
                 .iter()
                 .filter_map(|id| self.providers.iter().find(|p| p.id() == *id))
                 .collect()
@@ -182,7 +183,7 @@ impl ProviderSet {
         if candidates.is_empty() {
             return Err(Self::no_provider(cap));
         }
-        match self.routes.fetch {
+        match self.routes.fetch_mode_for(cap) {
             Fetch::Sequential => {
                 let mut last = None;
                 let mut unsupported = None;

--- a/src/providers/tests.rs
+++ b/src/providers/tests.rs
@@ -233,10 +233,8 @@ async fn real_errors_outrank_not_supported_in_final_error() {
         }
     }
 
-    let mut routes = Routes::new(Fetch::Sequential);
-    routes
-        .map
-        .insert(Capability::CHART, vec![Provider::Yahoo, Provider::Edgar]);
+    let routes =
+        Routes::new(Fetch::Sequential).route(Capability::CHART, [Provider::Yahoo, Provider::Edgar]);
     let set = ProviderSet::new(
         vec![Arc::new(NoSparkProvider), Arc::new(FailingChartProvider)],
         routes,
@@ -370,10 +368,8 @@ async fn retry_policy_retries_rate_limited_then_succeeds() {
 async fn retry_policy_exhausts_and_falls_through_to_next_provider() {
     let always_limited = Arc::new(FlakyChartProvider::new(Provider::Yahoo, usize::MAX));
     let succeeds = Arc::new(FlakyChartProvider::new(Provider::Edgar, 0));
-    let mut routes = Routes::new(Fetch::Sequential);
-    routes
-        .map
-        .insert(Capability::CHART, vec![Provider::Yahoo, Provider::Edgar]);
+    let routes =
+        Routes::new(Fetch::Sequential).route(Capability::CHART, [Provider::Yahoo, Provider::Edgar]);
     let set = ProviderSet::new(
         vec![
             always_limited.clone() as Arc<dyn ProviderAdapter>,
@@ -526,4 +522,138 @@ fn every_variant_has_its_serialized_form_pinned() {
         assert_eq!(provider.as_str(), id);
         assert_eq!(Provider::from_id_str(id), Some(provider));
     }
+}
+
+#[test]
+fn a_route_without_a_mode_uses_the_table_default() {
+    let routes = Routes::new(Fetch::Parallel).route(Capability::QUOTE, [Provider::Yahoo]);
+    assert_eq!(routes.fetch_mode_for(Capability::QUOTE), Fetch::Parallel);
+}
+
+#[test]
+fn a_route_mode_overrides_the_table_default() {
+    let routes = Routes::new(Fetch::Parallel).route_with(
+        Capability::FUNDAMENTALS,
+        [Provider::Yahoo],
+        Fetch::Sequential,
+    );
+    assert_eq!(
+        routes.fetch_mode_for(Capability::FUNDAMENTALS),
+        Fetch::Sequential
+    );
+    assert_eq!(routes.fetch_mode(), Fetch::Parallel);
+}
+
+#[test]
+fn an_unrouted_capability_uses_the_table_default() {
+    let routes = Routes::new(Fetch::Sequential).route_with(
+        Capability::QUOTE,
+        [Provider::Yahoo],
+        Fetch::Parallel,
+    );
+    assert_eq!(routes.fetch_mode_for(Capability::CHART), Fetch::Sequential);
+}
+
+#[test]
+fn modes_are_independent_across_capabilities() {
+    let routes = Routes::new(Fetch::Sequential)
+        .route_with(Capability::QUOTE, [Provider::Yahoo], Fetch::Parallel)
+        .route(Capability::FUNDAMENTALS, [Provider::Yahoo]);
+    assert_eq!(routes.fetch_mode_for(Capability::QUOTE), Fetch::Parallel);
+    assert_eq!(
+        routes.fetch_mode_for(Capability::FUNDAMENTALS),
+        Fetch::Sequential
+    );
+}
+
+struct CountingChartProvider {
+    id: Provider,
+    calls: std::sync::atomic::AtomicUsize,
+}
+
+impl CountingChartProvider {
+    fn new(id: Provider) -> Self {
+        Self {
+            id,
+            calls: std::sync::atomic::AtomicUsize::new(0),
+        }
+    }
+
+    fn calls(&self) -> usize {
+        self.calls.load(std::sync::atomic::Ordering::SeqCst)
+    }
+}
+
+impl ProviderCore for CountingChartProvider {
+    fn id(&self) -> Provider {
+        self.id
+    }
+}
+
+#[async_trait::async_trait]
+impl ChartProvider for CountingChartProvider {
+    async fn fetch_chart(
+        &self,
+        symbol: &str,
+        _: crate::Interval,
+        _: crate::TimeRange,
+    ) -> Result<crate::models::chart::Chart> {
+        self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        tokio::task::yield_now().await;
+        Ok(crate::models::chart::Chart {
+            symbol: symbol.to_string(),
+            meta: Default::default(),
+            candles: Vec::new(),
+            interval: None,
+            range: None,
+            provider_id: Some(self.id),
+        })
+    }
+}
+
+impl ProviderAdapter for CountingChartProvider {
+    fn as_chart(&self) -> Option<&dyn ChartProvider> {
+        Some(self)
+    }
+}
+
+async fn chart_calls_under(routes: Routes) -> (usize, usize) {
+    let first = Arc::new(CountingChartProvider::new(Provider::Yahoo));
+    let second = Arc::new(CountingChartProvider::new(Provider::Edgar));
+    let set = ProviderSet::new(
+        vec![
+            first.clone() as Arc<dyn ProviderAdapter>,
+            second.clone() as Arc<dyn ProviderAdapter>,
+        ],
+        routes,
+    );
+    set.fetch(Capability::CHART, |p| {
+        let p = p.clone();
+        async move {
+            p.as_chart()
+                .ok_or_else(|| p.not_supported(Operation::Chart))?
+                .fetch_chart("AAPL", crate::Interval::OneDay, crate::TimeRange::FiveDays)
+                .await
+        }
+    })
+    .await
+    .expect("a provider succeeds");
+    (first.calls(), second.calls())
+}
+
+#[tokio::test]
+async fn a_sequential_route_stops_at_the_first_success() {
+    let routes =
+        Routes::new(Fetch::Sequential).route(Capability::CHART, [Provider::Yahoo, Provider::Edgar]);
+    assert_eq!(chart_calls_under(routes).await, (1, 0));
+}
+
+#[tokio::test]
+async fn route_with_parallel_overrides_a_sequential_default() {
+    let routes = Routes::new(Fetch::Sequential).route_with(
+        Capability::CHART,
+        [Provider::Yahoo, Provider::Edgar],
+        Fetch::Parallel,
+    );
+    assert_eq!(chart_calls_under(routes).await, (1, 1));
 }


### PR DESCRIPTION
## Description

`Routes` held one `Fetch` for the whole table, so racing QUOTE across providers meant racing everything, including a capability on a 250-call-a-day quota. Each route can now carry its own mode and falls back to the table default. `Routes.map` is crate-private, so the public surface only gains `route_with` and `fetch_mode_for`.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Moved `Fetch` into a per-capability `Route` entry holding the provider list and an optional mode.
- Added `Routes::route_with` and `ProvidersBuilder::route_with` to set a mode for one capability.
- Added `Routes::fetch_mode_for`, which resolves a route's own mode and falls back to the table default.
- Switched dispatch in `ProviderSet::fetch` from the table-wide mode to `fetch_mode_for(cap)`.
- Added dispatch-level tests asserting the observable difference: a sequential route calls one provider, a `route_with` parallel override calls both.

## Breaking Changes

None. `Routes::route` keeps its signature, `Routes::new` and `fetch_mode` are unchanged, and the reshaped `map` field is crate-private.

## Testing

`cargo test --workspace --features finance-query/full`: 2065 passed, 0 failed. The parallel-override test was mutation-checked: reverting the `ProviderSet::fetch` call site to the table-wide mode makes it fail, and the accessor tests alone do not catch that.

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] All tests pass (`cargo test`)

## Documentation
- [x] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy`)
- [x] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

None.
