### PR TITLE
ci: gate captured example output on pull requests

### DIFF
--- a/.github/workflows/soothfast.yml
+++ b/.github/workflows/soothfast.yml
@@ -207,6 +207,10 @@ jobs:
         run: |
           cargo soothfast docs check -p finance-query --features full --baseline base \
             docs/library README.md
+      - name: Check captured example output
+        # Shares the Makefile's path list so CI and `make soothfast` check the
+        # same set; the excluded pages capture live prices and timestamps.
+        run: make docs-capture-check
       - name: Public API doc coverage (ratchet — currently 99%)
         run: cargo soothfast coverage docs -p finance-query --features full --min 95
       - name: Public API surface diff vs PR base

--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,9 @@ docs: ## Serve the docs site locally with live reload (run `make docs-pages` fir
 # are point-in-time and jitter between runs — regression detection is the
 # `gate` step below, not this. Every step stays inline rather than becoming
 # its own target; run one standalone with `cargo soothfast <cmd>` directly.
+docs-capture-check: ## Verify every captured example's output is current
+	$(SOOTHFAST) docs capture -p finance-query --features full --check $(CAPTURE_CHECK_PATHS)
+
 soothfast: ## Run every soothfast check + refresh: gate, baseline, docs check/capture/coverage, proto, doc regen, trend, changelog, llms.txt staleness
 	@echo "$(GREEN)Running soothfast gate against merge-base of $(BASE)...$(NC)"
 	$(SOOTHFAST) gate -p finance-query --features bench-gate --against-ref $(BASE)
@@ -161,7 +164,7 @@ soothfast: ## Run every soothfast check + refresh: gate, baseline, docs check/ca
 	@echo "$(GREEN)Checking living docs (binds, claims, generated tests)...$(NC)"
 	$(SOOTHFAST) docs check -p finance-query --features full --baseline base docs/library README.md
 	@echo "$(GREEN)Verifying captured doc example output...$(NC)"
-	$(SOOTHFAST) docs capture -p finance-query --features full --check $(CAPTURE_CHECK_PATHS)
+	@$(MAKE) --no-print-directory docs-capture-check
 	@echo "$(GREEN)Checking public API doc coverage...$(NC)"
 	$(SOOTHFAST) coverage docs -p finance-query --features full --min 95
 	@echo "$(GREEN)Reconciling pricing.proto against PricingData...$(NC)"


### PR DESCRIPTION
## Description

`docs capture --check` ran in exactly two places: inside `make soothfast`, which the working agreements say to run only when asked or before a release, and in a post-merge job that regenerates captures rather than verifying them. So a computed table could drift through review unnoticed and then heal silently on master — the same trap as a bind that only fires after someone runs it by hand.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Added a `docs capture --check` step to the gating `docs-binds` job.
- Extracted the path list into a `docs-capture-check` Makefile target so CI and `make soothfast` cannot check different sets. The excluded pages capture live prices and timestamps.
## Breaking Changes

None.

## Testing

`cargo test --workspace --features finance-query/full`: 0 failed. `cargo clippy --workspace --all-targets --features finance-query/full`: 0 findings.

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] All tests pass (`cargo test`)

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy`)
- [x] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

None.
