### PR TITLE
fix: install soothfast 0.3.2 in CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4276,9 +4276,9 @@ dependencies = [
 
 [[package]]
 name = "soothfast"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d650986446dd3133049747fc470b2d444b0f2ccdcaa493e5b8b747b52a1fde"
+checksum = "dbb6e9e5744092d823ba62f5b545e885a2a27b1d93722bac373a31d6a06f13d3"
 dependencies = [
  "soothfast-macros",
  "soothfast-measure",
@@ -4287,9 +4287,9 @@ dependencies = [
 
 [[package]]
 name = "soothfast-macros"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d2d9dffe18895313f30e597e40402723547185c1a823ce4c478a1481a98b9e"
+checksum = "1d25e359bba29667cc4a9b2745f1849fadd981698d042b0dd350144bfc9a0b27"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4298,9 +4298,9 @@ dependencies = [
 
 [[package]]
 name = "soothfast-measure"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "431b76aed29f013a49ff43deb1ed8933d4c1d1681b06a49c8e02dc16dc2f4dd5"
+checksum = "cb48a4727b4bdf77b7d3295b4c45033e5279569665146829b38797eb52f7a74a"
 dependencies = [
  "libc",
  "soothfast-registry",
@@ -4308,9 +4308,9 @@ dependencies = [
 
 [[package]]
 name = "soothfast-registry"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2eed30b290b158c39e8399650918d336a8eafc198ffce586f9a18007384e73a"
+checksum = "bb02cf1bbf2c21edd60dab4ee9868c1c878fcfefe3c682377ed06248fe5f580f"
 dependencies = [
  "linkme",
 ]


### PR DESCRIPTION
## Description

#480 was closed by bumping the pinned soothfast action SHA to v0.3.2, and the first bot regeneration after that merge put the bot's own commits straight back into the changelog. The action picks which cargo-soothfast to install by grepping `Cargo.lock`, not from its own pinned ref, and `Cargo.lock` still said 0.3.0. That made the SHA bump inert: the action's own `action.yml` and shell scripts are byte-identical between 0.3.1 and 0.3.2, so the CLI version named in the lockfile is the only thing that changes behavior. This moves the lockfile entry to 0.3.2, the release that filters `soothfast-bot[bot]` out of the generated changelog.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Moved the `soothfast` entry in `Cargo.lock` from 0.3.0 to 0.3.2 with `cargo update -p soothfast --precise 0.3.2`.
- Moved `soothfast-macros`, `soothfast-measure`, and `soothfast-registry` from 0.3.0 to 0.3.2 in the same update. They are versioned in lockstep with `soothfast` and are reachable only through it, as a dev-dependency of the three workspace crates. No package outside that subtree changed.
- Left `Cargo.toml` alone. It declares `soothfast = { version = "0.3", features = ["runner"] }`, and the caret requirement already admits 0.3.2.

## Breaking Changes

None. `soothfast` is a dev-dependency used by the benchmark and living-docs tooling, so nothing in the published library or server graph is affected.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] All tests pass (`cargo test`)

`cargo metadata --locked --format-version 1` exits 0, so the lockfile is self-consistent and nothing else needs resolving. `prek run --files Cargo.lock` passes: large-file check, TOML check, end-of-file fixer, trailing-whitespace, and mixed-line-ending all ran and passed; the Rust and YAML hooks skipped with no matching files. No build or test suite was run, since the change only rewrites the lockfile.

The real signal is post-merge. After the next bot regeneration lands on master, `CHANGELOG.md`'s `Internal` section must no longer gain `Regenerate soothfast outputs` or `Regenerate derived artifacts` lines, and `Dependencies` must still list its dependabot entries (`Bump debian from ...`, `Bump rust from ...`). The already-committed lines from earlier regenerations are expected to disappear as well, because the generator rewrites the whole Unreleased section rather than appending to it. If the dependabot entries disappear too, the filter over-matches and this should be reverted.

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [ ] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [ ] Code compiles without warnings (`cargo check`)
- [ ] Tests pass (`cargo test`)
- [ ] Code formatted (`cargo fmt`)
- [ ] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues
Closes #480
