### PR TITLE
ci: bump soothfast to v0.3.2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -106,7 +106,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: Verdenroz/soothfast
-          ref: 80b18d8831521646b65fec79c6df14d6f763c602 # v0.3.1
+          ref: 69e2e9250414bd1dcaa1f45529f1e3fe12c593dd # v0.3.2
           path: soothfast-action
           sparse-checkout: action
           persist-credentials: false
@@ -124,7 +124,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y valgrind
       - name: Install cargo-soothfast
-        uses: Verdenroz/soothfast@80b18d8831521646b65fec79c6df14d6f763c602 # v0.3.1
+        uses: Verdenroz/soothfast@69e2e9250414bd1dcaa1f45529f1e3fe12c593dd # v0.3.2
         with:
           gate: false
           changelog: false

--- a/.github/workflows/io-probe.yml
+++ b/.github/workflows/io-probe.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: Verdenroz/soothfast
-          ref: 80b18d8831521646b65fec79c6df14d6f763c602 # v0.3.1
+          ref: 69e2e9250414bd1dcaa1f45529f1e3fe12c593dd # v0.3.2
           path: soothfast-action
           sparse-checkout: action
           persist-credentials: false
@@ -49,7 +49,7 @@ jobs:
           shared-key: io-probe
           cache-on-failure: true
       - name: Install cargo-soothfast
-        uses: Verdenroz/soothfast@80b18d8831521646b65fec79c6df14d6f763c602 # v0.3.1
+        uses: Verdenroz/soothfast@69e2e9250414bd1dcaa1f45529f1e3fe12c593dd # v0.3.2
         with:
           gate: false
           changelog: false

--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           enable-cache: false
       - name: Install cargo-soothfast
-        uses: Verdenroz/soothfast@80b18d8831521646b65fec79c6df14d6f763c602 # v0.3.1
+        uses: Verdenroz/soothfast@69e2e9250414bd1dcaa1f45529f1e3fe12c593dd # v0.3.2
         with:
           gate: false
           changelog: false

--- a/.github/workflows/soothfast.yml
+++ b/.github/workflows/soothfast.yml
@@ -106,7 +106,7 @@ jobs:
           restore-keys: |
             soothfast-runs-${{ github.ref_name }}-
             soothfast-runs-
-      - uses: Verdenroz/soothfast@80b18d8831521646b65fec79c6df14d6f763c602 # v0.3.1
+      - uses: Verdenroz/soothfast@69e2e9250414bd1dcaa1f45529f1e3fe12c593dd # v0.3.2
         with:
           packages: finance-query
           features: bench-gate
@@ -136,7 +136,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y valgrind
       - name: Install cargo-soothfast
-        uses: Verdenroz/soothfast@80b18d8831521646b65fec79c6df14d6f763c602 # v0.3.1
+        uses: Verdenroz/soothfast@69e2e9250414bd1dcaa1f45529f1e3fe12c593dd # v0.3.2
         with:
           gate: false
           changelog: false
@@ -186,7 +186,7 @@ jobs:
           shared-key: docs-binds
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Install cargo-soothfast
-        uses: Verdenroz/soothfast@80b18d8831521646b65fec79c6df14d6f763c602 # v0.3.1
+        uses: Verdenroz/soothfast@69e2e9250414bd1dcaa1f45529f1e3fe12c593dd # v0.3.2
         with:
           gate: false
           changelog: false
@@ -236,7 +236,7 @@ jobs:
           shared-key: spec
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Install cargo-soothfast
-        uses: Verdenroz/soothfast@80b18d8831521646b65fec79c6df14d6f763c602 # v0.3.1
+        uses: Verdenroz/soothfast@69e2e9250414bd1dcaa1f45529f1e3fe12c593dd # v0.3.2
         with:
           gate: false
           changelog: false
@@ -287,7 +287,7 @@ jobs:
           shared-key: spec
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Install cargo-soothfast
-        uses: Verdenroz/soothfast@80b18d8831521646b65fec79c6df14d6f763c602 # v0.3.1
+        uses: Verdenroz/soothfast@69e2e9250414bd1dcaa1f45529f1e3fe12c593dd # v0.3.2
         with:
           gate: false
           changelog: false
@@ -326,7 +326,7 @@ jobs:
           # near-empty target; saving would poison the shared spec key
           save-if: false
       - name: Install cargo-soothfast
-        uses: Verdenroz/soothfast@80b18d8831521646b65fec79c6df14d6f763c602 # v0.3.1
+        uses: Verdenroz/soothfast@69e2e9250414bd1dcaa1f45529f1e3fe12c593dd # v0.3.2
         with:
           gate: false
           changelog: false
@@ -358,7 +358,7 @@ jobs:
           shared-key: docs-binds
           save-if: ${{ github.ref == 'refs/heads/master' }}
       - name: Install cargo-soothfast
-        uses: Verdenroz/soothfast@80b18d8831521646b65fec79c6df14d6f763c602 # v0.3.1
+        uses: Verdenroz/soothfast@69e2e9250414bd1dcaa1f45529f1e3fe12c593dd # v0.3.2
         with:
           gate: false
           changelog: false
@@ -399,7 +399,7 @@ jobs:
         run: rustup toolchain install nightly --profile minimal
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Install cargo-soothfast
-        uses: Verdenroz/soothfast@80b18d8831521646b65fec79c6df14d6f763c602 # v0.3.1
+        uses: Verdenroz/soothfast@69e2e9250414bd1dcaa1f45529f1e3fe12c593dd # v0.3.2
         with:
           gate: false
           changelog: false


### PR DESCRIPTION
## Description

`CHANGELOG.md`'s Unreleased section currently lists `Regenerate soothfast outputs (#474)` and `Regenerate derived artifacts (#473)`. Both are soothfast-bot commits that exist only to land generated files, so two of the changelog's entries describe the changelog regenerating itself. The cause was upstream and is fixed in v0.3.2, where the generator reads the author alongside the subject and drops the commits its own bot wrote. This repo's entire share of the fix is a version pin.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Bumped the pinned `Verdenroz/soothfast` action from `80b18d8831521646b65fec79c6df14d6f763c602` (v0.3.1) to `69e2e9250414bd1dcaa1f45529f1e3fe12c593dd` (v0.3.2) at all 13 pin sites: 8 in `soothfast.yml`, 2 in `deploy.yml`, 2 in `io-probe.yml`, 1 in `sdk-publish.yml`.
- Covered both kinds of pin. Eleven are `uses: Verdenroz/soothfast@<sha>`; the other two are `ref:` on the `actions/checkout` steps in `deploy.yml` and `io-probe.yml` that sparse-check-out the action's `action/` directory for `land.sh`. The two kinds are kept in lockstep. A bump driven by a `uses:` grep alone misses the `ref:` pins and leaves those workflows running v0.3.1 scripts against a v0.3.2 CLI.
- Left `soothfast.toml` alone. The generator's default bot author is `soothfast-bot[bot]`, which is what this repo's bot commits are already authored by, so a `[changelog] bot-author` key would only be one more value to drift.
- Left `soothfast.lock`, `Cargo.toml` and `Cargo.lock` alone. 0.3.1 to 0.3.2 is caret-compatible; only the action SHAs are pinned by hand.

## Breaking Changes

None. The composite action and its seven shell scripts are byte-identical between the two tags, so the bump changes the CLI and nothing else. No library, server, or MCP code is touched.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] All tests pass (`cargo test`)

The change is YAML only, so no cargo gate applies and the boxes above stay unticked. What ran, on all four changed workflows:

- `python3 -c "import yaml; yaml.safe_load(open(f))"` parses each of `soothfast.yml`, `deploy.yml`, `sdk-publish.yml`, `io-probe.yml`.
- `zizmor --no-online-audits` over the four reports no findings (27 suppressed).
- `prek run --files` over the four passes.
- `grep -rn '80b18d8831521646b65fec79c6df14d6f763c602' .github/` returns nothing, and `grep -ro '69e2e9250414bd1dcaa1f45529f1e3fe12c593dd' .github/ | wc -l` returns 13.
- `actionlint` did not run. It is not installed on the machine this was written on.

The fix itself cannot be verified before merge, since it only shows up when the bot next regenerates the changelog on `master`. Two things to check then. The Unreleased section should no longer carry `Regenerate soothfast outputs` or `Regenerate derived artifacts` under `### 🔧 Internal`. The `### 📦 Dependencies` section must still list its dependabot entries, `Bump debian from ...` and `Bump rust from ...`. The filter compares the author string exactly, so `dependabot[bot]` should survive it; dependabot entries disappearing would mean the filter is over-matching, which is a worse bug than the one this fixes and is grounds to revert.

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

`CHANGELOG.md` is deliberately not touched here. The Unreleased section is generated, and the bot rewrites it after merge.

## Checklist
- [ ] Code compiles without warnings (`cargo check`)
- [ ] Tests pass (`cargo test`)
- [ ] Code formatted (`cargo fmt`)
- [ ] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

Closes #480

Third in a stack. Base is `ci/bot-land-sdk-regeneration`, so this stacks on #487, which stacks on #486, and it merges last. #486 and #487 both rewrite `soothfast.yml` and `deploy.yml`, which this also touches.
