### PR TITLE
ci: collapse the two bot regeneration commits into one

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,6 +97,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          fetch-tags: true
           persist-credentials: false
       - name: Checkout soothfast-bot scripts
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -194,6 +195,12 @@ jobs:
           cargo soothfast spec html -p finance-query-server --target soothfast-routes --out docs/server/api
           cargo soothfast spec html -p finance-query-mcp --target soothfast-routes --out docs/server/api
 
+      - name: Regenerate specs, MCP tool manifest, and SDKs
+        run: |
+          cargo soothfast spec gen -p finance-query-server --target soothfast-routes
+          cargo soothfast sdk gen -p finance-query-server --target soothfast-routes
+          cargo soothfast spec gen -p finance-query-mcp --target soothfast-routes --features backtesting
+
       - name: Regenerate API reference, perf report, coverage page, and llms.txt
         run: |
           cargo soothfast docs reference -p finance-query --baseline base --features full --out docs/reference
@@ -232,6 +239,13 @@ jobs:
           git show HEAD:llms.txt | sed '/^\*\*Measured:\*\*/d' > target/llms-churn/old.txt
           cmp -s target/llms-churn/old.txt target/llms-churn/new.txt && git checkout -- llms.txt || true
 
+      - name: Regenerate CHANGELOG.md
+        # Without --against-ref the draft carries no commit entries and
+        # replaces the real Unreleased section, so a missing tag must fail.
+        run: |
+          prev=$(git describe --tags --abbrev=0)
+          cargo soothfast report changelog -p finance-query --baseline base --features full --against-ref "$prev"
+
       # Minted after every step that compiles the tree has run.
       - name: Mint a soothfast-bot token
         id: bot
@@ -254,8 +268,8 @@ jobs:
           APP_SLUG: ${{ steps.bot.outputs.app_slug }}
           BRANCH: bot/derived-artifacts
           TITLE: "chore: regenerate derived artifacts"
-          BODY: Automated trend, captured-output, and llms.txt regeneration.
-          PATHS: .soothfast/trend.jsonl llms.txt docs/library README.md
+          BODY: Automated regeneration of the changelog, trend, captured output, llms.txt, specs, and SDKs.
+          PATHS: CHANGELOG.md .soothfast/trend.jsonl llms.txt docs/library README.md server/openapi.yaml server/asyncapi.yaml sdks finance-query-mcp/mcp-tools.json
         run: soothfast-action/action/land.sh
       - name: Revoke the soothfast-bot token
         if: always() && steps.bot.outputs.token != ''

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,8 @@ permissions:
 jobs:
   build-and-push:
     name: Build ${{ matrix.image.name }}
+    # Not a blanket [bot] test: dependabot's base-image bumps must still rebuild.
+    if: github.actor != 'soothfast-bot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -78,6 +80,7 @@ jobs:
 
   deploy-docs:
     name: Deploy docs site to GitHub Pages
+    if: github.actor != 'soothfast-bot[bot]'
     runs-on: ubuntu-latest
     # Rapid merges would each branch trend.jsonl off their own checkout,
     # and the second trend PR would conflict on master and hang.

--- a/.github/workflows/soothfast.yml
+++ b/.github/workflows/soothfast.yml
@@ -1,6 +1,6 @@
 name: Soothfast
 
-# Perf gate, bot-landed regeneration, living docs, spec reconciliation, and site build.
+# Perf gate, living docs, spec reconciliation, and site build.
 
 # No paths filter: a skipped job satisfies required checks, but a workflow
 # that never triggers blocks the merge.
@@ -61,8 +61,8 @@ jobs:
               - 'finance-query-mcp/mcp-tools.json'
 
   # Pull requests: gate against the base branch, commented by soothfast-bot.
-  # Master pushes: regenerate CHANGELOG.md, specs, and SDKs, landed as a
-  # soothfast-bot PR. "Gate" is a required check on master.
+  # "Gate" is a required check on master, but deploy.yml owns the
+  # regeneration and its bot PR, so master pushes here do nothing else.
   gate:
     name: Gate
     needs: changes
@@ -107,12 +107,7 @@ jobs:
         with:
           packages: finance-query
           features: bench-gate
-          changelog-features: full
-          regen-run: |
-            "$SOOTHFAST" spec gen -p finance-query-server --target soothfast-routes
-            "$SOOTHFAST" sdk gen -p finance-query-server --target soothfast-routes
-            "$SOOTHFAST" spec gen -p finance-query-mcp --target soothfast-routes --features backtesting
-          regen-paths: server/openapi.yaml server/asyncapi.yaml sdks finance-query-mcp/mcp-tools.json
+          changelog: false
 
   baseline:
     name: Baseline

--- a/.github/workflows/soothfast.yml
+++ b/.github/workflows/soothfast.yml
@@ -93,6 +93,9 @@ jobs:
         with:
           shared-key: bench-gate
           cache-on-failure: true
+          # Compiles nothing on a master push; saving would overwrite the
+          # baseline job's warm target under the shared key.
+          save-if: false
       # Unique per commit with the prefix in restore-keys: an exact key is
       # never rewritten once saved, so later commits would all miss.
       - name: Restore measured reference runs


### PR DESCRIPTION
## Description
Every human merge to `master` lands two soothfast-bot commits and runs three Docker build-and-deploy cycles. Two workflows each regenerate half the derived artifacts and each open their own bot PR, and nothing stops those bot commits from rebuilding all three images. The `deploy-docs` job already runs last and already builds the `soothfast-routes` bench target, so it can produce the changelog and the specs as well. Moving that work there and skipping the rebuild for the bot's own commit leaves one bot PR and one build cycle per merge.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Moved the `spec gen`, `sdk gen`, and MCP `spec gen` regeneration out of the `gate` job's `regen-run` in `soothfast.yml` into a step in `deploy.yml`'s `deploy-docs`, placed after the endpoint reference pages so it reuses the bench binary already built there.
- Added a `report changelog` step to `deploy-docs`, before the token mint so every step that compiles the tree still runs first. It resolves the latest tag with `git describe` and passes it as `--against-ref`.
- Added `fetch-tags: true` to the `deploy-docs` checkout. `actions/checkout` passes `--no-tags` by default even at `fetch-depth: 0`, and without a tag the changelog step would replace the real Unreleased section with an initial-surface dump.
- Extended `deploy-docs`'s `land.sh` `PATHS` to the union of both landings: `CHANGELOG.md`, `.soothfast/trend.jsonl`, `llms.txt`, `docs/library`, `README.md`, `server/openapi.yaml`, `server/asyncapi.yaml`, `sdks`, `finance-query-mcp/mcp-tools.json`.
- Set `changelog: false` on the `Verdenroz/soothfast` action in the `gate` job and dropped its `regen-run`, `regen-paths`, and `changelog-features` inputs. With no regen inputs the action's regen step collects no pathspecs and reports `changed=false`, so it mints no token and opens no pull request.
- Set `save-if: false` on the `gate` job's `rust-cache`. It now compiles nothing on a master push and would finish first, saving a near-empty target under the `bench-gate` key it shares with `baseline`.
- Guarded `build-and-push` and `deploy-docs` with `if: github.actor != 'soothfast-bot[bot]'`. `deploy` has `needs: build-and-push`, so the VPS deploy skips along with it.
- Updated the header comment and the `gate` job comment in `soothfast.yml`, which described the regeneration that job no longer does.

The guard matches the soothfast bot by name rather than testing for any `[bot]` actor. Dependabot's base-image digest bumps for `debian` and `rust` must still rebuild the images.

## Breaking Changes
None. No library, server, or MCP code changed.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] All tests pass (`cargo test`)

Verified statically: both workflows parse under `yaml.safe_load`, `prek run --files` on both is clean, and `zizmor --no-online-audits` over both reports no findings. `actionlint` is not installed on this machine, so it did not run. No Rust changed, so no `cargo` gate applies.

The `github.actor` guard was checked against real run payloads before it was written. Runs `34423002373` and `34042536402`, the two soothfast-bot commits, report `actor.login` as `soothfast-bot[bot]`. Run `33565318087`, a dependabot base-image bump, reports `actor.login` as `Verdenroz` with `head_commit.author` as `dependabot[bot]`, which is why the guard cannot key off the commit author.

Three behaviors cannot be verified before merge: that exactly one bot PR opens per human merge, that the rebuild is skipped for it, and that the changelog regenerates with its entries intact. The first merge to `master` after this is the test. What to watch for:

- One `bot/derived-artifacts` PR and no `bot/soothfast-update` PR.
- `Build and Deploy` skipped on the bot's own push.
- `CHANGELOG.md` still headed `## Unreleased (draft vs v3.0.0)` with its entry lists intact, not `## Unreleased (initial public surface)`.

That last one is the rollback trigger. If the heading changes, revert this rather than hand-editing the file.

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [ ] Code compiles without warnings (`cargo check`)
- [ ] Tests pass (`cargo test`)
- [ ] Code formatted (`cargo fmt`)
- [ ] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues
Closes #479
