### PR TITLE
ci: fix publish linker crash, reflow release notes

### DIFF
--- a/.github/scripts/extract_changelog.sh
+++ b/.github/scripts/extract_changelog.sh
@@ -17,6 +17,16 @@ VERSION=${VERSION#v}
 
 # Extract the section for this version
 # Skip the header line, then print until the next ## [
-awk "/## \[$VERSION\]/{found=1; next} found && /## \[/{exit} found" "$CHANGELOG_FILE"
+# Then unwrap hard-wrapped lines: GitHub renders newlines in release bodies
+# as hard breaks, so 80-column continuation lines come out jagged.
+awk "/## \[$VERSION\]/{found=1; next} found && /## \[/{exit} found" "$CHANGELOG_FILE" | awk '
+  function trim(s) { sub(/^[[:space:]]+/, "", s); return s }
+  /^```/ { if (buf != "") { print buf; buf = "" }; print; fence = !fence; next }
+  fence { print; next }
+  /^[[:space:]]*$/ { if (buf != "") { print buf; buf = "" }; print; next }
+  /^(#{1,6} |\||[-*] |[0-9]+\. )/ { if (buf != "") { print buf }; buf = $0; next }
+  { t = trim($0); buf = (buf == "" ? t : buf " " t) }
+  END { if (buf != "") print buf }
+'
 
 exit 0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_PROFILE_DEV_DEBUG: "0"
+  CARGO_PROFILE_TEST_DEBUG: "0"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description
The v3.0.0 tag's publish run died in Pre-publish Tests: linking the ~60 capture examples in a full-feature debug build with debuginfo exhausted the runner's disk and `ld` crashed with SIGBUS. `ci.yml` already zeroes debuginfo for exactly this reason; `publish.yml` never got the same env. While in there, release bodies have always rendered squished because GitHub treats newlines in them as hard breaks and the extraction script kept the CHANGELOG's 80-column wrapping; the unwrap pass from soothfast's release job fixes that.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Added `CARGO_PROFILE_DEV_DEBUG=0` and `CARGO_PROFILE_TEST_DEBUG=0` to `publish.yml`, matching `ci.yml`.
- Added an unwrap pass to `.github/scripts/extract_changelog.sh` that joins hard-wrapped continuation lines while passing code fences, blank lines, headings, tables, and list-item starts through untouched. Ported from soothfast's release workflow.

## Breaking Changes
None.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed (`extract_changelog.sh 3.0.0` reflows the 521-line entry to 107 logical lines; `2.8.0` still extracts)
- [ ] All tests pass (`cargo test`)

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [ ] Code compiles without warnings (`cargo check`)
- [ ] Tests pass (`cargo test`)
- [ ] Code formatted (`cargo fmt`)
- [ ] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues
N/A
