### PR TITLE
chore: lock the forex probe

### DIFF
--- a/server/probes.lock
+++ b/server/probes.lock
@@ -681,6 +681,21 @@
         "[].values[].value": "always"
       }
     },
+    "forex": {
+      "fields": {
+        "baseCurrency": "always",
+        "change": "always",
+        "changePercent": "always",
+        "price": "always",
+        "quoteCurrency": "always",
+        "symbol": "always",
+        "timestamp": "always"
+      },
+      "uncovered": [
+        "ask",
+        "bid"
+      ]
+    },
     "forex-news": {
       "fields": {
         "[]": "always",


### PR DESCRIPTION
## Description

Locks the last declared probe without a locked field population. `probes.lock`
goes to 94 of 94 declared, closing a gap that predates the endpoint work.

`forex` is a strict substring of `forex-news`, and `spec probe --filter` matches
on a plain substring, so the two can only be accepted together. `forex-news`
depends on a GDELT query that answers either side of the 30s client timeout, so
locking `forex` needed a run where that query came back in time. This is that
run.

Measured while diagnosing it: the endpoint failed three times at 30.006s, which
is our timeout rather than an upstream error, while the query answered directly
in 24.8s once and not at all twice after. Raising that timeout would make this
reliable and belongs in its own change.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

Generated artifact refresh; none of the above apply.

## Changes

- `server/probes.lock`: add the `forex` entry. No other entry added, removed or
  changed.

## Breaking Changes

None.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] All tests pass (`cargo test`)

Produced by `cargo soothfast spec probe -p finance-query-server --accept
--filter forex` against a release server. Diff verified as one added key and
zero changed keys.

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [ ] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

None.