### PR TITLE
fix: close four silent-failure gaps around the nightly probe

### DIFF
--- a/.github/workflows/io-probe.yml
+++ b/.github/workflows/io-probe.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Build release server
         run: cargo build --release -p finance-query-server
       - name: Probe
+        # `spec probe` exits 1 on problems, but the default step shell has no
+        # pipefail, so `tee` would mask it and skip the issue step below.
+        shell: bash
         run: cargo soothfast spec probe -p finance-query-server | tee probe.out
       - name: File or update failure issue
         if: failure()
@@ -53,9 +56,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           title="Nightly data-quality probe failing"
+          # An earlier step failing leaves no probe.out, which would otherwise
+          # file an issue whose only content is an empty code block.
+          summary="$(grep -E 'FAIL|spec probe:' probe.out 2>/dev/null | head -60)"
+          [ -n "$summary" ] || summary="No probe output: the job failed before probing."
           body="$(printf 'Run: %s\n\n```\n%s\n```\n' \
             "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            "$(grep -E 'FAIL|spec probe:' probe.out | head -60)")"
+            "$summary")"
           number=$(gh issue list --state open --search "in:title \"$title\"" --json number --jq '.[0].number // empty')
           if [ -n "$number" ]; then
             gh issue comment "$number" --body "$body"

--- a/.github/workflows/io-probe.yml
+++ b/.github/workflows/io-probe.yml
@@ -23,15 +23,25 @@ jobs:
     name: Probe live endpoints
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    environment: soothfast-bot
     permissions:
       contents: read
       issues: write
+      id-token: write
     steps:
       - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
+      - name: Checkout soothfast-bot scripts
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: Verdenroz/soothfast
+          ref: 80b18d8831521646b65fec79c6df14d6f763c602 # v0.3.1
+          path: soothfast-action
+          sparse-checkout: action
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -50,6 +60,118 @@ jobs:
         # pipefail, so `tee` would mask it and skip the issue step below.
         shell: bash
         run: cargo soothfast spec probe -p finance-query-server | tee probe.out
+      - name: Accept probes whose only drift is new fields
+        # `--accept` returns before `baseline.gate` ever runs, so a whole-run
+        # accept would demote a regressed field to `sometimes` and land the
+        # drift. The gate run above is the only thing that tells new from
+        # regressed, so only probes it reported as new-only are re-run under
+        # `--accept --filter`. Any other problem line, including one a later
+        # soothfast adds, taints the probe instead.
+        #
+        # `--filter` is a substring match, so an accept run also sweeps in
+        # names the eligible one is a prefix of. That is refused only when a
+        # swept-in probe is tainted, since re-locking a clean one is a no-op.
+        if: always()
+        id: accept
+        shell: bash
+        run: |
+          [ -f probe.out ] || exit 0
+          : > accept-summary.txt
+          : > eligible.txt
+          : > tainted.txt
+          : > accept.out
+          awk '
+            function flush() {
+              if (name == "") return
+              if (bad == 0 && good > 0) {
+                print name > "eligible.txt"
+                printf "%s", block > "accept-summary.txt"
+              } else if (bad > 0) {
+                print name > "tainted.txt"
+              }
+              name = ""; good = 0; bad = 0; block = ""
+            }
+            /^FAIL  / {
+              flush()
+              if ($0 ~ /^FAIL  [^: ]+:$/) {
+                name = substr($0, 7, length($0) - 7); block = $0 "\n"
+              } else if ($0 ~ /^FAIL  [^: ]+: /) {
+                print substr($0, 7, index($0, ":") - 7) > "tainted.txt"
+              }
+              next
+            }
+            /^      / {
+              if (name != "") {
+                if ($0 ~ /^      population: .* is new/) good++; else bad++
+                block = block $0 "\n"
+              }
+              next
+            }
+            { flush() }
+            END { flush() }
+          ' probe.out
+          eligible=$(sort -u eligible.txt)
+          if [ -z "$eligible" ]; then
+            echo "No probe reported new fields; probes.lock is unchanged."
+            exit 0
+          fi
+          echo "Eligible for accept:"
+          echo "$eligible"
+          for name in $eligible; do
+            status=0
+            cargo soothfast spec probe -p finance-query-server --accept --filter "$name" \
+              | tee -a accept.out || status=$?
+            # 1 is "NOT accepted", the normal refusal. Anything above it is
+            # soothfast itself failing, which no set check should paper over.
+            if [ "$status" -gt 1 ]; then
+              echo "spec probe --filter $name exited $status; not landing."
+              exit 1
+            fi
+          done
+          accepted=$(awk '$1 == "probe:" && / accepted \(/ { print $2 }' accept.out | sort -u)
+          if [ -z "$accepted" ]; then
+            echo "Every accept run refused; probes.lock is unchanged."
+            exit 0
+          fi
+          swept=$(echo "$accepted" | grep -Fxf tainted.txt || true)
+          if [ -n "$swept" ]; then
+            echo "Accept reached probes with non-new drift; not landing:"
+            echo "$swept"
+            exit 1
+          fi
+          {
+            echo "landed=true"
+            echo "summary<<SUMMARY_EOF"
+            echo "New fields accepted into \`probes.lock\` by the nightly probe."
+            echo
+            echo '```'
+            cat accept-summary.txt
+            echo '```'
+            echo "SUMMARY_EOF"
+          } >> "$GITHUB_OUTPUT"
+      - name: Mint a soothfast-bot token
+        if: always() && steps.accept.outputs.landed == 'true'
+        id: bot
+        run: soothfast-action/action/bot-token.sh
+      - name: Land the accepted probes.lock
+        # The accept run re-requests the endpoint, so a field the gate run saw
+        # populated and this one sees empty still demotes to `sometimes`, for
+        # swept-in clean probes as much as for eligible ones. That residual is
+        # accepted; the bot PR diff is where it stays reviewable.
+        if: always() && steps.accept.outputs.landed == 'true'
+        env:
+          TOKEN: ${{ steps.bot.outputs.token }}
+          APP_SLUG: ${{ steps.bot.outputs.app_slug }}
+          BRANCH: bot/probes-lock
+          TITLE: "chore: accept new probe fields into probes.lock"
+          BODY: ${{ steps.accept.outputs.summary }}
+          PATHS: server/probes.lock
+        run: soothfast-action/action/land.sh
+      - name: Revoke the soothfast-bot token
+        if: always() && steps.bot.outputs.token != ''
+        env:
+          GH_TOKEN: ${{ steps.bot.outputs.token }}
+        run: gh api -X DELETE /installation/token || true
       - name: File or update failure issue
         if: failure()
         env:

--- a/finance-query-mcp/src/main.rs
+++ b/finance-query-mcp/src/main.rs
@@ -57,7 +57,7 @@ async fn main() -> Result<()> {
 
     // MCP is stateless — never connect to Redis, always fetch fresh.
     let cache = Cache::new(None).await;
-    let providers = finance_query_server::build_providers().await;
+    let providers = finance_query_server::build_providers().await?;
     let state = AppState {
         cache,
         stream_hub: StreamHub::new(),

--- a/server/examples/dump_graphql_schema.rs
+++ b/server/examples/dump_graphql_schema.rs
@@ -16,7 +16,9 @@ async fn main() {
         cache: Cache::new(None).await,
         stream_hub: StreamHub::new(),
         feed_hub: FeedHub::new(),
-        providers: finance_query_server::build_providers().await,
+        providers: finance_query_server::build_providers()
+            .await
+            .expect("provider routing should build"),
     };
     print!("{}", graphql::build_schema(state).sdl());
 }

--- a/server/probes.toml
+++ b/server/probes.toml
@@ -238,7 +238,7 @@ shape = false
 path = "/v2/treasury/auctions?from=2025-01-01&to=2025-01-31&count=50"
 sometimes = ["highYield", "intRate", "highDiscntRate", "highInvestmentRate"]
 assert = [
-  "[]#len >= 1",
+  "#len >= 1",
   "[].cusip exists",
   "[].securityType exists",
   "[].bidToCoverRatio > 0",
@@ -251,6 +251,7 @@ shape = false
 path = "/v2/treasury/auctions/upcoming"
 sometimes = ["offeringAmt"]
 assert = [
+  "#len >= 1",
   "[].cusip exists",
   "[].auctionDate exists",
   "[].announcementDate exists",

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -18,6 +18,7 @@ use std::collections::{HashMap, HashSet};
 use std::pin::Pin;
 use std::sync::{Arc, OnceLock};
 use std::task::{Context, Poll};
+use std::time::Duration;
 use tokio::sync::broadcast;
 use tokio_stream::wrappers::BroadcastStream;
 
@@ -204,11 +205,23 @@ fn route_table(
     routes
 }
 
+/// Attempts at the provider build. Its only fallible step is Yahoo's live
+/// cookie + crumb handshake, which a retry re-runs rather than replaying:
+/// only successful sessions are cached.
+const PROVIDER_BUILD_ATTEMPTS: u32 = 3;
+
+/// Delay before the first retry, scaled by the attempt number.
+const PROVIDER_BUILD_BACKOFF: Duration = Duration::from_millis(500);
+
 /// Build the multi-provider routing shared by `AppState`. Each keyed
 /// provider is only routed in when its API key env var is set; a field
 /// backed solely by an unconfigured provider falls through to
 /// `NotSupported`, surfaced as a `501` by `finance_error_to_gql`.
-pub async fn build_providers() -> Arc<finance_query::Providers> {
+///
+/// Errors after [`PROVIDER_BUILD_ATTEMPTS`] rather than degrading to a
+/// narrower set: a caller handed a partial route table answers
+/// `NotSupported` for capabilities the deployment is configured to serve.
+pub async fn build_providers() -> Result<Arc<finance_query::Providers>, FinanceError> {
     use finance_query::Providers;
 
     let log_routing = |name: &str, key: &str, enabled: bool| match enabled {
@@ -226,23 +239,25 @@ pub async fn build_providers() -> Arc<finance_query::Providers> {
     log_routing("FRED", "FRED_API_KEY", flags.fred);
     log_routing("Polygon", "POLYGON_API_KEY", flags.polygon);
 
-    let mut builder = Providers::builder();
-    for (cap, route) in route_table(flags) {
-        builder = builder.route(cap, route);
-    }
-
-    match builder.build().await {
-        Ok(providers) => Arc::new(providers),
-        Err(e) => {
-            tracing::warn!(
-                "Failed to initialize provider routing, falling back to Yahoo-only: {e}"
-            );
-            Arc::new(
-                Providers::builder()
-                    .build()
-                    .await
-                    .expect("Yahoo-only Providers build cannot fail"),
-            )
+    let routes = route_table(flags);
+    let mut attempt = 1;
+    loop {
+        let mut builder = Providers::builder();
+        for (cap, route) in routes.clone() {
+            builder = builder.route(cap, route);
+        }
+        match builder.build().await {
+            Ok(providers) => return Ok(Arc::new(providers)),
+            Err(e) => {
+                if attempt == PROVIDER_BUILD_ATTEMPTS {
+                    return Err(e);
+                }
+                tracing::warn!(
+                    "Provider routing build failed (attempt {attempt}/{PROVIDER_BUILD_ATTEMPTS}), retrying: {e}"
+                );
+                tokio::time::sleep(PROVIDER_BUILD_BACKOFF * attempt).await;
+                attempt += 1;
+            }
         }
     }
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -158,7 +158,9 @@ async fn create_app() -> Router {
         rate_limit_config.requests_per_minute
     );
 
-    let providers = finance_query_server::build_providers().await;
+    let providers = finance_query_server::build_providers()
+        .await
+        .expect("Failed to initialize provider routing");
 
     let state = AppState {
         cache,

--- a/server/tests/gql_wire_shape.rs
+++ b/server/tests/gql_wire_shape.rs
@@ -167,7 +167,9 @@ async fn sdl_field_names_are_the_graphql_spelling_not_the_serde_one() {
         cache: Cache::new(None).await,
         stream_hub: StreamHub::new(),
         feed_hub: FeedHub::new(),
-        providers: finance_query_server::build_providers().await,
+        providers: finance_query_server::build_providers()
+            .await
+            .expect("provider routing should build"),
     };
     let sdl = graphql::build_schema(state).sdl();
 

--- a/server/tests/graphql_schema.rs
+++ b/server/tests/graphql_schema.rs
@@ -10,7 +10,9 @@ async fn schema_graphql_is_up_to_date() {
         cache: Cache::new(None).await,
         stream_hub: StreamHub::new(),
         feed_hub: FeedHub::new(),
-        providers: finance_query_server::build_providers().await,
+        providers: finance_query_server::build_providers()
+            .await
+            .expect("provider routing should build"),
     };
     let live_sdl = graphql::build_schema(state).sdl();
     let checked_in =


### PR DESCRIPTION
## Description

The Treasury auctions work in #476 serves fine over REST and GraphQL. Its two new probes have been failing since it merged and nobody found out, because the nightly pipes `cargo soothfast spec probe` through `tee`, which swallows the exit code and leaves the run green. The probe assertion itself was malformed: `[]#len >= 1` descends into the array and asks each element object for a length. Two more of the same kind turned up while looking. The nightly is documented in `CLAUDE.md` as owning `probes.lock` but has no step that writes it, and `build_providers()` answered a failed Yahoo handshake by discarding every route in `route_table()` and logging a warning, which is why `finance-query.com/mcp` reports that Yahoo does not support treasury auctions while the same data over GraphQL works.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Replaced `[]#len >= 1` with `#len >= 1` on the `treasury-auctions` probe. The `[]` prefix resolves to each element of the array, so the assertion asked a JSON object for its length and always failed with `object has no length`.
- Added `#len >= 1` to the `treasury-auctions-upcoming` probe. Its three `[].x exists` assertions are all vacuously true on an empty array, which is what its `record_date` dedup returns if it ever over-filters.
- Set `shell: bash` on the nightly probe step so the pipeline gets `-o pipefail`. `spec probe` exits 1 on problems, but the default step shell is `bash -e` with no pipefail, so the step took `tee`'s exit code and the `if: failure()` issue step never ran.
- Made the issue step fall back to a plain message when `probe.out` does not exist. That step is reachable for the first time, including when the release build fails before any probing.
- Added an accept step that re-runs `spec probe --accept --filter` for probes whose only reported drift is new fields, and lands the resulting `probes.lock` through the existing `soothfast-bot` token and `land.sh` scripts. A probe that reported any other kind of problem is refused, including one swept in by `--filter`'s substring match.
- Changed `build_providers()` to retry the builder three times with a 500ms backoff per attempt and return `Result` instead of rebuilding a Yahoo-only `Providers`. The old error arm discarded every route from `route_table()`, and its own `.expect("Yahoo-only Providers build cannot fail")` ran the same network handshake it was catching.
- Updated the five call sites of `build_providers()`. `server/src/main.rs` uses `.expect()`, matching the `.expect("Failed to bind address")` already there; `finance-query-mcp/src/main.rs` uses `?`; the example and two test targets use `.expect()`.

## Breaking Changes

`finance_query_server::build_providers()` now returns `Result<Arc<Providers>, FinanceError>` instead of `Arc<Providers>`, and both binaries exit rather than serve a narrower route table. `finance-query-server` is not published to crates.io, so there is no external consumer to migrate. Both containers run `restart: unless-stopped`.

**Migration Guide:**
```rust
// Before
let providers = finance_query_server::build_providers().await;

// After
let providers = finance_query_server::build_providers().await?;
```

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] All tests pass (`cargo test`)

Run, all clean:
- `cargo check -p finance-query-server --features finance-query/full --all-targets`
- `cargo check -p finance-query-mcp --features full --all-targets`
- `cargo clippy --workspace --all-targets --features finance-query/full -- -D warnings`

Run, with counts from `cargo test`:
- `cargo test -p finance-query-server --features finance-query/full --lib`: 42 passed, 0 failed, including all 6 `provider_routing_tests`.
- `cargo test -p finance-query-server --features finance-query/full --test graphql_schema`: 1 passed, 0 failed. The checked-in `server/schema.graphql` is unchanged by this branch.

No full-workspace run and no release build, so "All tests pass" is unchecked. `cargo-nextest` is not installed locally; the counts above came from `cargo test`.

Not verified and not verifiable without a release build:
- That either auction probe now passes. The assertion fix is verified against soothfast's own parser, which strips a `#len` suffix and then splits the remaining path on `.`, leaving an empty path that targets the response root. It stays unproven against live data until the nightly runs.
- The workflow changes. `io-probe.yml` only runs on its nightly schedule or a manual dispatch. The two `awk` passes were verified against synthetic probe output covering regressed fields, new fields, mixed blocks, single-line HTTP failures, a locked-but-removed probe, and an unknown future problem category.

## Documentation
- [x] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [x] Examples updated (if API changed)

## Checklist
- [x] Code compiles without warnings (`cargo check`)
- [ ] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

Follows up on #476. No issue is closed by this PR.

Sibling branch: `fix/probe-failures` fixes the probe failures themselves. This PR only fixes the reporting and acceptance machinery around them, so the two are deliberately disjoint. Nothing here changes a probe's expected data beyond the two auction assertions.

Notes for review, none of them changed here:
- Six other probes are failing and are deliberately left alone here, all being root-caused on `fix/probe-failures`. `search` (`quotes[].dispSecIndFlag`) and `indicators-batch` (`indicators[].indicators.hma20`) report population regressions. `screener-most-actives` reports postMarket* regressed together with preMarket* new, which is the signature of probing during a different market session rather than of fields disappearing. `fred-series` (400), `protocol-tvl` (500), `gdelt-news` (429) and `crypto-news` (429) are HTTP failures, and all four routes return 200 live. `quote` reports only new preMarket* fields, so the accept step treats it as eligible rather than tainted.
- A full Yahoo outage now takes the process down even for keyless capabilities like crypto, economic, and forex that do not need Yahoo. Keeping those serving is worth doing separately.
- `docker-compose.yml` gives the `finance-query-mcp` service only `EDGAR_EMAIL` and `FRED_API_KEY`, while `v2` receives the full `server/.env`. Unrelated to the route-table bug fixed here, since both containers routed identically before and after.
- The accept run re-requests each endpoint, so a field the gate run saw populated and the accept run sees empty still demotes to `sometimes`. The bot PR diff is where that stays reviewable.
