### PR TITLE
fix: state the real default routing on Capability

### DIFF
--- a/src/providers/capability.rs
+++ b/src/providers/capability.rs
@@ -5,7 +5,8 @@ use super::Provider;
 /// Capability bits that a provider can declare.
 ///
 /// Route a capability to specific providers using `.route(Capability::QUOTE, [Provider::Fmp])`.
-/// If no route is configured for a capability, all providers declaring that capability are used.
+/// If no route is configured for a capability, only Yahoo is used, or EDGAR
+/// then Yahoo for [`Capability::FILINGS`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Capability(u32);
 


### PR DESCRIPTION
## Description

`Capability`'s doc said an unrouted capability falls back to every provider declaring it. `candidates_for` does the opposite: Yahoo alone, or EDGAR then Yahoo for `FILINGS`. Anyone sizing a route table from that sentence was told the reverse of what happens, and the same sentence had propagated into the generated `llms.txt`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Corrected the default-routing sentence on `Capability` and regenerated `llms.txt`.
## Breaking Changes

None.

## Testing

`cargo test --workspace --features finance-query/full`: 0 failed. `cargo clippy --workspace --all-targets --features finance-query/full`: 0 findings.

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] All tests pass (`cargo test`)

## Documentation
- [x] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy`)
- [x] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

None.
