### PR TITLE
ci: stop gating generated specs and SDKs at PR time

### DIFF
--- a/.github/workflows/soothfast.yml
+++ b/.github/workflows/soothfast.yml
@@ -242,10 +242,8 @@ jobs:
           changelog: false
       - name: Reconcile OpenAPI/AsyncAPI/GraphQL routes against handlers
         run: cargo soothfast spec check -p finance-query-server --target soothfast-routes
-      - name: Generated openapi.yaml/asyncapi.yaml are fresh
-        run: cargo soothfast spec gen -p finance-query-server --target soothfast-routes --check
-      - name: Generated Python SDK is fresh
-        run: cargo soothfast sdk gen -p finance-query-server --target soothfast-routes --check
+      # --from-committed reads the base's committed spec, not a fresh rebuild.
+      # A branch older than the bot's spec commit reports a BREAKING; rebase.
       - name: Spec compat gate vs merge-base
         if: github.event_name == 'pull_request'
         env:
@@ -295,8 +293,6 @@ jobs:
           changelog: false
       - name: Reconcile MCP tool routes against mcp-tools.json
         run: cargo soothfast spec check -p finance-query-mcp --target soothfast-routes --features backtesting
-      - name: Generated mcp-tools.json is fresh
-        run: cargo soothfast spec gen -p finance-query-mcp --target soothfast-routes --check --features backtesting
       - name: Regenerate MCP route pages
         run: make docs-pages PAGES=mcp
       - name: Upload MCP route pages


### PR DESCRIPTION
## Description

The generator behind `openapi.yaml`, `asyncapi.yaml`, `mcp-tools.json` and the Python SDK reads the hand-authored manifests in `server/spec/routes.rs` and `finance-query-mcp/spec/routes.rs`, not the axum router or the `#[tool]` impls. A route missing from its manifest is missing from both sides of a `spec gen --check` comparison, so the check passes green on exactly the mistake it looks like it would catch. `spec check`, which reconciles the manifests against the actual handlers, is the step with teeth there and it stays. Dropping the three `--check` steps lets the bot land the regenerated files after merge and makes `make sdk` convenience rather than a required step before opening a PR.

The workflow half of #482 is here. The documentation half cannot be. `CLAUDE.md` and `.claude/**` are gitignored (`.gitignore:9` and `.gitignore:22`) and exist only as untracked files in each clone, so no commit can reach them. They still tell the reader that CI gates the generated specs with `spec gen --check` and `sdk gen --check`, which stops being true when this merges. The issue stays open until that drift is handled.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Removed the `spec gen --check` and `sdk gen --check` steps from the `Spec & SDK (server)` job.
- Removed the `spec gen --check` step from the `Spec (MCP)` job.
- Kept `spec check` in both jobs. It reconciles the route and tool manifests against the handlers and is unaffected by this change.
- Kept `spec gate` and its `--from-committed` flag, with a comment recording why the flag is there and what a stale base spec looks like.

## Breaking Changes

None. No library, server, or MCP code changes. The generated artifacts are still generated and still must not be hand-edited; only the point at which they get regenerated moves from before the PR to after the merge.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] All tests pass (`cargo test`)

The change is YAML only, so no cargo gate applies and the boxes above stay unticked. What ran:

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/soothfast.yml'))"` parses.
- `zizmor --no-online-audits .github/workflows/soothfast.yml` reports no findings (10 suppressed).
- `prek run --files .github/workflows/soothfast.yml` passes.
- `actionlint` did not run. It is not installed on the machine this was written on.

The real verification is post-merge and cannot be performed here. The signal to watch: the first PR that changes a route or a tool without running `make sdk` should pass CI, and the regenerated `openapi.yaml`, `asyncapi.yaml`, `mcp-tools.json` and `sdks/**` should then show up in the bot's `bot/derived-artifacts` PR.

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

The documentation that needs this change is untracked. See the Description.

## Checklist
- [ ] Code compiles without warnings (`cargo check`)
- [ ] Tests pass (`cargo test`)
- [ ] Code formatted (`cargo fmt`)
- [ ] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

Refs #482

Stacks on #486. Base is `ci/collapse-bot-regeneration` and this must merge after it. #486 already routes the generated specs and SDKs through the bot's single `land.sh` call, which is what makes removing these gates safe.
