### PR TITLE
feat: scope API keys to a Providers instance

### DIFF
--- a/src/adapters/keys.rs
+++ b/src/adapters/keys.rs
@@ -1,0 +1,191 @@
+//! API keys scoped to one [`Providers`](crate::Providers) instance.
+//!
+//! The keyed adapters read their credentials from process-global
+//! [`OnceLock`](std::sync::OnceLock) singletons, which allows exactly one key
+//! per provider per process. A key configured on a builder is instead published
+//! into a task-local for the duration of a dispatch call, so two `Providers`
+//! can hold different keys for the same provider, and a key can be rotated
+//! without restarting.
+//!
+//! `build_client` resolves in order: scoped key, singleton, environment
+//! variable. Anything dispatched outside a scope behaves exactly as before.
+
+// Everything below is reached from the keyed adapters' `build_client`, which
+// only exists when one of their features is enabled.
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock, OnceLock, RwLock, Weak};
+use std::time::Duration;
+
+use crate::rate_limiter::RateLimiter;
+
+#[derive(Clone)]
+pub(crate) struct ScopedKey {
+    pub(crate) api_key: String,
+    pub(crate) timeout: Duration,
+    limiter: Arc<OnceLock<Arc<RateLimiter>>>,
+}
+
+impl ScopedKey {
+    pub(crate) fn new(api_key: String, timeout: Duration) -> Self {
+        Self {
+            api_key,
+            timeout,
+            limiter: Arc::new(OnceLock::new()),
+        }
+    }
+
+    /// Rate limits are enforced per API key upstream, so each distinct key gets
+    /// its own bucket rather than sharing the singleton's.
+    pub(crate) fn limiter(&self, provider_key: &'static str, rate: f64) -> Arc<RateLimiter> {
+        Arc::clone(
+            self.limiter
+                .get_or_init(|| shared_limiter(provider_key, &self.api_key, rate)),
+        )
+    }
+}
+
+pub(crate) type KeyMap = HashMap<&'static str, ScopedKey>;
+
+tokio::task_local! {
+    static SCOPED: Arc<KeyMap>;
+}
+
+type LimiterMap = HashMap<(&'static str, String), Weak<RateLimiter>>;
+
+/// Weak so a rotated-out key's bucket is dropped with the `Providers` holding
+/// it. The strong reference lives in that instance's [`ScopedKey`].
+static LIMITERS: LazyLock<RwLock<LimiterMap>> = LazyLock::new(|| RwLock::new(HashMap::new()));
+
+fn shared_limiter(provider_key: &'static str, api_key: &str, rate: f64) -> Arc<RateLimiter> {
+    let id = (provider_key, api_key.to_string());
+    if let Some(limiter) = LIMITERS
+        .read()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(&id)
+        .and_then(Weak::upgrade)
+    {
+        return limiter;
+    }
+    let mut limiters = LIMITERS.write().unwrap_or_else(|e| e.into_inner());
+    if let Some(limiter) = limiters.get(&id).and_then(Weak::upgrade) {
+        return limiter;
+    }
+    limiters.retain(|_, held| held.strong_count() > 0);
+    let limiter = Arc::new(RateLimiter::new(rate));
+    limiters.insert(id, Arc::downgrade(&limiter));
+    limiter
+}
+
+fn tracked_limiters() -> usize {
+    LIMITERS.read().unwrap_or_else(|e| e.into_inner()).len()
+}
+
+pub(crate) fn scoped_key(provider_key: &str) -> Option<ScopedKey> {
+    SCOPED
+        .try_with(|keys| keys.get(provider_key).cloned())
+        .ok()
+        .flatten()
+}
+
+pub(crate) async fn scope<F>(keys: Arc<KeyMap>, f: F) -> F::Output
+where
+    F: std::future::Future,
+{
+    if keys.is_empty() {
+        return f.await;
+    }
+    SCOPED.scope(keys, f).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn map(pairs: &[(&'static str, &str)]) -> Arc<KeyMap> {
+        Arc::new(
+            pairs
+                .iter()
+                .map(|(p, k)| {
+                    (
+                        *p,
+                        ScopedKey::new((*k).to_string(), Duration::from_secs(30)),
+                    )
+                })
+                .collect(),
+        )
+    }
+
+    #[tokio::test]
+    async fn no_scope_yields_no_key() {
+        assert!(scoped_key("fmp").is_none());
+    }
+
+    #[tokio::test]
+    async fn a_scope_publishes_its_own_keys() {
+        scope(map(&[("fmp", "abc")]), async {
+            assert_eq!(scoped_key("fmp").map(|k| k.api_key), Some("abc".into()));
+            assert!(scoped_key("polygon").is_none());
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn an_empty_map_leaves_the_scope_unset() {
+        scope(Arc::new(KeyMap::new()), async {
+            assert!(scoped_key("fmp").is_none());
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn concurrent_scopes_do_not_see_each_other() {
+        let one = tokio::spawn(scope(map(&[("fmp", "first")]), async {
+            tokio::task::yield_now().await;
+            scoped_key("fmp").map(|k| k.api_key)
+        }));
+        let two = tokio::spawn(scope(map(&[("fmp", "second")]), async {
+            tokio::task::yield_now().await;
+            scoped_key("fmp").map(|k| k.api_key)
+        }));
+        assert_eq!(one.await.unwrap(), Some("first".into()));
+        assert_eq!(two.await.unwrap(), Some("second".into()));
+    }
+
+    #[test]
+    fn each_key_gets_its_own_limiter() {
+        let a = ScopedKey::new("key-a".into(), Duration::from_secs(30));
+        let b = ScopedKey::new("key-b".into(), Duration::from_secs(30));
+        assert!(Arc::ptr_eq(&a.limiter("fmp", 5.0), &a.limiter("fmp", 5.0)));
+        assert!(!Arc::ptr_eq(&a.limiter("fmp", 5.0), &b.limiter("fmp", 5.0)));
+    }
+
+    #[test]
+    fn two_instances_of_one_key_share_a_bucket() {
+        let first = ScopedKey::new("shared".into(), Duration::from_secs(30));
+        let second = ScopedKey::new("shared".into(), Duration::from_secs(30));
+        assert!(Arc::ptr_eq(
+            &first.limiter("polygon", 5.0),
+            &second.limiter("polygon", 5.0)
+        ));
+    }
+
+    #[test]
+    fn a_dropped_key_stops_being_tracked() {
+        let before = tracked_limiters();
+        {
+            let key = ScopedKey::new("transient-xyz".into(), Duration::from_secs(30));
+            let _live = key.limiter("fred", 5.0);
+            assert!(tracked_limiters() > before);
+        }
+        let _prune =
+            ScopedKey::new("prune-trigger".into(), Duration::from_secs(30)).limiter("fred", 5.0);
+        assert!(
+            !LIMITERS
+                .read()
+                .unwrap()
+                .contains_key(&("fred", "transient-xyz".to_string()))
+        );
+    }
+}

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -47,6 +47,7 @@
 //! - Full mockito test coverage (no API key needed to run tests)
 
 pub(crate) mod common;
+pub(crate) mod keys;
 pub(crate) mod singleton;
 
 /// Alpha Vantage financial data API (requires `alphavantage` feature).

--- a/src/adapters/singleton.rs
+++ b/src/adapters/singleton.rs
@@ -77,10 +77,9 @@ macro_rules! provider_singleton_state {
 /// Generates `build_client()` and `build_test_client()` for a provider whose
 /// client is constructed via `$builder::new(api_key).timeout(t).build_with_limiter(limiter)`.
 ///
-/// `build_client()` falls back to reading `$env_var` if [`init`]/
-/// [`init_with_timeout`] was never called (convenience for scripts/tests that
-/// only set the env var), then reads the shared singleton state back out to
-/// build a fresh client. Requires [`provider_singleton_state!`] to have been
+/// `build_client()` resolves the key in order: a key scoped to the running
+/// dispatch (see [`crate::adapters::keys`]), the singleton set by [`init`]/
+/// [`init_with_timeout`], then `$env_var`. It then builds a fresh client. Requires [`provider_singleton_state!`] to have been
 /// invoked first in the same module (uses its `$struct_name`/`$static_name`).
 #[allow(unused_macros)]
 macro_rules! provider_build_client {
@@ -98,6 +97,12 @@ macro_rules! provider_build_client {
         ///
         /// Used internally by all query functions.
         pub(crate) fn build_client() -> crate::error::Result<$client_ty> {
+            if let Some(scoped) = crate::adapters::keys::scoped_key($provider_key) {
+                let limiter = scoped.limiter($provider_key, $rate_const);
+                return <$builder>::new(&scoped.api_key)
+                    .timeout(scoped.timeout)
+                    .build_with_limiter(limiter);
+            }
             if $static_name.get().is_none()
                 && let Ok(key) = ::std::env::var($env_var)
                 && !key.trim().is_empty()

--- a/src/providers/config.rs
+++ b/src/providers/config.rs
@@ -258,6 +258,7 @@ pub struct ProvidersBuilder {
     config: ClientConfig,
     routes: Routes,
     retry: Option<RetryPolicy>,
+    api_keys: std::collections::HashMap<&'static str, String>,
 }
 
 impl std::fmt::Debug for ProvidersBuilder {
@@ -270,6 +271,10 @@ impl std::fmt::Debug for ProvidersBuilder {
             )
             .field("routes", &self.routes)
             .field("retry", &self.retry)
+            .field(
+                "api_keys",
+                &self.api_keys.keys().copied().collect::<Vec<_>>(),
+            )
             .finish()
     }
 }
@@ -282,6 +287,7 @@ impl Default for ProvidersBuilder {
             config: ClientConfig::default(),
             routes: Routes::new(Fetch::Sequential),
             retry: None,
+            api_keys: std::collections::HashMap::new(),
         }
     }
 }
@@ -292,6 +298,18 @@ impl ProvidersBuilder {
     /// Use [`Fetch::Sequential`] or [`Fetch::Parallel`].
     pub fn fetch(mut self, mode: Fetch) -> Self {
         self.routes.fetch = mode;
+        self
+    }
+
+    /// Set `provider`'s API key for the [`Providers`] this builds, instead of
+    /// the process-global key from its `init` function.
+    ///
+    /// Two `Providers` can hold different keys for the same provider, and a
+    /// key can be replaced without restarting. Each distinct key gets its own
+    /// rate-limit budget. Providers left unset fall back to the process-global
+    /// key, then to the environment variable.
+    pub fn api_key(mut self, provider: Provider, key: impl Into<String>) -> Self {
+        self.api_keys.insert(provider.as_str(), key.into());
         self
     }
 
@@ -450,9 +468,28 @@ impl ProvidersBuilder {
             }
         }
         let lang = self.config.lang.clone();
-        let set = build_providers(&self.provider_ids, self.adapters, &self.config, self.routes)
-            .await?
-            .with_retry_policy(self.retry);
+        let mut keys = crate::adapters::keys::KeyMap::new();
+        for (provider_key, api_key) in self.api_keys {
+            if api_key.trim().is_empty() {
+                return Err(crate::FinanceError::InvalidParameter {
+                    param: provider_key.to_string(),
+                    reason: "API key must not be empty".to_string(),
+                });
+            }
+            keys.insert(
+                provider_key,
+                crate::adapters::keys::ScopedKey::new(api_key, self.config.timeout),
+            );
+        }
+        // `initialize` builds each keyed client, so the scope has to cover
+        // construction as well as dispatch.
+        let set = crate::adapters::keys::scope(
+            Arc::new(keys.clone()),
+            build_providers(&self.provider_ids, self.adapters, &self.config, self.routes),
+        )
+        .await?
+        .with_api_keys(keys)
+        .with_retry_policy(self.retry);
         Ok(Providers {
             set: Arc::new(set),
             lang,

--- a/src/providers/set.rs
+++ b/src/providers/set.rs
@@ -25,6 +25,9 @@ pub struct ProviderSet {
     /// behavior exactly: a `RateLimited` error is treated like any
     /// other failure and dispatch moves straight to the next candidate.
     retry_policy: Option<RetryPolicy>,
+    /// Keys scoped to this set, published for the duration of each dispatch
+    /// so keyed adapters prefer them over the process-global singletons.
+    api_keys: Arc<crate::adapters::keys::KeyMap>,
     /// In-memory recent success/failure tracker, always active (cheap to
     /// maintain) and surfaced on request via [`ProviderSet::health`].
     health: HealthTracker,
@@ -53,6 +56,7 @@ impl ProviderSet {
             yahoo_client: None,
             routes,
             retry_policy: None,
+            api_keys: Arc::new(crate::adapters::keys::KeyMap::new()),
             health: HealthTracker::new(),
         }
     }
@@ -62,6 +66,12 @@ impl ProviderSet {
     /// part of the public constructor.
     pub(crate) fn with_yahoo_client(mut self, client: Option<Arc<YahooClient>>) -> Self {
         self.yahoo_client = client;
+        self
+    }
+
+    /// Scope API keys to this set rather than the process-global singletons.
+    pub(crate) fn with_api_keys(mut self, keys: crate::adapters::keys::KeyMap) -> Self {
+        self.api_keys = Arc::new(keys);
         self
     }
 
@@ -175,6 +185,23 @@ impl ProviderSet {
     }
 
     pub(crate) async fn fetch<T, F, Fut>(&self, cap: Capability, f: F) -> Result<T>
+    where
+        F: Fn(&Arc<dyn ProviderAdapter>) -> Fut,
+        Fut: std::future::Future<Output = Result<T>>,
+    {
+        if self.api_keys.is_empty() {
+            return self.dispatch(cap, f).await;
+        }
+        // Boxed so the scoped variant does not enlarge the future every
+        // dispatch builds; only callers that configure a key pay for it.
+        Box::pin(crate::adapters::keys::scope(
+            Arc::clone(&self.api_keys),
+            self.dispatch(cap, f),
+        ))
+        .await
+    }
+
+    async fn dispatch<T, F, Fut>(&self, cap: Capability, f: F) -> Result<T>
     where
         F: Fn(&Arc<dyn ProviderAdapter>) -> Fut,
         Fut: std::future::Future<Output = Result<T>>,

--- a/src/providers/tests.rs
+++ b/src/providers/tests.rs
@@ -657,3 +657,144 @@ async fn route_with_parallel_overrides_a_sequential_default() {
     );
     assert_eq!(chart_calls_under(routes).await, (1, 1));
 }
+
+#[tokio::test]
+async fn an_empty_api_key_is_rejected_at_build() {
+    let err = crate::Providers::builder()
+        .api_key(Provider::Yahoo, "   ")
+        .build()
+        .await
+        .expect_err("an empty key is refused");
+    assert!(matches!(err, FinanceError::InvalidParameter { .. }));
+}
+
+#[test]
+fn debug_names_keyed_providers_without_their_keys() {
+    let builder = crate::Providers::builder().api_key(Provider::Yahoo, "super-secret");
+    let rendered = format!("{builder:?}");
+    assert!(rendered.contains("yahoo"));
+    assert!(!rendered.contains("super-secret"));
+}
+
+struct KeyObservingProvider {
+    id: Provider,
+    seen: std::sync::Mutex<Option<Option<String>>>,
+}
+
+impl KeyObservingProvider {
+    fn new(id: Provider) -> Self {
+        Self {
+            id,
+            seen: std::sync::Mutex::new(None),
+        }
+    }
+
+    fn seen(&self) -> Option<String> {
+        self.seen
+            .lock()
+            .expect("not poisoned")
+            .clone()
+            .expect("the adapter was called")
+    }
+}
+
+impl ProviderCore for KeyObservingProvider {
+    fn id(&self) -> Provider {
+        self.id
+    }
+}
+
+#[async_trait::async_trait]
+impl ChartProvider for KeyObservingProvider {
+    async fn fetch_chart(
+        &self,
+        symbol: &str,
+        _: crate::Interval,
+        _: crate::TimeRange,
+    ) -> Result<crate::models::chart::Chart> {
+        let observed = crate::adapters::keys::scoped_key("fmp").map(|k| k.api_key);
+        *self.seen.lock().expect("not poisoned") = Some(observed);
+        tokio::task::yield_now().await;
+        Ok(crate::models::chart::Chart {
+            symbol: symbol.to_string(),
+            meta: Default::default(),
+            candles: Vec::new(),
+            interval: None,
+            range: None,
+            provider_id: Some(self.id),
+        })
+    }
+}
+
+impl ProviderAdapter for KeyObservingProvider {
+    fn as_chart(&self) -> Option<&dyn ChartProvider> {
+        Some(self)
+    }
+}
+
+fn scoped_fmp(key: &str) -> crate::adapters::keys::KeyMap {
+    let mut keys = crate::adapters::keys::KeyMap::new();
+    keys.insert(
+        "fmp",
+        crate::adapters::keys::ScopedKey::new(key.to_string(), std::time::Duration::from_secs(30)),
+    );
+    keys
+}
+
+async fn drive_chart(set: &ProviderSet) {
+    set.fetch(Capability::CHART, |p| {
+        let p = p.clone();
+        async move {
+            p.as_chart()
+                .ok_or_else(|| p.not_supported(Operation::Chart))?
+                .fetch_chart("AAPL", crate::Interval::OneDay, crate::TimeRange::FiveDays)
+                .await
+        }
+    })
+    .await
+    .expect("a provider succeeds");
+}
+
+#[tokio::test]
+async fn dispatch_publishes_a_scoped_key_to_the_adapter() {
+    let provider = Arc::new(KeyObservingProvider::new(Provider::Yahoo));
+    let set = ProviderSet::new(
+        vec![provider.clone() as Arc<dyn ProviderAdapter>],
+        Routes::new(Fetch::Sequential),
+    )
+    .with_api_keys(scoped_fmp("scoped-key"));
+    drive_chart(&set).await;
+    assert_eq!(provider.seen(), Some("scoped-key".into()));
+}
+
+#[tokio::test]
+async fn dispatch_without_scoped_keys_leaves_the_adapter_unscoped() {
+    let provider = Arc::new(KeyObservingProvider::new(Provider::Yahoo));
+    let set = ProviderSet::new(
+        vec![provider.clone() as Arc<dyn ProviderAdapter>],
+        Routes::new(Fetch::Sequential),
+    );
+    drive_chart(&set).await;
+    assert_eq!(provider.seen(), None);
+}
+
+#[tokio::test]
+async fn parallel_dispatch_publishes_the_scope_to_every_provider() {
+    let first = Arc::new(KeyObservingProvider::new(Provider::Yahoo));
+    let second = Arc::new(KeyObservingProvider::new(Provider::Edgar));
+    let set = ProviderSet::new(
+        vec![
+            first.clone() as Arc<dyn ProviderAdapter>,
+            second.clone() as Arc<dyn ProviderAdapter>,
+        ],
+        Routes::new(Fetch::Sequential).route_with(
+            Capability::CHART,
+            [Provider::Yahoo, Provider::Edgar],
+            Fetch::Parallel,
+        ),
+    )
+    .with_api_keys(scoped_fmp("scoped-key"));
+    drive_chart(&set).await;
+    assert_eq!(first.seen(), Some("scoped-key".into()));
+    assert_eq!(second.seen(), Some("scoped-key".into()));
+}


### PR DESCRIPTION
## Description

API keys lived in process-global `OnceLock`s set exactly once, through a different module from the builder. Two `Providers` could not hold different keys for the same provider, and neither key rotation nor test isolation was possible. Keys set on the builder are now published into a task-local for the duration of a dispatch call. `build_client` resolves scoped key, then singleton, then environment variable, so anything dispatched outside a scope behaves as it did.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Added `ProvidersBuilder::api_key`, scoping a provider's key to the `Providers` being built.
- Added `src/adapters/keys.rs`, holding the task-local key map and the shared rate-limiter registry.
- Extended the `provider_build_client!` macro to prefer a scoped key, covering all 150 `build_client` call sites in one place.
- Scoped the key map around `ProviderSet::fetch` and around provider construction, since `initialize` builds each keyed client.
- Gave each distinct API key its own rate-limit bucket, because upstream limits are enforced per key.
- Held each bucket in the owning `ScopedKey` and tracked it weakly in the registry, so a rotated-out key's bucket is dropped rather than accumulating.
- Rejected an empty key at `build()`, and kept key values out of the `ProvidersBuilder` `Debug` output.
- Boxed the scoped dispatch path so its variant does not size the future every dispatch builds. Left unboxed it cost `ticker_quote_then_cached` 43800 -> 83672 `alloc_bytes` and +19% instructions, because `async_trait` boxing turns future size into heap bytes on a cache-hit path with no fetch to hide it behind.

## Breaking Changes

None. `ProviderSet::new` is unchanged, the `init` functions still work, and resolution falls back to the singleton and then the environment variable.

## Testing

`cargo test --workspace --features finance-query/full`: 2065 passed, 0 failed. Coverage includes concurrent scopes observing different keys, bucket sharing and eviction, and that dispatch publishes the scope to every provider in a parallel race. That last test was mutation-checked: removing the scope wrapper from `ProviderSet::fetch` fails the two scoped tests while the unscoped control still passes.

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] All tests pass (`cargo test`)

## Documentation
- [x] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy`)
- [x] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

None.
