### PR TITLE
feat: expose thirteen unreachable provider operations

### DIFF
--- a/src/adapters/keys.rs
+++ b/src/adapters/keys.rs
@@ -1,0 +1,191 @@
+//! API keys scoped to one [`Providers`](crate::Providers) instance.
+//!
+//! The keyed adapters read their credentials from process-global
+//! [`OnceLock`](std::sync::OnceLock) singletons, which allows exactly one key
+//! per provider per process. A key configured on a builder is instead published
+//! into a task-local for the duration of a dispatch call, so two `Providers`
+//! can hold different keys for the same provider, and a key can be rotated
+//! without restarting.
+//!
+//! `build_client` resolves in order: scoped key, singleton, environment
+//! variable. Anything dispatched outside a scope behaves exactly as before.
+
+// Everything below is reached from the keyed adapters' `build_client`, which
+// only exists when one of their features is enabled.
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock, OnceLock, RwLock, Weak};
+use std::time::Duration;
+
+use crate::rate_limiter::RateLimiter;
+
+#[derive(Clone)]
+pub(crate) struct ScopedKey {
+    pub(crate) api_key: String,
+    pub(crate) timeout: Duration,
+    limiter: Arc<OnceLock<Arc<RateLimiter>>>,
+}
+
+impl ScopedKey {
+    pub(crate) fn new(api_key: String, timeout: Duration) -> Self {
+        Self {
+            api_key,
+            timeout,
+            limiter: Arc::new(OnceLock::new()),
+        }
+    }
+
+    /// Rate limits are enforced per API key upstream, so each distinct key gets
+    /// its own bucket rather than sharing the singleton's.
+    pub(crate) fn limiter(&self, provider_key: &'static str, rate: f64) -> Arc<RateLimiter> {
+        Arc::clone(
+            self.limiter
+                .get_or_init(|| shared_limiter(provider_key, &self.api_key, rate)),
+        )
+    }
+}
+
+pub(crate) type KeyMap = HashMap<&'static str, ScopedKey>;
+
+tokio::task_local! {
+    static SCOPED: Arc<KeyMap>;
+}
+
+type LimiterMap = HashMap<(&'static str, String), Weak<RateLimiter>>;
+
+/// Weak so a rotated-out key's bucket is dropped with the `Providers` holding
+/// it. The strong reference lives in that instance's [`ScopedKey`].
+static LIMITERS: LazyLock<RwLock<LimiterMap>> = LazyLock::new(|| RwLock::new(HashMap::new()));
+
+fn shared_limiter(provider_key: &'static str, api_key: &str, rate: f64) -> Arc<RateLimiter> {
+    let id = (provider_key, api_key.to_string());
+    if let Some(limiter) = LIMITERS
+        .read()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(&id)
+        .and_then(Weak::upgrade)
+    {
+        return limiter;
+    }
+    let mut limiters = LIMITERS.write().unwrap_or_else(|e| e.into_inner());
+    if let Some(limiter) = limiters.get(&id).and_then(Weak::upgrade) {
+        return limiter;
+    }
+    limiters.retain(|_, held| held.strong_count() > 0);
+    let limiter = Arc::new(RateLimiter::new(rate));
+    limiters.insert(id, Arc::downgrade(&limiter));
+    limiter
+}
+
+fn tracked_limiters() -> usize {
+    LIMITERS.read().unwrap_or_else(|e| e.into_inner()).len()
+}
+
+pub(crate) fn scoped_key(provider_key: &str) -> Option<ScopedKey> {
+    SCOPED
+        .try_with(|keys| keys.get(provider_key).cloned())
+        .ok()
+        .flatten()
+}
+
+pub(crate) async fn scope<F>(keys: Arc<KeyMap>, f: F) -> F::Output
+where
+    F: std::future::Future,
+{
+    if keys.is_empty() {
+        return f.await;
+    }
+    SCOPED.scope(keys, f).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn map(pairs: &[(&'static str, &str)]) -> Arc<KeyMap> {
+        Arc::new(
+            pairs
+                .iter()
+                .map(|(p, k)| {
+                    (
+                        *p,
+                        ScopedKey::new((*k).to_string(), Duration::from_secs(30)),
+                    )
+                })
+                .collect(),
+        )
+    }
+
+    #[tokio::test]
+    async fn no_scope_yields_no_key() {
+        assert!(scoped_key("fmp").is_none());
+    }
+
+    #[tokio::test]
+    async fn a_scope_publishes_its_own_keys() {
+        scope(map(&[("fmp", "abc")]), async {
+            assert_eq!(scoped_key("fmp").map(|k| k.api_key), Some("abc".into()));
+            assert!(scoped_key("polygon").is_none());
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn an_empty_map_leaves_the_scope_unset() {
+        scope(Arc::new(KeyMap::new()), async {
+            assert!(scoped_key("fmp").is_none());
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn concurrent_scopes_do_not_see_each_other() {
+        let one = tokio::spawn(scope(map(&[("fmp", "first")]), async {
+            tokio::task::yield_now().await;
+            scoped_key("fmp").map(|k| k.api_key)
+        }));
+        let two = tokio::spawn(scope(map(&[("fmp", "second")]), async {
+            tokio::task::yield_now().await;
+            scoped_key("fmp").map(|k| k.api_key)
+        }));
+        assert_eq!(one.await.unwrap(), Some("first".into()));
+        assert_eq!(two.await.unwrap(), Some("second".into()));
+    }
+
+    #[test]
+    fn each_key_gets_its_own_limiter() {
+        let a = ScopedKey::new("key-a".into(), Duration::from_secs(30));
+        let b = ScopedKey::new("key-b".into(), Duration::from_secs(30));
+        assert!(Arc::ptr_eq(&a.limiter("fmp", 5.0), &a.limiter("fmp", 5.0)));
+        assert!(!Arc::ptr_eq(&a.limiter("fmp", 5.0), &b.limiter("fmp", 5.0)));
+    }
+
+    #[test]
+    fn two_instances_of_one_key_share_a_bucket() {
+        let first = ScopedKey::new("shared".into(), Duration::from_secs(30));
+        let second = ScopedKey::new("shared".into(), Duration::from_secs(30));
+        assert!(Arc::ptr_eq(
+            &first.limiter("polygon", 5.0),
+            &second.limiter("polygon", 5.0)
+        ));
+    }
+
+    #[test]
+    fn a_dropped_key_stops_being_tracked() {
+        let before = tracked_limiters();
+        {
+            let key = ScopedKey::new("transient-xyz".into(), Duration::from_secs(30));
+            let _live = key.limiter("fred", 5.0);
+            assert!(tracked_limiters() > before);
+        }
+        let _prune =
+            ScopedKey::new("prune-trigger".into(), Duration::from_secs(30)).limiter("fred", 5.0);
+        assert!(
+            !LIMITERS
+                .read()
+                .unwrap()
+                .contains_key(&("fred", "transient-xyz".to_string()))
+        );
+    }
+}

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -47,6 +47,7 @@
 //! - Full mockito test coverage (no API key needed to run tests)
 
 pub(crate) mod common;
+pub(crate) mod keys;
 pub(crate) mod singleton;
 
 /// Alpha Vantage financial data API (requires `alphavantage` feature).

--- a/src/adapters/singleton.rs
+++ b/src/adapters/singleton.rs
@@ -77,10 +77,9 @@ macro_rules! provider_singleton_state {
 /// Generates `build_client()` and `build_test_client()` for a provider whose
 /// client is constructed via `$builder::new(api_key).timeout(t).build_with_limiter(limiter)`.
 ///
-/// `build_client()` falls back to reading `$env_var` if [`init`]/
-/// [`init_with_timeout`] was never called (convenience for scripts/tests that
-/// only set the env var), then reads the shared singleton state back out to
-/// build a fresh client. Requires [`provider_singleton_state!`] to have been
+/// `build_client()` resolves the key in order: a key scoped to the running
+/// dispatch (see [`crate::adapters::keys`]), the singleton set by [`init`]/
+/// [`init_with_timeout`], then `$env_var`. It then builds a fresh client. Requires [`provider_singleton_state!`] to have been
 /// invoked first in the same module (uses its `$struct_name`/`$static_name`).
 #[allow(unused_macros)]
 macro_rules! provider_build_client {
@@ -98,6 +97,12 @@ macro_rules! provider_build_client {
         ///
         /// Used internally by all query functions.
         pub(crate) fn build_client() -> crate::error::Result<$client_ty> {
+            if let Some(scoped) = crate::adapters::keys::scoped_key($provider_key) {
+                let limiter = scoped.limiter($provider_key, $rate_const);
+                return <$builder>::new(&scoped.api_key)
+                    .timeout(scoped.timeout)
+                    .build_with_limiter(limiter);
+            }
             if $static_name.get().is_none()
                 && let Ok(key) = ::std::env::var($env_var)
                 && !key.trim().is_empty()

--- a/src/domains/mod.rs
+++ b/src/domains/mod.rs
@@ -539,80 +539,28 @@ macro_rules! impl_chartable_analytics {
 // ── Modules ─────────────────────────────────────────────────────────
 
 pub(crate) mod commodities;
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "binance",
-    feature = "crypto",
-    feature = "defi",
-    feature = "fmp",
-    feature = "gdelt",
-    feature = "kraken",
-    feature = "polygon"
-))]
 pub(crate) mod crypto;
 pub(crate) mod discovery;
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "bls",
-    feature = "fiscaldata",
-    feature = "fred",
-    feature = "polygon",
-    feature = "worldbank"
-))]
 pub(crate) mod economic;
 pub(crate) mod filings;
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "fmp",
-    feature = "frankfurter",
-    feature = "gdelt",
-    feature = "polygon"
-))]
 pub(crate) mod forex;
 pub(crate) mod futures;
 pub(crate) mod indices;
 pub(crate) mod market;
-#[cfg(feature = "polygon")]
 pub(crate) mod snapshot;
 
 // ── Re-exports ──────────────────────────────────────────────────────
 
 pub use commodities::Commodity;
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "binance",
-    feature = "crypto",
-    feature = "defi",
-    feature = "fmp",
-    feature = "gdelt",
-    feature = "kraken",
-    feature = "polygon"
-))]
 pub use crypto::CryptoCoin;
 pub use discovery::Discovery;
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "bls",
-    feature = "fiscaldata",
-    feature = "fred",
-    feature = "polygon",
-    feature = "worldbank"
-))]
 pub use economic::{EconomicCatalog, EconomicIndicator};
 pub use filings::Filings;
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "fmp",
-    feature = "frankfurter",
-    feature = "gdelt",
-    feature = "polygon"
-))]
 pub use forex::ForexPair;
 pub use futures::FuturesContract;
 pub use indices::Index;
 pub use market::Market;
 pub use market::MarketCalendar;
-#[cfg(feature = "polygon")]
 pub use snapshot::Snapshot;
 
 // ── Tests ───────────────────────────────────────────────────────────

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -309,33 +309,8 @@ pub mod quote {
     pub use crate::models::quote::price::Price;
     pub use crate::models::quote::quote_type::QuoteTypeData;
 }
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "binance",
-    feature = "crypto",
-    feature = "defi",
-    feature = "fmp",
-    feature = "gdelt",
-    feature = "kraken",
-    feature = "polygon"
-))]
 pub use providers::CryptoProvider;
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "bls",
-    feature = "fiscaldata",
-    feature = "fred",
-    feature = "polygon",
-    feature = "worldbank"
-))]
 pub use providers::EconomicProvider;
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "fmp",
-    feature = "frankfurter",
-    feature = "gdelt",
-    feature = "polygon"
-))]
 pub use providers::ForexProvider;
 pub use providers::config::{Providers, ProvidersBuilder};
 pub use providers::{
@@ -355,33 +330,8 @@ pub use async_trait::async_trait;
 pub use ticker::{ClientHandle, Ticker, TickerBuilder};
 
 // Domain-specific query handles — constructable via Providers factory methods.
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "binance",
-    feature = "crypto",
-    feature = "defi",
-    feature = "fmp",
-    feature = "gdelt",
-    feature = "kraken",
-    feature = "polygon"
-))]
 pub use domains::CryptoCoin;
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "fmp",
-    feature = "frankfurter",
-    feature = "gdelt",
-    feature = "polygon"
-))]
 pub use domains::ForexPair;
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "bls",
-    feature = "fiscaldata",
-    feature = "fred",
-    feature = "polygon",
-    feature = "worldbank"
-))]
 pub use domains::{EconomicCatalog, EconomicIndicator};
 
 // Remaining Capability handles — indices, futures, commodities, filings, discovery
@@ -390,7 +340,6 @@ pub use domains::Discovery;
 pub use domains::Filings;
 pub use domains::FuturesContract;
 pub use domains::Index;
-#[cfg(feature = "polygon")]
 pub use domains::Snapshot;
 // `Market` is unconditional — its grouped-daily/crypto methods route through
 // CHART/CRYPTO, which have their own (broader) per-method gating rather than
@@ -490,41 +439,15 @@ pub use models::{
 pub use models::sentiment::{Sentiment, SentimentLabel, analyze as analyze_sentiment};
 // Multi-provider capability response types (feature-gated)
 pub use models::commodities::CommodityQuote;
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "binance",
-    feature = "crypto",
-    feature = "defi",
-    feature = "fmp",
-    feature = "gdelt",
-    feature = "kraken",
-    feature = "polygon"
-))]
 pub use models::crypto::CryptoQuote;
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "bls",
-    feature = "fiscaldata",
-    feature = "fred",
-    feature = "polygon",
-    feature = "worldbank"
-))]
 pub use models::economic::{
     EconomicCategory, EconomicRelease, EconomicSeries, EconomicSeriesMatch,
 };
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "fmp",
-    feature = "frankfurter",
-    feature = "gdelt",
-    feature = "polygon"
-))]
 pub use models::forex::ForexQuote;
 pub use models::futures::FuturesQuote;
 #[cfg(feature = "cftc")]
 pub use models::futures::cot::{CommitmentsOfTraders, CotObservation};
 pub use models::indices::{IndexConstituent, IndexConstituentChange, IndexQuote, MajorIndex};
-#[cfg(feature = "polygon")]
 pub use models::quote::snapshot::{AssetClass, MarketSnapshot};
 
 // ============================================================================

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,7 +318,9 @@ pub use providers::{
     FilingsProvider, FundamentalsProvider, FuturesProvider, IndicesProvider, MarketProvider,
     OptionsProvider, ProviderAdapter, ProviderCore, ProviderSet, QuoteProvider, Routes,
 };
-pub use providers::{Capability, Fetch, Operation, Provider, ProviderHealth, RetryPolicy};
+pub use providers::{
+    Capability, CustomId, Fetch, Operation, Provider, ProviderHealth, RetryPolicy,
+};
 
 /// The attribute every capability trait implementation needs.
 ///

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -36,35 +36,10 @@ pub mod sentiment;
 /// Commodities market data (gold, silver, oil, etc.) — Yahoo / FMP / Alpha Vantage.
 pub mod commodities;
 /// Cryptocurrency market data — CoinGecko, Alpha Vantage, FMP, Polygon.
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "binance",
-    feature = "crypto",
-    feature = "defi",
-    feature = "fmp",
-    feature = "gdelt",
-    feature = "kraken",
-    feature = "polygon"
-))]
 pub mod crypto;
 /// Macro-economic data — FRED, Alpha Vantage, Polygon.
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "bls",
-    feature = "fiscaldata",
-    feature = "fred",
-    feature = "polygon",
-    feature = "worldbank"
-))]
 pub mod economic;
 /// Forex (foreign exchange) data models — Polygon / FMP / Alpha Vantage.
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "fmp",
-    feature = "frankfurter",
-    feature = "gdelt",
-    feature = "polygon"
-))]
 pub mod forex;
 /// Futures market data models — Yahoo / Polygon / CFTC.
 pub mod futures;

--- a/src/models/quote/mod.rs
+++ b/src/models/quote/mod.rs
@@ -12,7 +12,6 @@ pub mod data;
 /// Formatted value wrapper for Yahoo Finance numeric fields.
 pub mod formatted_value;
 /// Cross-market snapshot models (provider-routed; Polygon-only).
-#[cfg(feature = "polygon")]
 pub mod snapshot;
 
 // Re-export only the final flattened Quote struct and FormattedValue (used in Quote's public fields)

--- a/src/providers/adapter/dispatch.rs
+++ b/src/providers/adapter/dispatch.rs
@@ -68,39 +68,14 @@ pub trait ProviderAdapter: ProviderCore {
     fn as_market(&self) -> Option<&dyn MarketProvider> {
         None
     }
-    #[cfg(any(
-        feature = "alphavantage",
-        feature = "binance",
-        feature = "crypto",
-        feature = "defi",
-        feature = "fmp",
-        feature = "gdelt",
-        feature = "kraken",
-        feature = "polygon"
-    ))]
     /// Override to `Some(self)` to serve [`crate::Capability::CRYPTO`].
     fn as_crypto(&self) -> Option<&dyn CryptoProvider> {
         None
     }
-    #[cfg(any(
-        feature = "alphavantage",
-        feature = "bls",
-        feature = "fiscaldata",
-        feature = "fred",
-        feature = "polygon",
-        feature = "worldbank"
-    ))]
     /// Override to `Some(self)` to serve [`crate::Capability::ECONOMIC`].
     fn as_economic(&self) -> Option<&dyn EconomicProvider> {
         None
     }
-    #[cfg(any(
-        feature = "alphavantage",
-        feature = "fmp",
-        feature = "frankfurter",
-        feature = "gdelt",
-        feature = "polygon"
-    ))]
     /// Override to `Some(self)` to serve [`crate::Capability::FOREX`].
     fn as_forex(&self) -> Option<&dyn ForexProvider> {
         None

--- a/src/providers/adapter/equity.rs
+++ b/src/providers/adapter/equity.rs
@@ -22,7 +22,6 @@ pub trait QuoteProvider: ProviderCore {
     /// Fetch a snapshot for symbols spanning several asset classes in one
     /// request. Rows the provider could not resolve are returned with
     /// `error` set rather than dropped.
-    #[cfg(feature = "polygon")]
     async fn fetch_unified_snapshot(
         &self,
         _symbols: &[&str],

--- a/src/providers/adapter/markets.rs
+++ b/src/providers/adapter/markets.rs
@@ -110,16 +110,6 @@ pub trait MarketProvider: ProviderCore {
 }
 
 /// [`crate::Capability::CRYPTO`] — cryptocurrency quotes.
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "binance",
-    feature = "crypto",
-    feature = "defi",
-    feature = "fmp",
-    feature = "gdelt",
-    feature = "kraken",
-    feature = "polygon"
-))]
 #[async_trait::async_trait]
 pub trait CryptoProvider: ProviderCore {
     /// Fetch a quote for one coin, priced in `vs_currency`.
@@ -169,14 +159,6 @@ pub trait CryptoProvider: ProviderCore {
 }
 
 /// [`crate::Capability::ECONOMIC`] — macro-economic data series.
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "bls",
-    feature = "fiscaldata",
-    feature = "fred",
-    feature = "polygon",
-    feature = "worldbank"
-))]
 #[async_trait::async_trait]
 pub trait EconomicProvider: ProviderCore {
     /// Fetch observations for one macro-economic series.
@@ -237,13 +219,6 @@ pub trait EconomicProvider: ProviderCore {
 }
 
 /// [`crate::Capability::FOREX`] — currency-pair quotes.
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "fmp",
-    feature = "frankfurter",
-    feature = "gdelt",
-    feature = "polygon"
-))]
 #[async_trait::async_trait]
 pub trait ForexProvider: ProviderCore {
     /// Fetch the exchange rate for one currency pair.

--- a/src/providers/adapter/mod.rs
+++ b/src/providers/adapter/mod.rs
@@ -36,33 +36,8 @@ pub use equity::{
     ChartProvider, CorporateProvider, FilingsProvider, FundamentalsProvider, OptionsProvider,
     QuoteProvider,
 };
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "binance",
-    feature = "crypto",
-    feature = "defi",
-    feature = "fmp",
-    feature = "gdelt",
-    feature = "kraken",
-    feature = "polygon"
-))]
 pub use markets::CryptoProvider;
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "bls",
-    feature = "fiscaldata",
-    feature = "fred",
-    feature = "polygon",
-    feature = "worldbank"
-))]
 pub use markets::EconomicProvider;
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "fmp",
-    feature = "frankfurter",
-    feature = "gdelt",
-    feature = "polygon"
-))]
 pub use markets::ForexProvider;
 pub use markets::{
     CalendarProvider, CommoditiesProvider, DiscoveryProvider, FuturesProvider, IndicesProvider,

--- a/src/providers/build.rs
+++ b/src/providers/build.rs
@@ -89,7 +89,7 @@ pub(crate) async fn build_providers(
         providers.push(Arc::new(edgar::EdgarProvider));
     }
     for routed in routes.map.values() {
-        for provider in routed {
+        for provider in &routed.providers {
             if !providers.iter().any(|p| p.id() == *provider) {
                 return Err(FinanceError::ProviderNotRegistered {
                     provider: *provider,

--- a/src/providers/config.rs
+++ b/src/providers/config.rs
@@ -258,6 +258,7 @@ pub struct ProvidersBuilder {
     config: ClientConfig,
     routes: Routes,
     retry: Option<RetryPolicy>,
+    api_keys: std::collections::HashMap<&'static str, String>,
 }
 
 impl std::fmt::Debug for ProvidersBuilder {
@@ -270,6 +271,10 @@ impl std::fmt::Debug for ProvidersBuilder {
             )
             .field("routes", &self.routes)
             .field("retry", &self.retry)
+            .field(
+                "api_keys",
+                &self.api_keys.keys().copied().collect::<Vec<_>>(),
+            )
             .finish()
     }
 }
@@ -282,6 +287,7 @@ impl Default for ProvidersBuilder {
             config: ClientConfig::default(),
             routes: Routes::new(Fetch::Sequential),
             retry: None,
+            api_keys: std::collections::HashMap::new(),
         }
     }
 }
@@ -292,6 +298,18 @@ impl ProvidersBuilder {
     /// Use [`Fetch::Sequential`] or [`Fetch::Parallel`].
     pub fn fetch(mut self, mode: Fetch) -> Self {
         self.routes.fetch = mode;
+        self
+    }
+
+    /// Set `provider`'s API key for the [`Providers`] this builds, instead of
+    /// the process-global key from its `init` function.
+    ///
+    /// Two `Providers` can hold different keys for the same provider, and a
+    /// key can be replaced without restarting. Each distinct key gets its own
+    /// rate-limit budget. Providers left unset fall back to the process-global
+    /// key, then to the environment variable.
+    pub fn api_key(mut self, provider: Provider, key: impl Into<String>) -> Self {
+        self.api_keys.insert(provider.as_str(), key.into());
         self
     }
 
@@ -450,9 +468,28 @@ impl ProvidersBuilder {
             }
         }
         let lang = self.config.lang.clone();
-        let set = build_providers(&self.provider_ids, self.adapters, &self.config, self.routes)
-            .await?
-            .with_retry_policy(self.retry);
+        let mut keys = crate::adapters::keys::KeyMap::new();
+        for (provider_key, api_key) in self.api_keys {
+            if api_key.trim().is_empty() {
+                return Err(crate::FinanceError::InvalidParameter {
+                    param: provider_key.to_string(),
+                    reason: "API key must not be empty".to_string(),
+                });
+            }
+            keys.insert(
+                provider_key,
+                crate::adapters::keys::ScopedKey::new(api_key, self.config.timeout),
+            );
+        }
+        // `initialize` builds each keyed client, so the scope has to cover
+        // construction as well as dispatch.
+        let set = crate::adapters::keys::scope(
+            Arc::new(keys.clone()),
+            build_providers(&self.provider_ids, self.adapters, &self.config, self.routes),
+        )
+        .await?
+        .with_api_keys(keys)
+        .with_retry_policy(self.retry);
         Ok(Providers {
             set: Arc::new(set),
             lang,

--- a/src/providers/config.rs
+++ b/src/providers/config.rs
@@ -301,9 +301,31 @@ impl ProvidersBuilder {
     /// initialisation list if not already present. If omitted for a capability,
     /// Yahoo is used as default.
     pub fn route(
+        self,
+        cap: crate::providers::Capability,
+        providers: impl IntoIterator<Item = Provider>,
+    ) -> Self {
+        self.insert_route(cap, providers, None)
+    }
+
+    /// Route a capability, overriding [`fetch`](Self::fetch) for it alone.
+    ///
+    /// Lets a quota-limited capability stay sequential while another races
+    /// its providers.
+    pub fn route_with(
+        self,
+        cap: crate::providers::Capability,
+        providers: impl IntoIterator<Item = Provider>,
+        fetch: Fetch,
+    ) -> Self {
+        self.insert_route(cap, providers, Some(fetch))
+    }
+
+    fn insert_route(
         mut self,
         cap: crate::providers::Capability,
         providers: impl IntoIterator<Item = Provider>,
+        fetch: Option<Fetch>,
     ) -> Self {
         let providers: Vec<Provider> = providers.into_iter().collect();
         for provider in &providers {
@@ -316,7 +338,9 @@ impl ProvidersBuilder {
                 self.provider_ids.push(*provider);
             }
         }
-        self.routes.map.insert(cap, providers);
+        self.routes
+            .map
+            .insert(cap, super::routes::Route { providers, fetch });
         self
     }
 

--- a/src/providers/config.rs
+++ b/src/providers/config.rs
@@ -110,28 +110,11 @@ impl Providers {
     }
 
     /// Create a [`CryptoCoin`](crate::CryptoCoin) handle backed by this provider set.
-    #[cfg(any(
-        feature = "alphavantage",
-        feature = "binance",
-        feature = "crypto",
-        feature = "defi",
-        feature = "fmp",
-        feature = "gdelt",
-        feature = "kraken",
-        feature = "polygon"
-    ))]
     pub fn crypto(&self, id: impl Into<String>) -> crate::domains::CryptoCoin {
         crate::domains::CryptoCoin::with_providers(id.into().into(), Arc::clone(&self.set))
     }
 
     /// Create a [`ForexPair`](crate::ForexPair) handle backed by this provider set.
-    #[cfg(any(
-        feature = "alphavantage",
-        feature = "fmp",
-        feature = "frankfurter",
-        feature = "gdelt",
-        feature = "polygon"
-    ))]
     pub fn forex(
         &self,
         from: impl Into<String>,
@@ -145,14 +128,6 @@ impl Providers {
     }
 
     /// Create an [`EconomicIndicator`](crate::EconomicIndicator) handle backed by this provider set.
-    #[cfg(any(
-        feature = "alphavantage",
-        feature = "bls",
-        feature = "fiscaldata",
-        feature = "fred",
-        feature = "polygon",
-        feature = "worldbank"
-    ))]
     pub fn economic(&self, series_id: impl Into<String>) -> crate::domains::EconomicIndicator {
         crate::domains::EconomicIndicator::with_providers(
             series_id.into().into(),
@@ -209,7 +184,6 @@ impl Providers {
     /// [`Capability::ECONOMIC`](crate::Capability::ECONOMIC). Unlike
     /// [`economic`](Self::economic) it takes no series id — it is how you find
     /// one.
-    #[cfg(any(feature = "fred", feature = "alphavantage", feature = "polygon"))]
     pub fn economic_catalog(&self) -> crate::domains::EconomicCatalog {
         crate::domains::EconomicCatalog::with_providers(Arc::clone(&self.set))
     }
@@ -220,7 +194,6 @@ impl Providers {
     /// [`Capability::QUOTE`](crate::Capability::QUOTE). Needs a provider whose
     /// snapshot endpoint spans asset classes — currently Polygon only, which is
     /// why the handle is gated on that feature.
-    #[cfg(feature = "polygon")]
     pub fn snapshot(&self) -> crate::domains::Snapshot {
         crate::domains::Snapshot::with_providers(Arc::clone(&self.set))
     }

--- a/src/providers/config.rs
+++ b/src/providers/config.rs
@@ -110,11 +110,19 @@ impl Providers {
     }
 
     /// Create a [`CryptoCoin`](crate::CryptoCoin) handle backed by this provider set.
+    ///
+    /// Compiled in unconditionally. With no built-in provider for this
+    /// capability, register one with [`ProvidersBuilder::with_adapter`] or
+    /// enable its feature, or these calls return `NoProviderAvailable`.
     pub fn crypto(&self, id: impl Into<String>) -> crate::domains::CryptoCoin {
         crate::domains::CryptoCoin::with_providers(id.into().into(), Arc::clone(&self.set))
     }
 
     /// Create a [`ForexPair`](crate::ForexPair) handle backed by this provider set.
+    ///
+    /// Compiled in unconditionally. With no built-in provider for this
+    /// capability, register one with [`ProvidersBuilder::with_adapter`] or
+    /// enable its feature, or these calls return `NoProviderAvailable`.
     pub fn forex(
         &self,
         from: impl Into<String>,
@@ -128,6 +136,10 @@ impl Providers {
     }
 
     /// Create an [`EconomicIndicator`](crate::EconomicIndicator) handle backed by this provider set.
+    ///
+    /// Compiled in unconditionally. With no built-in provider for this
+    /// capability, register one with [`ProvidersBuilder::with_adapter`] or
+    /// enable its feature, or these calls return `NoProviderAvailable`.
     pub fn economic(&self, series_id: impl Into<String>) -> crate::domains::EconomicIndicator {
         crate::domains::EconomicIndicator::with_providers(
             series_id.into().into(),
@@ -184,6 +196,10 @@ impl Providers {
     /// [`Capability::ECONOMIC`](crate::Capability::ECONOMIC). Unlike
     /// [`economic`](Self::economic) it takes no series id — it is how you find
     /// one.
+    ///
+    /// Compiled in unconditionally. With no built-in provider for this
+    /// capability, register one with [`ProvidersBuilder::with_adapter`] or
+    /// enable its feature, or these calls return `NoProviderAvailable`.
     pub fn economic_catalog(&self) -> crate::domains::EconomicCatalog {
         crate::domains::EconomicCatalog::with_providers(Arc::clone(&self.set))
     }
@@ -192,8 +208,11 @@ impl Providers {
     ///
     /// Routes cross-market snapshots through
     /// [`Capability::QUOTE`](crate::Capability::QUOTE). Needs a provider whose
-    /// snapshot endpoint spans asset classes — currently Polygon only, which is
-    /// why the handle is gated on that feature.
+    /// snapshot endpoint spans asset classes, currently Polygon alone.
+    ///
+    /// Compiled in unconditionally. With no built-in provider for this
+    /// capability, register one with [`ProvidersBuilder::with_adapter`] or
+    /// enable its feature, or these calls return `NoProviderAvailable`.
     pub fn snapshot(&self) -> crate::domains::Snapshot {
         crate::domains::Snapshot::with_providers(Arc::clone(&self.set))
     }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -51,33 +51,8 @@ pub(crate) mod worldbank;
 pub(crate) mod yahoo;
 mod yahoo_ttm;
 
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "binance",
-    feature = "crypto",
-    feature = "defi",
-    feature = "fmp",
-    feature = "gdelt",
-    feature = "kraken",
-    feature = "polygon"
-))]
 pub use adapter::CryptoProvider;
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "bls",
-    feature = "fiscaldata",
-    feature = "fred",
-    feature = "polygon",
-    feature = "worldbank"
-))]
 pub use adapter::EconomicProvider;
-#[cfg(any(
-    feature = "alphavantage",
-    feature = "fmp",
-    feature = "frankfurter",
-    feature = "gdelt",
-    feature = "polygon"
-))]
 pub use adapter::ForexProvider;
 /// Not part of the stable public API — see [`ProviderAdapter`].
 #[doc(hidden)]

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -77,7 +77,7 @@ pub use capability::Capability;
 #[allow(unused_imports)] // each is used only by a feature-gated provider bridge
 pub(crate) use convert::{build_financial_statement, build_options, range_to_dates};
 pub use operation::Operation;
-pub use provider::Provider;
+pub use provider::{CustomId, Provider};
 pub use routes::{Fetch, Routes};
 pub use set::ProviderSet;
 

--- a/src/providers/routes.rs
+++ b/src/providers/routes.rs
@@ -14,15 +14,25 @@ pub enum Fetch {
     Parallel,
 }
 
+#[derive(Debug)]
+pub(crate) struct Route {
+    pub(crate) providers: Vec<Provider>,
+    pub(crate) fetch: Option<Fetch>,
+}
+
 /// Per-capability provider routing table.
 ///
 /// Maps each [`Capability`] to an ordered list of [`Provider`]s to try. A
 /// capability with no entry falls back to Yahoo, or to EDGAR then Yahoo for
 /// [`Capability::FILINGS`].
+///
+/// Each route may carry its own [`Fetch`] mode, so a quota-limited capability
+/// can stay sequential while another races its providers. Routes without one
+/// use the table default.
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct Routes {
-    pub(crate) map: HashMap<Capability, Vec<Provider>>,
+    pub(crate) map: HashMap<Capability, Route>,
     pub(crate) fetch: Fetch,
 }
 
@@ -41,18 +51,52 @@ impl Routes {
     /// Without this a hand-built table is empty and every capability falls
     /// back to its default, so a registered adapter would never be reached.
     #[must_use]
-    pub fn route(mut self, cap: Capability, providers: impl IntoIterator<Item = Provider>) -> Self {
-        self.map.insert(cap, providers.into_iter().collect());
+    pub fn route(self, cap: Capability, providers: impl IntoIterator<Item = Provider>) -> Self {
+        self.insert(cap, providers, None)
+    }
+
+    /// Route one capability, overriding the table's [`Fetch`] mode for it.
+    #[must_use]
+    pub fn route_with(
+        self,
+        cap: Capability,
+        providers: impl IntoIterator<Item = Provider>,
+        fetch: Fetch,
+    ) -> Self {
+        self.insert(cap, providers, Some(fetch))
+    }
+
+    fn insert(
+        mut self,
+        cap: Capability,
+        providers: impl IntoIterator<Item = Provider>,
+        fetch: Option<Fetch>,
+    ) -> Self {
+        self.map.insert(
+            cap,
+            Route {
+                providers: providers.into_iter().collect(),
+                fetch,
+            },
+        );
         self
     }
 
-    /// The concurrency mode this table was built with.
+    /// The default concurrency mode for capabilities that do not override it.
     pub fn fetch_mode(&self) -> Fetch {
         self.fetch
     }
 
+    /// The concurrency mode `cap` resolves to.
+    pub fn fetch_mode_for(&self, cap: Capability) -> Fetch {
+        self.map
+            .get(&cap)
+            .and_then(|r| r.fetch)
+            .unwrap_or(self.fetch)
+    }
+
     /// The providers routed to `cap`, or `None` when it falls back to the default.
     pub fn providers_for(&self, cap: Capability) -> Option<&[Provider]> {
-        self.map.get(&cap).map(Vec::as_slice)
+        self.map.get(&cap).map(|r| r.providers.as_slice())
     }
 }

--- a/src/providers/set.rs
+++ b/src/providers/set.rs
@@ -25,6 +25,9 @@ pub struct ProviderSet {
     /// behavior exactly: a `RateLimited` error is treated like any
     /// other failure and dispatch moves straight to the next candidate.
     retry_policy: Option<RetryPolicy>,
+    /// Keys scoped to this set, published for the duration of each dispatch
+    /// so keyed adapters prefer them over the process-global singletons.
+    api_keys: Arc<crate::adapters::keys::KeyMap>,
     /// In-memory recent success/failure tracker, always active (cheap to
     /// maintain) and surfaced on request via [`ProviderSet::health`].
     health: HealthTracker,
@@ -53,6 +56,7 @@ impl ProviderSet {
             yahoo_client: None,
             routes,
             retry_policy: None,
+            api_keys: Arc::new(crate::adapters::keys::KeyMap::new()),
             health: HealthTracker::new(),
         }
     }
@@ -62,6 +66,12 @@ impl ProviderSet {
     /// part of the public constructor.
     pub(crate) fn with_yahoo_client(mut self, client: Option<Arc<YahooClient>>) -> Self {
         self.yahoo_client = client;
+        self
+    }
+
+    /// Scope API keys to this set rather than the process-global singletons.
+    pub(crate) fn with_api_keys(mut self, keys: crate::adapters::keys::KeyMap) -> Self {
+        self.api_keys = Arc::new(keys);
         self
     }
 
@@ -175,6 +185,23 @@ impl ProviderSet {
     }
 
     pub(crate) async fn fetch<T, F, Fut>(&self, cap: Capability, f: F) -> Result<T>
+    where
+        F: Fn(&Arc<dyn ProviderAdapter>) -> Fut,
+        Fut: std::future::Future<Output = Result<T>>,
+    {
+        if self.api_keys.is_empty() {
+            return self.dispatch(cap, f).await;
+        }
+        // Boxed so the scoped variant does not enlarge the future every
+        // dispatch builds; only callers that configure a key pay for it.
+        Box::pin(crate::adapters::keys::scope(
+            Arc::clone(&self.api_keys),
+            self.dispatch(cap, f),
+        ))
+        .await
+    }
+
+    async fn dispatch<T, F, Fut>(&self, cap: Capability, f: F) -> Result<T>
     where
         F: Fn(&Arc<dyn ProviderAdapter>) -> Fut,
         Fut: std::future::Future<Output = Result<T>>,

--- a/src/providers/set.rs
+++ b/src/providers/set.rs
@@ -90,8 +90,9 @@ impl ProviderSet {
     /// explicit route configured via `.route()`. When no route is configured,
     /// defaults to Yahoo for all capabilities and EDGAR for filings.
     fn candidates_for(&self, cap: Capability) -> Vec<&Arc<dyn ProviderAdapter>> {
-        if let Some(provider_ids) = self.routes.map.get(&cap) {
-            provider_ids
+        if let Some(route) = self.routes.map.get(&cap) {
+            route
+                .providers
                 .iter()
                 .filter_map(|id| self.providers.iter().find(|p| p.id() == *id))
                 .collect()
@@ -182,7 +183,7 @@ impl ProviderSet {
         if candidates.is_empty() {
             return Err(Self::no_provider(cap));
         }
-        match self.routes.fetch {
+        match self.routes.fetch_mode_for(cap) {
             Fetch::Sequential => {
                 let mut last = None;
                 let mut unsupported = None;

--- a/src/providers/tests.rs
+++ b/src/providers/tests.rs
@@ -233,10 +233,8 @@ async fn real_errors_outrank_not_supported_in_final_error() {
         }
     }
 
-    let mut routes = Routes::new(Fetch::Sequential);
-    routes
-        .map
-        .insert(Capability::CHART, vec![Provider::Yahoo, Provider::Edgar]);
+    let routes =
+        Routes::new(Fetch::Sequential).route(Capability::CHART, [Provider::Yahoo, Provider::Edgar]);
     let set = ProviderSet::new(
         vec![Arc::new(NoSparkProvider), Arc::new(FailingChartProvider)],
         routes,
@@ -370,10 +368,8 @@ async fn retry_policy_retries_rate_limited_then_succeeds() {
 async fn retry_policy_exhausts_and_falls_through_to_next_provider() {
     let always_limited = Arc::new(FlakyChartProvider::new(Provider::Yahoo, usize::MAX));
     let succeeds = Arc::new(FlakyChartProvider::new(Provider::Edgar, 0));
-    let mut routes = Routes::new(Fetch::Sequential);
-    routes
-        .map
-        .insert(Capability::CHART, vec![Provider::Yahoo, Provider::Edgar]);
+    let routes =
+        Routes::new(Fetch::Sequential).route(Capability::CHART, [Provider::Yahoo, Provider::Edgar]);
     let set = ProviderSet::new(
         vec![
             always_limited.clone() as Arc<dyn ProviderAdapter>,
@@ -526,4 +522,138 @@ fn every_variant_has_its_serialized_form_pinned() {
         assert_eq!(provider.as_str(), id);
         assert_eq!(Provider::from_id_str(id), Some(provider));
     }
+}
+
+#[test]
+fn a_route_without_a_mode_uses_the_table_default() {
+    let routes = Routes::new(Fetch::Parallel).route(Capability::QUOTE, [Provider::Yahoo]);
+    assert_eq!(routes.fetch_mode_for(Capability::QUOTE), Fetch::Parallel);
+}
+
+#[test]
+fn a_route_mode_overrides_the_table_default() {
+    let routes = Routes::new(Fetch::Parallel).route_with(
+        Capability::FUNDAMENTALS,
+        [Provider::Yahoo],
+        Fetch::Sequential,
+    );
+    assert_eq!(
+        routes.fetch_mode_for(Capability::FUNDAMENTALS),
+        Fetch::Sequential
+    );
+    assert_eq!(routes.fetch_mode(), Fetch::Parallel);
+}
+
+#[test]
+fn an_unrouted_capability_uses_the_table_default() {
+    let routes = Routes::new(Fetch::Sequential).route_with(
+        Capability::QUOTE,
+        [Provider::Yahoo],
+        Fetch::Parallel,
+    );
+    assert_eq!(routes.fetch_mode_for(Capability::CHART), Fetch::Sequential);
+}
+
+#[test]
+fn modes_are_independent_across_capabilities() {
+    let routes = Routes::new(Fetch::Sequential)
+        .route_with(Capability::QUOTE, [Provider::Yahoo], Fetch::Parallel)
+        .route(Capability::FUNDAMENTALS, [Provider::Yahoo]);
+    assert_eq!(routes.fetch_mode_for(Capability::QUOTE), Fetch::Parallel);
+    assert_eq!(
+        routes.fetch_mode_for(Capability::FUNDAMENTALS),
+        Fetch::Sequential
+    );
+}
+
+struct CountingChartProvider {
+    id: Provider,
+    calls: std::sync::atomic::AtomicUsize,
+}
+
+impl CountingChartProvider {
+    fn new(id: Provider) -> Self {
+        Self {
+            id,
+            calls: std::sync::atomic::AtomicUsize::new(0),
+        }
+    }
+
+    fn calls(&self) -> usize {
+        self.calls.load(std::sync::atomic::Ordering::SeqCst)
+    }
+}
+
+impl ProviderCore for CountingChartProvider {
+    fn id(&self) -> Provider {
+        self.id
+    }
+}
+
+#[async_trait::async_trait]
+impl ChartProvider for CountingChartProvider {
+    async fn fetch_chart(
+        &self,
+        symbol: &str,
+        _: crate::Interval,
+        _: crate::TimeRange,
+    ) -> Result<crate::models::chart::Chart> {
+        self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        tokio::task::yield_now().await;
+        Ok(crate::models::chart::Chart {
+            symbol: symbol.to_string(),
+            meta: Default::default(),
+            candles: Vec::new(),
+            interval: None,
+            range: None,
+            provider_id: Some(self.id),
+        })
+    }
+}
+
+impl ProviderAdapter for CountingChartProvider {
+    fn as_chart(&self) -> Option<&dyn ChartProvider> {
+        Some(self)
+    }
+}
+
+async fn chart_calls_under(routes: Routes) -> (usize, usize) {
+    let first = Arc::new(CountingChartProvider::new(Provider::Yahoo));
+    let second = Arc::new(CountingChartProvider::new(Provider::Edgar));
+    let set = ProviderSet::new(
+        vec![
+            first.clone() as Arc<dyn ProviderAdapter>,
+            second.clone() as Arc<dyn ProviderAdapter>,
+        ],
+        routes,
+    );
+    set.fetch(Capability::CHART, |p| {
+        let p = p.clone();
+        async move {
+            p.as_chart()
+                .ok_or_else(|| p.not_supported(Operation::Chart))?
+                .fetch_chart("AAPL", crate::Interval::OneDay, crate::TimeRange::FiveDays)
+                .await
+        }
+    })
+    .await
+    .expect("a provider succeeds");
+    (first.calls(), second.calls())
+}
+
+#[tokio::test]
+async fn a_sequential_route_stops_at_the_first_success() {
+    let routes =
+        Routes::new(Fetch::Sequential).route(Capability::CHART, [Provider::Yahoo, Provider::Edgar]);
+    assert_eq!(chart_calls_under(routes).await, (1, 0));
+}
+
+#[tokio::test]
+async fn route_with_parallel_overrides_a_sequential_default() {
+    let routes = Routes::new(Fetch::Sequential).route_with(
+        Capability::CHART,
+        [Provider::Yahoo, Provider::Edgar],
+        Fetch::Parallel,
+    );
+    assert_eq!(chart_calls_under(routes).await, (1, 1));
 }

--- a/src/providers/tests.rs
+++ b/src/providers/tests.rs
@@ -657,3 +657,144 @@ async fn route_with_parallel_overrides_a_sequential_default() {
     );
     assert_eq!(chart_calls_under(routes).await, (1, 1));
 }
+
+#[tokio::test]
+async fn an_empty_api_key_is_rejected_at_build() {
+    let err = crate::Providers::builder()
+        .api_key(Provider::Yahoo, "   ")
+        .build()
+        .await
+        .expect_err("an empty key is refused");
+    assert!(matches!(err, FinanceError::InvalidParameter { .. }));
+}
+
+#[test]
+fn debug_names_keyed_providers_without_their_keys() {
+    let builder = crate::Providers::builder().api_key(Provider::Yahoo, "super-secret");
+    let rendered = format!("{builder:?}");
+    assert!(rendered.contains("yahoo"));
+    assert!(!rendered.contains("super-secret"));
+}
+
+struct KeyObservingProvider {
+    id: Provider,
+    seen: std::sync::Mutex<Option<Option<String>>>,
+}
+
+impl KeyObservingProvider {
+    fn new(id: Provider) -> Self {
+        Self {
+            id,
+            seen: std::sync::Mutex::new(None),
+        }
+    }
+
+    fn seen(&self) -> Option<String> {
+        self.seen
+            .lock()
+            .expect("not poisoned")
+            .clone()
+            .expect("the adapter was called")
+    }
+}
+
+impl ProviderCore for KeyObservingProvider {
+    fn id(&self) -> Provider {
+        self.id
+    }
+}
+
+#[async_trait::async_trait]
+impl ChartProvider for KeyObservingProvider {
+    async fn fetch_chart(
+        &self,
+        symbol: &str,
+        _: crate::Interval,
+        _: crate::TimeRange,
+    ) -> Result<crate::models::chart::Chart> {
+        let observed = crate::adapters::keys::scoped_key("fmp").map(|k| k.api_key);
+        *self.seen.lock().expect("not poisoned") = Some(observed);
+        tokio::task::yield_now().await;
+        Ok(crate::models::chart::Chart {
+            symbol: symbol.to_string(),
+            meta: Default::default(),
+            candles: Vec::new(),
+            interval: None,
+            range: None,
+            provider_id: Some(self.id),
+        })
+    }
+}
+
+impl ProviderAdapter for KeyObservingProvider {
+    fn as_chart(&self) -> Option<&dyn ChartProvider> {
+        Some(self)
+    }
+}
+
+fn scoped_fmp(key: &str) -> crate::adapters::keys::KeyMap {
+    let mut keys = crate::adapters::keys::KeyMap::new();
+    keys.insert(
+        "fmp",
+        crate::adapters::keys::ScopedKey::new(key.to_string(), std::time::Duration::from_secs(30)),
+    );
+    keys
+}
+
+async fn drive_chart(set: &ProviderSet) {
+    set.fetch(Capability::CHART, |p| {
+        let p = p.clone();
+        async move {
+            p.as_chart()
+                .ok_or_else(|| p.not_supported(Operation::Chart))?
+                .fetch_chart("AAPL", crate::Interval::OneDay, crate::TimeRange::FiveDays)
+                .await
+        }
+    })
+    .await
+    .expect("a provider succeeds");
+}
+
+#[tokio::test]
+async fn dispatch_publishes_a_scoped_key_to_the_adapter() {
+    let provider = Arc::new(KeyObservingProvider::new(Provider::Yahoo));
+    let set = ProviderSet::new(
+        vec![provider.clone() as Arc<dyn ProviderAdapter>],
+        Routes::new(Fetch::Sequential),
+    )
+    .with_api_keys(scoped_fmp("scoped-key"));
+    drive_chart(&set).await;
+    assert_eq!(provider.seen(), Some("scoped-key".into()));
+}
+
+#[tokio::test]
+async fn dispatch_without_scoped_keys_leaves_the_adapter_unscoped() {
+    let provider = Arc::new(KeyObservingProvider::new(Provider::Yahoo));
+    let set = ProviderSet::new(
+        vec![provider.clone() as Arc<dyn ProviderAdapter>],
+        Routes::new(Fetch::Sequential),
+    );
+    drive_chart(&set).await;
+    assert_eq!(provider.seen(), None);
+}
+
+#[tokio::test]
+async fn parallel_dispatch_publishes_the_scope_to_every_provider() {
+    let first = Arc::new(KeyObservingProvider::new(Provider::Yahoo));
+    let second = Arc::new(KeyObservingProvider::new(Provider::Edgar));
+    let set = ProviderSet::new(
+        vec![
+            first.clone() as Arc<dyn ProviderAdapter>,
+            second.clone() as Arc<dyn ProviderAdapter>,
+        ],
+        Routes::new(Fetch::Sequential).route_with(
+            Capability::CHART,
+            [Provider::Yahoo, Provider::Edgar],
+            Fetch::Parallel,
+        ),
+    )
+    .with_api_keys(scoped_fmp("scoped-key"));
+    drive_chart(&set).await;
+    assert_eq!(first.seen(), Some("scoped-key".into()));
+    assert_eq!(second.seen(), Some("scoped-key".into()));
+}

--- a/src/ticker/core.rs
+++ b/src/ticker/core.rs
@@ -122,7 +122,7 @@ impl TickerBuilder {
         self.config = c;
         self
     }
-    /// Pre-inject a shared provider set (used by [`Providers::stock`](crate::Providers::stock)).
+    /// Pre-inject a shared provider set (used by [`Providers::ticker`](crate::Providers::ticker)).
     ///
     /// Not part of the stable public API — see [`ProviderAdapter`](crate::ProviderAdapter).
     #[doc(hidden)]

--- a/tests/custom_provider.rs
+++ b/tests/custom_provider.rs
@@ -161,3 +161,53 @@ fn routes_report_what_they_carry() {
     );
     assert_eq!(routes.providers_for(Capability::QUOTE), None);
 }
+
+struct CannedForex;
+
+impl ProviderCore for CannedForex {
+    fn id(&self) -> Provider {
+        Provider::custom("canned-forex")
+    }
+}
+
+#[finance_query::async_trait]
+impl finance_query::ForexProvider for CannedForex {
+    async fn fetch_forex_quote(
+        &self,
+        from: &str,
+        to: &str,
+    ) -> finance_query::Result<finance_query::ForexQuote> {
+        serde_json::from_value(serde_json::json!({
+            "symbol": format!("{from}{to}=X"),
+            "price": 1.25,
+        }))
+        .map_err(|e| FinanceError::ResponseStructureError {
+            field: "forex".to_string(),
+            context: e.to_string(),
+        })
+    }
+}
+
+impl ProviderAdapter for CannedForex {
+    fn as_forex(&self) -> Option<&dyn finance_query::ForexProvider> {
+        Some(self)
+    }
+}
+
+#[tokio::test]
+async fn forex_handle_reachable_with_no_builtin_forex_feature() {
+    let providers = Providers::builder()
+        .with_adapter(Arc::new(CannedForex))
+        .route(Capability::FOREX, [Provider::custom("canned-forex")])
+        .build()
+        .await
+        .expect("builds");
+
+    let quote = providers
+        .forex("EUR", "USD")
+        .quote()
+        .await
+        .expect("the custom adapter serves FOREX");
+    assert_eq!(quote.price, Some(1.25));
+    assert_eq!(quote.symbol, "EURUSD=X");
+}


### PR DESCRIPTION
## Description

Thirteen provider operations were implemented in the library and reachable from
nothing. This exposes all thirteen over GraphQL, REST and MCP, deletes the
adapter code that really was dead, and fixes two query-construction bugs found
by sweeping every endpoint afterwards.

The audit behind it asked four questions: are the paid-only operations covered
by a FOSS alternative, is the provider layer extendable, is every capability
actually reachable from the server and MCP, and is the dead code truly dead.
One and two already held. Three and four did not, and this closes both.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes

- Expose six ticker fundamentals (short volume, grading actions, price target
  summary, executive compensation, key metrics TTM, financial ratios TTM) and
  seven more operations (protocol TVL and its history, symbol details, index
  constituent changes, sector performance history, forex quotes, FRED
  `as_of`) over GraphQL, REST and MCP.
- Delete two unreachable Polygon aggregate adapters and four unreachable
  functions and DTOs. `intraday_limit` stays: its constants are the only
  record of Yahoo's interval bounds, so its false doc comment is corrected
  instead, since nothing clamps a request to them.
- Fix `escape_gql_string` call sites that used the returned contents without
  wrapping them in quotes. One of these was on master and broke
  `POST /v2/backtest/{symbol}`.
- Fix two field names in `GQL_PROTOCOL_TVL_VALID_FIELDS`, and add a test that
  compares every `VALID_FIELDS` constant against `schema.graphql`.
- Restore adjusted Alpha Vantage weekly and monthly bars. Daily stays
  unadjusted because `TIME_SERIES_DAILY_ADJUSTED` is premium-only.
- Reach 100% soothfast doc coverage, up from 99%.
- Add twelve `[[probe]]` entries, an MCP tool-marker reconciliation test, and
  a docs-nav coverage test.

## Breaking Changes

None. Every change is additive or a fix to a path that was already broken.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] All tests pass (`cargo test`)

Full workspace suite: 2073 passing, 0 failing, run before the last two fix
commits. Those two commits are covered by new tests that CI will run first --
locally they have only been through `cargo clippy --workspace --all-targets
--features finance-query/full`, which is clean.

Manual sweep of every endpoint on both surfaces:

- **REST, all 90 operations.** 54 answered 200. The rest were harness
  parameter errors, unset environment (`EDGAR_EMAIL`, `FRED_API_KEY`), or
  correct rejections. All thirteen new endpoints answer 200, including the
  repaired backtest POST.
- **MCP, all 63 tools over stdio.** No failures attributable to this branch.

Two findings are pre-existing and left alone rather than widening this PR:
`POST /v2/screeners/custom` with an empty filter list answers 500 where it
should answer 400, and `mcp-tools.json` disagrees with the live schema on
which parameters are required.

`probes.lock` is not refreshed here. `--accept` is all-or-nothing and GDELT
answers slowly enough to fail a probe on most runs, so the lock cannot be
written from this branch.

## Documentation
- [x] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [x] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [ ] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy`)
- [x] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

None.
