### PR TITLE
fix: deflake the dropped-key limiter test

### DIFF
--- a/src/adapters/keys.rs
+++ b/src/adapters/keys.rs
@@ -78,10 +78,6 @@ fn shared_limiter(provider_key: &'static str, api_key: &str, rate: f64) -> Arc<R
     limiter
 }
 
-fn tracked_limiters() -> usize {
-    LIMITERS.read().unwrap_or_else(|e| e.into_inner()).len()
-}
-
 pub(crate) fn scoped_key(provider_key: &str) -> Option<ScopedKey> {
     SCOPED
         .try_with(|keys| keys.get(provider_key).cloned())
@@ -173,11 +169,17 @@ mod tests {
 
     #[test]
     fn a_dropped_key_stops_being_tracked() {
-        let before = tracked_limiters();
         {
             let key = ScopedKey::new("transient-xyz".into(), Duration::from_secs(30));
             let _live = key.limiter("fred", 5.0);
-            assert!(tracked_limiters() > before);
+            // Assert on this entry, not the map size: parallel tests prune
+            // their own dropped keys and shift the count.
+            assert!(
+                LIMITERS
+                    .read()
+                    .unwrap()
+                    .contains_key(&("fred", "transient-xyz".to_string()))
+            );
         }
         let _prune =
             ScopedKey::new("prune-trigger".into(), Duration::from_secs(30)).limiter("fred", 5.0);


### PR DESCRIPTION
## Description
`a_dropped_key_stops_being_tracked` failed both v3.0.0 publish attempts. It asserted the global limiter map grew, but `limiter()` prunes dead entries on insert, so a parallel test dropping its own keys between the two reads shrinks the count and fails the assertion with no real defect. It now asserts the specific entry instead, which concurrent prunes cannot touch while the test holds the `Arc`. Regular CI never saw this because nextest gives each test its own process; `publish.yml` runs plain `cargo test`, where every lib test shares one process.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Replaced the map-size assertions in `a_dropped_key_stops_being_tracked` with a `contains_key` check on the test's own entry, mirroring the negative assertion the test already ends with.
- Removed `tracked_limiters()`, which existed only for the deleted assertion.

## Breaking Changes
None.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] All tests pass (`cargo test -p finance-query --lib --features full`: 1525 passed, 0 failed)

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [ ] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues
Fixes #449
