### PR TITLE
feat: route the keyless providers that were unreachable

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Finance library (our own)
-finance-query = { path = "..", features = ["indicators", "fred", "crypto", "risk", "sentiment", "gdelt", "cftc", "alphavantage", "fmp", "worldbank", "fiscaldata", "frankfurter", "binance", "kraken", "secftd", "housetrades", "nasdaq", "wikipedia"] }
+finance-query = { path = "..", features = ["indicators", "fred", "crypto", "risk", "sentiment", "gdelt", "cftc", "alphavantage", "fmp", "worldbank", "fiscaldata", "frankfurter", "binance", "kraken", "secftd", "housetrades", "nasdaq", "wikipedia", "polygon", "bls", "finra", "defi"] }
 
 # GraphQL
 async-graphql = { version = "7", features = ["graphiql"] }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -40,6 +40,7 @@ struct ProviderFlags {
     fmp: bool,
     alphavantage: bool,
     fred: bool,
+    polygon: bool,
 }
 
 /// The capability → provider fallback list for every routed capability.
@@ -88,10 +89,9 @@ fn route_table(
         fundamentals.push(Provider::AlphaVantage);
     }
     fundamentals.push(Provider::Yahoo);
+    fundamentals.push(Provider::Finra); // short-sale volume only
     routes.push((Capability::FUNDAMENTALS, fundamentals));
 
-    // FMP/AV are additive; DISCOVERY stays Yahoo-served through `finance::`
-    // shortcuts rather than this route (never provider-routed).
     let mut discovery = Vec::new();
     if flags.fmp {
         discovery.push(Provider::Fmp);
@@ -99,9 +99,9 @@ fn route_table(
     if flags.alphavantage {
         discovery.push(Provider::AlphaVantage);
     }
-    if !discovery.is_empty() {
-        routes.push((Capability::DISCOVERY, discovery));
-    }
+    discovery.push(Provider::Yahoo);
+    discovery.push(Provider::LocalExchange); // static exchange table
+    routes.push((Capability::DISCOVERY, discovery));
 
     let mut calendar = vec![Provider::Yahoo, Provider::LocalMarketCalendar];
     if flags.fmp {
@@ -131,7 +131,7 @@ fn route_table(
     }
     routes.push((Capability::INDICES, indices));
 
-    routes.push((Capability::FUTURES, vec![Provider::Yahoo]));
+    routes.push((Capability::FUTURES, vec![Provider::Yahoo, Provider::Cftc]));
 
     let mut economic = Vec::new();
     if flags.fred {
@@ -142,6 +142,7 @@ fn route_table(
     if flags.alphavantage {
         economic.push(Provider::AlphaVantage);
     }
+    economic.push(Provider::Bls);
     routes.push((Capability::ECONOMIC, economic));
 
     let mut crypto = Vec::new();
@@ -151,6 +152,7 @@ fn route_table(
     crypto.push(Provider::CoinGecko);
     crypto.push(Provider::Binance);
     crypto.push(Provider::Kraken);
+    crypto.push(Provider::DefiLlama); // TVL and stablecoin supply only
     crypto.push(Provider::Gdelt); // market-wide news only
     routes.push((Capability::CRYPTO, crypto));
 
@@ -174,6 +176,31 @@ fn route_table(
     filings.push(Provider::Yahoo);
     routes.push((Capability::FILINGS, filings));
 
+    if flags.polygon {
+        // Appended last so a Polygon key widens reach without reordering the
+        // providers already serving these capabilities.
+        const POLYGON_CAPS: [Capability; 13] = [
+            Capability::QUOTE,
+            Capability::CHART,
+            Capability::OPTIONS,
+            Capability::CORPORATE,
+            Capability::FUNDAMENTALS,
+            Capability::DISCOVERY,
+            Capability::CALENDAR,
+            Capability::INDICES,
+            Capability::FUTURES,
+            Capability::ECONOMIC,
+            Capability::CRYPTO,
+            Capability::FOREX,
+            Capability::FILINGS,
+        ];
+        for (cap, route) in &mut routes {
+            if POLYGON_CAPS.contains(cap) {
+                route.push(Provider::Polygon);
+            }
+        }
+    }
+
     routes
 }
 
@@ -192,10 +219,12 @@ pub async fn build_providers() -> Arc<finance_query::Providers> {
         fmp: std::env::var("FMP_API_KEY").is_ok(),
         alphavantage: std::env::var("ALPHAVANTAGE_API_KEY").is_ok(),
         fred: std::env::var("FRED_API_KEY").is_ok(),
+        polygon: std::env::var("POLYGON_API_KEY").is_ok(),
     };
     log_routing("Alpha Vantage", "ALPHAVANTAGE_API_KEY", flags.alphavantage);
     log_routing("FMP", "FMP_API_KEY", flags.fmp);
     log_routing("FRED", "FRED_API_KEY", flags.fred);
+    log_routing("Polygon", "POLYGON_API_KEY", flags.polygon);
 
     let mut builder = Providers::builder();
     for (cap, route) in route_table(flags) {
@@ -236,6 +265,7 @@ mod provider_routing_tests {
             fmp: false,
             alphavantage: false,
             fred: false,
+            polygon: false,
         });
         assert_eq!(
             route(&routes, Capability::QUOTE),
@@ -248,6 +278,7 @@ mod provider_routing_tests {
                     Provider::CoinGecko,
                     Provider::Binance,
                     Provider::Kraken,
+                    Provider::DefiLlama,
                     Provider::Gdelt
                 ][..]
             )
@@ -258,9 +289,12 @@ mod provider_routing_tests {
         );
         assert_eq!(
             route(&routes, Capability::ECONOMIC),
-            Some(&[Provider::WorldBank, Provider::FiscalData][..])
+            Some(&[Provider::WorldBank, Provider::FiscalData, Provider::Bls][..])
         );
-        assert_eq!(route(&routes, Capability::DISCOVERY), None);
+        assert_eq!(
+            route(&routes, Capability::DISCOVERY),
+            Some(&[Provider::Yahoo, Provider::LocalExchange][..])
+        );
         assert_eq!(
             route(&routes, Capability::INDICES),
             Some(&[Provider::Yahoo, Provider::Wikipedia][..])
@@ -271,7 +305,7 @@ mod provider_routing_tests {
         );
         assert_eq!(
             route(&routes, Capability::FUTURES),
-            Some(&[Provider::Yahoo][..])
+            Some(&[Provider::Yahoo, Provider::Cftc][..])
         );
         assert_eq!(
             route(&routes, Capability::CALENDAR),
@@ -295,6 +329,7 @@ mod provider_routing_tests {
             fmp: true,
             alphavantage: false,
             fred: false,
+            polygon: false,
         });
         assert!(
             route(&routes, Capability::QUOTE)
@@ -329,10 +364,78 @@ mod provider_routing_tests {
             fmp: true,
             alphavantage: true,
             fred: false,
+            polygon: false,
         });
-        assert_eq!(
-            route(&routes, Capability::FUNDAMENTALS).unwrap().last(),
-            Some(&Provider::Yahoo)
+        let fundamentals = route(&routes, Capability::FUNDAMENTALS).unwrap();
+        let position = |p| fundamentals.iter().position(|q| *q == p);
+        assert!(position(Provider::Yahoo) > position(Provider::Fmp));
+        assert!(position(Provider::Yahoo) > position(Provider::AlphaVantage));
+    }
+
+    #[test]
+    fn keyless_providers_are_reachable_with_no_key_set() {
+        let routes = route_table(ProviderFlags {
+            fmp: false,
+            alphavantage: false,
+            fred: false,
+            polygon: false,
+        });
+        let serves = |cap, provider| route(&routes, cap).unwrap().contains(&provider);
+        assert!(serves(Capability::FUNDAMENTALS, Provider::Finra));
+        assert!(serves(Capability::CRYPTO, Provider::DefiLlama));
+        assert!(serves(Capability::FUTURES, Provider::Cftc));
+        assert!(serves(Capability::DISCOVERY, Provider::LocalExchange));
+        assert!(serves(Capability::ECONOMIC, Provider::Bls));
+    }
+
+    #[test]
+    fn a_polygon_key_appends_without_reordering() {
+        let keyless = route_table(ProviderFlags {
+            fmp: false,
+            alphavantage: false,
+            fred: false,
+            polygon: false,
+        });
+        let keyed = route_table(ProviderFlags {
+            fmp: false,
+            alphavantage: false,
+            fred: false,
+            polygon: true,
+        });
+        for (cap, before) in &keyless {
+            let after = route(&keyed, *cap).unwrap();
+            match after.len() == before.len() {
+                true => assert_eq!(after, before.as_slice()),
+                false => {
+                    assert_eq!(&after[..before.len()], before.as_slice());
+                    assert_eq!(after.last(), Some(&Provider::Polygon));
+                }
+            }
+        }
+        assert!(
+            route(&keyed, Capability::QUOTE)
+                .unwrap()
+                .contains(&Provider::Polygon)
+        );
+    }
+
+    #[test]
+    fn polygon_stays_out_of_capabilities_it_does_not_serve() {
+        let routes = route_table(ProviderFlags {
+            fmp: false,
+            alphavantage: false,
+            fred: false,
+            polygon: true,
+        });
+        assert!(
+            !route(&routes, Capability::MARKET)
+                .unwrap()
+                .contains(&Provider::Polygon)
+        );
+        assert!(
+            !route(&routes, Capability::COMMODITIES)
+                .unwrap()
+                .contains(&Provider::Polygon)
         );
     }
 }

--- a/src/adapters/defillama/crypto/mod.rs
+++ b/src/adapters/defillama/crypto/mod.rs
@@ -23,11 +23,29 @@ pub(super) fn slug(id: &str) -> String {
 /// the *same* capital (`"Ethereum-borrowed"`, `"pool2"`, `"staking"`).
 /// Summing everything would double-count, so only keys naming a chain the
 /// protocol actually reports are kept.
+/// Capital breakdowns DefiLlama reports beside chains in the same map, either
+/// bare or suffixed onto a chain name.
+const BREAKDOWN_KEYS: [&str; 5] = ["borrowed", "pool2", "staking", "treasury", "vesting"];
+
+fn is_breakdown_key(key: &str) -> bool {
+    BREAKDOWN_KEYS.contains(&key)
+        || key
+            .rsplit_once('-')
+            .is_some_and(|(_, suffix)| BREAKDOWN_KEYS.contains(&suffix))
+}
+
 pub(super) fn chain_allocations(response: &ProtocolResponse) -> Vec<ChainAllocation> {
+    // `chains` is the authoritative allow-list when present. Some protocols
+    // now come back with it empty while still reporting per-chain TVL, so fall
+    // back to every key that is not a breakdown.
+    let named = !response.chains.is_empty();
     let mut out: Vec<ChainAllocation> = response
         .current_chain_tvls
         .iter()
-        .filter(|(key, _)| response.chains.iter().any(|chain| chain == *key))
+        .filter(|(key, _)| match named {
+            true => response.chains.iter().any(|chain| chain == *key),
+            false => !is_breakdown_key(key),
+        })
         .map(|(chain, tvl)| ChainAllocation {
             chain: chain.clone(),
             tvl: *tvl,
@@ -72,14 +90,21 @@ pub(super) fn to_history(response: &ProtocolResponse) -> Vec<TvlPoint> {
 /// Build the public [`ProtocolTvl`] summary.
 pub(super) fn to_protocol_tvl(slug: &str, response: &ProtocolResponse) -> ProtocolTvl {
     let history = to_history(response);
+    let tvl_by_chain = chain_allocations(response);
+    // DefiLlama has started returning an empty `chains` for protocols whose
+    // `chainTvls` still names them, so fall back to the chains it allocates to.
+    let chains = match response.chains.is_empty() {
+        true => tvl_by_chain.iter().map(|a| a.chain.clone()).collect(),
+        false => response.chains.clone(),
+    };
     ProtocolTvl {
         slug: slug.to_string(),
         name: response.name.clone(),
         symbol: response.symbol.clone(),
         url: response.url.clone(),
-        chains: response.chains.clone(),
+        chains,
         tvl: history.last().map(|point| point.tvl),
-        tvl_by_chain: chain_allocations(response),
+        tvl_by_chain,
         change_1d_percent: change_percent(&history, 1),
         change_7d_percent: change_percent(&history, 7),
         market_cap: response.mcap,

--- a/src/adapters/defillama/mod.rs
+++ b/src/adapters/defillama/mod.rs
@@ -175,6 +175,37 @@ mod tests {
     }
 
     #[test]
+    fn an_empty_chains_list_falls_back_to_the_non_breakdown_keys() {
+        let payload = serde_json::json!({
+            "name": "Aave",
+            "chains": [],
+            "currentChainTvls": {
+                "Ethereum": 9_000_000_000.0_f64,
+                "Ethereum-borrowed": 5_000_000_000.0_f64,
+                "Ethereum-staking": 1_000_000.0_f64,
+                "OP Mainnet": 2_000_000_000.0_f64,
+                "borrowed": 7_000_000_000.0_f64,
+                "pool2": 12_345.0_f64,
+                "staking": 999.0_f64
+            },
+            "tvl": []
+        })
+        .to_string();
+        let response: ProtocolResponse = serde_json::from_str(&payload).unwrap();
+        let summary = to_protocol_tvl("aave", &response);
+
+        assert_eq!(summary.chains, vec!["Ethereum", "OP Mainnet"]);
+        assert_eq!(summary.tvl_by_chain.len(), 2);
+        assert!(
+            summary
+                .tvl_by_chain
+                .iter()
+                .all(|a| summary.chains.contains(&a.chain)),
+            "an allocation named something absent from the chain list"
+        );
+    }
+
+    #[test]
     fn change_is_measured_against_the_closest_earlier_snapshot() {
         let history = vec![
             super::super::super::models::crypto::defi::TvlPoint {

--- a/src/adapters/defillama/models.rs
+++ b/src/adapters/defillama/models.rs
@@ -42,10 +42,30 @@ pub(crate) struct ChainResponse {
     pub token_symbol: Option<String>,
     #[serde(default)]
     pub gecko_id: Option<String>,
-    #[serde(default, rename = "chainId")]
+    #[serde(default, rename = "chainId", deserialize_with = "lenient_chain_id")]
     pub chain_id: Option<i64>,
     #[serde(default)]
     pub tvl: Option<f64>,
+}
+
+/// DefiLlama serialises `chainId` as a number for most chains and as a string
+/// for others, so one string would otherwise fail the whole chains response.
+fn lenient_chain_id<'de, D>(deserializer: D) -> Result<Option<i64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum ChainId {
+        Int(i64),
+        Text(String),
+    }
+
+    Ok(match Option::<ChainId>::deserialize(deserializer)? {
+        Some(ChainId::Int(id)) => Some(id),
+        Some(ChainId::Text(id)) => id.parse().ok(),
+        None => None,
+    })
 }
 
 /// `GET stablecoins.llama.fi/stablecoins`.

--- a/src/adapters/polygon/live_tests.rs
+++ b/src/adapters/polygon/live_tests.rs
@@ -212,7 +212,10 @@ fn is_plan_gap(context: &str) -> bool {
 #[ignore = "requires POLYGON_API_KEY and consumes live Massive API quota"]
 #[allow(clippy::too_many_lines)]
 async fn all_routed_polygon_endpoints_return_populated_data() {
-    let api_key = std::env::var("POLYGON_API_KEY").expect("POLYGON_API_KEY must be set");
+    let Ok(api_key) = std::env::var("POLYGON_API_KEY") else {
+        eprintln!("skipping: POLYGON_API_KEY not set");
+        return;
+    };
     super::init_with_timeout(api_key.clone(), std::time::Duration::from_secs(120))
         .expect("Polygon client must initialize");
 


### PR DESCRIPTION
## Description

FINRA short-sale volume, DefiLlama TVL, CFTC positioning, BLS labor series and the static exchange table are all implemented and wired to their capability accessors, and none of them was in the server's route table. A deployment with no API keys got `NotSupported` for capabilities this repo already ships. Polygon was worse off: no route and no flag, so every Polygon-only operation was unreachable even with a key set.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Routed `Provider::Finra` into `FUNDAMENTALS`, `Provider::DefiLlama` into `CRYPTO`, `Provider::Cftc` into `FUTURES` and `Provider::Bls` into `ECONOMIC`.
- Gave `DISCOVERY` a keyless floor of `[Yahoo, LocalExchange]`. It previously had no route at all without a key, falling back to the Yahoo default, so adding one without Yahoo would have removed that fallback.
- Added `polygon` to `ProviderFlags`, driven by `POLYGON_API_KEY`, and appended `Provider::Polygon` to the 13 capabilities it serves.
- Enabled the `polygon`, `bls`, `finra` and `defi` features on the server.
- Added route tests covering the keyless floor and asserting a Polygon key appends without reordering any existing route.
- Made the Polygon live test skip when `POLYGON_API_KEY` is absent instead of `expect`ing it, matching the FMP live test. The network job builds with default features, so enabling `polygon` compiled and selected that test for the first time and it panicked.
- Fixed two latent DefiLlama breaks that enabling `defi` surfaced the same way. `chainId` now arrives as a string for some chains, which failed the whole chains response; and `chains` now comes back empty for protocols whose `currentChainTvls` still names them, which emptied both the chain list and its allocations.

## Breaking Changes

None. Every addition is a fallback appended after the providers already serving a capability, so a configured deployment keeps its current precedence. `DISCOVERY` gains Yahoo as a fallback where a keyed setup previously failed outright.

## Testing

`cargo test --workspace --features finance-query/full`: 2051 passed, 0 failed.

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] All tests pass (`cargo test`)

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy`)
- [x] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

None.
