### PR TITLE
chore: release v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased (draft vs v3.0.0)
+## [3.1.0] - 2026-09-12
 
 <!-- soothfast:notes -->
-<!-- ### Overview -->
-<!-- What this release means for someone using it. One paragraph. -->
+### 📖 Overview
 
-<!-- ### Upgrade notes -->
-<!-- What a consumer has to do. "Nothing" is a useful answer. -->
+A small release on top of 3.0.0's provider wave. Treasury auction results and
+the announced auction schedule join the keyless FiscalData surface:
+`EconomicCatalog::treasury_auctions()` returns auction records with the
+primary-dealer/direct/indirect bidder split, and `upcoming_auctions()` returns
+the schedule of auctions not yet held, both off
+`Providers::economic_catalog()`. This extends the FiscalData adapter rather
+than adding a provider, since the auction datasets sit behind the same query
+grammar as the curated series. A round of probe-driven fixes closes the gaps
+that let a misconfigured provider look like a transport failure.
+
+### ⬆️ Upgrade notes
+
+Nothing required. There are no breaking changes, and the Treasury types
+(`TreasuryAuction`, `UpcomingAuction`, `TreasuryAuctionQuery`) land under the
+existing `fiscaldata` feature rather than a new flag.
+
+Two things worth knowing:
+
+- A provider compiled in without credentials now reports
+  `FinanceError::ProviderNotConfigured { provider, env_var }`, naming the
+  environment variable that supplies them; a missing `FRED_API_KEY` produced a
+  generic client error before. The variant is new on a `#[non_exhaustive]`
+  enum, so existing matches keep compiling, but code that keyed off the old
+  error should move over. It is distinct from `AuthenticationFailed`, which
+  means a credential was supplied and refused.
+- `upcoming_auctions()` keeps only the rows carrying the newest published
+  `record_date`. Treasury appends each week's schedule without retiring the
+  last, so reading the dataset straight returns auctions from 2024.
 <!-- /soothfast:notes -->
 
 ### ✨ Features
@@ -46,6 +71,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump step-security/harden-runner from 2.19.4 to 2.21.0 (#465)
 - Bump actions/upload-artifact from 4.6.2 to 7.0.1 (#462)
 - Bump taiki-e/install-action from 2.82.3 to 2.86.7 (#466)
+
+### 🔒 Security
+
+- No publicly known run-time vulnerabilities with a CVE or RUSTSEC assignment
+  were fixed in the library or its direct dependencies in this release.
+  `flate2` 1.1.9 was replaced with 1.1.10, which switches its backend and
+  brings `miniz_oxide` 0.9.1 and the new transitive `zlib-rs` 0.6.7 into the
+  graph; `flate2` is optional here, so this reaches only builds that enable
+  it.
+- Three advisories were cleared in the legacy v1 documentation tooling, which
+  is not part of the published crate and ships in nothing the library links:
+  a high-severity ReDoS in `pymdown-extensions` (fixed in 11.0.1, taken at
+  11.0.2) and two DOM XSS advisories in `mkdocs-material` (fixed in 9.7.7).
 
 ---
 
@@ -1266,7 +1304,8 @@ The adapter additions in this release were contributed by [@Johnson-f](https://g
 - Options chain data
 - News and analyst recommendations
 
-[Unreleased]: https://github.com/Verdenroz/finance-query/compare/v3.0.0...HEAD
+[Unreleased]: https://github.com/Verdenroz/finance-query/compare/v3.1.0...HEAD
+[3.1.0]: https://github.com/Verdenroz/finance-query/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/Verdenroz/finance-query/compare/v2.8.0...v3.0.0
 [2.8.0]: https://github.com/Verdenroz/finance-query/compare/v2.7.1...v2.8.0
 [2.7.1]: https://github.com/Verdenroz/finance-query/compare/v2.7.0...v2.7.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,7 +1515,7 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "finance-query"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1551,7 +1551,7 @@ dependencies = [
 
 [[package]]
 name = "finance-query-derive"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1560,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "finance-query-mcp"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -1583,7 +1583,7 @@ dependencies = [
 
 [[package]]
 name = "finance-query-server"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "finance-query"
-version = "3.0.0"
+version = "3.1.0"
 edition = "2024"
 authors = ["Harvey Tseng <harveytseng2@gmail.com>"]
 description = "A Rust library for querying financial data"
@@ -73,7 +73,7 @@ base64 = "0.22"
 
 # Optional: DataFrame support
 polars = { version = "0.53", optional = true, default-features = false, features = ["lazy", "polars-ops", "fmt"] }
-finance-query-derive = { version = "3.0.0", path = "finance-query-derive" }
+finance-query-derive = { version = "3.1.0", path = "finance-query-derive" }
 
 # Optional: CSV parsing for macro-economic data (Treasury yields)
 csv = { version = "1", optional = true }

--- a/finance-query-derive/Cargo.toml
+++ b/finance-query-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "finance-query-derive"
-version = "3.0.0"
+version = "3.1.0"
 edition = "2024"
 authors = ["Harvey Tseng <harveytseng2@gmail.com>"]
 description = "Derive macros for finance-query library"

--- a/finance-query-mcp/CHANGELOG.md
+++ b/finance-query-mcp/CHANGELOG.md
@@ -12,6 +12,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [3.1.0] - 2026-09-12
+
+One new tool, and a fix for a route-table failure that made the hosted server
+deny capabilities it actually had.
+
+### Added
+
+- **`get_treasury_auctions`** — Treasury auction results with the
+  primary-dealer/direct/indirect bidder split, and the announced schedule of
+  auctions not yet held. Keyless via FiscalData, with the standard `fields`
+  selection and pagination contracts.
+
+### Changed
+
+- The `rust` and `debian` base images in `finance-query-mcp/Dockerfile` were
+  bumped to current digests. Routine refreshes; no CVE fix is claimed.
+
+### Fixed
+
+- **`finance-query.com/mcp` denied capabilities it had.** A failed Yahoo
+  handshake during provider construction discarded the entire route table
+  rather than the one provider, so the hosted server reported that Yahoo does
+  not support Treasury auctions while the same data over GraphQL worked.
+
+### Security
+
+- No publicly known run-time vulnerabilities with a CVE or RUSTSEC assignment
+  were fixed in the MCP server or its direct dependencies in this release.
+
 ## [3.0.0] - 2026-08-30
 
 The tool surface doubles from 32 to 64: the backtesting engine is exposed over MCP for the first time, and every operation from the library's keyless-provider wave gets a tool.

--- a/finance-query-mcp/Cargo.toml
+++ b/finance-query-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "finance-query-mcp"
-version = "3.0.0"
+version = "3.1.0"
 edition = "2024"
 description = "MCP server exposing finance-query tools to AI agents"
 license = "MIT"

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -10,6 +10,54 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [3.1.0] - 2026-09-12
+
+Treasury auctions reach the wire, and a nightly probe run that had been
+failing silently since 3.0.0 is now believed. Four of the six failures it
+reported were real server defects; this release fixes them.
+
+### Added
+
+- **Treasury auction routes** — `GET /v2/treasury/auctions` and
+  `GET /v2/treasury/auctions/upcoming`, with matching GraphQL fields on the
+  metadata root. Both keyless via FiscalData.
+
+### Changed
+
+- **Indicators default range is now 1 year**, up from 1 month. The
+  200-period indicators need roughly 200 candles and a month of daily candles
+  is 21, so the old default left 20 of the 57 indicators null in a response
+  that looked complete. Callers passing an explicit `range` are unaffected.
+- The `rust` and `debian` base images in `server/Dockerfile` were bumped to
+  current digests. Routine refreshes; no CVE fix is claimed.
+
+### Fixed
+
+- **A failed Yahoo handshake no longer discards every route.** Provider
+  construction answered a handshake failure by dropping the whole route
+  table and logging a warning, so the deployed MCP server reported that
+  Yahoo does not support Treasury auctions while the same query over GraphQL
+  worked.
+- **An unconfigured provider answers 501, not 400.** `ProviderNotConfigured`
+  maps to `NOT_SUPPORTED`/501 rather than being reported as a malformed
+  request.
+- **Keyless transport timeouts answer 408, not 500.** Providers that
+  withhold the request URL surface their timeouts as `HttpError`, which fell
+  through to a generic internal error; those are now classified as
+  `TIMEOUT`/408.
+- **The nightly probe can fail.** `cargo soothfast spec probe` was piped
+  through `tee`, which swallowed its exit code and left every run green, so
+  two Treasury auction probes had been failing unnoticed since they were
+  added. The probe assertion `[]#len >= 1` was itself malformed — it descends
+  into the array and asks each element for a length — as were two others of
+  the same shape. The workflow also had no step that writes `probes.lock`
+  despite being documented as owning it.
+
+### Security
+
+- No publicly known run-time vulnerabilities with a CVE or RUSTSEC assignment
+  were fixed in the server or its direct dependencies in this release.
+
 ## [3.0.0] - 2026-08-30
 
 Every operation the library gained this cycle reaches the wire: strategy

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "finance-query-server"
-version = "3.0.0"
+version = "3.1.0"
 edition = "2024"
 authors = ["Harvey Tseng <harveytseng2@gmail.com>"]
 description = "High-performance financial data API server built on finance-query library"

--- a/server/soothfast.toml
+++ b/server/soothfast.toml
@@ -4,7 +4,7 @@
 path = "openapi.yaml"
 mode = "generate"
 title = "Finance Query v2"
-version = "3.0.0"
+version = "3.1.0"
 servers = ["https://finance-query.com", "http://localhost:8000"]
 
 [spec.responses]
@@ -22,7 +22,7 @@ servers = ["https://finance-query.com", "http://localhost:8000"]
 path = "asyncapi.yaml"
 mode = "generate"
 title = "Finance Query Streaming API"
-version = "3.0.0"
+version = "3.1.0"
 servers = ["wss://finance-query.com", "ws://localhost:8000"]
 
 [[sdk]]

--- a/soothfast.toml
+++ b/soothfast.toml
@@ -2,7 +2,7 @@
 
 [site]
 name = "finance-query"
-version = "3.0.0"
+version = "3.1.0"
 repo = "https://github.com/Verdenroz/finance-query"
 logo = "assets/logo.png"
 favicon = "assets/logo.png"


### PR DESCRIPTION
## Description

Cuts 3.1.0: version bumps across the workspace plus the release notes to go
with them. The root changelog stays soothfast-generated; renaming its
`Unreleased` heading to `[3.1.0] - 2026-09-12` freezes the section, so the
filled notes block and the hand-written Security section survive the next bot
run. Server and MCP changelogs carry their own 3.1.0 entries. No source code
changes.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes
- Bumped every crate to `3.1.0` (`Cargo.toml`, `Cargo.lock`, `finance-query-derive`, `finance-query-mcp`, `server`) along with `soothfast.toml` and `server/soothfast.toml`.
- Cut the root `CHANGELOG.md` heading from `## Unreleased (draft vs v3.0.0)` to `## [3.1.0] - 2026-09-12`.
- Filled the `soothfast:notes` block with Overview and Upgrade notes covering the Treasury auction surface and `FinanceError::ProviderNotConfigured`.
- Added a Security section to the root `CHANGELOG.md`.
- Added the `[3.1.0]` link reference and repointed `[Unreleased]` at `v3.1.0...HEAD`.
- Added hand-written 3.1.0 entries to `server/CHANGELOG.md` and `finance-query-mcp/CHANGELOG.md`.

## Breaking Changes

None. This PR changes version numbers and release notes only.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] All tests pass (`cargo test`)

## Documentation
- [ ] Code documentation updated (doc comments)
- [ ] README updated (if needed)
- [x] CHANGELOG.md updated (if releasing)
- [ ] Examples updated (if API changed)

## Checklist
- [ ] Code compiles without warnings (`cargo check`)
- [ ] Tests pass (`cargo test`)
- [ ] Code formatted (`cargo fmt`)
- [ ] Clippy checks pass (`cargo clippy`)
- [ ] Documentation builds (`cargo doc --no-deps`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Related Issues

None.
