### PR TITLE
fix: reconcile MCP tools against their route markers

### DIFF
--- a/finance-query-mcp/mcp-tools.json
+++ b/finance-query-mcp/mcp-tools.json
@@ -186,6 +186,56 @@
       }
     },
     {
+      "name": "get_company_profile",
+      "description": "A company's identity/classification profile (name, description, asset type, exchange, currency, country, sector, industry, market capitalization).",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "fields": {
+            "description": "Comma-separated list of GraphQL field names to include; omitted = all fields",
+            "type": "string"
+          },
+          "symbol": {
+            "description": "Stock ticker symbol",
+            "type": "string"
+          }
+        },
+        "required": [
+          "symbol"
+        ]
+      }
+    },
+    {
+      "name": "get_congressional_trades",
+      "description": "Congressional trading disclosures for a symbol, FMP when keyed and keyless House PTR filings otherwise.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "cursor": {
+            "description": "Opaque continuation token from a previous response's `pageInfo.endCursor`; omitted = first page",
+            "type": "string"
+          },
+          "fields": {
+            "description": "Comma-separated list of GraphQL field names to include; omitted = all fields",
+            "type": "string"
+          },
+          "limit": {
+            "description": "Maximum entries per page; omitted = curated default (25)",
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "symbol": {
+            "description": "Stock ticker symbol",
+            "type": "string"
+          }
+        },
+        "required": [
+          "symbol"
+        ]
+      }
+    },
+    {
       "name": "get_crypto",
       "description": "Get top cryptocurrency coins by market cap from CoinGecko (no API key required).",
       "inputSchema": {
@@ -214,6 +264,35 @@
           "vs_currency": {
             "description": "Quote currency (default: usd)",
             "type": "string"
+          }
+        }
+      }
+    },
+    {
+      "name": "get_crypto_news",
+      "description": "Market-wide crypto news (currently FMP only, requires FMP_API_KEY).",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "count": {
+            "description": "Overall cap on articles fetched (default: 20)",
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "cursor": {
+            "description": "Opaque continuation token from a previous response's `pageInfo.endCursor`; omitted = first page",
+            "type": "string"
+          },
+          "fields": {
+            "description": "Comma-separated list of GraphQL field names to include; omitted = curated default set",
+            "type": "string"
+          },
+          "limit": {
+            "description": "Maximum articles per page; omitted = curated default (25)",
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
           }
         }
       }
@@ -266,6 +345,67 @@
               "10y",
               "ytd",
               "max"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "get_earnings_surprises",
+      "description": "A stock's earnings-surprise history (actual vs. estimated EPS).",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "fields": {
+            "description": "Comma-separated list of GraphQL field names to include; omitted = all fields",
+            "type": "string"
+          },
+          "symbol": {
+            "description": "Stock ticker symbol",
+            "type": "string"
+          }
+        },
+        "required": [
+          "symbol"
+        ]
+      }
+    },
+    {
+      "name": "get_earnings_transcript",
+      "description": "An earnings call transcript for a symbol, latest when quarter and year are omitted.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "fields": {
+            "description": "Comma-separated list of GraphQL field names to include; omitted = all fields",
+            "type": "string"
+          },
+          "quarter": {
+            "description": "Fiscal quarter (Q1, Q2, Q3, Q4). Required alongside `year` for providers\nwith no \"latest\" shortcut (Alpha Vantage); Yahoo defaults to latest when omitted",
+            "$ref": "#/$defs/Quarter"
+          },
+          "symbol": {
+            "description": "Stock ticker symbol",
+            "type": "string"
+          },
+          "year": {
+            "description": "Fiscal year. See `quarter`",
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": [
+          "symbol"
+        ],
+        "$defs": {
+          "Quarter": {
+            "description": "Fiscal quarter for `GET /v2/transcripts/{symbol}`.",
+            "type": "string",
+            "enum": [
+              "Q1",
+              "Q2",
+              "Q3",
+              "Q4"
             ]
           }
         }
@@ -391,6 +531,36 @@
           },
           "symbol": {
             "description": "ETF ticker symbol",
+            "type": "string"
+          }
+        },
+        "required": [
+          "symbol"
+        ]
+      }
+    },
+    {
+      "name": "get_fails_to_deliver",
+      "description": "Fails-to-deliver records for a symbol, FMP when keyed and keyless EDGAR otherwise.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "cursor": {
+            "description": "Opaque continuation token from a previous response's `pageInfo.endCursor`; omitted = first page",
+            "type": "string"
+          },
+          "fields": {
+            "description": "Comma-separated list of GraphQL field names to include; omitted = all fields",
+            "type": "string"
+          },
+          "limit": {
+            "description": "Maximum entries per page; omitted = curated default (25)",
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "symbol": {
+            "description": "Stock ticker symbol",
             "type": "string"
           }
         },
@@ -554,6 +724,35 @@
           "from",
           "to"
         ]
+      }
+    },
+    {
+      "name": "get_forex_news",
+      "description": "Market-wide forex news (currently FMP only, requires FMP_API_KEY).",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "count": {
+            "description": "Overall cap on articles fetched (default: 20)",
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "cursor": {
+            "description": "Opaque continuation token from a previous response's `pageInfo.endCursor`; omitted = first page",
+            "type": "string"
+          },
+          "fields": {
+            "description": "Comma-separated list of GraphQL field names to include; omitted = curated default set",
+            "type": "string"
+          },
+          "limit": {
+            "description": "Maximum articles per page; omitted = curated default (25)",
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          }
+        }
       }
     },
     {

--- a/finance-query-mcp/spec/routes.rs
+++ b/finance-query-mcp/spec/routes.rs
@@ -275,6 +275,97 @@ fn route_mcp_get_futures() {}
 )]
 fn route_mcp_get_forex() {}
 
+/// A company's identity/classification profile (name, description, asset type, exchange, currency, country, sector, industry, market capitalization).
+///
+/// Implements `tools::FinanceTools::get_company_profile`.
+#[allow(dead_code)]
+#[soothfast::route(
+    spec = "mcp-tools.json",
+    operation = "get_company_profile",
+    method = "TOOL",
+    path = "get_company_profile",
+    params = "CompanyProfileParams"
+)]
+fn route_mcp_get_company_profile() {}
+
+/// Congressional trading disclosures for a symbol, FMP when keyed and keyless House PTR filings otherwise.
+///
+/// Implements `tools::FinanceTools::get_congressional_trades`.
+#[allow(dead_code)]
+#[soothfast::route(
+    spec = "mcp-tools.json",
+    operation = "get_congressional_trades",
+    method = "TOOL",
+    path = "get_congressional_trades",
+    params = "CongressionalTradesParams"
+)]
+fn route_mcp_get_congressional_trades() {}
+
+/// Market-wide crypto news (currently FMP only, requires FMP_API_KEY).
+///
+/// Implements `tools::FinanceTools::get_crypto_news`.
+#[allow(dead_code)]
+#[soothfast::route(
+    spec = "mcp-tools.json",
+    operation = "get_crypto_news",
+    method = "TOOL",
+    path = "get_crypto_news",
+    params = "CryptoNewsParams"
+)]
+fn route_mcp_get_crypto_news() {}
+
+/// A stock's earnings-surprise history (actual vs. estimated EPS).
+///
+/// Implements `tools::FinanceTools::get_earnings_surprises`.
+#[allow(dead_code)]
+#[soothfast::route(
+    spec = "mcp-tools.json",
+    operation = "get_earnings_surprises",
+    method = "TOOL",
+    path = "get_earnings_surprises",
+    params = "EarningsSurprisesParams"
+)]
+fn route_mcp_get_earnings_surprises() {}
+
+/// An earnings call transcript for a symbol, latest when quarter and year are omitted.
+///
+/// Implements `tools::FinanceTools::get_earnings_transcript`.
+#[allow(dead_code)]
+#[soothfast::route(
+    spec = "mcp-tools.json",
+    operation = "get_earnings_transcript",
+    method = "TOOL",
+    path = "get_earnings_transcript",
+    params = "EarningsTranscriptParams"
+)]
+fn route_mcp_get_earnings_transcript() {}
+
+/// Fails-to-deliver records for a symbol, FMP when keyed and keyless EDGAR otherwise.
+///
+/// Implements `tools::FinanceTools::get_fails_to_deliver`.
+#[allow(dead_code)]
+#[soothfast::route(
+    spec = "mcp-tools.json",
+    operation = "get_fails_to_deliver",
+    method = "TOOL",
+    path = "get_fails_to_deliver",
+    params = "FailsToDeliverParams"
+)]
+fn route_mcp_get_fails_to_deliver() {}
+
+/// Market-wide forex news (currently FMP only, requires FMP_API_KEY).
+///
+/// Implements `tools::FinanceTools::get_forex_news`.
+#[allow(dead_code)]
+#[soothfast::route(
+    spec = "mcp-tools.json",
+    operation = "get_forex_news",
+    method = "TOOL",
+    path = "get_forex_news",
+    params = "ForexNewsParams"
+)]
+fn route_mcp_get_forex_news() {}
+
 /// Get an index's current constituent list, provider-routed (Wikipedia, S&P 500 only).
 ///
 /// Implements `tools::FinanceTools::get_index_constituents`.

--- a/finance-query-mcp/src/tools/mod.rs
+++ b/finance-query-mcp/src/tools/mod.rs
@@ -1377,6 +1377,13 @@ impl FinanceTools {
         crypto::get_crypto_news(&self.schema, p.0.count, p.0.fields, p.0.limit, p.0.cursor).await
     }
 
+    #[tool(
+        description = "Get a currency pair's current exchange rate, provider-routed (Capability::FOREX)."
+    )]
+    async fn get_forex(&self, p: Parameters<ForexParams>) -> Result<CallToolResult, McpError> {
+        forex::get_forex(&self.schema, p.0.from, p.0.to, p.0.fields).await
+    }
+
     #[tool(description = "Get market-wide forex news (currently FMP only, requires FMP_API_KEY).")]
     async fn get_forex_news(
         &self,

--- a/finance-query-mcp/tests/tool_marker_reconciliation.rs
+++ b/finance-query-mcp/tests/tool_marker_reconciliation.rs
@@ -1,0 +1,54 @@
+//! Every `#[tool]` must have a `#[soothfast::route]` marker, and vice versa.
+//!
+//! `spec gen --check` reconciles markers against `mcp-tools.json` but never
+//! against the tools themselves, so a tool with no marker is absent from the
+//! manifest and a marker with no tool advertises something that cannot be
+//! called. Neither shows up in any other gate.
+
+const TOOLS: &str = include_str!("../src/tools/mod.rs");
+const MARKERS: &str = include_str!("../spec/routes.rs");
+
+fn declared_tools() -> Vec<String> {
+    let mut names = Vec::new();
+    for block in TOOLS.split("#[tool(").skip(1) {
+        let Some(start) = block.find("async fn ") else {
+            continue;
+        };
+        let rest = &block[start + "async fn ".len()..];
+        let end = rest
+            .find(|c: char| !c.is_alphanumeric() && c != '_')
+            .unwrap_or(rest.len());
+        names.push(rest[..end].to_string());
+    }
+    names.sort();
+    names
+}
+
+fn marker_operations() -> Vec<String> {
+    let mut names: Vec<String> = MARKERS
+        .split("operation = \"")
+        .skip(1)
+        .filter_map(|rest| rest.split('"').next().map(str::to_string))
+        .collect();
+    names.sort();
+    names
+}
+
+#[test]
+fn every_tool_has_a_marker_and_every_marker_has_a_tool() {
+    let tools = declared_tools();
+    let markers = marker_operations();
+    assert!(!tools.is_empty(), "no #[tool] found — parser is broken");
+
+    let unmarked: Vec<&String> = tools.iter().filter(|t| !markers.contains(t)).collect();
+    let unimplemented: Vec<&String> = markers.iter().filter(|m| !tools.contains(m)).collect();
+
+    assert!(
+        unmarked.is_empty(),
+        "tools missing a spec/routes.rs marker, so absent from mcp-tools.json: {unmarked:?}"
+    );
+    assert!(
+        unimplemented.is_empty(),
+        "markers naming no #[tool], so advertised but uncallable: {unimplemented:?}"
+    );
+}


### PR DESCRIPTION
## Description

`spec gen --check` reconciles route markers against `mcp-tools.json`, and nothing reconciles the markers against the tools themselves. Both directions had drifted. Seven `#[tool]`s had no marker, so the manifest never listed them and no agent could discover them. One marker named no tool at all, so the manifest advertised `get_forex` while nothing implemented it — the function and its params both existed, they were simply never wired to a `#[tool]`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Wired `get_forex` to a `#[tool]`, which the manifest had been advertising as callable.
- Added markers for `get_company_profile`, `get_congressional_trades`, `get_crypto_news`, `get_earnings_surprises`, `get_earnings_transcript`, `get_fails_to_deliver` and `get_forex_news`.
- Added a test asserting the two sets match in both directions.
- Regenerated `mcp-tools.json`, which goes from 46 tools to 53.
## Breaking Changes

None.

## Testing

`cargo test --workspace --features finance-query/full`: 0 failed. `spec check`: 53 declared, 53 matched.

The reconciliation test was mutation-checked: renaming one marker makes it fail naming that tool, and restoring it passes.

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] All tests pass (`cargo test`)

## Documentation
- [x] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy`)
- [x] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

None.
