### PR TITLE
fix: put every docs page in the site nav

### DIFF
--- a/soothfast.toml
+++ b/soothfast.toml
@@ -58,6 +58,8 @@ pages = [
   "library/providers/cftc.md",
   "library/providers/housetrades.md",
   "library/providers/senatetrades.md",
+  "library/providers/nasdaq.md",
+  "library/providers/wikipedia.md",
 ]
 
 [[site.nav]]

--- a/tests/docs_nav_coverage.rs
+++ b/tests/docs_nav_coverage.rs
@@ -1,0 +1,61 @@
+//! Every page under `docs/` must be reachable from the site nav.
+//!
+//! An unlisted page still builds and still passes `docs check`, so it goes
+//! live unreachable and nothing says so.
+//!
+//! One direction only: the nav also names pages that `make docs-pages`
+//! generates (the spec HTML and reconciliation status), which are gitignored
+//! and absent from a fresh checkout.
+
+use std::path::{Path, PathBuf};
+
+fn repo(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn nav_pages() -> Vec<String> {
+    std::fs::read_to_string(repo("soothfast.toml"))
+        .expect("soothfast.toml is readable")
+        .split('"')
+        .filter(|piece| piece.ends_with(".md"))
+        // Entries may be written as `Label: path.md`.
+        .map(|piece| {
+            piece
+                .rsplit(": ")
+                .next()
+                .unwrap_or(piece)
+                .trim()
+                .to_string()
+        })
+        .collect()
+}
+
+fn markdown_under_docs(dir: &Path, found: &mut Vec<String>) {
+    for entry in std::fs::read_dir(dir).expect("docs directory is readable") {
+        let path = entry.expect("entry is readable").path();
+        if path.is_dir() {
+            markdown_under_docs(&path, found);
+        } else if path.extension().is_some_and(|e| e == "md") {
+            let relative = path
+                .strip_prefix(repo("docs"))
+                .expect("page lives under docs/");
+            found.push(relative.to_string_lossy().replace('\\', "/"));
+        }
+    }
+}
+
+#[test]
+fn every_docs_page_is_reachable_from_the_nav() {
+    let nav = nav_pages();
+    assert!(!nav.is_empty(), "no nav pages parsed — parser is broken");
+
+    let mut pages = Vec::new();
+    markdown_under_docs(&repo("docs"), &mut pages);
+    assert!(!pages.is_empty(), "no pages found under docs/");
+
+    let orphaned: Vec<&String> = pages.iter().filter(|p| !nav.contains(p)).collect();
+    assert!(
+        orphaned.is_empty(),
+        "pages absent from soothfast.toml's nav, so unreachable on the site: {orphaned:?}"
+    );
+}


### PR DESCRIPTION
## Description

`nasdaq.md` and `wikipedia.md` were written, committed and built, and no nav entry pointed at either. Both shipped unreachable from the site, and no gate had an opinion about it.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Added both pages to the Providers nav in `soothfast.toml`.
- Added a test asserting every page under `docs/` appears in the nav. It runs page to nav only, because the nav also names spec HTML and reconciliation pages that `make docs-pages` generates and a fresh checkout does not have.
## Breaking Changes

None.

## Testing

`cargo test --workspace --features finance-query/full`: 0 failed.

Mutation-checked: removing one page from the nav makes the test fail naming that page, and restoring it passes.

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] All tests pass (`cargo test`)

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy`)
- [x] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

None.
