### PR TITLE
feat: non_exhaustive growable enums, complete v3 changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,83 +8,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased (draft vs v2.8.0)
 
 <!-- soothfast:notes -->
-### Breaking
-
-- `Ticker`, `Tickers`, and the domain handles cache responses by default for the
-  lifetime of the handle. Previously caching was off unless `.cache(ttl)` was
-  set, so every accessor refetched — which contradicted the documentation. Call
-  `.no_cache()` for the old behavior.
-- `BacktestEngine::run` and `run_with_dividends` now reject candles that are not
-  sorted ascending by timestamp, with the same `InvalidParameter` error already
-  used for unsorted dividends. Conditions binary-search the candle slice, so an
-  unsorted series previously produced a silently wrong entry index. `GridSearch`,
-  `BayesianSearch`, and `WalkForward` apply the same check once per series rather
-  than once per candidate.
-- A Yahoo HTTP 403 whose body names the crumb now surfaces as
-  `AuthenticationFailed` rather than `UnexpectedResponse`, so the shared session
-  refreshes instead of failing every later caller on it. A 403 that does *not*
-  mention the crumb — a datacenter-IP block or abuse throttle — keeps mapping to
-  `UnexpectedResponse`, since no handshake can clear it and retrying would cost
-  an extra handshake and a discarded session per blocked request.
-- `FinanceError` is now `#[non_exhaustive]`, as every other public enum in the
-  crate already is. Downstream `match` expressions over it need a wildcard arm;
-  in exchange, later variants are additive.
-- `Region`, `IndicesRegion`, `Screener`, `Sector`, and `Fetch` are now
-  `#[non_exhaustive]` — these sets grow (new markets, screeners, dispatch
-  modes), so later variants become additive rather than semver-major.
-  Downstream `match` expressions over them need a wildcard arm. The closed-set
-  constants enums (`Interval`, `TimeRange`, `Frequency`, `StatementType`,
-  `ValueFormat`) deliberately stay exhaustive.
-
-### Changed
-
-- The Polygon adapter now calls `api.massive.com` and
-  `wss://socket.massive.com` rather than the `polygon.io` hosts, following
-  Polygon.io's rebrand to Massive on 2025-10-30. Existing `POLYGON_API_KEY`
-  values and the `polygon` feature flag are unchanged.
-- `Capability` values combining several bits display as `"quote|chart"`
-  instead of `"unknown"`; `Capability::name()` keeps its documented
-  single-bit contract.
-- When no routed provider supports the specific operation, the error now
-  names that operation and the providers that could serve it
-  (`NotSupported`) instead of the generic capability-level
-  `NoProviderAvailable`.
-- Yahoo sessions are now shared per tokio runtime and client configuration.
-  The `finance::*` functions and `Ticker`/`Tickers` construction reuse one
-  authenticated session instead of running a fresh cookie + crumb handshake per
-  call, cutting each `finance::*` call from three HTTP requests to one.
-- Eight oversized source files were split into directories of focused modules:
-  `constants.rs`, `backtesting/refs/computed.rs`, `backtesting/result.rs`,
-  `backtesting/engine.rs`, `tickers/core.rs`, and the CLI's
-  `dashboard/render.rs`, `backtest/results.rs`, and `backtest/state.rs`. Every
-  existing path is preserved by re-export; no public API or behavior change.
+The library opens up: downstream crates can now register their own providers,
+implement the sixteen capability traits directly, and route them alongside the
+built-ins. A wave of new keyless providers — World Bank, US Treasury
+FiscalData, BLS, Frankfurter/ECB, Binance, Kraken, FINRA, OpenFIGI, DefiLlama,
+GDELT, CFTC, plus House/Senate congressional trades and SEC fails-to-deliver —
+closes the last key-only capabilities, so forex, crypto, short volume, and
+filings all work with nothing configured. The backtesting engine gains margin,
+leverage, financing costs, position-sizing schemes, and Pareto multi-objective
+search, alongside a large batch of correctness fixes. Streaming adds options
+chains, trades, order-book depth, and price alerts. `Ticker`/`Tickers` and the
+domain handles now cache by default. Includes several breaking API changes —
+see the **Breaking** items under Changed.
 
 ### Added
 
-- `FinanceError::NetworkError` for transport failures whose source is withheld.
-  Alpha Vantage, FMP, FRED, and Massive all authenticate with a query
-  parameter, so all four now use it instead of `HttpError`, whose
-  `reqwest::Error` renders the full URL in both `Display` and `Debug` and would
-  leak the key into logs. It is retriable.
-- `finance_query::alphavantage`, `finance_query::fmp`, and
-  `finance_query::polygon` config modules, each exposing `init` and
-  `init_with_timeout` alongside the existing `fred::init`. An API key can now
-  come from application configuration rather than only from the process
-  environment. The adapters' response types stay internal; data still flows
-  through `Providers`.
-- **CoinGecko trending, global stats, and coin search** are exposed keylessly on
-  the server: `GET /v2/crypto/trending`, `GET /v2/crypto/global`, and
-  `GET /v2/crypto/search` (plus the `cryptoTrending`/`cryptoGlobal`/`cryptoSearch`
-  GraphQL root fields). The library gains matching `crypto::trending()`,
-  `crypto::global()`, and `crypto::search()` shortcuts alongside
-  `crypto::coins()`/`crypto::coin()`.
-- `CalendarKind::MarketStatus` and `MarketCalendar::market_status()` for live
-  exchange open/closed status, which Alpha Vantage serves. It was previously
-  mapped onto `CalendarKind::MarketHoliday`, so a holiday-calendar query routed
-  to Alpha Vantage silently returned live status rows instead.
-- `SymbolMatch` gains `id`, `market_cap_rank`, `thumbnail`, and `image`. `id`
-  carries a provider-native identifier when it differs from the ticker — the
-  CoinGecko coin id, for instance, is what `Providers::crypto` accepts.
+- **Custom provider registration** — the Providers API is now an extension
+  point. All sixteen capability traits are public and implementable
+  (`async_trait` is re-exported so impls can't version-skew), their signature
+  types are nameable, and the capability layer — traits, models, domain
+  handles — is compiled unconditionally rather than gated behind built-in
+  provider features, so `Providers::forex()` exists even when no built-in
+  forex provider is compiled in. `ProvidersBuilder::with_adapter` registers a
+  downstream adapter under `Provider::Custom(CustomId)`, `Routes::route` names
+  it in a route, and `Providers::from_set` wraps a hand-built set. Routing to
+  an id nothing registered fails at build with the new
+  `ProviderNotRegistered` error rather than `NoProviderAvailable` on first
+  call. Custom ids are interned and capped at `u16`; a collision is checked
+  against built-ins only.
+- **Provider introspection** — `Provider::all()`, `Provider::capabilities()`,
+  and `Capability::candidate_providers()` are now public, so code can ask
+  what a provider serves or who serves a capability instead of triggering an
+  error and reading its hint. `Capability::all()` iterates the single-bit
+  constants, and `Capability::NONE`/`union` allow declaring capability sets
+  in a `const`. All three answer for built-ins; a custom provider's set
+  lives on its adapter.
+- **Instance-scoped API keys** — `ProvidersBuilder` can carry keys per
+  `Providers` instance instead of only process-global `init` singletons, so
+  two instances can hold different keys for one provider, and rotation and
+  test isolation work. Resolution order is scoped key, then singleton, then
+  environment; rate-limit buckets are per key.
+- **Per-capability fetch mode** — `Routes::route_with` and `fetch_mode_for`
+  set `Fetch::Sequential`/`Fetch::Parallel` per capability, so `QUOTE` can
+  race providers while a quota-limited capability stays sequential.
 - **World Bank Open Data** (`worldbank` feature, keyless) — `Provider::WorldBank`
   serves `Capability::ECONOMIC` with roughly 1,600 global development and macro
   indicators across 200+ economies, closing the gap left by FRED's US focus.
@@ -180,15 +146,102 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   …) to their CFTC contract code; anything else is passed through as a raw
   `cftc_contract_market_code`. New public model `CommitmentsOfTraders` /
   `CotObservation`. Covers physical commodities only (agriculture, energy,
-  metals) — CFTC reports financial futures (equity indices, rates,
-  currencies) separately in the Traders in Financial Futures report, which
-  this adapter does not serve; CFTC publishes no price quotes at all, so
-  `fetch_futures_quote` reports `NotSupported` and falls through to another
-  routed provider (e.g. Polygon).
-- Both keyless providers are exposed on the server: `GET /v2/gdelt/news/{symbol}`
-  and `GET /v2/cftc/cot/{symbol}`, plus the `gdeltNews`/`commitmentsOfTraders`
-  GraphQL root fields. The library gains `gdelt::news()` and
-  `cftc::commitments_of_traders()` shortcuts so neither needs provider routing.
+  metals) — CFTC reports financial futures separately in the Traders in
+  Financial Futures report, which this adapter does not serve; CFTC publishes
+  no price quotes at all, so `fetch_futures_quote` reports `NotSupported` and
+  falls through to another routed provider (e.g. Polygon).
+- **Congressional trades** (`housetrades` / `senatetrades` features, keyless)
+  — `Provider::CongressTrades` serves House and Senate Periodic Transaction
+  Reports. The House adapter downloads the Clerk's yearly bulk ZIP archives
+  and extracts text from born-digital PTR PDFs in-crate (scanned or
+  hand-signed filings are skipped — there is no OCR); there is no per-symbol
+  query endpoint upstream, so a lookup scans the most recent filings,
+  trading completeness for bounded latency. The Senate site renders
+  client-side behind bot protection with no query API, so its adapter
+  (`senatetrades`) drives the real search flow through headless Chromium.
+  With both features compiled in, House and Senate fetch concurrently and
+  merge into one result, each row labeled by `office`; if Senate fails — bot
+  block, rate limit, network — the merge returns House-only data rather than
+  failing the call. New public model `CongressionalTrade`.
+- **SEC fails-to-deliver** (`secftd` feature, keyless) — the EDGAR adapter
+  now reads the SEC's bi-monthly fails-to-deliver flat files, so
+  `Ticker::fails_to_deliver()` works without FMP. `FILINGS` routes
+  EDGAR + Yahoo unconditionally instead of only when `FMP_API_KEY` is set.
+- **Keyless replacements for keyed-only surfaces** — capabilities that
+  previously required FMP, Alpha Vantage, or Polygon now have primary-source
+  or derived keyless routes: executive compensation parsed from DEF 14A
+  proxy-statement HTML (the Summary Compensation Table, matched by header
+  shape since the data is not XBRL-tagged), employee count from EDGAR's
+  `dei:EntityNumberOfEmployees` cover-page tag (voluntary — falls back to
+  FMP when absent), active listing status from the SEC's bulk ticker files
+  (delisted history stays keyed-only), symbol details composed from Yahoo's
+  profile modules plus an EDGAR submissions lookup, sector performance
+  history derived from the 11 SPDR sector ETFs' daily closes, S&P 500
+  constituent changes scraped from Wikipedia's historical-components table,
+  and exchange listings served from a local static table of 18 major venues.
+  `CALENDAR`, `DISCOVERY`, `INDICES`, `COMMODITIES`, `FUTURES`, and
+  `FILINGS` all route through keyless providers by default.
+- **Backtesting: margin, leverage, and financing** — `BacktestConfig` gains
+  `max_leverage`, margin interest, and a short borrow fee (leverage is free
+  without a financing rate, so a debit cash balance accrues margin interest
+  alongside the borrow fee), margin-call liquidation, and peak-leverage
+  reporting on results. Portfolio backtests accept the same knobs at the
+  account level — largest-first maintenance liquidation, pro-rata margin
+  interest — instead of rejecting them, and per-trade stop-loss/take-profit
+  brackets fire in portfolios through the same shared check as the
+  single-symbol engine.
+- **Backtesting: position sizing schemes** — configurable sizing
+  (`PositionSizing`) replaces all-in entries, applied consistently across
+  single-symbol and portfolio engines.
+- **Backtesting: Pareto multi-objective search** — optimize across several
+  objectives at once and get the non-dominated front back, alongside the
+  existing `GridSearch`/`BayesianSearch`/`WalkForward`.
+- **New indicators and risk metrics** — Pivot Points, Heikin-Ashi, ZigZag,
+  and Fibonacci Retracement join the indicator suite (computation function,
+  `Indicator` dispatch, `Chart` extension method, and `IndicatorsSummary`
+  field each). CVaR joins `risk::`, and Omega Ratio, Kelly Criterion, Ulcer
+  Index, and Information Ratio move from backtest-only metrics to fields on
+  the standalone `risk::RiskSummary`, sharing formulas through one
+  feature-independent module. Fear & Greed picks up a crypto variant from
+  Alternative.me.
+- **Streaming: options chains, trades, order-book depth, and price alerts** —
+  four new subscribable streams, each a thin handle over the shared
+  subscription machinery rather than its own copy.
+- **Retry policy and provider health** — opt-in retry with backoff and
+  jitter on provider dispatch (`RetryPolicy`), a per-provider health
+  snapshot (`ProviderHealth`: success/failure counts, last error,
+  rate-limit budget), and exponential reconnect backoff for streaming, all
+  sharing one delay implementation.
+- Provider-neutral models for company profile, earnings surprises, earnings
+  transcripts, and analyst grading history (`CompanyProfile`,
+  `EarningsSurprise`, `EarningsTranscript`, grading actions), routed through
+  `Ticker` and the filings handle across providers.
+- Polygon grouped-daily aggregates and Alpha Vantage market status, wired
+  through the public API (both already existed in the adapters, unrouted).
+- `FinanceError::NetworkError` for transport failures whose source is withheld.
+  Alpha Vantage, FMP, FRED, and Massive all authenticate with a query
+  parameter, so all four now use it instead of `HttpError`, whose
+  `reqwest::Error` renders the full URL in both `Display` and `Debug` and would
+  leak the key into logs. It is retriable.
+- `finance_query::alphavantage`, `finance_query::fmp`, and
+  `finance_query::polygon` config modules, each exposing `init` and
+  `init_with_timeout` alongside the existing `fred::init`. An API key can now
+  come from application configuration rather than only from the process
+  environment. The adapters' response types stay internal; data still flows
+  through `Providers`.
+- **CoinGecko trending, global stats, and coin search** are exposed keylessly on
+  the server: `GET /v2/crypto/trending`, `GET /v2/crypto/global`, and
+  `GET /v2/crypto/search` (plus the `cryptoTrending`/`cryptoGlobal`/`cryptoSearch`
+  GraphQL root fields). The library gains matching `crypto::trending()`,
+  `crypto::global()`, and `crypto::search()` shortcuts alongside
+  `crypto::coins()`/`crypto::coin()`.
+- `CalendarKind::MarketStatus` and `MarketCalendar::market_status()` for live
+  exchange open/closed status, which Alpha Vantage serves. It was previously
+  mapped onto `CalendarKind::MarketHoliday`, so a holiday-calendar query routed
+  to Alpha Vantage silently returned live status rows instead.
+- `SymbolMatch` gains `id`, `market_cap_rank`, `thumbnail`, and `image`. `id`
+  carries a provider-native identifier when it differs from the ticker — the
+  CoinGecko coin id, for instance, is what `Providers::crypto` accepts.
 - Alpha Vantage gains the `DISCOVERY` capability and ETF coverage:
   `Ticker::etf_profile()` returns a fund's profile and portfolio holdings
   (heaviest first) — no other wired provider serves ETF composition —
@@ -242,33 +295,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fiscal period and reason about whether it is still current. New public models
   `KeyMetricsTtm` and `FinancialRatiosTtm`.
 - Ownership/governance on `Ticker`: `executive_compensation()` and
-  `employee_count()` via the `CORPORATE` route (FMP), both extracted from the
+  `employee_count()` via the `CORPORATE` route, both extracted from the
   company's own SEC filings and returned newest-first. FMP also now serves
   `share_float()` on the `FUNDAMENTALS` route, so it works when FMP is routed
   ahead of Yahoo. New public models `ExecutiveCompensation` and `EmployeeCount`.
 - Index constituents: `providers.index("^GSPC").constituents()` and
   `.constituent_changes()` list the current members and membership history of
-  the S&P 500, Nasdaq 100, and Dow Jones (FMP; changes are S&P 500 only).
+  the S&P 500, Nasdaq 100, and Dow Jones. Constituents and S&P 500 changes
+  have keyless routes (Wikipedia); FMP serves the rest.
   `MajorIndex::from_symbol` maps common symbol spellings.
 - Short data on `Ticker`: `short_interest()`, `short_volume()`, and
   `share_float()` via the `FUNDAMENTALS` route. The default Yahoo route
   derives short interest (current + prior-month snapshots) and float from
-  key statistics keylessly; Polygon adds the full history and daily short
-  volume.
+  key statistics keylessly; FINRA serves daily short volume keyless, and
+  Polygon adds the full history.
 - Filing text: `providers.filings("AAPL").sections(accession, form)` returns
   the sectioned 10-K/8-K text of a filing and `.risk_factors()` the extracted
-  risk factors (Polygon; EDGAR still serves metadata).
+  risk factors (EDGAR keyless, Polygon keyed).
 - `Ticker::press_releases(limit)` — the company's own releases, distinct from
-  press coverage via `news()` (FMP).
+  press coverage via `news()`.
 - `providers.calendar().holidays()` — upcoming market holidays and early
-  closes as a new `CalendarKind::MarketHoliday` (Polygon).
-- `providers.market().sector_performance_history(limit)` (FMP), and market
+  closes as a new `CalendarKind::MarketHoliday`, served keylessly from a
+  local rules table with Polygon as a keyed route.
+- `providers.market().sector_performance_history(limit)`, and market
   movers now work on the default keyless route: Yahoo serves
   `gainers()`/`losers()`/`most_active()` derived from its predefined
   screeners, with Alpha Vantage as a second keyed route. `providers.market()`
   and the mover/sector models are available without any provider feature.
-- Three market-wide capabilities and handles on the Providers API (each needs
-  at least one of the `fmp`/`polygon`/`alphavantage` features):
+- Three market-wide capabilities and handles on the Providers API:
   `Capability::DISCOVERY` with `providers.discovery()` (symbol search,
   reference data, exchanges, screeners), `Capability::CALENDAR` with
   `providers.calendar()` (market-wide earnings/IPO/dividend/split/economic
@@ -278,7 +332,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   non-Yahoo provider previously fell back to one request per symbol; a
   10-symbol batch now costs one request instead of ten.
 - `TickerBuilder::no_cache()`, `TickersBuilder::no_cache()`, and `no_cache()`
-  on the domain handles.
+  on the domain handles; `.cache_forever()` for the old unbounded-lifetime
+  caching.
 - `backtesting::PositionExtremes` and `StrategyContext::extremes` — the highest
   and lowest bar high/low/close since the open position was entered. The engine
   folds these once per bar, so `TrailingStop` and `TrailingTakeProfit` read one
@@ -289,8 +344,121 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Yahoo handshake once and retries. If the refresh itself fails, the shared
   session is dropped so the next caller builds a fresh one.
 
+### Changed
+
+- **Breaking**: `Ticker`, `Tickers`, and the domain handles now cache
+  responses by default with a 60-second TTL (matching the server's own quote
+  TTL), deduplicating concurrent identical fetches. Previously caching was
+  off unless `.cache(ttl)` was set — contradicting the documentation — and
+  `CacheMode`'s default was an unbounded lifetime.
+  - Migration: `.no_cache()` restores uncached behavior; `.cache_forever()`
+    restores unbounded-lifetime caching.
+- **Breaking**: `BacktestEngine::run` and `run_with_dividends` now reject
+  candles that are not sorted ascending by timestamp, with the same
+  `InvalidParameter` error already used for unsorted dividends. Conditions
+  binary-search the candle slice, so an unsorted series previously produced
+  a silently wrong entry index. `GridSearch`, `BayesianSearch`, and
+  `WalkForward` apply the same check once per series rather than once per
+  candidate.
+- **Breaking**: a Yahoo HTTP 403 whose body names the crumb now surfaces as
+  `AuthenticationFailed` rather than `UnexpectedResponse`, so the shared
+  session refreshes instead of failing every later caller on it. A 403 that
+  does *not* mention the crumb — a datacenter-IP block or abuse throttle —
+  keeps mapping to `UnexpectedResponse`, since no handshake can clear it and
+  retrying would cost an extra handshake and a discarded session per blocked
+  request.
+- **Breaking**: `FinanceError` is now `#[non_exhaustive]`. Downstream `match`
+  expressions over it need a wildcard arm; in exchange, later variants are
+  additive.
+- **Breaking**: `Region`, `IndicesRegion`, `Screener`, `Sector`, and `Fetch`
+  are now `#[non_exhaustive]` — these sets grow (new markets, screeners,
+  dispatch modes), so later variants become additive rather than
+  semver-major. Downstream `match` expressions over them need a wildcard
+  arm. The closed-set constants enums (`Interval`, `TimeRange`, `Frequency`,
+  `StatementType`, `ValueFormat`) deliberately stay exhaustive.
+- **Breaking**: `Provider`'s `Serialize` implementation now emits the
+  lowercase provider id (`"yahoo"`) instead of the variant name (`"Yahoo"`),
+  matching `as_str`, `Display`, and `from_id_str` — previously the
+  documented id was the one form that failed to deserialize.
+  `Provider::Custom` serializes but does not round-trip, since `from_id_str`
+  knows only built-in ids.
+- **Breaking**: `streaming::pricing::OptionTypeProto` is renamed to
+  `OptionType`.
+- The Polygon adapter now calls `api.massive.com` and
+  `wss://socket.massive.com` rather than the `polygon.io` hosts, following
+  Polygon.io's rebrand to Massive on 2025-10-30. Existing `POLYGON_API_KEY`
+  values and the `polygon` feature flag are unchanged.
+- Keyed adapters (Alpha Vantage, BLS, FMP, FRED, OpenFIGI, Massive) resolve
+  their API keys lazily at request time instead of eagerly from the
+  environment, and FMP moved off its legacy `/api/v3`/`/api/v4` paths to
+  `/stable` wherever one is published. Transport errors are sanitized so
+  keys and request URLs cannot leak through public error types.
+- `Capability` values combining several bits display as `"quote|chart"`
+  instead of `"unknown"`; `Capability::name()` keeps its documented
+  single-bit contract.
+- When no routed provider supports the specific operation, the error now
+  names that operation and the providers that could serve it
+  (`NotSupported`) instead of the generic capability-level
+  `NoProviderAvailable`.
+- Yahoo sessions are now shared per tokio runtime and client configuration.
+  The `finance::*` functions and `Ticker`/`Tickers` construction reuse one
+  authenticated session instead of running a fresh cookie + crumb handshake per
+  call, cutting each `finance::*` call from three HTTP requests to one.
+- Eight oversized source files were split into directories of focused modules:
+  `constants.rs`, `backtesting/refs/computed.rs`, `backtesting/result.rs`,
+  `backtesting/engine.rs`, `tickers/core.rs`, and the CLI's
+  `dashboard/render.rs`, `backtest/results.rs`, and `backtest/state.rs`. Every
+  existing path is preserved by re-export; no public API or behavior change.
+- The `fq` CLI moved out of the workspace to
+  [Verdenroz/fq-cli](https://github.com/Verdenroz/fq-cli) (history
+  preserved), removing the only source of `backtesting`/`rayon` compilation
+  in default-feature workspace builds. The CLI itself is unaffected.
+- Doc examples in `docs/library/**.md` are now generated and compiled
+  living docs, and the CI performance gate runs on native `perf_event`
+  measurement (soothfast) instead of valgrind, so regressions reproduce
+  locally.
+
 ### Fixed
 
+- **Backtesting sizing and margin** — the engine sizes entries from the last
+  bar closed before the fill, not the fill bar itself. Short scale-ins are
+  sized off equity at 1x and capped at the leverage ceiling, short proceeds
+  are reserved in portfolio sizing, and gross exposure is capped at equity.
+  Sleeve leverage is measured against portfolio equity. A levered short now
+  gets margin-called at any leverage, an intrabar stop outranks a margin
+  call on the same bar, a limit fill measures leverage on its fill bar, and
+  a leverage setting that would liquidate its own entry is rejected up
+  front.
+- **Backtesting orders and accounting** — the engine honors order expiry and
+  intrabar timing, charges financing on a position still open at the end of
+  the series, keeps reinvested dividends across position scaling, and
+  measures peak leverage after dividend adjustments. An open position counts
+  in summary metrics, crossover and prebuilt exits share one set of
+  semantics, and `total_financing_cost` defaults when decoding results
+  serialized by older versions.
+- **Backtesting metrics and validation** — break-even trades no longer count
+  toward the Kelly win rate, and Kelly's inputs are corrected. Metric edge
+  cases (empty or degenerate series) return `None` instead of nonsense.
+  Non-finite configs, position-sizing parameters the engine cannot honor,
+  and degenerate optimizer parameter ranges are rejected with
+  `InvalidParameter`. A volatility window ending on a zero close is skipped,
+  and sizing schemes stay inside the risk budget.
+- **Indicator causality** — the Ichimoku Chikou span reference is causal
+  (no look-ahead), and higher-timeframe conditions are evaluated in base
+  index space, fixing off-by-one signal alignment inside HTF strategies.
+- Yahoo chart candles now populate `adj_close`; it was parsed correctly and
+  then discarded during conversion to the public `Candle` model. Alpha
+  Vantage weekly and monthly bars carry it too (daily stays unadjusted —
+  the adjusted daily endpoint is premium-only).
+- Polygon's index-value websocket event (`ev: "V"`) is parsed; it previously
+  fell through to `Unknown` and every index-value update was discarded.
+- The Yahoo earnings-calls scraper forces HTTP/1.1: reqwest's default HTTP/2
+  negotiation against Yahoo's edge intermittently reset streams with
+  `PROTOCOL_ERROR`.
+- EDGAR's filing-index URL pointed at the wrong host, Yahoo's sector-PE
+  sampling had drifted from the sector list, and the local market-calendar
+  provider errored on an empty date range instead of defaulting to upcoming
+  holidays.
 - Alpha Vantage, FMP, and Massive classified an HTTP 429 or 5xx that carried a
   JSON error body as a non-retriable `InvalidParameter`, because the envelope
   was inspected before the status. The status is now authoritative and the
@@ -341,7 +509,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A zero base delay produced the maximum delay instead of zero at high
   attempt counts (`0.0 * inf` is NaN, and `f64::min` returns the other
   operand for NaN).
-
 - `finance::hours()` no longer labels every region's market "U.S. markets".
   Yahoo returns correct per-region session times but hardcodes the U.S.
   label; the name (and its occurrence in the status message) is now derived
@@ -352,6 +519,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   than returning a value derived from a cancelled-out denominator.
 - A batch quote response whose `result` array contains a non-object element now
   fails that batch instead of yielding an all-empty quote for it.
+
+### Security
+
+- No publicly known run-time vulnerabilities with a CVE or RUSTSEC assignment
+  were fixed in the library or its direct dependencies in this release. The
+  yanked `chacha20` 0.10.1 was replaced with 0.10.2.
+- Keyed-provider error paths no longer leak credentials: the configured API
+  key is redacted from forwarded upstream error text, and transport errors
+  no longer render the keyed request URL (see Fixed).
 <!-- /soothfast:notes -->
 
 ### API surface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `FinanceError` is now `#[non_exhaustive]`, as every other public enum in the
   crate already is. Downstream `match` expressions over it need a wildcard arm;
   in exchange, later variants are additive.
+- `Region`, `IndicesRegion`, `Screener`, `Sector`, and `Fetch` are now
+  `#[non_exhaustive]` — these sets grow (new markets, screeners, dispatch
+  modes), so later variants become additive rather than semver-major.
+  Downstream `match` expressions over them need a wildcard arm. The closed-set
+  constants enums (`Interval`, `TimeRange`, `Frequency`, `StatementType`,
+  `ValueFormat`) deliberately stay exhaustive.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-finance-query = "2.3"
+finance-query = "3"
 
 # Or with additional features
-finance-query = { version = "2.3", features = ["dataframe", "indicators", "fred", "crypto", "risk", "translation"] }
+finance-query = { version = "3", features = ["dataframe", "indicators", "fred", "crypto", "risk", "translation"] }
 ```
 
 **Single symbol:**

--- a/docs/library/backtesting.md
+++ b/docs/library/backtesting.md
@@ -14,7 +14,7 @@ Backtesting requires the `backtesting` feature (which depends on `indicators`):
 
 ```toml
 [dependencies]
-finance-query = { version = "2.0", features = ["backtesting"] }
+finance-query = { version = "3", features = ["backtesting"] }
 ```
 
 ## Pre-built Strategies

--- a/docs/library/dataframe.md
+++ b/docs/library/dataframe.md
@@ -10,7 +10,7 @@ Finance Query provides optional Polars DataFrame conversion for data analysis wo
 
     ```toml
     [dependencies]
-    finance-query = { version = "2.0", features = ["dataframe"] }
+    finance-query = { version = "3", features = ["dataframe"] }
     polars = "0.53"
     ```
 
@@ -232,7 +232,7 @@ shape: (50, 59)
 !!! note "Feature Flag Required"
     The `indicators()` method requires the `indicators` feature flag:
     ```toml
-    finance-query = { version = "2.0", features = ["dataframe", "indicators"] }
+    finance-query = { version = "3", features = ["dataframe", "indicators"] }
     ```
 
 Convert technical indicators to DataFrame:

--- a/docs/library/getting-started.md
+++ b/docs/library/getting-started.md
@@ -9,7 +9,7 @@ Add `finance-query` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-finance-query = "2.0"
+finance-query = "3"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -17,7 +17,7 @@ tokio = { version = "1", features = ["full"] }
 
 ```toml
 [dependencies]
-finance-query = { version = "2.0", features = ["dataframe", "backtesting"] }
+finance-query = { version = "3", features = ["dataframe", "backtesting"] }
 ```
 
 | Feature | Description |

--- a/docs/library/indicators.md
+++ b/docs/library/indicators.md
@@ -11,14 +11,14 @@ Add the `indicators` feature to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-finance-query = { version = "2", features = ["indicators"] }
+finance-query = { version = "3", features = ["indicators"] }
 ```
 
 Or enable it alongside other features:
 
 ```toml
 [dependencies]
-finance-query = { version = "2", features = ["dataframe", "indicators"] }
+finance-query = { version = "3", features = ["dataframe", "indicators"] }
 ```
 
 ## Getting Started

--- a/docs/library/tickers.md
+++ b/docs/library/tickers.md
@@ -673,7 +673,7 @@ AAPL: 23 expirations
 
     ```toml
     [dependencies]
-    finance-query = { version = "2", features = ["indicators"] }
+    finance-query = { version = "3", features = ["indicators"] }
     ```
 
 Fetch technical indicators for all symbols concurrently.

--- a/finance-query-derive/src/lib.rs
+++ b/finance-query-derive/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! finance-query = { version = "2.0", features = ["dataframe"] }
+//! finance-query = { version = "3", features = ["dataframe"] }
 //! ```
 //!
 //! ## Example

--- a/finance-query-mcp/CHANGELOG.md
+++ b/finance-query-mcp/CHANGELOG.md
@@ -12,6 +12,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+The tool surface doubles from 32 to 64: the backtesting engine is exposed over MCP for the first time, and every operation from the library's keyless-provider wave gets a tool.
+
+### Added
+
+- **`run_backtest`** — exposes the backtesting engine over MCP for the first time (prebuilt strategy, symbol, interval/range, commission, short selling), extended with the new leverage, margin, and borrow-cost knobs and peak-leverage reporting as the engine gained them. The equity curve and trade log paginate through the shared `Connection` plumbing (`equity_limit`/`equity_cursor`, `trades_limit`/`trades_cursor`).
+- **`get_forex`** — forex pair quotes (only `get_forex_news` existed before), keyless via Frankfurter/ECB.
+- **30 further tools** covering the newly routed operations: `get_congressional_trades`, `get_fails_to_deliver`, `get_short_volume`, `get_protocol_tvl`(+`_history`), `get_symbol_details`, `get_company_profile`, `get_etf_profile`, `get_index_constituents`, `get_index_constituent_changes`, `get_sector_pe`, `get_sector_performance`(+`_history`), `get_earnings_surprises`, `get_earnings_transcript`, `get_executive_compensation`, `get_grading_actions`, `get_price_target_consensus`, `get_price_target_summary`, `get_rating_consensus`, `get_key_metrics_ttm`, `get_ratios_ttm`, `get_press_releases`, `get_filing_sections`, `get_risk_factors`, `get_market_calendar`, `get_commodity`, `get_futures`, `get_forex_news`, and `get_crypto_news` — each with the standard `fields` selection and pagination contracts.
+
+### Fixed
+
+- **Seven tools were undiscoverable** — they had no route marker, so `mcp-tools.json` never listed them; one marker named `get_forex` while nothing implemented it, so the manifest advertised a tool that did not exist. Markers and tools are reconciled, and the manifest freshness check now runs with the `backtesting` feature so `run_backtest` cannot silently drop out of it.
+- **Financing prorated by bar interval** on `run_backtest` — an intraday run charged borrow and margin rates as if every bar were a day, undercharging by the intraday bar multiple.
+- The shared GraphQL bridge fixes land here too: string arguments are quoted in generated queries (unquoted values parsed as enums and were rejected), and two crypto field names use the correct camelCase (`change1DPercent`).
+
 ## [2.8.0] - 2026-07-10
 
 Bridges every MCP tool through the same in-process GraphQL schema that powers the REST API, adding consistent field selection and pagination — and folding several paired batch tools into their singular counterparts along the way. **This includes a breaking change to the MCP tool surface**: six tools disappeared (see Changed below).

--- a/finance-query-mcp/src/tools/market.rs
+++ b/finance-query-mcp/src/tools/market.rs
@@ -112,6 +112,7 @@ fn indices_region_to_gql(region: IndicesRegion) -> &'static str {
         IndicesRegion::AsiaPacific => "ASIA_PACIFIC",
         IndicesRegion::MiddleEastAfrica => "MIDDLE_EAST_AFRICA",
         IndicesRegion::Currencies => "CURRENCIES",
+        _ => unreachable!("IndicesRegion variant missing a GqlIndicesRegion mapping"),
     }
 }
 

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -10,6 +10,87 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+Every operation the library gained this cycle reaches the wire: strategy
+backtesting gets its first HTTP surface, and the keyless-provider wave —
+forex, DeFi TVL, congressional trades, fails-to-deliver, short volume, COT,
+GDELT news, and the EDGAR-derived fundamentals — lands as new REST routes and
+GraphQL fields. Rate limiting is now per client IP, and a nightly data-quality
+probe gate watches field population on every route.
+
+### Added
+
+- **Strategy backtesting over REST and GraphQL** — `POST /v2/backtest/{symbol}`
+  and a `backtest` root field expose the engine, optimizer, and walk-forward
+  machinery that previously had no HTTP surface. REST and GraphQL share
+  `GqlBacktestParams` so the two surfaces cannot drift on which knobs they
+  accept; the equity curve and trade log paginate independently through the
+  shared `Connection` plumbing.
+- **Keyless-provider routes** — `GET /v2/forex/{base}/{quote}`,
+  `/v2/forex/news`, `/v2/gdelt/news/{symbol}`, `/v2/cftc/cot/{symbol}`,
+  `/v2/filings/{symbol}/congressional-trades`,
+  `/v2/filings/{symbol}/fails-to-deliver`, `/v2/filings/{symbol}/sections`,
+  `/v2/filings/{symbol}/risk-factors`, `/v2/crypto/trending`,
+  `/v2/crypto/global`, `/v2/crypto/search`, `/v2/crypto/coins/{id}/tvl`
+  (+`/tvl-history`), `/v2/crypto/news`, `/v2/market-calendar`,
+  `/v2/commodities/{symbol}`, `/v2/futures/{symbol}`,
+  `/v2/index-constituents/{symbol}`, `/v2/indices/{symbol}/constituent-changes`,
+  `/v2/sector-pe`, `/v2/sector-performance` (+`/history`),
+  `/v2/symbol-details/{symbol}`, `/v2/company-profile/{symbol}`,
+  `/v2/etf-profile/{symbol}`, `/v2/earnings-surprises/{symbol}`,
+  `/v2/earnings-transcript/{symbol}`, and `/v2/press-releases/{symbol}`,
+  each with a matching GraphQL field.
+- **Six ticker fundamentals bridged** — `/v2/short-volume/{symbol}`,
+  `/v2/grading-actions/{symbol}`, `/v2/executive-compensation/{symbol}`,
+  `/v2/price-target-consensus/{symbol}` (+ summary), `/v2/rating-consensus/{symbol}`,
+  `/v2/key-metrics-ttm/{symbol}`, and `/v2/ratios-ttm/{symbol}` — these
+  existed on `Ticker` but reached no published surface, so FINRA's keyless
+  short volume was routed but unreachable. Field selection is validated
+  against the shared allow-lists so REST and MCP cannot diverge.
+- **Remaining operations folded into existing surfaces** — `tvl`/`tvlHistory`
+  hang off `cryptoCoin`, `asOf` (ALFRED vintage) is an argument on
+  `fredSeries`, and `symbolDetails`, `listingStatus`, `constituentChanges`,
+  and `sectorPerformanceHistory` sit beside the fields they extend.
+- **Data-quality probe gate** — `server/probes.toml` declares a probe per
+  REST route (94 total) and `probes.lock` records accepted field population;
+  a nightly workflow (`io-probe.yml`) fires them against a release build and
+  files an issue on regression, catching the
+  200-with-silently-null-fields class of failure that no schema check sees.
+
+### Changed
+
+- **Full capability routing** (`route_table()` in `server/src/lib.rs`) — all
+  14 routable capabilities now have provider fallback chains with keyless
+  floors (previously only 5 were wired past Yahoo): `FOREX` falls through
+  FMP → Alpha Vantage → Frankfurter, `CRYPTO` through FMP → CoinGecko →
+  Binance → Kraken, `FUNDAMENTALS` always has a Yahoo floor, and keyed
+  providers are appended only when their env var is set. Extracted into a
+  pure, unit-tested function per key-configuration case.
+- **The server image drops the headless-Chromium stack** — the Senate eFD
+  adapter cannot pass Akamai bot protection from a cloud IP, so the hosted
+  server builds without `senatetrades` and serves House-only congressional
+  trades; endpoint descriptions say so. Eight unused dependencies dropped
+  and tokio/reqwest features narrowed alongside.
+
+### Fixed
+
+- **Rate limiting is per client IP** instead of a single global token bucket,
+  so one heavy client can no longer exhaust the public server's limit for
+  everyone. Buckets live in a bounded map with LRU/idle eviction so memory
+  stays capped under load.
+- **Dropped or null fields in quote, chart, options, transcripts, and risk**
+  — ten places where fields came back null or wrong despite upstream data:
+  serde key mismatches stacked across the library and Gql layers
+  (`forwardPE`, `52WeekChange`), chart meta hand-copied at three call sites,
+  options fields hardcoded to `None`, a singular transcripts route that
+  always returned 400, and GraphQL schema drift after risk/indicator
+  additions. Verified live against a rebuilt release server.
+- Two crypto valid-field names used the wrong camelCase (`change1DPercent`,
+  not `change1dPercent`), so both were rejected as unknown fields; a test
+  now compares every valid-fields constant against `schema.graphql`.
+- String arguments in generated GraphQL are quoted; an unquoted value parsed
+  as an enum, so every affected bridged query was rejected before reaching a
+  resolver.
+
 ## [2.8.0] - 2026-07-10
 
 Every REST and MCP data endpoint is now bridged through one typed GraphQL

--- a/server/src/handlers/market.rs
+++ b/server/src/handlers/market.rs
@@ -32,6 +32,7 @@ fn indices_region_to_gql(region: IndicesRegion) -> &'static str {
         IndicesRegion::AsiaPacific => "ASIA_PACIFIC",
         IndicesRegion::MiddleEastAfrica => "MIDDLE_EAST_AFRICA",
         IndicesRegion::Currencies => "CURRENCIES",
+        _ => unreachable!("IndicesRegion variant missing a GqlIndicesRegion mapping"),
     }
 }
 

--- a/src/constants/enums/region.rs
+++ b/src/constants/enums/region.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// Each region has predefined language and region codes that work together.
 /// Using the Region enum ensures correct lang/region pairing.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
 pub enum Region {
     /// Argentina (es-AR, AR)

--- a/src/constants/indices.rs
+++ b/src/constants/indices.rs
@@ -2,6 +2,7 @@
 ///
 /// The `alias`es mirror the shorthands [`FromStr`](std::str::FromStr) accepts, so
 /// deserializing (axum query extraction, JSON) takes the same spellings parsing does.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum Region {

--- a/src/constants/screeners.rs
+++ b/src/constants/screeners.rs
@@ -5,6 +5,7 @@
 ///
 /// The `alias`es mirror the shorthands [`FromStr`](std::str::FromStr) accepts, so
 /// deserializing (axum path extraction, JSON) takes the same spellings parsing does.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum Screener {

--- a/src/constants/sectors.rs
+++ b/src/constants/sectors.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// The `alias`es mirror the shorthands [`FromStr`](std::str::FromStr) accepts, so
 /// deserializing (axum path extraction, JSON) takes the same spellings parsing does.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum Sector {

--- a/src/providers/routes.rs
+++ b/src/providers/routes.rs
@@ -7,6 +7,7 @@ use super::{Capability, Provider};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// How providers are queried.
+#[non_exhaustive]
 pub enum Fetch {
     /// Try providers in priority order; first success wins.
     Sequential,

--- a/src/tickers/core/mod.rs
+++ b/src/tickers/core/mod.rs
@@ -462,7 +462,7 @@ impl Tickers {
         ClientHandle(
             self.providers
                 .first_yahoo()
-                .expect("Tickers always uses a Yahoo session"),
+                .expect("client_handle requires a Yahoo session; use Providers::tickers() for multi-provider tickers"),
         )
     }
 


### PR DESCRIPTION
## Description
Pre-release sweep ahead of v3.0.0. Adds `#[non_exhaustive]` to the five public enums that actually grow (`Region`, `IndicesRegion`, `Screener`, `Sector`, `Fetch`) while a major release makes it free; the closed sets (`Interval`, `TimeRange`, `Frequency`, `StatementType`, `ValueFormat`) stay exhaustive on purpose. The soothfast notes block covered roughly the first half of the 238-commit cycle, so the three changelogs now cover all of it, and the install snippets stop pinning new users to 2.x.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that causes existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Added `#[non_exhaustive]` to `Region`, `IndicesRegion`, `Screener`, `Sector`, and `Fetch`.
- Added wildcard arms to the two `IndicesRegion` GraphQL-literal mappers in `server/src/handlers/market.rs` and `finance-query-mcp/src/tools/market.rs`.
- Corrected `Tickers::client_handle`'s panic message to match its `# Panics` doc and the `Ticker` twin.
- Rewrote the root CHANGELOG's soothfast notes block to cover the full v2.8.0..HEAD cycle. The draft was missing the backtesting overhaul, congressional trades, custom-provider registration, new indicators, and streaming themes, plus the mandatory Security section.
- Wrote the lockstepped Unreleased entries in `server/CHANGELOG.md` and `finance-query-mcp/CHANGELOG.md`, both previously empty.
- Updated install snippets in `README.md`, `finance-query-derive`'s crate docs, and five `docs/library` pages from `2.x` to `3`. Regenerated living-doc tests came back byte-identical.

## Breaking Changes
Exhaustive `match` expressions over `Region`, `IndicesRegion`, `Screener`, `Sector`, or `Fetch` in downstream crates need a wildcard arm. In exchange, later variants (new markets, screeners, dispatch modes) become additive instead of semver-major. The closed-set enums (`Interval`, `TimeRange`, `Frequency`, `StatementType`, `ValueFormat`) are unchanged and stay exhaustively matchable.

**Migration Guide:**
```rust
// Before
match fetch {
    Fetch::Sequential => ...,
    Fetch::Parallel => ...,
}

// After
match fetch {
    Fetch::Sequential => ...,
    Fetch::Parallel => ...,
    _ => ...,
}
```

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] All tests pass (`cargo test`)

## Documentation
- [x] Code documentation updated (doc comments)
- [x] README updated (if needed)
- [x] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [ ] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [ ] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues
None.
