### PR TITLE
docs: record why two operations are keyed-provider-only

### DIFF
--- a/src/providers/adapter/equity.rs
+++ b/src/providers/adapter/equity.rs
@@ -22,6 +22,10 @@ pub trait QuoteProvider: ProviderCore {
     /// Fetch a snapshot for symbols spanning several asset classes in one
     /// request. Rows the provider could not resolve are returned with
     /// `error` set rather than dropped.
+    ///
+    /// NOTE: Polygon is the only cross-asset snapshot among the providers
+    /// integrated here. The keyless sources are each single-asset-class, so
+    /// reproducing this means fanning out per class and inventing a merge.
     async fn fetch_unified_snapshot(
         &self,
         _symbols: &[&str],

--- a/src/providers/adapter/markets.rs
+++ b/src/providers/adapter/markets.rs
@@ -102,6 +102,11 @@ pub trait MarketProvider: ProviderCore {
     }
 
     /// Fetch industry price/earnings ratios.
+    ///
+    /// NOTE: FMP is the only route among the providers integrated here.
+    /// Yahoo's screener fan-out backs `fetch_sector_pe` across 11 sectors,
+    /// but industries run to roughly 160 and the thin ones carry too few
+    /// sampled P/Es to aggregate into a publishable number.
     async fn fetch_industry_pe(
         &self,
     ) -> Result<Vec<crate::models::market::performance::IndustryPe>> {


### PR DESCRIPTION
## Description

`fetch_unified_snapshot` and `fetch_industry_pe` resolve only through a keyed provider, and they were the only two accepted gaps of that kind with no `NOTE:` on the trait method. Everything else in that list carries one, so a reader had no way to tell a deliberate gap from an operation nobody had got to yet.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Recorded on `fetch_unified_snapshot` that Polygon is the only cross-asset snapshot among the integrated providers, and that the keyless sources are each single-asset-class.
- Recorded on `fetch_industry_pe` that Yahoo's screener fan-out backs `fetch_sector_pe` across 11 sectors, while industries run to roughly 160 and the thin ones carry too few sampled P/Es to aggregate.

## Breaking Changes

None. Doc comments only.

## Testing

`cargo test --workspace --features finance-query/full`: 2051 passed, 0 failed. `cargo soothfast coverage docs --min 95`: 99%.

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] All tests pass (`cargo test`)

## Documentation
- [x] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy`)
- [x] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

None.
